### PR TITLE
GIX-996: SNS Transactions

### DIFF
--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -320,6 +320,42 @@ Source code: https://github.com/dfinity/ic/blob/master/rs/sns/root/src/lib.rs
 | ------------------ | --------------------------------------------------------------------------------- |
 | `listSnsCanisters` | `({ certified, }: { certified?: boolean; }) => Promise<ListSnsCanistersResponse>` |
 
+### :factory: SnsIndexCanister
+
+#### Constructors
+
+`public`
+
+Parameters:
+
+- `id`
+- `service`
+- `certifiedService`
+
+#### Methods
+
+- [create](#gear-create)
+- [getTransactions](#gear-gettransactions)
+
+##### :gear: create
+
+| Method   | Type                                                          |
+| -------- | ------------------------------------------------------------- |
+| `create` | `(options: SnsCanisterOptions<_SERVICE>) => SnsIndexCanister` |
+
+##### :gear: getTransactions
+
+Get the transactions of an account
+
+Always certified.
+`get_account_transactions` needs to be called with an update
+because the index canisters makes a call to the ledger canister to get the transaction data.
+Index Canister only holds the transactions ids in state, not the whole transaction data.
+
+| Method            | Type                                                                 |
+| ----------------- | -------------------------------------------------------------------- |
+| `getTransactions` | `(params: GetAccountTransactionsParams) => Promise<GetTransactions>` |
+
 ### :factory: SnsSwapCanister
 
 #### Constructors

--- a/packages/sns/src/converters/sns-index.converters.ts
+++ b/packages/sns/src/converters/sns-index.converters.ts
@@ -1,0 +1,13 @@
+import { toNullable } from "@dfinity/utils";
+import type { GetAccountTransactionsArgs } from "../../candid/sns_index";
+import type { GetAccountTransactionsParams } from "../types/sns-index.params";
+
+export const toGetTransactionsArgs = ({
+  account,
+  max_results,
+  start,
+}: GetAccountTransactionsParams): GetAccountTransactionsArgs => ({
+  account,
+  max_results,
+  start: toNullable(start),
+});

--- a/packages/sns/src/errors/sns-index.errors.ts
+++ b/packages/sns/src/errors/sns-index.errors.ts
@@ -1,0 +1,1 @@
+export class SnsIndexError extends Error {}

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -9,6 +9,11 @@ export type {
   Neuron as SnsNeuron,
   NeuronId as SnsNeuronId,
 } from "../candid/sns_governance";
+export type {
+  Transaction as SnsTransaction,
+  TransactionWithId as SnsTransactionWithId,
+  TxId as SnsTxId,
+} from "../candid/sns_index";
 export type { CanisterStatusResultV2 as SnsCanisterStatus } from "../candid/sns_root";
 export type {
   BuyerState as SnsSwapBuyerState,
@@ -30,6 +35,7 @@ export { SnsGovernanceCanister } from "./governance.canister";
 export { SnsLedgerCanister } from "./ledger.canister";
 export { SnsRootCanister } from "./root.canister";
 export * from "./sns";
+export { SnsIndexCanister } from "./sns-index.canister";
 export * from "./sns.wrapper";
 export { SnsSwapCanister } from "./swap.canister";
 export type { SnsCanisterOptions } from "./types/canister.options";

--- a/packages/sns/src/sns-index.canister.spec.ts
+++ b/packages/sns/src/sns-index.canister.spec.ts
@@ -1,0 +1,83 @@
+import type { ActorSubclass } from "@dfinity/agent";
+import { Principal } from "@dfinity/principal";
+import { mock } from "jest-mock-extended";
+import type {
+  Account,
+  Transaction,
+  _SERVICE as SnsIndexService,
+} from "../candid/sns_index";
+import { swapCanisterIdMock } from "./mocks/sns.mock";
+import { SnsIndexCanister } from "./sns-index.canister";
+
+describe("Index canister", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe("getTransactions", () => {
+    it("returns transactions", async () => {
+      const fakeAccount: Account = {
+        owner: Principal.fromText("aaaaa-aa"),
+        subaccount: [],
+      };
+      const transaction: Transaction = {
+        kind: "transfer",
+        timestamp: BigInt(12354),
+        burn: [],
+        mint: [],
+        transfer: [
+          {
+            to: fakeAccount,
+            from: fakeAccount,
+            memo: [],
+            created_at_time: [BigInt(123)],
+            amount: BigInt(33),
+          },
+        ],
+      };
+      const transactionWithId = {
+        id: BigInt(1),
+        transaction: transaction,
+      };
+      const service = mock<ActorSubclass<SnsIndexService>>();
+      service.get_account_transactions.mockResolvedValue({
+        Ok: {
+          transactions: [transactionWithId],
+          oldest_tx_id: [],
+        },
+      });
+
+      const canister = SnsIndexCanister.create({
+        canisterId: swapCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+      const res = await canister.getTransactions({
+        account: fakeAccount,
+        max_results: BigInt(10),
+      });
+      expect(res.transactions).toEqual([transactionWithId]);
+    });
+
+    it("raises error when Err in response", async () => {
+      const fakeAccount: Account = {
+        owner: Principal.fromText("aaaaa-aa"),
+        subaccount: [],
+      };
+      const service = mock<ActorSubclass<SnsIndexService>>();
+      service.get_account_transactions.mockResolvedValue({
+        Err: {
+          message: "Test error",
+        },
+      });
+
+      const canister = SnsIndexCanister.create({
+        canisterId: swapCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+      const call = () =>
+        canister.getTransactions({
+          account: fakeAccount,
+          max_results: BigInt(10),
+        });
+      expect(call).rejects.toThrow();
+    });
+  });
+});

--- a/packages/sns/src/sns-index.canister.spec.ts
+++ b/packages/sns/src/sns-index.canister.spec.ts
@@ -6,6 +6,7 @@ import type {
   Transaction,
   _SERVICE as SnsIndexService,
 } from "../candid/sns_index";
+import { SnsIndexError } from "./errors/sns-index.errors";
 import { swapCanisterIdMock } from "./mocks/sns.mock";
 import { SnsIndexCanister } from "./sns-index.canister";
 
@@ -77,7 +78,7 @@ describe("Index canister", () => {
           account: fakeAccount,
           max_results: BigInt(10),
         });
-      expect(call).rejects.toThrow();
+      expect(call).rejects.toThrowError(SnsIndexError);
     });
   });
 });

