### PR TITLE
GIX-1044: Add method to get transaction fee

### DIFF
--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -237,6 +237,7 @@ Parameters:
 
 - [create](#gear-create)
 - [metadata](#gear-metadata)
+- [transactionFee](#gear-transactionfee)
 - [balance](#gear-balance)
 - [transfer](#gear-transfer)
 
@@ -253,6 +254,14 @@ The token metadata (name, symbol, etc.).
 | Method     | Type                                                         |
 | ---------- | ------------------------------------------------------------ |
 | `metadata` | `(params: QueryParams) => Promise<SnsTokenMetadataResponse>` |
+
+##### :gear: transactionFee
+
+The ledger transaction fees.
+
+| Method           | Type                                       |
+| ---------------- | ------------------------------------------ |
+| `transactionFee` | `(params: QueryParams) => Promise<bigint>` |
 
 ##### :gear: balance
 
@@ -379,6 +388,7 @@ Parameters:
 - [listNeurons](#gear-listneurons)
 - [metadata](#gear-metadata)
 - [ledgerMetadata](#gear-ledgermetadata)
+- [transactionFee](#gear-transactionfee)
 - [balance](#gear-balance)
 - [transfer](#gear-transfer)
 - [getNeuron](#gear-getneuron)
@@ -408,6 +418,12 @@ Parameters:
 | Method           | Type                                                                            |
 | ---------------- | ------------------------------------------------------------------------------- |
 | `ledgerMetadata` | `(params: Omit<QueryParams, "certified">) => Promise<SnsTokenMetadataResponse>` |
+
+##### :gear: transactionFee
+
+| Method           | Type                                                          |
+| ---------------- | ------------------------------------------------------------- |
+| `transactionFee` | `(params: Omit<QueryParams, "certified">) => Promise<bigint>` |
 
 ##### :gear: balance
 

--- a/packages/sns/src/ledger.canister.spec.ts
+++ b/packages/sns/src/ledger.canister.spec.ts
@@ -26,6 +26,20 @@ describe("Ledger canister", () => {
     expect(res).toEqual(tokeMetadataResponseMock);
   });
 
+  it("should return the transaction fee", async () => {
+    const service = mock<ActorSubclass<SnsLedgerService>>();
+    const fee = BigInt(10_000);
+    service.icrc1_fee.mockResolvedValue(fee);
+
+    const canister = SnsLedgerCanister.create({
+      canisterId: rootCanisterIdMock,
+      certifiedServiceOverride: service,
+    });
+
+    const res = await canister.transactionFee({});
+    expect(res).toEqual(fee);
+  });
+
   describe("balance", () => {
     it("should return the balance of main account", async () => {
       const service = mock<ActorSubclass<SnsLedgerService>>();

--- a/packages/sns/src/ledger.canister.ts
+++ b/packages/sns/src/ledger.canister.ts
@@ -33,6 +33,14 @@ export class SnsLedgerCanister extends Canister<SnsLedgerService> {
     this.caller(params).icrc1_metadata();
 
   /**
+   * The ledger transaction fees.
+   *
+   * @returns {Tokens} The ledger transaction fees in Tokens
+   */
+  transactionFee = (params: QueryParams): Promise<Tokens> =>
+    this.caller(params).icrc1_fee();
+
+  /**
    * Returns the balance of the given account.
    *
    * @param {BalanceParams} params The parameters to get the balance of an account.

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -139,6 +139,14 @@ describe("SnsWrapper", () => {
     });
   });
 
+  it("should call leger transaction fee with query or update", async () => {
+    await snsWrapper.transactionFee({});
+    await certifiedSnsWrapper.transactionFee({});
+
+    expect(mockLedgerCanister.transactionFee).toHaveBeenCalled();
+    expect(mockCertifiedLedgerCanister.transactionFee).toHaveBeenCalled();
+  });
+
   it("should call leger balance with query or update", async () => {
     const owner = Principal.fromText("aaaaa-aa");
     await snsWrapper.balance({

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -102,6 +102,9 @@ export class SnsWrapper {
   ): Promise<SnsTokenMetadataResponse> =>
     this.ledger.metadata(this.mergeParams(params));
 
+  transactionFee = (params: Omit<QueryParams, "certified">): Promise<Tokens> =>
+    this.ledger.transactionFee(this.mergeParams(params));
+
   balance = (params: Omit<BalanceParams, "certified">): Promise<Tokens> =>
     this.ledger.balance(this.mergeParams(params));
 


### PR DESCRIPTION
# Motivation

Expose method to get SNS ledger transaction fee.

# Changes

* Add "transactionFee" method to sns ledger canister.
* Add "transactionFee" method to sns wrapper canister.

# Tests

* Test for new methods.
