### PR TITLE
build: nightly peer dependencies version

### DIFF
--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -17,10 +17,33 @@ const updateVersion = () => {
   }
 
   const packageJson = JSON.parse(readFileSync(packagePath, "utf-8"));
-  packageJson.version = `${packageJson.version}-nightly-${new Date()
+
+  // Update nightly version
+  const version = `${packageJson.version}-nightly-${new Date()
     .toISOString()
     .slice(0, 10)}`;
-  writeFileSync(packagePath, JSON.stringify(packageJson, null, 2), "utf-8");
+
+  // Peer dependencies nightly references - e.g. @dfinity/utils@0.0.1-nightly
+  const peerDependencies = Object.entries(
+    packageJson.peerDependencies ?? {}
+  ).reduce((acc, [key, value]) => {
+    acc[key] = `${value}-nightly`;
+    return acc;
+  }, {});
+
+  writeFileSync(
+    packagePath,
+    JSON.stringify(
+      {
+        ...packageJson,
+        version,
+        ...(Object.keys(peerDependencies).length > 0 && { peerDependencies }),
+      },
+      null,
+      2
+    ),
+    "utf-8"
+  );
 };
 
 updateVersion();


### PR DESCRIPTION
# Motivation

Make sns/nns nightly build reference also the utils peer dependency as nightly otherwise only previous major/minor version can be installed in consumer apps.

# Changes

- apprend `-nightly` to peer dependencies for nightly build
