### PR TITLE
build: fix nightly

### DIFF
--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "0.5.0",
+  "version": "0.5.0-nightly-2022-07-05-nightly-2022-07-05-nightly-2022-07-05-nightly-2022-07-05",
   "description": "A library for interfacing with the Internet Computer's Network Nervous System.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "0.5.0-nightly-2022-07-05-nightly-2022-07-05-nightly-2022-07-05-nightly-2022-07-05",
+  "version": "0.5.0",
   "description": "A library for interfacing with the Internet Computer's Network Nervous System.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/scripts/build-nightly
+++ b/scripts/build-nightly
@@ -4,11 +4,7 @@ set -eux
 npm ci
 
 : Update the version to SEMANTIC_VERSION-nightly-DATE e.g. 0.2.2-nightly-2022-02-28
-node -e 'fs=require("fs");n="package.json";e={encoding:"utf8"};x = JSON.parse(fs.readFileSync(n,e));x.version=`${x.version}-nightly-${new Date().toISOString().slice(0,10)}`;fs.writeFileSync(n, JSON.stringify(x, null, 2), e)'
-: The version then needs to be updated in the package.lock
-npm install
+node ./scripts/update-version.mjs nns
 
 : Now we can build
-npm run build
-: Create the release tarball
-npm pack
+npm run build --workspace=packages/nns

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -1,0 +1,26 @@
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+
+const updateVersion = () => {
+  if (process.argv.length !== 3) {
+    console.log("Invalid arguments: node update-version.mjs nns|sns|etc.");
+    return;
+  }
+
+  const project = process.argv[2];
+
+  const packagePath = join(process.cwd(), "packages", project, "package.json");
+
+  if (!existsSync(packagePath)) {
+    console.log(`Target ${packagePath} does not exist.`);
+    return;
+  }
+
+  const packageJson = JSON.parse(readFileSync(packagePath, "utf-8"));
+  packageJson.version = `${packageJson.version}-nightly-${new Date()
+    .toISOString()
+    .slice(0, 10)}`;
+  writeFileSync(packagePath, JSON.stringify(packageJson, null, 2), "utf-8");
+};
+
+updateVersion();

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync } from "fs";
+import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
 const updateVersion = () => {


### PR DESCRIPTION
# Motivation

Fix nightly job publish to npm.

# Changes

- create a build script that support workspace
- remove `npm install` to build version with exact dependencies and no minor updates
- remove `npm pack` that is executed automatically by `npm publish`
