### PR TITLE
L2-705: SNS Remove Hotkey

### DIFF
--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -1,0 +1,34 @@
+import type { ManageNeuron } from "../../candid/sns_governance";
+import type { SnsNeuronPermissionsParams } from "../types/governance.params";
+
+export const toAddPermissionsRequest = ({
+  neuronId,
+  permissions,
+  principal,
+}: SnsNeuronPermissionsParams): ManageNeuron => ({
+  subaccount: neuronId.id,
+  command: [
+    {
+      AddNeuronPermissions: {
+        permissions_to_add: [{ permissions }],
+        principal_id: [principal],
+      },
+    },
+  ],
+});
+
+export const toRemovePermissionsRequest = ({
+  neuronId,
+  permissions,
+  principal,
+}: SnsNeuronPermissionsParams): ManageNeuron => ({
+  subaccount: neuronId.id,
+  command: [
+    {
+      RemoveNeuronPermissions: {
+        permissions_to_remove: [{ permissions }],
+        principal_id: [principal],
+      },
+    },
+  ],
+});

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -212,6 +212,34 @@ describe("Governance canister", () => {
       await canister.manageNeuron(request);
       expect(service.manage_neuron).toBeCalled();
     });
+
+    it("should raise an error", async () => {
+      const principal = Principal.fromText("aaaaa-aa");
+      const permissions = [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE];
+      const request: ManageNeuron = {
+        subaccount: [1, 2, 3],
+        command: [
+          {
+            AddNeuronPermissions: {
+              permissions_to_add: [{ permissions }],
+              principal_id: [principal],
+            },
+          },
+        ],
+      };
+      const service = mock<ActorSubclass<SnsGovernanceService>>();
+      service.manage_neuron.mockResolvedValue({
+        command: [{ Error: { error_message: "test", error_type: 2 } }],
+      });
+
+      const canister = SnsGovernanceCanister.create({
+        canisterId: rootCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+      const call = () => canister.manageNeuron(request);
+      expect(call).rejects.toThrowError(SnsGovernanceError);
+      expect(service.manage_neuron).toBeCalled();
+    });
   });
 
   describe("metadata", () => {

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -135,6 +135,56 @@ describe("Governance canister", () => {
     });
   });
 