--- a/packages/sns/src/sns-index.canister.ts
+++ b/packages/sns/src/sns-index.canister.ts
@@ -6,6 +6,7 @@ import type {
 import { idlFactory as certifiedIdlFactory } from "../candid/sns_index.certified.idl";
 import { idlFactory } from "../candid/sns_index.idl";
 import { toGetTransactionsArgs } from "./converters/sns-index.converters";
+import { SnsIndexError } from "./errors/sns-index.errors";
 import { Canister } from "./services/canister";
 import type { SnsCanisterOptions } from "./types/canister.options";
 import type { GetAccountTransactionsParams } from "./types/sns-index.params";
@@ -23,10 +24,12 @@ export class SnsIndexCanister extends Canister<SnsIndexService> {
   }
 
   /**
-   * Get the state of the swap
+   * Get the transactions of an account
    *
    * Always certified.
-   * `get_account_transactions` needs to be called with an update to get the transactios from the ledger canister.
+   * `get_account_transactions` needs to be called with an update
+   * because the index canisters makes a call to the ledger canister to get the transaction data.
+   * Index Canister only holds the transactions ids in state, not the whole transaction data.
    */
   getTransactions = async (
     params: GetAccountTransactionsParams
@@ -36,7 +39,7 @@ export class SnsIndexCanister extends Canister<SnsIndexService> {
     }).get_account_transactions(toGetTransactionsArgs(params));
 
     if ("Err" in response) {
-      throw new Error(response.Err.message);
+      throw new SnsIndexError(response.Err.message);
     }
 
     return response.Ok;

--- a/packages/sns/src/sns-index.canister.ts
+++ b/packages/sns/src/sns-index.canister.ts
@@ -1,0 +1,44 @@
+import { createServices } from "@dfinity/utils";
+import type {
+  GetTransactions,
+  _SERVICE as SnsIndexService,
+} from "../candid/sns_index";
+import { idlFactory as certifiedIdlFactory } from "../candid/sns_index.certified.idl";
+import { idlFactory } from "../candid/sns_index.idl";
+import { toGetTransactionsArgs } from "./converters/sns-index.converters";
+import { Canister } from "./services/canister";
+import type { SnsCanisterOptions } from "./types/canister.options";
+import type { GetAccountTransactionsParams } from "./types/sns-index.params";
+
+export class SnsIndexCanister extends Canister<SnsIndexService> {
+  static create(options: SnsCanisterOptions<SnsIndexService>) {
+    const { service, certifiedService, canisterId } =
+      createServices<SnsIndexService>({
+        options,
+        idlFactory,
+        certifiedIdlFactory,
+      });
+
+    return new SnsIndexCanister(canisterId, service, certifiedService);
+  }
+
+  /**
+   * Get the state of the swap
+   *
+   * Always certified.
+   * `get_account_transactions` needs to be called with an update to get the transactios from the ledger canister.
+   */
+  getTransactions = async (
+    params: GetAccountTransactionsParams
+  ): Promise<GetTransactions> => {
+    const response = await this.caller({
+      certified: true,
+    }).get_account_transactions(toGetTransactionsArgs(params));
+
+    if ("Err" in response) {
+      throw new Error(response.Err.message);
+    }
+
+    return response.Ok;
+  };
+}

--- a/packages/sns/src/types/sns-index.params.ts
+++ b/packages/sns/src/types/sns-index.params.ts
@@ -1,0 +1,8 @@
+import type { Account } from "../../candid/icrc1_ledger";
+import type { TxId } from "../../candid/sns_index";
+
+export interface GetAccountTransactionsParams {
+  max_results: bigint;
+  start?: TxId;
+  account: Account;
+}

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -17,6 +17,7 @@ const snsInputFiles = [
   "./packages/sns/src/ledger.canister.ts",
   "./packages/sns/src/governance.canister.ts",
   "./packages/sns/src/root.canister.ts",
+  "./packages/sns/src/sns-index.canister.ts",
   "./packages/sns/src/sns.ts",
   "./packages/sns/src/sns.wrapper.ts",
   "./packages/sns/src/swap.canister.ts",


### PR DESCRIPTION
# Motivation

Add method to get the transactions of an account.

# Changes

* Add SnsIndexCanister with "getTransactions" method.

# Tests

* Test for the new sns canister.
