### PR TITLE
GIX-1005: Improve Token Amount Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - cmc `v0.0.2`
 - utils `v0.0.5`
 
+### Breaking changes
+
+- `token` param in `TokenAmount` factory methods is mandatory instead of using ICPToken as default.
+- `TokenAmount.fromNumber` does not return `FromStringToTokenError`, only `TokenAmount`.
+
 # 0.8.0 (2022-09-26)
 
 ## Release

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -211,9 +211,9 @@ Represents an amount of tokens.
 
 Initialize from a bigint. Bigint are considered e8s.
 
-| Method    | Type                                                                      |
-| --------- | ------------------------------------------------------------------------- |
-| `fromE8s` | `({ amount, token, }: { amount: bigint; token?: Token; }) => TokenAmount` |
+| Method    | Type                                                                     |
+| --------- | ------------------------------------------------------------------------ |
+| `fromE8s` | `({ amount, token, }: { amount: bigint; token: Token; }) => TokenAmount` |
 
 Parameters:
 
@@ -228,9 +228,9 @@ Initialize from a string. Accepted formats:
 1'234'567.8901
 1,234,567.8901
 
-| Method       | Type                                                                                                |
-| ------------ | --------------------------------------------------------------------------------------------------- |
-| `fromString` | `({ amount, token, }: { amount: string; token?: Token; }) => FromStringToTokenError or TokenAmount` |
+| Method       | Type                                                                                               |
+| ------------ | -------------------------------------------------------------------------------------------------- |
+| `fromString` | `({ amount, token, }: { amount: string; token: Token; }) => FromStringToTokenError or TokenAmount` |
 
 Parameters:
 
@@ -243,9 +243,9 @@ Initialize from a number.
 
 1 integer is considered E8S_PER_TOKEN
 
-| Method       | Type                                                                                                |
-| ------------ | --------------------------------------------------------------------------------------------------- |
-| `fromNumber` | `({ amount, token, }: { amount: number; token?: Token; }) => FromStringToTokenError or TokenAmount` |
+| Method       | Type                                                                     |
+| ------------ | ------------------------------------------------------------------------ |
+| `fromNumber` | `({ amount, token, }: { amount: number; token: Token; }) => TokenAmount` |
 
 Parameters:
 

--- a/packages/nns/src/token.spec.ts
+++ b/packages/nns/src/token.spec.ts
@@ -1,103 +1,119 @@
 import { describe, expect, it } from "@jest/globals";
 import { FromStringToTokenError } from "./enums/token.enums";
-import { TokenAmount } from "./token";
+import { ICPToken, TokenAmount } from "./token";
 
 describe("ICP", () => {
   it("can be initialized from a whole number string", () => {
-    expect(TokenAmount.fromString({ amount: "1" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(100000000) })
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "1" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000) })
     );
-    expect(TokenAmount.fromString({ amount: "1234" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(123400000000) })
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "1234" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(123400000000) })
     );
-    expect(TokenAmount.fromString({ amount: "000001234" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(123400000000) })
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "000001234" })
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(123400000000) })
     );
-    expect(TokenAmount.fromString({ amount: " 1" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(100000000) })
+    expect(TokenAmount.fromString({ token: ICPToken, amount: " 1" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000) })
     );
-    expect(TokenAmount.fromString({ amount: "1,000" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(100000000000) })
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "1,000" })
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000000) })
     );
-    expect(TokenAmount.fromString({ amount: "1'000" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(100000000000) })
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "1'000" })
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000000) })
     );
-    expect(TokenAmount.fromString({ amount: "1'000'000" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(100000000000000) })
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "1'000'000" })
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000000000) })
     );
-    expect(TokenAmount.fromString({ amount: "1'000'000" })).toEqual(
-      TokenAmount.fromNumber({ amount: 1_000_000 })
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "1'000'000" })
+    ).toEqual(TokenAmount.fromNumber({ token: ICPToken, amount: 1_000_000 }));
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "1'000'000" })
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000000000) })
     );
-    expect(TokenAmount.fromString({ amount: "1'000'000" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(100000000000000) })
-    );
-    expect(TokenAmount.fromString({ amount: "1'000" })).toEqual(
-      TokenAmount.fromNumber({ amount: 1_000 })
-    );
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "1'000" })
+    ).toEqual(TokenAmount.fromNumber({ token: ICPToken, amount: 1_000 }));
   });
 
   it("can be initialized from a fractional number string", () => {
-    expect(TokenAmount.fromString({ amount: "0.1" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(10000000) })
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "0.1" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(10000000) })
     );
-    expect(TokenAmount.fromString({ amount: "0.1" })).toEqual(
-      TokenAmount.fromNumber({ amount: 0.1 })
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "0.1" })).toEqual(
+      TokenAmount.fromNumber({ token: ICPToken, amount: 0.1 })
     );
