### PR TITLE
refactor: prefix sns types

### DIFF
--- a/packages/sns/src/enums/swap.enums.ts
+++ b/packages/sns/src/enums/swap.enums.ts
@@ -1,5 +1,5 @@
 // Source: https://github.com/dfinity/ic/blob/master/rs/sns/swap/gen/ic_sns_swap.pb.v1.rs - Lifecycle
-export enum SwapLifecycle {
+export enum SnsSwapLifecycle {
   Unspecified = 0,
   Pending = 1,
   Open = 2,

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -1,12 +1,15 @@
-export type { Neuron, NeuronId } from "../candid/sns_governance";
-export type { CanisterStatusResultV2 } from "../candid/sns_root";
 export type {
-  BuyerState,
-  DerivedState,
-  Init,
-  State,
-  Swap,
-  TimeWindow,
+  Neuron as SnsNeuron,
+  NeuronId as SnsNeuronId,
+} from "../candid/sns_governance";
+export type { CanisterStatusResultV2 as SnsCanisterStatus } from "../candid/sns_root";
+export type {
+  BuyerState as SnsSwapBuyerState,
+  DerivedState as SnsSwapDerivedState,
+  Init as SnsSwapInit,
+  State as SnsSwapState,
+  Swap as SnsSwap,
+  TimeWindow as SnsSwapTimeWindow,
 } from "../candid/sns_swap";
 export * from "./enums/swap.enums";
 export { GovernanceCanister } from "./governance.canister";

--- a/packages/sns/src/sns.spec.ts
+++ b/packages/sns/src/sns.spec.ts
@@ -7,14 +7,14 @@ import {
   rootCanisterIdMock,
   snsMock,
 } from "./mocks/sns.mock";
-import { initSns } from "./sns";
+import { initSnsWrapper } from "./sns";
 
 describe("Sns", () => {
   it("should init a wrapper", async () => {
     const service = mock<ActorSubclass<SnsRootCanister>>();
     service.list_sns_canisters.mockResolvedValue(snsMock);
 
-    const { canisterIds } = await initSns({
+    const { canisterIds } = await initSnsWrapper({
       rootOptions: {
         canisterId: rootCanisterIdMock,
         certifiedServiceOverride: service,

--- a/packages/sns/src/sns.ts
+++ b/packages/sns/src/sns.ts
@@ -24,14 +24,14 @@ export interface InitSnsCanistersOptions extends QueryParams {
   rootOptions: Omit<CanisterOptions<SnsRootCanister>, "agent">;
 }
 
-export interface InitSns {
+export interface InitSnsWrapper {
   (options: InitSnsCanistersOptions): Promise<SnsWrapper>;
 }
 
 /**
  * Lookup for the canister ids of a Sns and initialize the wrapper to access its features.
  */
-export const initSns: InitSns = async ({
+export const initSns: InitSnsWrapper = async ({
   agent,
   rootOptions,
   certified = true,

--- a/packages/sns/src/sns.ts
+++ b/packages/sns/src/sns.ts
@@ -31,7 +31,7 @@ export interface InitSnsWrapper {
 /**
  * Lookup for the canister ids of a Sns and initialize the wrapper to access its features.
  */
-export const initSns: InitSnsWrapper = async ({
+export const initSnsWrapper: InitSnsWrapper = async ({
   agent,
   rootOptions,
   certified = true,


### PR DESCRIPTION
# Motivation

Prefix exposed sns types from candid with keyword `sns` to make their intent more obvious.
