### PR TITLE
build: build and publish nightly sns to npm

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,11 @@ jobs:
         run: ./scripts/build-nightly
       - name: Set up npm
         run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
-      - name: Publish
+      - name: Publish NNS
         run: npm publish --tag nightly --workspace=packages/nns
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - name: Publish SNS
+        run: npm publish --tag nightly --workspace=packages/sns
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/scripts/build-nightly
+++ b/scripts/build-nightly
@@ -5,6 +5,7 @@ npm ci
 
 : Update the version to SEMANTIC_VERSION-nightly-DATE e.g. 0.2.2-nightly-2022-02-28
 node ./scripts/update-version.mjs nns
+node ./scripts/update-version.mjs sns
 
 : Now we can build
-npm run build --workspace=packages/nns
+npm run build --workspaces


### PR DESCRIPTION
# Motivation

As for nns-js, it would be handy to build and publish a nightly version of sns-js.

# Changes

For CI:

- update `package.json` with nightly info in sns package
- build all workspaces
- publish sns nighlty to npm in 
