### PR TITLE
L2-868: Get SNS neuron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 ### Features
 
 - more Sns related features: `notifyParticipation` and `getUserCommitment`
-- new library `@dfinity/utils`
 - sns: new method `getNeuron` to get neuron data by neuron id.
 
 # 0.6.0 (2022-07-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 ### Features
 
 - more Sns related features: `notifyParticipation` and `getUserCommitment`
+- new library `@dfinity/utils`
+- sns: new method `getNeuron` to get neuron data by neuron id.
 
 # 0.6.0 (2022-07-20)
 

--- a/packages/sns/src/errors/governance.errors.ts
+++ b/packages/sns/src/errors/governance.errors.ts
@@ -1,0 +1,1 @@
+export class SnsGovernanceError extends Error {}

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -40,7 +40,7 @@ describe("Governance canister", () => {
 
   describe("getNeuron", () => {
     it("should return the neuron", async () => {
-      const service = mock<ActorSubclass<SnsGovernanceCanister>>();
+      const service = mock<ActorSubclass<SnsGovernanceService>>();
       service.get_neuron.mockResolvedValue({
         result: [{ Neuron: neuronMock }],
       });
@@ -57,7 +57,7 @@ describe("Governance canister", () => {
     });
 
     it("should raise error on governance error", async () => {
-      const service = mock<ActorSubclass<SnsGovernanceCanister>>();
+      const service = mock<ActorSubclass<SnsGovernanceService>>();
       service.get_neuron.mockResolvedValue({
         result: [{ Error: { error_message: "error", error_type: 2 } }],
       });

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -2,8 +2,9 @@ import type { ActorSubclass } from "@dfinity/agent";
 import { mock } from "jest-mock-extended";
 import type { _SERVICE as SnsGovernanceService } from "../candid/sns_governance";
 import { MAX_LIST_NEURONS_RESULTS } from "./constants/governance.constants";
+import { SnsGovernanceError } from "./errors/governance.errors";
 import { SnsGovernanceCanister } from "./governance.canister";
-import { neuronsMock } from "./mocks/governance.mock";
+import { neuronIdMock, neuronMock, neuronsMock } from "./mocks/governance.mock";
 import { rootCanisterIdMock } from "./mocks/sns.mock";
 
 describe("Governance canister", () => {
@@ -34,6 +35,43 @@ describe("Governance canister", () => {
       limit: MAX_LIST_NEURONS_RESULTS,
       of_principal: [],
       start_page_at: [],
+    });
+  });
+
+  describe("getNeuron", () => {
+    it("should return the neuron", async () => {
+      const service = mock<ActorSubclass<SnsGovernanceCanister>>();
+      service.get_neuron.mockResolvedValue({
+        result: [{ Neuron: neuronMock }],
+      });
+
+      const canister = SnsGovernanceCanister.create({
+        canisterId: rootCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+      const res = await canister.getNeuron({
+        neuronId: neuronIdMock,
+        certified: true,
+      });
+      expect(res).toEqual(neuronMock);
+    });
+
+    it("should raise error on governance error", async () => {
+      const service = mock<ActorSubclass<SnsGovernanceCanister>>();
+      service.get_neuron.mockResolvedValue({
+        result: [{ Error: { error_message: "error", error_type: 2 } }],
+      });
+
+      const canister = SnsGovernanceCanister.create({
+        canisterId: rootCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+      const call = () =>
+        canister.getNeuron({
+          neuronId: neuronIdMock,
+          certified: true,
+        });
+      expect(call).rejects.toThrowError(SnsGovernanceError);
     });
   });
 });

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -14,6 +14,7 @@ export type {
   TimeWindow as SnsSwapTimeWindow,
 } from "../candid/sns_swap";
 export * from "./enums/swap.enums";
+export * from "./errors/governance.errors";
 export { SnsGovernanceCanister } from "./governance.canister";
 export { SnsLedgerCanister } from "./ledger.canister";
 export { SnsRootCanister } from "./root.canister";
@@ -21,5 +22,8 @@ export * from "./sns";
 export * from "./sns.wrapper";
 export { SnsSwapCanister } from "./swap.canister";
 export type { SnsCanisterOptions } from "./types/canister.options";
-export type { SnsListNeuronsParams } from "./types/governance.params";
+export type {
+  SnsGetNeuronParams,
+  SnsListNeuronsParams,
+} from "./types/governance.params";
 export type { QueryParams } from "./types/query.params";

--- a/packages/sns/src/mocks/governance.mock.ts
+++ b/packages/sns/src/mocks/governance.mock.ts
@@ -1,9 +1,9 @@
 import type { Neuron, NeuronId } from "../../candid/sns_governance";
 
-const neuronId: NeuronId = { id: [1] };
+export const neuronIdMock: NeuronId = { id: [1] };
 
-export const neuronsMock: Neuron[] = [
-  {
-    id: [neuronId],
-  } as Neuron,
-];
+export const neuronMock = {
+  id: [neuronIdMock],
+} as Neuron;
+
+export const neuronsMock: Neuron[] = [neuronMock];

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -59,8 +59,8 @@ describe("SnsWrapper", () => {
 
   it("should call get neuron with query or update", async () => {
     const neuronId = {
-      id: [1,2,3]
-    }
+      id: [1, 2, 3],
+    };
     await snsWrapper.getNeuron({ neuronId });
     expect(mockGovernanceCanister.getNeuron).toHaveBeenCalledWith({
       neuronId,

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -57,6 +57,22 @@ describe("SnsWrapper", () => {
     });
   });
 
+  it("should call get neuron with query or update", async () => {
+    const neuronId = {
+      id: [1,2,3]
+    }
+    await snsWrapper.getNeuron({ neuronId });
+    expect(mockGovernanceCanister.getNeuron).toHaveBeenCalledWith({
+      neuronId,
+      certified: false,
+    });
+    await certifiedSnsWrapper.getNeuron({ neuronId });
+    expect(mockCertifiedGovernanceCanister.getNeuron).toHaveBeenCalledWith({
+      neuronId,
+      certified: true,
+    });
+  });
+
   it("should call metadata with query or update", async () => {
     await snsWrapper.metadata({});
     expect(mockGovernanceCanister.metadata).toHaveBeenCalledWith({

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -10,7 +10,10 @@ import type { SnsGovernanceCanister } from "./governance.canister";
 import type { SnsLedgerCanister } from "./ledger.canister";
 import type { SnsRootCanister } from "./root.canister";
 import type { SnsSwapCanister } from "./swap.canister";
-import type { SnsListNeuronsParams } from "./types/governance.params";
+import type {
+  SnsGetNeuronParams,
+  SnsListNeuronsParams,
+} from "./types/governance.params";
 import type { QueryParams } from "./types/query.params";
 
 interface SnsWrapperOptions {
@@ -79,6 +82,10 @@ export class SnsWrapper {
 
   metadata = (params: Omit<QueryParams, "certified">): Promise<string> =>
     this.governance.metadata(this.mergeParams(params));
+
+  getNeuron = (
+    params: Omit<SnsGetNeuronParams, "certified">
+  ): Promise<Neuron> => this.governance.getNeuron(this.mergeParams(params));
 
   swapState = (
     params: Omit<QueryParams, "certified">

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -13,3 +13,10 @@ export interface SnsListNeuronsParams extends QueryParams {
   /** Index the search to returns a list that starts after specified neuron id */
   beforeNeuronId?: NeuronId;
 }
+
+/**
+ * The parameters to get an sns neuron
+ */
+export interface SnsGetNeuronParams extends QueryParams {
+  neuronId: NeuronId;
+}


### PR DESCRIPTION
# Motivation

Add method `getNeuron` to get neuron data by id.

# Changes

* Add getNeuron to wrapper and governance classes.

# Tests

* Add tests for new method.
* Add and change a little bit the mock data for testing.