+  describe("removeNeuronPermissions", () => {
+    it("should manage the neuron", async () => {
+      const neuronId = {
+        id: [1, 2, 3],
+      };
+      const principal = Principal.fromText("aaaaa-aa");
+      const permissions = [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE];
+      const service = mock<ActorSubclass<SnsGovernanceService>>();
+      service.manage_neuron.mockResolvedValue({
+        command: [{ AddNeuronPermission: {} }],
+      });
+
+      const canister = SnsGovernanceCanister.create({
+        canisterId: rootCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+      await canister.removeNeuronPermissions({
+        neuronId: neuronIdMock,
+        permissions,
+        principal,
+      });
+      expect(service.manage_neuron).toBeCalled();
+    });
+
+    it("should raise error", async () => {
+      const neuronId = {
+        id: [1, 2, 3],
+      };
+      const principal = Principal.fromText("aaaaa-aa");
+      const permissions = [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE];
+      const service = mock<ActorSubclass<SnsGovernanceService>>();
+      service.manage_neuron.mockResolvedValue({
+        command: [{ Error: { error_message: "test", error_type: 2 } }],
+      });
+
+      const canister = SnsGovernanceCanister.create({
+        canisterId: rootCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+      const call = () =>
+        canister.removeNeuronPermissions({
+          neuronId: neuronIdMock,
+          permissions,
+          principal,
+        });
+      expect(call).rejects.toThrowError(SnsGovernanceError);
+      expect(service.manage_neuron).toBeCalled();
+    });
+  });
+
   describe("manageNeuron", () => {
     it("should manage the neuron", async () => {
       const principal = Principal.fromText("aaaaa-aa");

--- a/packages/sns/src/governance.canister.ts
+++ b/packages/sns/src/governance.canister.ts
@@ -15,9 +15,9 @@ import { SnsGovernanceError } from "./errors/governance.errors";
 import { Canister } from "./services/canister";
 import type { SnsCanisterOptions } from "./types/canister.options";
 import type {
-  SnsAddNeuronPermissions,
   SnsGetNeuronParams,
   SnsListNeuronsParams,
+  SnsNeuronPermissionsParams,
 } from "./types/governance.params";
 import type { QueryParams } from "./types/query.params";
 
@@ -80,19 +80,42 @@ export class SnsGovernanceCanister extends Canister<SnsGovernanceService> {
     this.caller({ certified: true }).manage_neuron(request);
 
   /**
-   * Set permissions of a neuron for a specific principal
+   * Add permissions to a neuron for a specific principal
    */
   addNeuronPermissions = async ({
     neuronId,
     permissions,
     principal,
-  }: SnsAddNeuronPermissions): Promise<void> => {
+  }: SnsNeuronPermissionsParams): Promise<void> => {
     const request: ManageNeuron = {
       subaccount: neuronId.id,
       command: [
         {
           AddNeuronPermissions: {
             permissions_to_add: [{ permissions }],
+            principal_id: [principal],
+          },
+        },
+      ],
+    };
+    const response = await this.manageNeuron(request);
+    this.assertManageNeuronError(response);
+  };
+
+  /**
+   * Remove permissions to a neuron for a specific principal
+   */
+  removeNeuronPermissions = async ({
+    neuronId,
+    permissions,
+    principal,
+  }: SnsNeuronPermissionsParams): Promise<void> => {
+    const request: ManageNeuron = {
+      subaccount: neuronId.id,
+      command: [
+        {
+          RemoveNeuronPermissions: {
+            permissions_to_remove: [{ permissions }],
             principal_id: [principal],
           },
         },

--- a/packages/sns/src/governance.canister.ts
+++ b/packages/sns/src/governance.canister.ts
@@ -11,6 +11,10 @@ import type {
 import { idlFactory as certifiedIdlFactory } from "../candid/sns_governance.certified.idl";
 import { idlFactory } from "../candid/sns_governance.idl";
 import { MAX_LIST_NEURONS_RESULTS } from "./constants/governance.constants";
+import {
+  toAddPermissionsRequest,
+  toRemovePermissionsRequest,
+} from "./converters/governance.converters";
 import { SnsGovernanceError } from "./errors/governance.errors";
 import { Canister } from "./services/canister";
 import type { SnsCanisterOptions } from "./types/canister.options";
@@ -76,53 +80,34 @@ export class SnsGovernanceCanister extends Canister<SnsGovernanceService> {
   /**
    * Manage neuron. For advanced users.
    */
-  manageNeuron = async (request: ManageNeuron): Promise<ManageNeuronResponse> =>
-    this.caller({ certified: true }).manage_neuron(request);
+  manageNeuron = async (
+    request: ManageNeuron
+  ): Promise<ManageNeuronResponse> => {
+    const response = await this.caller({ certified: true }).manage_neuron(
+      request
+    );
+    this.assertManageNeuronError(response);
+    return response;
+  };
 
   /**
    * Add permissions to a neuron for a specific principal
    */
-  addNeuronPermissions = async ({
-    neuronId,
-    permissions,
-    principal,
-  }: SnsNeuronPermissionsParams): Promise<void> => {
-    const request: ManageNeuron = {
-      subaccount: neuronId.id,
-      command: [
-        {
-          AddNeuronPermissions: {
-            permissions_to_add: [{ permissions }],
-            principal_id: [principal],
-          },
-        },
-      ],
-    };
-    const response = await this.manageNeuron(request);
-    this.assertManageNeuronError(response);
+  addNeuronPermissions = async (
+    params: SnsNeuronPermissionsParams
+  ): Promise<void> => {
+    const request: ManageNeuron = toAddPermissionsRequest(params);
+    await this.manageNeuron(request);
   };
 
   /**
    * Remove permissions to a neuron for a specific principal
    */
-  removeNeuronPermissions = async ({
-    neuronId,
-    permissions,
-    principal,
-  }: SnsNeuronPermissionsParams): Promise<void> => {
-    const request: ManageNeuron = {
-      subaccount: neuronId.id,
-      command: [
-        {
-          RemoveNeuronPermissions: {
-            permissions_to_remove: [{ permissions }],
-            principal_id: [principal],
-          },
-        },
-      ],
-    };
-    const response = await this.manageNeuron(request);
-    this.assertManageNeuronError(response);
+  removeNeuronPermissions = async (
+    params: SnsNeuronPermissionsParams
+  ): Promise<void> => {
+    const request: ManageNeuron = toRemovePermissionsRequest(params);
+    await this.manageNeuron(request);
   };
 
   /**

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -96,6 +96,26 @@ describe("SnsWrapper", () => {
     });
   });
 
+  it("should call removeNeuronPermissions with query or update", async () => {
+    const neuronId = {
+      id: [1, 2, 3],
+    };
+    const principal = Principal.fromText("aaaaa-aa");
+    const permissions = [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE];
+    await snsWrapper.removeNeuronPermissions({
+      permissions,
+      neuronId,
+      principal,
+    });
+    expect(mockGovernanceCanister.removeNeuronPermissions).toHaveBeenCalledWith(
+      {
+        neuronId,
+        permissions,
+        principal,
+      }
+    );
+  });
+
   it("should collect metadata with query or update", async () => {
     await snsWrapper.metadata({});
     await certifiedSnsWrapper.metadata({});

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -11,9 +11,9 @@ import type { SnsLedgerCanister } from "./ledger.canister";
 import type { SnsRootCanister } from "./root.canister";
 import type { SnsSwapCanister } from "./swap.canister";
 import type {
-  SnsAddNeuronPermissions,
   SnsGetNeuronParams,
   SnsListNeuronsParams,
+  SnsNeuronPermissionsParams,
 } from "./types/governance.params";
 import type { SnsTokenMetadataResponse } from "./types/ledger.responses";
 import type { QueryParams } from "./types/query.params";
@@ -95,8 +95,13 @@ export class SnsWrapper {
   ): Promise<Neuron> => this.governance.getNeuron(this.mergeParams(params));
 
   // Always certified
-  addNeuronPermissions = (params: SnsAddNeuronPermissions): Promise<void> =>
+  addNeuronPermissions = (params: SnsNeuronPermissionsParams): Promise<void> =>
     this.governance.addNeuronPermissions(params);
+
+  // Always certified
+  removeNeuronPermissions = (
+    params: SnsNeuronPermissionsParams
+  ): Promise<void> => this.governance.removeNeuronPermissions(params);
 
   swapState = (
     params: Omit<QueryParams, "certified">

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -25,7 +25,7 @@ export interface SnsGetNeuronParams extends QueryParams {
 /**
  * Parametes to add permissions to a neuron
  */
-export interface SnsAddNeuronPermissions {
+export interface SnsNeuronPermissionsParams {
   principal: Principal;
   neuronId: NeuronId;
   permissions: SnsNeuronPermissionType[];


### PR DESCRIPTION
# Motivation

Method to remove neuron permissions.

# Changes

* New method in sns governance "removeNeuronPermissions".
* New method in sns wrapper "removeNeuronPermissions"

# Tests

* Test for new wrapper method.
* Test for new sns governance method.
