### PR TITLE
build: agent-js peer dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Breaking changes
 
+- `agent-js` dependencies set as `peerDependencies`
 - Sns canisters' classes renamed with prefix `Sns`
 
 ### Features

--- a/HACKING.md
+++ b/HACKING.md
@@ -55,6 +55,8 @@ The files of the [candid](./candid) folders are shared across packages. Their ar
 
 # Update peer dependencies
 
+Saving peer dependencies in `package-lock.json` needs npm >= v7.
+
 ```bash
 npm rm @dfinity/principal @dfinity/agent @dfinity/candid
 npm i @dfinity/principal@0.12.0 @dfinity/agent@0.12.0 @dfinity/candid@0.12.0 --save-peer

--- a/HACKING.md
+++ b/HACKING.md
@@ -52,3 +52,10 @@ The files of the [candid](./candid) folders are shared across packages. Their ar
 - `something.certified.idl.d.ts`: the typescript definition of the above factory file
 
 (1) auto-generated with [didc](https://github.com/dfinity/candid)
+
+# Update peer dependencies
+
+```bash
+npm rm @dfinity/principal @dfinity/agent @dfinity/candid
+npm i @dfinity/principal@0.12.0 @dfinity/agent@0.12.0 @dfinity/candid@0.12.0 --save-peer
+```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,24 @@ The libraries are still in active development, and new features will incremental
 - cmc: querying the Cmc canister (_coming soon_)
 - [utils](/packages/utils): a collection of utilities and constants for NNS/SNS projects.
 
+## Installation
+
+Install [nns](/packages/nns) and/or [sns](/packages/sns) in your project from [npm](https://www.npmjs.com):
+
+```bash
+npm i @dfinity/nns
+npm i @dfinity/sns
+```
+
+You may be using both [nns](/packages/nns) and [sns](/packages/sns) in your project - as we do in [NNS-dapp](https://github.com/dfinity/nns-dapp/).
+That is s why, to help tree-shaking and avoid duplication of code, the libraries of this project are referencing [agent-js](https://github.com/dfinity/agent-js) as peer dependencies.
+
+Therefore, be sure that the needed `agent-js` dependencies are available in your project or install these as following:
+
+```bash
+npm i @dfinity/agent @dfinity/candid @dfinity/principal
+```
+
 ## Links
 
 Here are some useful links:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,16 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/ic-js",
-      "version": "0.5.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "@dfinity/agent": "^0.12.0",
-        "@dfinity/candid": "^0.12.0",
-        "@dfinity/principal": "^0.12.0"
-      },
       "devDependencies": {
         "@types/jest": "^28.1.4",
         "@types/text-encoding": "^0.0.36",
@@ -36,6 +31,11 @@
         "ts-protoc-gen": "^0.15.0",
         "typescript": "^4.5.5",
         "whatwg-fetch": "^3.6.2"
+      },
+      "peerDependencies": {
+        "@dfinity/agent": "^0.12.0",
+        "@dfinity/candid": "^0.12.0",
+        "@dfinity/principal": "^0.12.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -622,6 +622,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.12.0.tgz",
       "integrity": "sha512-dYOEwo4jl5yipuGTfTG/5hIZL6E7/oWLZ1d5gfq7p4cOBE3KeTp46JymAMiKYaGtgbKhKbDfhd4JveX3m//DJg==",
+      "peer": true,
       "dependencies": {
         "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
@@ -637,11 +638,8 @@
     "node_modules/@dfinity/candid": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.12.0.tgz",
-      "integrity": "sha512-TX9eL5D4F5EZPf+uKoxE0X3umg+mSA7RWrS+zTQxMRBe/1aBXVOFqChAiSupfKHI3wSWTvOImIxLRmCrAP+69w=="
-    },
-    "node_modules/@dfinity/utils": {
-      "resolved": "packages/utils",
-      "link": true
+      "integrity": "sha512-TX9eL5D4F5EZPf+uKoxE0X3umg+mSA7RWrS+zTQxMRBe/1aBXVOFqChAiSupfKHI3wSWTvOImIxLRmCrAP+69w==",
+      "peer": true
     },
     "node_modules/@dfinity/nns": {
       "resolved": "packages/nns",
@@ -650,10 +648,15 @@
     "node_modules/@dfinity/principal": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.12.0.tgz",
-      "integrity": "sha512-kah+gxPYKagvjrFLs8+WtQzpKPaFpUU5kG6cTiYXG8MKEX+Yls3ycdla693XwZo3neW5NRnG75Skq1ZNscQSaw=="
+      "integrity": "sha512-kah+gxPYKagvjrFLs8+WtQzpKPaFpUU5kG6cTiYXG8MKEX+Yls3ycdla693XwZo3neW5NRnG75Skq1ZNscQSaw==",
+      "peer": true
     },
     "node_modules/@dfinity/sns": {
       "resolved": "packages/sns",
+      "link": true
+    },
+    "node_modules/@dfinity/utils": {
+      "resolved": "packages/utils",
       "link": true
     },
     "node_modules/@eslint/eslintrc": {
@@ -1796,6 +1799,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
       "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -1817,12 +1821,14 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "peer": true
     },
     "node_modules/bignumber.js": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
       "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -1831,6 +1837,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
       "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+      "peer": true,
       "dependencies": {
         "bignumber.js": "^9.0.0",
         "buffer": "^5.5.0",
@@ -1933,6 +1940,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -2086,7 +2094,8 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2194,7 +2203,8 @@
     "node_modules/delimit-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ=="
+      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ==",
+      "peer": true
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -3597,8 +3607,7 @@
     "node_modules/google-protobuf": {
       "version": "3.20.1",
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.20.1.tgz",
-      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw==",
-      "dev": true
+      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw=="
     },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
@@ -3707,7 +3716,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "peer": true
     },
     "node_modules/ignore": {
       "version": "5.2.0",
@@ -4031,6 +4041,7 @@
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
       "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4735,6 +4746,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
       "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
+      "peer": true,
       "dependencies": {
         "delimit-stream": "0.1.0"
       }
@@ -5430,6 +5442,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -5645,7 +5658,8 @@
     "node_modules/simple-cbor": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
-      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w=="
+      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
+      "peer": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -5712,6 +5726,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -5733,7 +5748,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "peer": true
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -6158,7 +6174,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "peer": true
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
@@ -6324,7 +6341,7 @@
     },
     "packages/nns": {
       "name": "@dfinity/nns",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "crc": "^4.1.1",
@@ -6373,14 +6390,9 @@
         "buffer": ">=6.0.3"
       }
     },
-    "packages/nns/node_modules/google-protobuf": {
-      "version": "3.19.4",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.19.4.tgz",
-      "integrity": "sha512-OIPNCxsG2lkIvf+P5FNfJ/Km95CsXOBecS9ZcAU6m2Rq3svc0Apl9nB3GMDNKfQ9asNv4KjyAqGwPQFrVle3Yg=="
-    },
     "packages/sns": {
       "name": "@dfinity/sns",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "devDependencies": {}
     },
@@ -6838,6 +6850,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.12.0.tgz",
       "integrity": "sha512-dYOEwo4jl5yipuGTfTG/5hIZL6E7/oWLZ1d5gfq7p4cOBE3KeTp46JymAMiKYaGtgbKhKbDfhd4JveX3m//DJg==",
+      "peer": true,
       "requires": {
         "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
@@ -6849,10 +6862,8 @@
     "@dfinity/candid": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.12.0.tgz",
-      "integrity": "sha512-TX9eL5D4F5EZPf+uKoxE0X3umg+mSA7RWrS+zTQxMRBe/1aBXVOFqChAiSupfKHI3wSWTvOImIxLRmCrAP+69w=="
-    },
-    "@dfinity/utils": {
-      "version": "file:packages/utils"
+      "integrity": "sha512-TX9eL5D4F5EZPf+uKoxE0X3umg+mSA7RWrS+zTQxMRBe/1aBXVOFqChAiSupfKHI3wSWTvOImIxLRmCrAP+69w==",
+      "peer": true
     },
     "@dfinity/nns": {
       "version": "file:packages/nns",
@@ -6881,21 +6892,20 @@
           "resolved": "https://registry.npmjs.org/crc/-/crc-4.1.1.tgz",
           "integrity": "sha512-2U3ZqJ2phJl9ANuP2q5VS53LMpNmYU9vcpmh6nutJmsqUREhtWpTRh9yYxG7sDg3xkwaEEXytSeffTxw4cgwPg==",
           "requires": {}
-        },
-        "google-protobuf": {
-          "version": "3.19.4",
-          "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.19.4.tgz",
-          "integrity": "sha512-OIPNCxsG2lkIvf+P5FNfJ/Km95CsXOBecS9ZcAU6m2Rq3svc0Apl9nB3GMDNKfQ9asNv4KjyAqGwPQFrVle3Yg=="
         }
       }
     },
     "@dfinity/principal": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.12.0.tgz",
-      "integrity": "sha512-kah+gxPYKagvjrFLs8+WtQzpKPaFpUU5kG6cTiYXG8MKEX+Yls3ycdla693XwZo3neW5NRnG75Skq1ZNscQSaw=="
+      "integrity": "sha512-kah+gxPYKagvjrFLs8+WtQzpKPaFpUU5kG6cTiYXG8MKEX+Yls3ycdla693XwZo3neW5NRnG75Skq1ZNscQSaw==",
+      "peer": true
     },
     "@dfinity/sns": {
       "version": "file:packages/sns"
+    },
+    "@dfinity/utils": {
+      "version": "file:packages/utils"
     },
     "@eslint/eslintrc": {
       "version": "1.3.0",
@@ -7764,22 +7774,26 @@
     "base64-arraybuffer": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
-      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ=="
+      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+      "peer": true
     },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "peer": true
     },
     "bignumber.js": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+      "peer": true
     },
     "borc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
       "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+      "peer": true,
       "requires": {
         "bignumber.js": "^9.0.0",
         "buffer": "^5.5.0",
@@ -7843,6 +7857,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "peer": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -7961,7 +7976,8 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -8040,7 +8056,8 @@
     "delimit-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ=="
+      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ==",
+      "peer": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -8979,8 +8996,7 @@
     "google-protobuf": {
       "version": "3.20.1",
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.20.1.tgz",
-      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw==",
-      "dev": true
+      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw=="
     },
     "graceful-fs": {
       "version": "4.2.10",
@@ -9048,7 +9064,8 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "peer": true
     },
     "ignore": {
       "version": "5.2.0",
@@ -9266,7 +9283,8 @@
     "iso-url": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
+      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+      "peer": true
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -9810,6 +9828,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
       "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
+      "peer": true,
       "requires": {
         "delimit-stream": "0.1.0"
       }
@@ -10309,6 +10328,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "peer": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -10451,7 +10471,8 @@
     "simple-cbor": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
-      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w=="
+      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
+      "peer": true
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -10508,6 +10529,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "peer": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       },
@@ -10515,7 +10537,8 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "peer": true
         }
       }
     },
@@ -10811,7 +10834,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "peer": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A collection of library for interfacing with the Internet Computer.",
   "license": "Apache-2.0",
   "workspaces": [
@@ -19,11 +19,6 @@
   },
   "bugs": {
     "url": "https://github.com/dfinity/ic-js"
-  },
-  "dependencies": {
-    "@dfinity/agent": "^0.12.0",
-    "@dfinity/candid": "^0.12.0",
-    "@dfinity/principal": "^0.12.0"
   },
   "devDependencies": {
     "@types/jest": "^28.1.4",
@@ -45,5 +40,10 @@
     "ts-protoc-gen": "^0.15.0",
     "typescript": "^4.5.5",
     "whatwg-fetch": "^3.6.2"
+  },
+  "peerDependencies": {
+    "@dfinity/agent": "^0.12.0",
+    "@dfinity/candid": "^0.12.0",
+    "@dfinity/principal": "^0.12.0"
   }
 }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A library for interfacing with the Internet Computer's Network Nervous System.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/sns",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A library for interfacing with a Service Nervous System (SNS) project.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/scripts/esbuild.mjs
+++ b/scripts/esbuild.mjs
@@ -3,10 +3,19 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
+  readFileSync,
   statSync,
   writeFileSync,
 } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+/** Core peerDependencies are common external dependencies for all libraries of the mono-repo */
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageJson = join(__dirname, "../package.json");
+const json = readFileSync(packageJson, "utf8");
+const { peerDependencies } = JSON.parse(json)
 
 const dist = join(process.cwd(), "dist");
 
@@ -39,6 +48,7 @@ const buildEsmCjs = () => {
       format: "esm",
       define: { global: "window" },
       target: ["esnext"],
+      external: [...Object.keys(peerDependencies || {})],
     })
     .catch(() => process.exit(1));
 
@@ -52,6 +62,7 @@ const buildEsmCjs = () => {
       minify: true,
       platform: "node",
       target: ["node16"],
+      external: [...Object.keys(peerDependencies || {})],
     })
     .catch(() => process.exit(1));
 };


### PR DESCRIPTION
# Motivation

Developers may be using both [nns](/packages/nns) and [sns](/packages/sns) in their projects - as we do in [NNS-dapp](https://github.com/dfinity/nns-dapp/). That is s why, to help tree-shaking and avoid duplication of code, the libraries of this project need to reference [agent-js](https://github.com/dfinity/agent-js) as peer dependencies.

When we are building here both `nns` and `sns`, as both builds are standalone, `agent-js` libs get bundled within the outcome. Which is fine if the libraries were always use separately but unfortunately, as we noticed in NNS-dapp, when both are consumed app bundlers are not always able to tree-shake correctly the code afterwards. So developers might end-up with `agent-js` libs twice in their code.

# Breaking Changes

- set `agent-js` libraries as peer dependencies

# Tests

Libraries were locally bundled, then packed (`npm pack`) and integrated in NNS-dapp to build and run the dapp.
