### PR TITLE
build: bump utils-js version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - nns `v0.7.0`
 - sns `v0.0.3`
-- utils `v0.0.1`
+- utils `v0.0.2`
 
 ### Breaking changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6492,7 +6492,7 @@
         "@types/randombytes": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/utils": "^0.0.1"
+        "@dfinity/utils": "^0.0.2"
       }
     },
     "packages/nns/node_modules/buffer": {
@@ -6536,12 +6536,12 @@
       "license": "Apache-2.0",
       "devDependencies": {},
       "peerDependencies": {
-        "@dfinity/utils": "^0.0.1"
+        "@dfinity/utils": "^0.0.2"
       }
     },
     "packages/utils": {
       "name": "@dfinity/utils",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "devDependencies": {}
     }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -55,6 +55,6 @@
     "network-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/utils": "^0.0.1"
+    "@dfinity/utils": "^0.0.2"
   }
 }

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -37,6 +37,6 @@
     "sns"
   ],
   "peerDependencies": {
-    "@dfinity/utils": "^0.0.1"
+    "@dfinity/utils": "^0.0.2"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/utils",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A collection of utilities and constants for NNS/SNS projects.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",


### PR DESCRIPTION
# Motivation

A first versio of `@dfinity/utils` has been released already, this bumps to next `v0.0.2`.
