### PR TITLE
build: bump google-protobuf for nns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3605,9 +3605,9 @@
       }
     },
     "node_modules/google-protobuf": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.20.1.tgz",
-      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw=="
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.0.tgz",
+      "integrity": "sha512-byR7MBTK4tZ5PZEb+u5ZTzpt4SfrTxv5682MjPlHN16XeqgZE2/8HOIWeiXe8JKnT9OVbtBGhbq8mtvkK8cd5g=="
     },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
@@ -6346,7 +6346,7 @@
       "dependencies": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
-        "google-protobuf": "^3.19.4",
+        "google-protobuf": "^3.21.0",
         "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0"
       },
@@ -6872,7 +6872,7 @@
         "@types/randombytes": "^2.0.0",
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
-        "google-protobuf": "^3.19.4",
+        "google-protobuf": "*",
         "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0"
       },
@@ -8994,9 +8994,9 @@
       }
     },
     "google-protobuf": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.20.1.tgz",
-      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw=="
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.0.tgz",
+      "integrity": "sha512-byR7MBTK4tZ5PZEb+u5ZTzpt4SfrTxv5682MjPlHN16XeqgZE2/8HOIWeiXe8JKnT9OVbtBGhbq8mtvkK8cd5g=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "crc": "^4.1.1",
     "crc-32": "^1.2.2",
-    "google-protobuf": "^3.19.4",
+    "google-protobuf": "^3.21.0",
     "js-sha256": "^0.9.0",
     "randombytes": "^2.1.0"
   },


### PR DESCRIPTION
# Motivation

Resolve #143.

This will also fix the usage of the lib for testing purpose as it referenced a version of `google-protobuf` that fails with `jest` in a NodeJS context - e.g. when running tests in NNS-dapp.

# Changes

- bump `google-protobuf` last version
