### PR TITLE
build: scope git diff to fix ci

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Compile candid
         run: ./scripts/compile-idl-js
       - name: Verify that there are no changes to the compiled did files
-        run: git diff --exit-code
+        run: git diff --exit-code -- candid/
 
   build-protobuf:
     runs-on: ubuntu-20.04
@@ -72,7 +72,7 @@ jobs:
       - name: Compile protobuf
         run: npm run protoc
       - name: Verify that there are no changes to the compiled proto files
-        run: git diff --exit-code
+        run: git diff --exit-code -- packages/nns/proto/
 
   build:
     needs: [build-candid, build-protobuf]


### PR DESCRIPTION
# Motivation

If the formatter runs slowely, the `candid` ci job might crash first because it runs a `git diff` on the all project to compare changes.

# Changes

- scope `git diff` in ci jobs to consider only changes that matters for the job

