### PR TITLE
feat: nns enums consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,18 @@
 
 - `agent-js` dependencies set as `peerDependencies`
 - Sns canisters' classes renamed with prefix `Sns`
+- enums renamed with Pascal case for consistency reason 
 
 ### Features
 
 - new library `@dfinity/utils`
-- more Sns related features: `notifyParticipation`, `getUserCommitment`, `getNeuron` and ledger and governance `metadata`
+- more Sns related features: `notifyParticipation`, `getUserCommitment`, some Sns neurons related features and governance `metadata`
+
+### Build
+
+- bump agent-js `v0.13.1`
+- publish `next` instead of `nightly-build` working versions
+- add manual trigger to GitHub Actions for npm publish
 
 # 0.6.0 (2022-07-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - `agent-js` dependencies set as `peerDependencies`
 - Sns canisters' classes renamed with prefix `Sns`
-- enums renamed with Pascal case for consistency reason 
+- enums renamed with Pascal case for consistency reason
 
 ### Features
 

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -706,16 +706,16 @@ const convertPbBallot = (pbBallot: PbBallotInfo): BallotInfo => {
 
 const pbNeuronToNeuronState = (neuron?: PbNeuron): NeuronState => {
   if (neuron?.hasWhenDissolvedTimestampSeconds()) {
-    return NeuronState.DISSOLVING;
+    return NeuronState.Dissolving;
   }
   if (neuron?.hasDissolveDelaySeconds()) {
     const delay = neuron.getDissolveDelaySeconds();
     if (delay === "0") {
-      return NeuronState.DISSOLVED;
+      return NeuronState.Dissolved;
     }
-    return NeuronState.LOCKED;
+    return NeuronState.Locked;
   }
-  return NeuronState.UNSPECIFIED;
+  return NeuronState.Unspecified;
 };
 
 const convertPbFolloweesMapToFollowees = (

--- a/packages/nns/src/enums/governance.enums.ts
+++ b/packages/nns/src/enums/governance.enums.ts
@@ -2,7 +2,7 @@
 // These enums are used to map back numbers provided by the backend through the Candid declaration.
 // We use Pascal case for consistency reason.
 //
-// Proto source: https://github.com/dfinity/ic/blob/master/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+// Proto source: https://github.com/dfinity/ic/blob/master/rs/nns/governance/proto/icNns_governance/pb/v1/governance.proto
 
 export enum NeuronState {
   Unspecified = 0,
@@ -73,4 +73,38 @@ export enum Vote {
   Unspecified = 0,
   Yes = 1,
   No = 2,
+}
+
+export enum NnsFunction {
+  Unspecified = 0,
+  CreateSubnet = 1,
+  AddNodeToSubnet = 2,
+  NnsCanisterInstall = 3,
+  NnsCanisterUpgrade = 4,
+  BlessReplicaVersion = 5,
+  RecoverSubnet = 6,
+  UpdateConfigOfSubnet = 7,
+  AssignNoid = 8,
+  NnsRootUpgrade = 9,
+  IcpXdrConversionRate = 10,
+  UpdateSubnetReplicaVersion = 11,
+  ClearProvisionalWhitelist = 12,
+  RemoveNodesFromSubnet = 13,
+  SetAuthorizedSubnetworks = 14,
+  SetFirewallConfig = 15,
+  UpdateNodeOperatorConfig = 16,
+  StopOrStartNnsCanister = 17,
+  RemoveNodes = 18,
+  UninstallCode = 19,
+  UpdateNodeRewardsTable = 20,
+  AddOrRemoveDataCenters = 21,
+  UpdateUnassignedNodesConfig = 22,
+  RemoveNodeOperators = 23,
+  RerouteCanisterRanges = 24,
+  AddFirewallRules = 25,
+  RemoveFirewallRules = 26,
+  UpdateFirewallRules = 27,
+  PrepareCanisterMigration = 28,
+  CompleteCanisterMigration = 29,
+  AddSnsWasm = 30,
 }

--- a/packages/nns/src/enums/governance.enums.ts
+++ b/packages/nns/src/enums/governance.enums.ts
@@ -1,4 +1,4 @@
-// The Candid files are generated from Proto, that's why the enums are currently lost in the process.
+// The Candid files are generated from Proto. That's why the enums are currently lost in the conversion process.
 // These enums are used to map back numbers provided by the backend through the Candid declaration.
 // We use Pascal case for consistency reason.
 //

--- a/packages/nns/src/enums/governance.enums.ts
+++ b/packages/nns/src/enums/governance.enums.ts
@@ -1,13 +1,18 @@
+// The Candid files are generated from Proto, that's why the enums are currently lost in the process.
+// These enums are used to map back numbers provided by the backend through the Candid declaration.
+// We use Pascal case for consistency reason.
+//
+// Proto source: https://github.com/dfinity/ic/blob/master/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+
 export enum NeuronState {
-  UNSPECIFIED = 0,
-  LOCKED = 1,
-  DISSOLVING = 2,
-  DISSOLVED = 3,
-  SPAWNING = 4,
+  Unspecified = 0,
+  Locked = 1,
+  Dissolving = 2,
+  Dissolved = 3,
+  Spawning = 4,
 }
 
 export enum Topic {
-  // https://github.com/dfinity/ic/blob/master/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto#L27
   Unspecified = 0,
   ManageNeuron = 1,
   ExchangeRate = 2,
@@ -25,47 +30,47 @@ export enum Topic {
 // The proposal status, with respect to reward distribution.
 // See also ProposalStatus.
 export enum ProposalRewardStatus {
-  PROPOSAL_REWARD_STATUS_UNKNOWN = 0,
+  Unknown = 0,
 
   // The proposal still accept votes, for the purpose of
   // vote rewards. This implies nothing on the ProposalStatus.
-  PROPOSAL_REWARD_STATUS_ACCEPT_VOTES = 1,
+  AcceptVotes = 1,
 
   // The proposal no longer accepts votes. It is due to settle
   // at the next reward event.
-  PROPOSAL_REWARD_STATUS_READY_TO_SETTLE = 2,
+  ReadyToSettle = 2,
 
   // The proposal has been taken into account in a reward event.
-  PROPOSAL_REWARD_STATUS_SETTLED = 3,
+  Settled = 3,
 
   // The proposal is not eligible to be taken into account in a reward event.
-  PROPOSAL_REWARD_STATUS_INELIGIBLE = 4,
+  Ineligible = 4,
 }
 
 // The proposal status, with respect to decision making and execution.
 // See also ProposalRewardStatus.
 export enum ProposalStatus {
-  PROPOSAL_STATUS_UNKNOWN = 0,
+  Unknown = 0,
 
   // A decision (accept/reject) has yet to be made.
-  PROPOSAL_STATUS_OPEN = 1,
+  Open = 1,
 
   // The proposal has been rejected.
-  PROPOSAL_STATUS_REJECTED = 2,
+  Rejected = 2,
 
   // The proposal has been accepted. At this time, either execution
   // as not yet started, or it has but the outcome is not yet known.
-  PROPOSAL_STATUS_ACCEPTED = 3,
+  Accepted = 3,
 
   // The proposal was accepted and successfully executed.
-  PROPOSAL_STATUS_EXECUTED = 4,
+  Executed = 4,
 
   // The proposal was accepted, but execution failed.
-  PROPOSAL_STATUS_FAILED = 5,
+  Failed = 5,
 }
 
 export enum Vote {
-  UNSPECIFIED = 0,
-  YES = 1,
-  NO = 2,
+  Unspecified = 0,
+  Yes = 1,
+  No = 2,
 }

--- a/packages/nns/src/enums/icp.enums.ts
+++ b/packages/nns/src/enums/icp.enums.ts
@@ -1,4 +1,4 @@
 export enum FromICPStringError {
-  FRACTIONAL_MORE_THAN_8_DECIMALS,
-  INVALID_FORMAT,
+  FractionalMoreThan8Decimals,
+  InvalidFormat,
 }

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -302,7 +302,7 @@ describe("GovernanceCanister", () => {
       });
       await governance.registerVote({
         neuronId: BigInt(1),
-        vote: Vote.YES,
+        vote: Vote.Yes,
         proposalId: BigInt(2),
       });
       expect(service.manage_neuron).toBeCalled();
@@ -327,7 +327,7 @@ describe("GovernanceCanister", () => {
       const call = async () =>
         await governance.registerVote({
           neuronId: BigInt(1),
-          vote: Vote.YES,
+          vote: Vote.Yes,
           proposalId: BigInt(2),
         });
 
@@ -348,7 +348,7 @@ describe("GovernanceCanister", () => {
       const call = async () =>
         await governance.registerVote({
           neuronId: BigInt(1),
-          vote: Vote.YES,
+          vote: Vote.Yes,
           proposalId: BigInt(2),
         });
 

--- a/packages/nns/src/icp.spec.ts
+++ b/packages/nns/src/icp.spec.ts
@@ -22,7 +22,7 @@ describe("ICP", () => {
     expect(ICP.fromString("0.0001")).toEqual(ICP.fromE8s(BigInt(10000)));
     expect(ICP.fromString("0.00000001")).toEqual(ICP.fromE8s(BigInt(1)));
     expect(ICP.fromString("0.0000000001")).toEqual(
-      FromICPStringError.FRACTIONAL_MORE_THAN_8_DECIMALS
+      FromICPStringError.FractionalMoreThan8Decimals
     );
     expect(ICP.fromString(".01")).toEqual(ICP.fromE8s(BigInt(1000000)));
   });
@@ -42,15 +42,15 @@ describe("ICP", () => {
   });
 
   it("returns an error on invalid formats", () => {
-    expect(ICP.fromString("1.1.1")).toBe(FromICPStringError.INVALID_FORMAT);
-    expect(ICP.fromString("a")).toBe(FromICPStringError.INVALID_FORMAT);
-    expect(ICP.fromString("3.a")).toBe(FromICPStringError.INVALID_FORMAT);
+    expect(ICP.fromString("1.1.1")).toBe(FromICPStringError.InvalidFormat);
+    expect(ICP.fromString("a")).toBe(FromICPStringError.InvalidFormat);
+    expect(ICP.fromString("3.a")).toBe(FromICPStringError.InvalidFormat);
     expect(ICP.fromString("123asdf$#@~!")).toBe(
-      FromICPStringError.INVALID_FORMAT
+      FromICPStringError.InvalidFormat
     );
   });
 
   it("rejects negative numbers", () => {
-    expect(ICP.fromString("-1")).toBe(FromICPStringError.INVALID_FORMAT);
+    expect(ICP.fromString("-1")).toBe(FromICPStringError.InvalidFormat);
   });
 });

--- a/packages/nns/src/icp.ts
+++ b/packages/nns/src/icp.ts
@@ -23,7 +23,7 @@ export class ICP {
     // Verify that the string is of the format 1234.5678
     const regexMatch = amount.match(/\d*(\.\d*)?/);
     if (!regexMatch || regexMatch[0] !== amount) {
-      return FromICPStringError.INVALID_FORMAT;
+      return FromICPStringError.InvalidFormat;
     }
 
     const [integral, fractional] = amount.split(".");
@@ -34,18 +34,18 @@ export class ICP {
       try {
         e8s += BigInt(integral) * E8S_PER_ICP;
       } catch {
-        return FromICPStringError.INVALID_FORMAT;
+        return FromICPStringError.InvalidFormat;
       }
     }
 
     if (fractional) {
       if (fractional.length > 8) {
-        return FromICPStringError.FRACTIONAL_MORE_THAN_8_DECIMALS;
+        return FromICPStringError.FractionalMoreThan8Decimals;
       }
       try {
         e8s += BigInt(fractional.padEnd(8, "0"));
       } catch {
-        return FromICPStringError.INVALID_FORMAT;
+        return FromICPStringError.InvalidFormat;
       }
     }
 

--- a/packages/nns/src/utils/neurons.utils.spec.ts
+++ b/packages/nns/src/utils/neurons.utils.spec.ts
@@ -18,7 +18,7 @@ describe("neurons-utils", () => {
     ballots: [
       {
         neuronId: proposalNeuronId,
-        vote: Vote.YES,
+        vote: Vote.Yes,
         votingPower: BigInt(1),
       },
     ],
@@ -93,7 +93,7 @@ describe("neurons-utils", () => {
           recentBallots: [
             {
               proposalId,
-              vote: Vote.NO,
+              vote: Vote.No,
             },
           ],
         },
@@ -111,7 +111,7 @@ describe("neurons-utils", () => {
           recentBallots: [
             {
               proposalId: BigInt(4),
-              vote: Vote.NO,
+              vote: Vote.No,
             },
           ],
         },
@@ -166,7 +166,7 @@ describe("neurons-utils", () => {
           recentBallots: [
             {
               proposalId: BigInt(4),
-              vote: Vote.NO,
+              vote: Vote.No,
             },
           ],
         },
@@ -197,7 +197,7 @@ describe("neurons-utils", () => {
           recentBallots: [
             {
               proposalId,
-              vote: Vote.NO,
+              vote: Vote.No,
             },
           ],
         },


### PR DESCRIPTION
# Motivation

Bring consistency in the exposed enums of NNS-js. Useful for the community to follow a pattern and for NNS-dapp/dashboard to share the i18n labels.

# Changes

- governance and icp enums renamed with Pascal case
- new enum `NnsFunction`
