### PR TITLE
build: fix missing publish steps and manual trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish Release
 
 on:
+  workflow_dispatch:
   release:
     types: [released]
 
@@ -11,6 +12,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: npm ci
+      - name: Build
+        run: run build --workspaces
       - name: Set up npm
         run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
       - name: Publish utils


### PR DESCRIPTION
# Motivation

`npm ci` and `npm run build` need to be run before being able to publish.

in addition, add manual trigger so that we can also (re) launch manually if needed.
