### PR TITLE
refact: sns neuron management interfaces

### DIFF
--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -1,4 +1,9 @@
-import type { ManageNeuron, NeuronId } from "../../candid/sns_governance";
+import type {
+  Command,
+  ManageNeuron,
+  NeuronId,
+  Operation,
+} from "../../candid/sns_governance";
 import type {
   SnsDisburseNeuronParams,
   SnsIncreaseDissolveDelayParams,
@@ -6,45 +11,72 @@ import type {
   SnsSetDissolveTimestampParams,
 } from "../types/governance.params";
 
+// Helper for building `ManageNeuron` structure
+const toManageNeuronCommand = ({
+  neuronId: { id },
+  command,
+}: {
+  neuronId: NeuronId;
+  command: Command;
+}): ManageNeuron => ({
+  subaccount: id,
+  command: [command],
+});
+
+// Helper for building `ManageNeuron` structure for type `Operation` commands
+const toManageNeuronConfigureCommand = ({
+  neuronId,
+  operation,
+}: {
+  neuronId: NeuronId;
+  operation: Operation;
+}): ManageNeuron =>
+  toManageNeuronCommand({
+    neuronId,
+    command: {
+      Configure: {
+        operation: [operation],
+      },
+    },
+  });
+
 export const toAddPermissionsRequest = ({
   neuronId,
   permissions,
   principal,
-}: SnsNeuronPermissionsParams): ManageNeuron => ({
-  subaccount: neuronId.id,
-  command: [
-    {
+}: SnsNeuronPermissionsParams): ManageNeuron =>
+  toManageNeuronCommand({
+    neuronId,
+    command: {
       AddNeuronPermissions: {
         permissions_to_add: [{ permissions: Int32Array.from(permissions) }],
         principal_id: [principal],
       },
     },
-  ],
-});
+  });
 
 export const toRemovePermissionsRequest = ({
   neuronId,
   permissions,
   principal,
-}: SnsNeuronPermissionsParams): ManageNeuron => ({
-  subaccount: neuronId.id,
-  command: [
-    {
+}: SnsNeuronPermissionsParams): ManageNeuron =>
+  toManageNeuronCommand({
+    neuronId,
+    command: {
       RemoveNeuronPermissions: {
         permissions_to_remove: [{ permissions: Int32Array.from(permissions) }],
         principal_id: [principal],
       },
     },
-  ],
-});
+  });
 
 export const toDisburseNeuronRequest = ({
-  neuronId: { id },
+  neuronId,
   amount,
-}: SnsDisburseNeuronParams): ManageNeuron => ({
-  subaccount: id,
-  command: [
-    {
+}: SnsDisburseNeuronParams): ManageNeuron =>
+  toManageNeuronCommand({
+    neuronId,
+    command: {
       Disburse: {
         // currently there is a main account only support
         to_account: [],
@@ -58,71 +90,46 @@ export const toDisburseNeuronRequest = ({
               ],
       },
     },
-  ],
-});
+  });
 
-export const toStartDissolvingNeuronRequest = ({
-  id,
-}: NeuronId): ManageNeuron => ({
-  subaccount: id,
-  command: [
-    {
-      Configure: {
-        operation: [{ StartDissolving: {} }],
-      },
-    },
-  ],
-});
+export const toStartDissolvingNeuronRequest = (
+  neuronId: NeuronId
+): ManageNeuron =>
+  toManageNeuronConfigureCommand({
+    neuronId,
+    operation: { StartDissolving: {} },
+  });
 
-export const toStopDissolvingNeuronRequest = ({
-  id,
-}: NeuronId): ManageNeuron => ({
-  subaccount: id,
-  command: [
-    {
-      Configure: {
-        operation: [{ StopDissolving: {} }],
-      },
-    },
-  ],
-});
+export const toStopDissolvingNeuronRequest = (
+  neuronId: NeuronId
+): ManageNeuron =>
+  toManageNeuronConfigureCommand({
+    neuronId,
+    operation: { StopDissolving: {} },
+  });
 
 export const toSetDissolveTimestampRequest = ({
-  neuronId: { id },
+  neuronId,
   dissolveTimestampSeconds,
-}: SnsSetDissolveTimestampParams): ManageNeuron => ({
-  subaccount: id,
-  command: [
-    {
-      Configure: {
-        operation: [
-          {
-            SetDissolveTimestamp: {
-              dissolve_timestamp_seconds: dissolveTimestampSeconds,
-            },
-          },
-        ],
+}: SnsSetDissolveTimestampParams): ManageNeuron =>
+  toManageNeuronConfigureCommand({
+    neuronId,
+    operation: {
+      SetDissolveTimestamp: {
+        dissolve_timestamp_seconds: dissolveTimestampSeconds,
       },
     },
-  ],
-});
+  });
 
 export const toIncreaseDissolveDelayRequest = ({
-  neuronId: { id },
+  neuronId,
   additionalDissolveDelaySeconds,
-}: SnsIncreaseDissolveDelayParams): ManageNeuron => ({
-  subaccount: id,
-  command: [
-    {
-      Configure: {
-        operation: [
-          {
-            IncreaseDissolveDelay: {
-              additional_dissolve_delay_seconds: additionalDissolveDelaySeconds,
-            },
-          },
-        ],
+}: SnsIncreaseDissolveDelayParams): ManageNeuron =>
+  toManageNeuronConfigureCommand({
+    neuronId,
+    operation: {
+      IncreaseDissolveDelay: {
+        additional_dissolve_delay_seconds: additionalDissolveDelaySeconds,
       },
     },
-  ],
-});
+  });

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -24,34 +24,37 @@ export interface SnsGetNeuronParams extends QueryParams {
 }
 
 /**
+ * General neuron management request parameter interface
+ */
+interface SnsNeuronManagementParams extends Omit<QueryParams, "certified"> {
+  neuronId: NeuronId;
+}
+
+/**
  * The parameters to add permissions to a neuron
  */
-export interface SnsNeuronPermissionsParams {
+export interface SnsNeuronPermissionsParams extends SnsNeuronManagementParams {
   principal: Principal;
-  neuronId: NeuronId;
   permissions: SnsNeuronPermissionType[];
 }
 
 /**
  * The parameters to disburse a neuron
  */
-export interface SnsDisburseNeuronParams {
-  neuronId: NeuronId;
+export interface SnsDisburseNeuronParams extends SnsNeuronManagementParams {
   amount?: E8s;
 }
 
 /**
  * The parameters to set dissolve timestamp
  */
-export interface SnsSetDissolveTimestampParams {
-  neuronId: NeuronId;
+export interface SnsSetDissolveTimestampParams extends SnsNeuronManagementParams {
   dissolveTimestampSeconds: bigint;
 }
 
 /**
  * The parameters to increase dissolve delay
  */
-export interface SnsIncreaseDissolveDelayParams {
-  neuronId: NeuronId;
+export interface SnsIncreaseDissolveDelayParams extends SnsNeuronManagementParams {
   additionalDissolveDelaySeconds: number;
 }


### PR DESCRIPTION
# Motivation

Refactor interfaces and sns neuron management param converters to improve types and spare some bytes in built js.

# Changes

- helper functions in sns governance converters
  - `toManageNeuronCommand(...)`
  - `toManageNeuronConfigureCommand(...)`
- `SnsNeuronManagementParams` interface to consolidate neuron management param converters

# Tests

- no changes