### PR TITLE
refactor: wasm list sns plural

### DIFF
--- a/packages/nns/src/sns_wasm.spec.ts
+++ b/packages/nns/src/sns_wasm.spec.ts
@@ -14,7 +14,7 @@ describe("Sns-wasm", () => {
     const canister = SnsWasmCanister.create({
       certifiedServiceOverride: service,
     });
-    const res = await canister.listSns({});
+    const res = await canister.listSnses({});
     expect(res).toEqual(snsMock);
   });
 });

--- a/packages/nns/src/sns_wasm.ts
+++ b/packages/nns/src/sns_wasm.ts
@@ -27,7 +27,7 @@ export class SnsWasmCanister {
     return new SnsWasmCanister(service, certifiedService);
   }
 
-  public listSns = async ({
+  public listSnses = async ({
     certified = true,
   }: {
     certified?: boolean;


### PR DESCRIPTION
# Motivation

There are many sns therefore use a function name with plural as in candid.
