### PR TITLE
build: agent-js v0.13.2

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -59,5 +59,5 @@ Saving peer dependencies in `package-lock.json` needs npm >= v7.
 
 ```bash
 npm rm @dfinity/principal @dfinity/agent @dfinity/candid
-npm i @dfinity/principal@0.12.0 @dfinity/agent@0.12.0 @dfinity/candid@0.12.0 --save-peer
+npm i @dfinity/principal@latest @dfinity/agent@latest @dfinity/candid@latest --save-peer
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,9 +35,9 @@
         "whatwg-fetch": "^3.6.2"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.13.1",
-        "@dfinity/candid": "^0.13.1",
-        "@dfinity/principal": "^0.13.1"
+        "@dfinity/agent": "^0.13.2",
+        "@dfinity/candid": "^0.13.2",
+        "@dfinity/principal": "^0.13.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -643,9 +643,9 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.13.1.tgz",
-      "integrity": "sha512-ALBgvdOvj0hWDV4GGy+d80CLGIr9Rm8TEDCJc+VrROEQe6TJiI1PAGpvq8fMeN8vv2O4m0yDIvIgseN901oHXA==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.13.2.tgz",
+      "integrity": "sha512-wvlJS6bB731FQ0n8s+91N7NZMrGaVFGyTmGGMPqklv1H1CkxTpiRzi5vCfUsIJwFggsCXpk+Jjbpwbo9OWM48A==",
       "peer": true,
       "dependencies": {
         "base64-arraybuffer": "^0.2.0",
@@ -656,14 +656,14 @@
         "ts-node": "^10.8.2"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.13.1",
-        "@dfinity/principal": "^0.13.1"
+        "@dfinity/candid": "^0.13.2",
+        "@dfinity/principal": "^0.13.2"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.13.1.tgz",
-      "integrity": "sha512-kle1v5/D4Tvj0UZlFjfb/k0ET/iwOov0TugfxsuXrPBaeDyOgFNfICeB7QOflFC5B9OsI+CkZwNdbWC3th5QIg==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.13.2.tgz",
+      "integrity": "sha512-PuzAgCvd41DYB2TlWFPKOKOT3LHR5C1ncYtCs9iQPVRv5CUtVnJTFBzy3gX/hq4VP131f7t0t8a+7IpVUnHw1w==",
       "peer": true,
       "dependencies": {
         "ts-node": "^10.8.2"
@@ -674,9 +674,9 @@
       "link": true
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.13.1.tgz",
-      "integrity": "sha512-JB8JS5HQIOtb8ITBgDnW5A1RIr0bBJE73yuEq8q7y8cVtI9ZKShI6eDYz0qpWZLQhWZd1demZcfQOymW2xgtHg==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.13.2.tgz",
+      "integrity": "sha512-sOpse3YJ3XboqE31KaLWk0T3QeSy50fmqxCzTe5ugxHTfBJ77NwBUHOHARA0UVo+9EkQnN51fLKfMARYfaTGMw==",
       "peer": true,
       "dependencies": {
         "ts-node": "^10.8.2"
@@ -7011,9 +7011,9 @@
       }
     },
     "@dfinity/agent": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.13.1.tgz",
-      "integrity": "sha512-ALBgvdOvj0hWDV4GGy+d80CLGIr9Rm8TEDCJc+VrROEQe6TJiI1PAGpvq8fMeN8vv2O4m0yDIvIgseN901oHXA==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.13.2.tgz",
+      "integrity": "sha512-wvlJS6bB731FQ0n8s+91N7NZMrGaVFGyTmGGMPqklv1H1CkxTpiRzi5vCfUsIJwFggsCXpk+Jjbpwbo9OWM48A==",
       "peer": true,
       "requires": {
         "base64-arraybuffer": "^0.2.0",
@@ -7025,9 +7025,9 @@
       }
     },
     "@dfinity/candid": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.13.1.tgz",
-      "integrity": "sha512-kle1v5/D4Tvj0UZlFjfb/k0ET/iwOov0TugfxsuXrPBaeDyOgFNfICeB7QOflFC5B9OsI+CkZwNdbWC3th5QIg==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.13.2.tgz",
+      "integrity": "sha512-PuzAgCvd41DYB2TlWFPKOKOT3LHR5C1ncYtCs9iQPVRv5CUtVnJTFBzy3gX/hq4VP131f7t0t8a+7IpVUnHw1w==",
       "peer": true,
       "requires": {
         "ts-node": "^10.8.2"
@@ -7064,9 +7064,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.13.1.tgz",
-      "integrity": "sha512-JB8JS5HQIOtb8ITBgDnW5A1RIr0bBJE73yuEq8q7y8cVtI9ZKShI6eDYz0qpWZLQhWZd1demZcfQOymW2xgtHg==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.13.2.tgz",
+      "integrity": "sha512-sOpse3YJ3XboqE31KaLWk0T3QeSy50fmqxCzTe5ugxHTfBJ77NwBUHOHARA0UVo+9EkQnN51fLKfMARYfaTGMw==",
       "peer": true,
       "requires": {
         "ts-node": "^10.8.2"

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "whatwg-fetch": "^3.6.2"
   },
   "peerDependencies": {
-    "@dfinity/agent": "^0.13.1",
-    "@dfinity/candid": "^0.13.1",
-    "@dfinity/principal": "^0.13.1"
+    "@dfinity/agent": "^0.13.2",
+    "@dfinity/candid": "^0.13.2",
+    "@dfinity/principal": "^0.13.2"
   }
 }


### PR DESCRIPTION
# Motivation

We are already using agent-js v0.13.2 in NNS-dapp. This PR aligns it in ic-js.

# Changes

- bump agent-js from v0.13.1 to v0.13.2
