### PR TITLE
L2-797: Swap Participation Functionality

### DIFF
--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -8,28 +8,24 @@ import { SwapCanister } from "./swap.canister";
 
 describe("SnsWrapper", () => {
   const mockGovernanceCanister = mock<GovernanceCanister>();
-  const mockListNeurons =
-    mockGovernanceCanister.listNeurons.mockResolvedValue(neuronsMock);
-  const mockMetadata = mockGovernanceCanister.metadata.mockResolvedValue("");
+  mockGovernanceCanister.listNeurons.mockResolvedValue(neuronsMock);
+  mockGovernanceCanister.metadata.mockResolvedValue("");
 
   const mockCertifiedGovernanceCanister = mock<GovernanceCanister>();
-  const mockCertifiedListNeurons =
-    mockCertifiedGovernanceCanister.listNeurons.mockResolvedValue(neuronsMock);
-  const mockCertifiedMetadata =
-    mockCertifiedGovernanceCanister.metadata.mockResolvedValue("");
+  mockCertifiedGovernanceCanister.listNeurons.mockResolvedValue(neuronsMock);
+  mockCertifiedGovernanceCanister.metadata.mockResolvedValue("");
 
   const mockSwapCanister = mock<SwapCanister>();
-  const mockSwapState = mockSwapCanister.state.mockResolvedValue({
+  mockSwapCanister.state.mockResolvedValue({
     swap: [],
     derived: [],
   });
 
   const mockCertifiedSwapCanister = mock<SwapCanister>();
-  const mockCertifiedSwapState =
-    mockCertifiedSwapCanister.state.mockResolvedValue({
-      swap: [],
-      derived: [],
-    });
+  mockCertifiedSwapCanister.state.mockResolvedValue({
+    swap: [],
+    derived: [],
+  });
 
   const snsWrapper: SnsWrapper = new SnsWrapper({
     root: {} as RootCanister,
@@ -47,17 +43,43 @@ describe("SnsWrapper", () => {
     certified: true,
   });
 
+  afterEach(() => jest.clearAllMocks());
+
   it("should call list of neurons with query or update", async () => {
     await snsWrapper.listNeurons({});
-    expect(mockListNeurons).toHaveBeenCalledWith({ certified: false });
+    expect(mockGovernanceCanister.listNeurons).toHaveBeenCalledWith({
+      certified: false,
+    });
     await certifiedSnsWrapper.listNeurons({});
-    expect(mockCertifiedListNeurons).toHaveBeenCalledWith({ certified: true });
+    expect(mockCertifiedGovernanceCanister.listNeurons).toHaveBeenCalledWith({
+      certified: true,
+    });
   });
 
   it("should call metadata with query or update", async () => {
     await snsWrapper.metadata({});
-    expect(mockListNeurons).toHaveBeenCalledWith({ certified: false });
+    expect(mockGovernanceCanister.metadata).toHaveBeenCalledWith({
+      certified: false,
+    });
     await certifiedSnsWrapper.metadata({});
-    expect(mockCertifiedListNeurons).toHaveBeenCalledWith({ certified: true });
+    expect(mockCertifiedGovernanceCanister.metadata).toHaveBeenCalledWith({
+      certified: true,
+    });
+  });
+
+  it("should call swapState with query and update", async () => {
+    await snsWrapper.swapState({});
+    expect(mockSwapCanister.state).toHaveBeenCalledWith({ certified: false });
+    await certifiedSnsWrapper.swapState({});
+    expect(mockCertifiedSwapCanister.state).toHaveBeenCalledWith({
+      certified: true,
+    });
+  });
+
+  it("should call notifyParticipation", async () => {
+    await snsWrapper.notifyParticipation({ buyer: "aaaaa-aa" });
+    expect(mockSwapCanister.notifyParticipation).toHaveBeenCalledWith({
+      buyer: "aaaaa-aa",
+    });
   });
 });

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -1,6 +1,9 @@
 import type { Principal } from "@dfinity/principal";
 import type { Neuron } from "../candid/sns_governance";
-import type { GetStateResponse } from "../candid/sns_swap";
+import type {
+  GetStateResponse,
+  RefreshBuyerTokensRequest,
+} from "../candid/sns_swap";
 import type { GovernanceCanister } from "./governance.canister";
 import type { LedgerCanister } from "./ledger.canister";
 import type { RootCanister } from "./root.canister";
@@ -76,6 +79,10 @@ export class SnsWrapper {
   swapState = (
     params: Omit<QueryParams, "certified">
   ): Promise<GetStateResponse> => this.swap.state(this.mergeParams(params));
+
+  // Always certified
+  notifyParticipation = (params: RefreshBuyerTokensRequest): Promise<void> =>
+    this.swap.notifyParticipation(params);
 
   private mergeParams(params: Omit<QueryParams, "certified">): QueryParams {
     return {

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -61,11 +61,13 @@ export class SnsWrapper {
     rootCanisterId: Principal;
     ledgerCanisterId: Principal;
     governanceCanisterId: Principal;
+    swapCanisterId: Principal;
   } {
     return {
       rootCanisterId: this.root.canisterId,
       ledgerCanisterId: this.ledger.canisterId,
       governanceCanisterId: this.governance.canisterId,
+      swapCanisterId: this.swap.canisterId,
     };
   }
 

--- a/packages/sns/src/swap.canister.spec.ts
+++ b/packages/sns/src/swap.canister.spec.ts
@@ -6,6 +6,8 @@ import { swapCanisterIdMock } from "./mocks/sns.mock";
 import { SwapCanister } from "./swap.canister";
 
 describe("Swap canister", () => {
+  afterEach(() => jest.clearAllMocks());
+
   it("should return the state of the swap canister", async () => {
     const mockSwap: Swap = {
       swap: [
@@ -31,5 +33,19 @@ describe("Swap canister", () => {
     });
     const res = await canister.state({});
     expect(res).toEqual(mockResponse);
+  });
+
+  it("should call to notify the buyer tokens", async () => {
+    const service = mock<ActorSubclass<SnsSwapCanister>>();
+    service.refresh_buyer_tokens.mockResolvedValue({});
+
+    const canister = SwapCanister.create({
+      canisterId: swapCanisterIdMock,
+      certifiedServiceOverride: service,
+    });
+    await canister.notifyParticipation({ buyer: "aaaaa-aa" });
+    expect(service.refresh_buyer_tokens).toHaveBeenCalledWith({
+      buyer: "aaaaa-aa",
+    });
   });
 });

--- a/packages/sns/src/swap.canister.ts
+++ b/packages/sns/src/swap.canister.ts
@@ -1,5 +1,6 @@
 import type {
   GetStateResponse,
+  RefreshBuyerTokensRequest,
   _SERVICE as SnsSwapCanister,
 } from "../candid/sns_swap";
 import { idlFactory as certifiedIdlFactory } from "../candid/sns_swap.certified.idl";
@@ -26,4 +27,13 @@ export class SwapCanister extends Canister<SnsSwapCanister> {
    */
   state = (params: QueryParams): Promise<GetStateResponse> =>
     this.caller(params).get_state({});
+
+  /**
+   * Notify of the user participating in the swap
+   */
+  notifyParticipation = async (
+    params: RefreshBuyerTokensRequest
+  ): Promise<void> => {
+    await this.caller({ certified: true }).refresh_buyer_tokens(params);
+  };
 }


### PR DESCRIPTION
# Motivation

User can notify the swap canister of a participation.

# Changes

* Add notifyParticipation method to Swap and Wrapper classes
* Use refresh_buyer_tokens service to in the notifyParticipation.

# Tests

* Test for the new methods.
