### PR TITLE
build: fix npm missing typo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Dependencies
         run: npm ci
       - name: Build
-        run: run build --workspaces
+        run: npm run build --workspaces
       - name: Set up npm
         run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
       - name: Publish utils


### PR DESCRIPTION
# Motivation

Com'on!  `npm` keyword missing in build script to `npm run build`
