### PR TITLE
feat: map proposal info deadline_timestamp_seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 - new library `@dfinity/sns`
 - use the governance canister id of the class in converters. This allows to also have proper conversion on testnets.
-- add "leaveCommunityFund" functionality to governance canister in `@dfinity/nns`.
+- add `leaveCommunityFund` functionality to governance canister in `@dfinity/nns`.
+- map `deadline_timestamp_seconds` to proposal object
 
 ### Fix
 

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -66,6 +66,7 @@ import {
   principalToAccountIdentifier,
 } from "../../utils/account_identifier.utils";
 import { arrayOfNumberToUint8Array } from "../../utils/converter.utils";
+import { fromNullable } from "../../utils/did.utils";
 
 const toNeuronInfo = ({
   neuronId,
@@ -608,6 +609,9 @@ export const toProposalInfo = (
   proposalTimestampSeconds: proposalInfo.proposal_timestamp_seconds,
   rewardEventRound: proposalInfo.reward_event_round,
   failedTimestampSeconds: proposalInfo.failed_timestamp_seconds,
+  deadlineTimestampSeconds: fromNullable(
+    proposalInfo.deadline_timestamp_seconds
+  ),
   decidedTimestampSeconds: proposalInfo.decided_timestamp_seconds,
   proposal: proposalInfo.proposal.length
     ? toProposal(proposalInfo.proposal[0])

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -266,6 +266,7 @@ export interface ProposalInfo {
   rewardEventRound: bigint;
   failedTimestampSeconds: bigint;
   decidedTimestampSeconds: bigint;
+  deadlineTimestampSeconds: Option<bigint>;
   latestTally: Option<Tally>;
   proposal: Option<Proposal>;
   proposer: Option<NeuronId>;

--- a/packages/nns/src/utils/did.utils.ts
+++ b/packages/nns/src/utils/did.utils.ts
@@ -1,0 +1,3 @@
+export const fromNullable = <T>(value: [] | [T]): T | undefined => {
+  return value?.[0];
+};

--- a/packages/nns/src/utils/did.utils.ts
+++ b/packages/nns/src/utils/did.utils.ts
@@ -1,3 +1,5 @@
+// There is also toNullable in sns-js project - in case we would like to create a utility package for both libs
+
 export const fromNullable = <T>(value: [] | [T]): T | undefined => {
   return value?.[0];
 };


### PR DESCRIPTION
# Motivation

Map proposal info `deadline_timestamp_seconds` to the converter. We will ultimately need this information in NNS-dapp to get to know if a proposal duration is still valid or not.

