### PR TITLE
Fix: Index canister candid parsing issue

### DIFF
--- a/packages/sns/candid/sns_index.certified.idl.js
+++ b/packages/sns/candid/sns_index.certified.idl.js
@@ -46,7 +46,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const GetTransactions = IDL.Record({
     'transactions' : IDL.Vec(TransactionWithId),
-    'oldest_tx_id' : IDL.Opt(TxId),
+    'oldest_tx_id' : IDL.Opt(IDL.Nat64),
   });
   const GetTransactionsErr = IDL.Record({ 'message' : IDL.Text });
   const GetTransactionsResult = IDL.Variant({

--- a/packages/sns/candid/sns_index.d.ts
+++ b/packages/sns/candid/sns_index.d.ts
@@ -12,7 +12,7 @@ export interface GetAccountTransactionsArgs {
 }
 export interface GetTransactions {
   transactions: Array<TransactionWithId>;
-  oldest_tx_id: [] | [TxId];
+  oldest_tx_id: [] | [bigint];
 }
 export interface GetTransactionsErr {
   message: string;

--- a/packages/sns/candid/sns_index.did
+++ b/packages/sns/candid/sns_index.did
@@ -47,7 +47,7 @@ type TransactionWithId = record {
 type GetTransactions = record {
   transactions : vec TransactionWithId;
   // The txid of the oldest transaction the account has
-  oldest_tx_id : opt TxId;
+  oldest_tx_id : opt nat64;
 };
 
 type GetTransactionsErr = record {

--- a/packages/sns/candid/sns_index.idl.js
+++ b/packages/sns/candid/sns_index.idl.js
@@ -46,7 +46,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const GetTransactions = IDL.Record({
     'transactions' : IDL.Vec(TransactionWithId),
-    'oldest_tx_id' : IDL.Opt(TxId),
+    'oldest_tx_id' : IDL.Opt(IDL.Nat64),
   });
   const GetTransactionsErr = IDL.Record({ 'message' : IDL.Text });
   const GetTransactionsResult = IDL.Variant({


### PR DESCRIPTION
# Motivation

There is a bug in the candid definition of the Index canister.

# Changes

* Change the type of oldest_tx_id from GetTransactions

# Tests

Not applicable