### PR TITLE
build: enforce type import

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,5 +17,8 @@
     "**/*.test.ts",
     "**/*.mock.ts",
     "scripts/**/*"
-  ]
+  ],
+  "rules": {
+    "@typescript-eslint/consistent-type-imports": "error"
+  }
 }

--- a/packages/nns/src/account_identifier.ts
+++ b/packages/nns/src/account_identifier.ts
@@ -1,4 +1,4 @@
-import { Principal } from "@dfinity/principal";
+import type { Principal } from "@dfinity/principal";
 import { sha224 } from "js-sha256";
 import { AccountIdentifier as AccountIdentifierPb } from "../proto/ledger_pb";
 import {

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -17,8 +17,8 @@ import type {
   RewardMode as RawRewardMode,
 } from "../../../../../candid/governance";
 import { UnsupportedValueError } from "../../errors/governance.errors";
-import { AccountIdentifier, E8s, NeuronId } from "../../types/common";
-import {
+import type { AccountIdentifier, E8s, NeuronId } from "../../types/common";
+import type {
   Action,
   By,
   Change,

--- a/packages/nns/src/canisters/governance/request.proto.converters.ts
+++ b/packages/nns/src/canisters/governance/request.proto.converters.ts
@@ -5,8 +5,8 @@ import {
 } from "../../../proto/base_types_pb";
 import { ManageNeuron as PbManageNeuron } from "../../../proto/governance_pb";
 import { AccountIdentifier as PbAccountIdentifier } from "../../../proto/ledger_pb";
-import { NeuronId } from "../../types/common";
-import {
+import type { NeuronId } from "../../types/common";
+import type {
   AddHotKeyRequest,
   DisburseRequest,
   FollowRequest,

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -1,5 +1,5 @@
 import { Principal } from "@dfinity/principal";
-import { Map } from "google-protobuf";
+import type { Map } from "google-protobuf";
 import type {
   AccountIdentifier as RawAccountIdentifier,
   Action as RawAction,
@@ -25,8 +25,8 @@ import type {
   RewardMode as RawRewardMode,
   Tally as RawTally,
 } from "../../../../../candid/governance";
-import { PrincipalId } from "../../../proto/base_types_pb";
-import {
+import type { PrincipalId } from "../../../proto/base_types_pb";
+import type {
   BallotInfo as PbBallotInfo,
   ListNeuronsResponse,
   Neuron as PbNeuron,
@@ -34,8 +34,8 @@ import {
 } from "../../../proto/governance_pb";
 import { GOVERNANCE_CANISTER_ID } from "../../constants/canister_ids";
 import { UnsupportedValueError } from "../../errors/governance.errors";
-import { AccountIdentifier, E8s, NeuronId } from "../../types/common";
-import {
+import type { AccountIdentifier, E8s, NeuronId } from "../../types/common";
+import type {
   Action,
   Ballot,
   BallotInfo,
@@ -49,7 +49,6 @@ import {
   Neuron,
   NeuronIdOrSubaccount,
   NeuronInfo,
-  NeuronState,
   NodeProvider,
   Operation,
   Proposal,
@@ -57,6 +56,7 @@ import {
   RewardMode,
   Tally,
 } from "../../types/governance_converters";
+import { NeuronState } from "../../types/governance_converters";
 import {
   accountIdentifierFromBytes,
   principalToAccountIdentifier,

--- a/packages/nns/src/canisters/ledger/ledger.request.converts.ts
+++ b/packages/nns/src/canisters/ledger/ledger.request.converts.ts
@@ -4,7 +4,7 @@ import type {
 } from "../../../../../candid/ledger";
 import { ICPTs, Subaccount } from "../../../proto/ledger_pb";
 import { TRANSACTION_FEE } from "../../constants/constants";
-import { TransferRequest } from "../../types/ledger_converters";
+import type { TransferRequest } from "../../types/ledger_converters";
 
 export const subAccountNumbersToSubaccount = (
   subAccountNumbers: number[]

--- a/packages/nns/src/errors/governance.errors.ts
+++ b/packages/nns/src/errors/governance.errors.ts
@@ -1,5 +1,5 @@
 import type { GovernanceError as GovernanceErrorDetail } from "../../../../candid/governance";
-import { ICP } from "../icp";
+import type { ICP } from "../icp";
 
 export abstract class StakeNeuronError extends Error {}
 

--- a/packages/nns/src/errors/ledger.errors.ts
+++ b/packages/nns/src/errors/ledger.errors.ts
@@ -1,6 +1,6 @@
 import type { TransferError as RawTransferError } from "../../../../candid/ledger";
 import { ICP } from "../icp";
-import { BlockHeight } from "../types/common";
+import type { BlockHeight } from "../types/common";
 
 export class TransferError extends Error {}
 

--- a/packages/nns/src/genesis_token.ts
+++ b/packages/nns/src/genesis_token.ts
@@ -1,9 +1,10 @@
-import { Actor, Agent } from "@dfinity/agent";
-import { Principal } from "@dfinity/principal";
+import type { Agent } from "@dfinity/agent";
+import { Actor } from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
 import type { _SERVICE as GenesisTokenService } from "../../../candid/genesis_token";
 import { idlFactory } from "../../../candid/genesis_token.idl";
 import { MAINNET_GENESIS_TOKEN_CANISTER_ID } from "./constants/canister_ids";
-import { NeuronId } from "./types/common";
+import type { NeuronId } from "./types/common";
 import { defaultAgent } from "./utils/agent.utils";
 
 // HttpAgent options that can be used at construction.

--- a/packages/nns/src/governance.ts
+++ b/packages/nns/src/governance.ts
@@ -1,5 +1,5 @@
 import { Actor, type Agent } from "@dfinity/agent";
-import { Principal } from "@dfinity/principal";
+import type { Principal } from "@dfinity/principal";
 import { sha256 } from "js-sha256";
 import randomBytes from "randombytes";
 import type {
@@ -9,10 +9,10 @@ import type {
 } from "../../../candid/governance";
 import { idlFactory as certifiedIdlFactory } from "../../../candid/governance.certified.idl";
 import { idlFactory } from "../../../candid/governance.idl";
+import type { ManageNeuron as PbManageNeuron } from "../proto/governance_pb";
 import {
   ListNeurons as PbListNeurons,
   ListNeuronsResponse as PbListNeuronsResponse,
-  ManageNeuron as PbManageNeuron,
   ManageNeuronResponse as PbManageNeuronResponse,
 } from "../proto/governance_pb";
 import { AccountIdentifier, SubAccount } from "./account_identifier";
@@ -68,10 +68,10 @@ import {
   UnrecognizedTypeError,
 } from "./errors/governance.errors";
 import { ICP } from "./icp";
-import { LedgerCanister } from "./ledger";
-import { E8s, NeuronId } from "./types/common";
-import { GovernanceCanisterOptions } from "./types/governance";
-import {
+import type { LedgerCanister } from "./ledger";
+import type { E8s, NeuronId } from "./types/common";
+import type { GovernanceCanisterOptions } from "./types/governance";
+import type {
   ClaimOrRefreshNeuronRequest,
   DisburseRequest,
   FollowRequest,

--- a/packages/nns/src/ledger.ts
+++ b/packages/nns/src/ledger.ts
@@ -1,5 +1,6 @@
-import { Actor, Agent } from "@dfinity/agent";
-import { Principal } from "@dfinity/principal";
+import type { Agent } from "@dfinity/agent";
+import { Actor } from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
 import type { _SERVICE as LedgerService } from "../../../candid/ledger";
 import { idlFactory as certifiedIdlFactory } from "../../../candid/ledger.certified.idl";
 import { idlFactory } from "../../../candid/ledger.idl";
@@ -11,7 +12,7 @@ import {
   Payment,
   SendRequest,
 } from "../proto/ledger_pb";
-import { AccountIdentifier } from "./account_identifier";
+import type { AccountIdentifier } from "./account_identifier";
 import {
   subAccountNumbersToSubaccount,
   toICPTs,
@@ -24,9 +25,9 @@ import {
   mapTransferProtoError,
 } from "./errors/ledger.errors";
 import { ICP } from "./icp";
-import { BlockHeight } from "./types/common";
-import { LedgerCanisterCall, LedgerCanisterOptions } from "./types/ledger";
-import { TransferRequest } from "./types/ledger_converters";
+import type { BlockHeight } from "./types/common";
+import type { LedgerCanisterCall, LedgerCanisterOptions } from "./types/ledger";
+import type { TransferRequest } from "./types/ledger_converters";
 import { defaultAgent } from "./utils/agent.utils";
 import { queryCall, updateCall } from "./utils/proto.utils";
 

--- a/packages/nns/src/sns_wasm.ts
+++ b/packages/nns/src/sns_wasm.ts
@@ -6,7 +6,7 @@ import type {
 import { idlFactory as certifiedIdlFactory } from "../../../candid/sns_wasm.certified.idl";
 import { idlFactory } from "../../../candid/sns_wasm.idl";
 import { MAINNET_SNS_WASM_CANISTER_ID } from "./constants/canister_ids";
-import { SnsWasmCanisterOptions } from "./types/sns_wasm";
+import type { SnsWasmCanisterOptions } from "./types/sns_wasm";
 import { defaultAgent } from "./utils/agent.utils";
 
 export class SnsWasmCanister {

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -1,6 +1,6 @@
-import { DerEncodedPublicKey } from "@dfinity/agent";
-import { Principal } from "@dfinity/principal";
-import {
+import type { DerEncodedPublicKey } from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+import type {
   AccountIdentifier,
   CanisterIdString,
   E8s,

--- a/packages/nns/src/types/ledger_converters.ts
+++ b/packages/nns/src/types/ledger_converters.ts
@@ -1,6 +1,6 @@
-import { AccountIdentifier } from "../account_identifier";
-import { ICP } from "../icp";
-import { E8s } from "./common";
+import type { AccountIdentifier } from "../account_identifier";
+import type { ICP } from "../icp";
+import type { E8s } from "./common";
 
 export type TransferRequest = {
   to: AccountIdentifier;

--- a/packages/nns/src/utils/account_identifier.utils.ts
+++ b/packages/nns/src/utils/account_identifier.utils.ts
@@ -1,7 +1,7 @@
-import { Principal } from "@dfinity/principal";
+import type { Principal } from "@dfinity/principal";
 import { Buffer } from "buffer";
 import { sha224 } from "js-sha256";
-import { AccountIdentifier } from "../types/common";
+import type { AccountIdentifier } from "../types/common";
 import {
   asciiStringToByteArray,
   calculateCrc32,

--- a/packages/nns/src/utils/agent.utils.ts
+++ b/packages/nns/src/utils/agent.utils.ts
@@ -1,4 +1,5 @@
-import { Agent, AnonymousIdentity, HttpAgent } from "@dfinity/agent";
+import type { Agent } from "@dfinity/agent";
+import { AnonymousIdentity, HttpAgent } from "@dfinity/agent";
 
 /**
  * @returns The default agent to use. An agent that connects to mainnet with the anonymous identity.

--- a/packages/nns/src/utils/proto.utils.ts
+++ b/packages/nns/src/utils/proto.utils.ts
@@ -1,5 +1,6 @@
-import { Agent, polling } from "@dfinity/agent";
-import { Principal } from "@dfinity/principal";
+import type { Agent } from "@dfinity/agent";
+import { polling } from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
 
 /**
  * Submits an update call to the IC.


### PR DESCRIPTION
# Motivation

Enforce usage of `type` in import with eslint rules [consistent-type-imports](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-type-imports.md).

This aligns the behavior to our svelte projects.

# Changes

- set `consistent-type-imports` and fix lint errors

