### PR TITLE
build: manually publish nightly version to npm

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,7 @@
 name: Nightly Publication
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
# Motivation

If would be convenient sometimes to be able to not wait for the nightly builds. This PR adds the support for manually triggering the GitHub actions workflow - i.e. to publish manually to npm the nightly build.

# Changes

- update actions to support manual trigger [workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)
- enhance versioning script to support multiple versions a day
