### PR TITLE
Feat: New HW functionalities

### DIFF
--- a/packages/nns/src/account_identifier.ts
+++ b/packages/nns/src/account_identifier.ts
@@ -60,7 +60,7 @@ export class AccountIdentifier {
     return Array.from(this.bytes);
   }
 
-  public toCandid(): AccountIdentifierCandid {
+  public toAccountIdentifierHash(): AccountIdentifierCandid {
     return {
       hash: this.toNumbers(),
     };

--- a/packages/nns/src/account_identifier.ts
+++ b/packages/nns/src/account_identifier.ts
@@ -1,5 +1,6 @@
 import type { Principal } from "@dfinity/principal";
 import { sha224 } from "js-sha256";
+import type { AccountIdentifier as AccountIdentifierCandid } from "../candid/governance";
 import { AccountIdentifier as AccountIdentifierPb } from "../proto/ledger_pb";
 import {
   asciiStringToByteArray,
@@ -57,6 +58,12 @@ export class AccountIdentifier {
 
   public toNumbers(): number[] {
     return Array.from(this.bytes);
+  }
+
+  public toCandid(): AccountIdentifierCandid {
+    return {
+      hash: this.toNumbers(),
+    };
   }
 }
 

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -1,5 +1,4 @@
 import { Principal } from "@dfinity/principal";
-import { AccountIdentifier as AccountIdentifierClass } from "../../account_identifier":
 import type {
   AccountIdentifier as RawAccountIdentifier,
   Action as RawAction,
@@ -17,6 +16,7 @@ import type {
   Operation as RawOperation,
   RewardMode as RawRewardMode,
 } from "../../../candid/governance";
+import type { AccountIdentifier as AccountIdentifierClass } from "../../account_identifier";
 import type { Vote } from "../../enums/governance.enums";
 import { UnsupportedValueError } from "../../errors/governance.errors";
 import type { AccountIdentifier, E8s, NeuronId } from "../../types/common";
@@ -907,8 +907,7 @@ export const toDisburseNeuronRequest = ({
     neuronId,
     command: {
       Disburse: {
-        to_account:
-          toAccountId !== undefined ? [toAccountId.toCandid()] : [],
+        to_account: toAccountId !== undefined ? [toAccountId.toCandid()] : [],
         amount: amount !== undefined ? [fromAmount(amount)] : [],
       },
     },

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -896,18 +896,21 @@ export const toManageNeuronsFollowRequest = ({
 
 export const toDisburseNeuronRequest = ({
   neuronId,
-  toAccountId,
+  toAccountIdentifier,
   amount,
 }: {
   neuronId: NeuronId;
-  toAccountId?: AccountIdentifierClass;
+  toAccountIdentifier?: AccountIdentifierClass;
   amount?: E8s;
 }): RawManageNeuron =>
   toCommand({
     neuronId,
     command: {
       Disburse: {
-        to_account: toAccountId !== undefined ? [toAccountId.toCandid()] : [],
+        to_account:
+          toAccountIdentifier !== undefined
+            ? [toAccountIdentifier.toAccountIdentifierHash()]
+            : [],
         amount: amount !== undefined ? [fromAmount(amount)] : [],
       },
     },

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -442,7 +442,7 @@ const fromAmount = (amount: E8s): Amount => ({
   e8s: amount,
 });
 
-export const fromAccountIdentifier = (
+const fromAccountIdentifier = (
   accountIdentifier: AccountIdentifier
 ): RawAccountIdentifier => {
   const bytes: Uint8Array = accountIdentifierToBytes(accountIdentifier);

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -441,7 +441,7 @@ const fromAmount = (amount: E8s): Amount => ({
   e8s: amount,
 });
 
-const fromAccountIdentifier = (
+export const fromAccountIdentifier = (
   accountIdentifier: AccountIdentifier
 ): RawAccountIdentifier => {
   const bytes: Uint8Array = accountIdentifierToBytes(accountIdentifier);
@@ -996,6 +996,22 @@ export const toIncreaseDissolveDelayRequest = ({
     operation: {
       IncreaseDissolveDelay: {
         additional_dissolve_delay_seconds: additionalDissolveDelaySeconds,
+      },
+    },
+  });
+
+export const toSetDissolveDelayRequest = ({
+  neuronId,
+  dissolveDelaySeconds,
+}: {
+  neuronId: NeuronId;
+  dissolveDelaySeconds: number;
+}): RawManageNeuron =>
+  toConfigureOperation({
+    neuronId,
+    operation: {
+      SetDissolveTimestamp: {
+        dissolve_timestamp_seconds: BigInt(dissolveDelaySeconds),
       },
     },
   });

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -1,4 +1,5 @@
 import { Principal } from "@dfinity/principal";
+import { AccountIdentifier as AccountIdentifierClass } from "../../account_identifier":
 import type {
   AccountIdentifier as RawAccountIdentifier,
   Action as RawAction,
@@ -899,7 +900,7 @@ export const toDisburseNeuronRequest = ({
   amount,
 }: {
   neuronId: NeuronId;
-  toAccountId?: string;
+  toAccountId?: AccountIdentifierClass;
   amount?: E8s;
 }): RawManageNeuron =>
   toCommand({
@@ -907,7 +908,7 @@ export const toDisburseNeuronRequest = ({
     command: {
       Disburse: {
         to_account:
-          toAccountId !== undefined ? [fromAccountIdentifier(toAccountId)] : [],
+          toAccountId !== undefined ? [toAccountId.toCandid()] : [],
         amount: amount !== undefined ? [fromAmount(amount)] : [],
       },
     },

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -13,6 +13,7 @@ import type {
   ListKnownNeuronsResponse,
   ManageNeuronResponse,
   ProposalInfo as RawProposalInfo,
+  Result,
   _SERVICE as GovernanceService,
 } from "../candid/governance";
 import { NeuronId as PbNeuronId } from "../proto/base_types_pb";
@@ -528,6 +529,127 @@ describe("GovernanceCanister", () => {
       await expect(call).rejects.toThrow(
         new GovernanceError(unexpectedGovernanceError)
       );
+    });
+  });
+
+  describe("GovernanceCanister.setDissolveDelay", () => {
+    it("sets dissolve delay of the neuron successfully", async () => {
+      const serviceResponse: ManageNeuronResponse = {
+        command: [{ Configure: {} }],
+      };
+      const service = mock<ActorSubclass<GovernanceService>>();
+      service.manage_neuron.mockResolvedValue(serviceResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+      });
+      await governance.setDissolveDelay({
+        neuronId: BigInt(1),
+        dissolveDelaySeconds: 100000,
+      });
+      expect(service.manage_neuron).toBeCalled();
+    });
+
+    it("throw error when setDissolveDelay fails with error", async () => {
+      const error: GovernanceErrorDetail = {
+        error_message: "Some error",
+        error_type: 1,
+      };
+      const serviceResponse: ManageNeuronResponse = {
+        command: [{ Error: error }],
+      };
+      const service = mock<ActorSubclass<GovernanceService>>();
+      service.manage_neuron.mockResolvedValue(serviceResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+      });
+
+      const call = async () =>
+        await governance.setDissolveDelay({
+          neuronId: BigInt(1),
+          dissolveDelaySeconds: 100000,
+        });
+
+      await expect(call).rejects.toThrow(new GovernanceError(error));
+    });
+
+    it("throw error when setDissolveDelay fails unexpectedly", async () => {
+      const serviceResponse: ManageNeuronResponse = {
+        command: [],
+      };
+      const service = mock<ActorSubclass<GovernanceService>>();
+      service.manage_neuron.mockResolvedValue(serviceResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+      });
+
+      const call = async () =>
+        await governance.setDissolveDelay({
+          neuronId: BigInt(1),
+          dissolveDelaySeconds: 100000,
+        });
+
+      await expect(call).rejects.toThrow(
+        new GovernanceError(unexpectedGovernanceError)
+      );
+    });
+  });
+
+  describe("GovernanceCanister.setNodeProviderAccount", () => {
+    const validAccount =
+      "cd70bfa0f092c38a0ff8643d4617219761eb61d199b15418c0b1114d59e30f8e";
+    it("sets node provider reward account successfully", async () => {
+      const serviceResponse: Result = {
+        Ok: null,
+      };
+      const service = mock<ActorSubclass<GovernanceService>>();
+      service.update_node_provider.mockResolvedValue(serviceResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+      });
+      await governance.setNodeProviderAccount(validAccount);
+      expect(service.update_node_provider).toBeCalled();
+    });
+
+    it("throw error when update_node_provider returns error", async () => {
+      const error: GovernanceErrorDetail = {
+        error_message: "Some error",
+        error_type: 1,
+      };
+      const serviceResponse: Result = {
+        Err: error,
+      };
+      const service = mock<ActorSubclass<GovernanceService>>();
+      service.update_node_provider.mockResolvedValue(serviceResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+      });
+
+      const call = async () =>
+        await governance.setNodeProviderAccount(validAccount);
+
+      await expect(call).rejects.toThrow(new GovernanceError(error));
+    });
+
+    it("throw error when account is not valid", async () => {
+      const serviceResponse: Result = {
+        Ok: null,
+      };
+      const service = mock<ActorSubclass<GovernanceService>>();
+      service.update_node_provider.mockResolvedValue(serviceResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+      });
+
+      const call = async () =>
+        await governance.setNodeProviderAccount("invalid");
+
+      await expect(call).rejects.toThrow(InvalidAccountIDError);
     });
   });
 

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -18,6 +18,7 @@ import {
 } from "../proto/governance_pb";
 import { AccountIdentifier, SubAccount } from "./account_identifier";
 import {
+  fromAccountIdentifier,
   fromClaimOrRefreshNeuronRequest,
   fromListNeurons,
   fromListProposalsRequest,
@@ -33,6 +34,7 @@ import {
   toMergeRequest,
   toRegisterVoteRequest,
   toRemoveHotkeyRequest,
+  toSetDissolveDelayRequest,
   toSpawnNeuronRequest,
   toSplitRawRequest,
   toStartDissolvingRequest,
@@ -296,6 +298,29 @@ export class GovernanceCanister {
   };
 
   /**
+   * Sets dissolve delay of a neuron
+   *
+   * @throws {@link GovernanceError}
+   */
+  public setDissolveDelay = async ({
+    neuronId,
+    dissolveDelaySeconds,
+  }: {
+    neuronId: NeuronId;
+    dissolveDelaySeconds: number;
+  }): Promise<void> => {
+    const request = toSetDissolveDelayRequest({
+      neuronId,
+      dissolveDelaySeconds,
+    });
+
+    return manageNeuron({
+      request,
+      service: this.certifiedService,
+    });
+  };
+
+  /**
    * Start dissolving process of a neuron
    *
    * @throws {@link GovernanceError}
@@ -355,6 +380,27 @@ export class GovernanceCanister {
       request,
       service: this.certifiedService,
     });
+  };
+
+  /**
+   * Sets node provider account
+   *
+   * @param {accountIdentifier}
+   * @throws {@link GovernanceError}
+   * @throws {@link InvalidAccountIDError}
+   */
+  public setNodeProviderAccount = async (
+    accountIdentifier: string
+  ): Promise<void> => {
+    // Might throw InvalidAccountIDError
+    checkAccountId(accountIdentifier);
+    const response = await this.certifiedService.update_node_provider({
+      reward_account: [fromAccountIdentifier(accountIdentifier)],
+    });
+
+    if ("Err" in response) {
+      throw new GovernanceError(response.Err);
+    }
   };
 
   /**

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -297,8 +297,11 @@ export class GovernanceCanister {
   };
 
   /**
-   * Sets dissolve delay of a neuron
+   * Sets dissolve delay of a neuron.
+   * The new date is now + dissolveDelaySeconds.
    *
+   * @param {NeuronId} neuronId
+   * @param {number} dissolveDelaySeconds
    * @throws {@link GovernanceError}
    */
   public setDissolveDelay = async ({
@@ -382,9 +385,10 @@ export class GovernanceCanister {
   };
 
   /**
-   * Sets node provider account
+   * Sets node provider reward account.
+   * Where the reward is paid to.
    *
-   * @param {accountIdentifier}
+   * @param {string} accountIdentifier
    * @throws {@link GovernanceError}
    * @throws {@link InvalidAccountIDError}
    */
@@ -395,7 +399,7 @@ export class GovernanceCanister {
     checkAccountId(accountIdentifier);
     const account = AccountIdentifier.fromHex(accountIdentifier);
     const response = await this.certifiedService.update_node_provider({
-      reward_account: [account.toCandid()],
+      reward_account: [account.toAccountIdentifierHash()],
     });
 
     if ("Err" in response) {
@@ -555,13 +559,13 @@ export class GovernanceCanister {
       return this.disburseHardwareWallet({ neuronId, toAccountId, amount });
     }
     // TODO: Test that the new way also works for disbursements.
-    const account =
+    const toAccountIdentifier =
       toAccountId !== undefined
         ? AccountIdentifier.fromHex(toAccountId)
         : undefined;
     const request = toDisburseNeuronRequest({
       neuronId,
-      toAccountId: account,
+      toAccountIdentifier,
       amount,
     });
 


### PR DESCRIPTION
# Motivation

Introduce new functionality to nns governance: setDissolveDelay and setNodeProviderAccount

# Changes

* New nns governance canister methods: setDissolveDelay and setNodeProviderAccount.
* Move how an account identifier is parse to candid to AccountIdentifier class.

# Tests

* Tests provided for the new methods.
