### PR TITLE
Add support for generating a `SubAccount` from a numeric ID.

### DIFF
--- a/packages/nns/src/account_identifier.spec.ts
+++ b/packages/nns/src/account_identifier.spec.ts
@@ -48,6 +48,23 @@ describe("SubAccount", () => {
       )
     );
   });
+
+  it("can be initialized from an ID", () => {
+    expect(SubAccount.fromID(0)).toEqual(SubAccount.fromBytes(new Uint8Array(32).fill(0)));
+    const bytes = new Uint8Array(32).fill(0);
+    bytes[31] = 1;
+    expect(SubAccount.fromID(1)).toEqual(SubAccount.fromBytes(bytes));
+    bytes[31] = 255;
+    expect(SubAccount.fromID(255)).toEqual(SubAccount.fromBytes(bytes))
+  });
+
+  it("throws an exception if initialized with an ID < 0", () => {
+    expect(() => {SubAccount.fromID(-1)}).toThrow();
+  });
+
+  it("throws an exception if initialized with an ID > 255", () => {
+    expect(() => {SubAccount.fromID(256)}).toThrow();
+  });
 });
 
 describe("AccountIdentifier", () => {
@@ -76,5 +93,25 @@ describe("AccountIdentifier", () => {
         subAccount: SubAccount.ZERO,
       }).toHex()
     ).toBe("df4ad42194201b15ecbbe66ff68559a126854d8141fd935c5bd53433c2fb28d4");
+  });
+
+  test("can be initialized from a principal and subaccount", () => {
+    expect(
+      AccountIdentifier.fromPrincipal({
+        principal: Principal.fromText(
+          "bwz3t-ercuj-owo6s-4adfr-sbu4o-l72hg-kfhc5-5sapm-tj6bn-3scho-uqe"
+        ),
+        subAccount: SubAccount.fromID(1)
+      }).toHex()
+    ).toBe("16c3ca805340f0e426023bea907488100f93d5e2a654644d5d6881c7a7b2071e");
+
+    expect(
+      AccountIdentifier.fromPrincipal({
+        principal: Principal.fromText(
+          "bwz3t-ercuj-owo6s-4adfr-sbu4o-l72hg-kfhc5-5sapm-tj6bn-3scho-uqe"
+        ),
+        subAccount: SubAccount.fromID(255)
+      }).toHex()
+    ).toBe("f9d8833b97d142d888d00606e2cadec4e70b9798d71c35091a20daaa14082e67");
   });
 });

--- a/packages/nns/src/account_identifier.ts
+++ b/packages/nns/src/account_identifier.ts
@@ -51,6 +51,10 @@ export class AccountIdentifier {
     return toHexString(this.bytes);
   }
 
+  public toUint8Array(): Uint8Array {
+    return this.bytes;
+  }
+
   public toNumbers(): number[] {
     return Array.from(this.bytes);
   }
@@ -80,7 +84,17 @@ export class SubAccount {
     return new SubAccount(bytes);
   }
 
-  public static ZERO: SubAccount = new SubAccount(new Uint8Array(32).fill(0));
+  public static fromID(id: number): SubAccount {
+    if (id < 0 || id > 255) {
+      throw "Subaccount ID must be >= 0 and <= 255";
+    }
+
+    const bytes: Uint8Array = new Uint8Array(32).fill(0);
+    bytes[31] = id;
+    return new SubAccount(bytes);
+  }
+
+  public static ZERO: SubAccount = this.fromID(0);
 
   public toUint8Array(): Uint8Array {
     return this.bytes;


### PR DESCRIPTION
# Motivation

This functionality is required to enable specifying subaccounts in
`hardware-wallet-cli`.

# Changes

A method `Subnet.fromID`.

# Tests

See unit tests.