-    expect(TokenAmount.fromString({ amount: "45.1231" })).toEqual(
-      TokenAmount.fromNumber({ amount: 45.1231 })
-    );
-    expect(TokenAmount.fromString({ amount: "0.0001" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(10000) })
-    );
-    expect(TokenAmount.fromString({ amount: "0.00000001" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(1) })
-    );
-    expect(TokenAmount.fromString({ amount: "0.0000000001" })).toEqual(
-      FromStringToTokenError.FractionalMoreThan8Decimals
-    );
-    expect(TokenAmount.fromNumber({ amount: 0.0000000001 })).toEqual(
-      TokenAmount.fromNumber({ amount: 0 })
-    );
-    expect(TokenAmount.fromString({ amount: ".01" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(1000000) })
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "45.1231" })
+    ).toEqual(TokenAmount.fromNumber({ token: ICPToken, amount: 45.1231 }));
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "0.0001" })
+    ).toEqual(TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(10000) }));
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "0.00000001" })
+    ).toEqual(TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1) }));
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "0.0000000001" })
+    ).toEqual(FromStringToTokenError.FractionalMoreThan8Decimals);
+    expect(
+      TokenAmount.fromNumber({ token: ICPToken, amount: 0.0000000001 })
+    ).toEqual(TokenAmount.fromNumber({ token: ICPToken, amount: 0 }));
+    expect(TokenAmount.fromString({ token: ICPToken, amount: ".01" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1000000) })
     );
   });
 
   it("can be initialized from a mixed string", () => {
-    expect(TokenAmount.fromString({ amount: "1.1" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(110000000) })
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "1.1" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(110000000) })
     );
-    expect(TokenAmount.fromString({ amount: "1.1" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(110000000) })
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "1.1" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(110000000) })
     );
-    expect(TokenAmount.fromString({ amount: "12,345.00000001" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(1234500000001) })
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "12,345.00000001" })
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1234500000001) })
     );
-    expect(TokenAmount.fromString({ amount: "12'345.00000001" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(1234500000001) })
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "12'345.00000001" })
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1234500000001) })
     );
-    expect(TokenAmount.fromString({ amount: "12345.00000001" })).toEqual(
-      TokenAmount.fromE8s({ amount: BigInt(1234500000001) })
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "12345.00000001" })
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1234500000001) })
     );
   });
 
   it("returns an error on invalid formats", () => {
-    expect(TokenAmount.fromString({ amount: "1.1.1" })).toBe(
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "1.1.1" })).toBe(
       FromStringToTokenError.InvalidFormat
     );
-    expect(TokenAmount.fromString({ amount: "a" })).toBe(
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "a" })).toBe(
       FromStringToTokenError.InvalidFormat
     );
-    expect(TokenAmount.fromString({ amount: "3.a" })).toBe(
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "3.a" })).toBe(
       FromStringToTokenError.InvalidFormat
     );
-    expect(TokenAmount.fromString({ amount: "123asdf$#@~!" })).toBe(
-      FromStringToTokenError.InvalidFormat
-    );
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "123asdf$#@~!" })
+    ).toBe(FromStringToTokenError.InvalidFormat);
   });
 
   it("rejects negative numbers", () => {
-    expect(TokenAmount.fromString({ amount: "-1" })).toBe(
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "-1" })).toBe(
       FromStringToTokenError.InvalidFormat
     );
   });

--- a/packages/nns/src/token.ts
+++ b/packages/nns/src/token.ts
@@ -1,5 +1,5 @@
 import { ICPTs } from "../proto/ledger_pb";
-import { E8S_PER_TOKEN, TOKEN_DECIMAL_ACCURACY } from "./constants/constants";
+import { E8S_PER_TOKEN } from "./constants/constants";
 import { FromStringToTokenError } from "./enums/token.enums";
 
 /**
@@ -74,10 +74,10 @@ export class TokenAmount {
    */
   public static fromE8s({
     amount,
-    token = ICPToken,
+    token,
   }: {
     amount: bigint;
-    token?: Token;
+    token: Token;
   }): TokenAmount {
     return new TokenAmount(amount, token);
   }
@@ -95,10 +95,10 @@ export class TokenAmount {
    */
   public static fromString({
     amount,
-    token = ICPToken,
+    token,
   }: {
     amount: string;
-    token?: Token;
+    token: Token;
   }): TokenAmount | FromStringToTokenError {
     const e8s = convertStringToE8s(amount);
 
@@ -119,14 +119,14 @@ export class TokenAmount {
    */
   public static fromNumber({
     amount,
-    token = ICPToken,
+    token,
   }: {
     amount: number;
-    token?: Token;
-  }): TokenAmount | FromStringToTokenError {
-    // If more than TOKEN_DECIMAL_ACCURACY, it returns 0, not the error.
-    return TokenAmount.fromString({
-      amount: amount.toFixed(TOKEN_DECIMAL_ACCURACY),
+    token: Token;
+  }): TokenAmount {
+    const e8s = BigInt(Math.floor(amount * Number(E8S_PER_TOKEN)));
+    return TokenAmount.fromE8s({
+      amount: e8s,
       token,
     });
   }


### PR DESCRIPTION
# Motivation

Improvements on `TokenAmount` API.

# Changes

- `token` param in `TokenAmount` factory methods is mandatory instead of using ICPToken as default.
- `TokenAmount.fromNumber` does not return `FromStringToTokenError`, only `TokenAmount`.

# Tests

* Add `token` param to all tests.
