### PR TITLE
GIX-1116: Check SNS Neuron balances

### DIFF
--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -74,17 +74,9 @@ console.log("Summary data:", metadata, token);
 
 ### :toolbox: Functions
 
-- [initSnsWrapper](#gear-initsnswrapper)
 - [encodeSnsAccount](#gear-encodesnsaccount)
 - [decodeSnsAccount](#gear-decodesnsaccount)
-
-#### :gear: initSnsWrapper
-
-Lookup for the canister ids of a Sns and initialize the wrapper to access its features.
-
-| Function         | Type             |
-| ---------------- | ---------------- |
-| `initSnsWrapper` | `InitSnsWrapper` |
+- [initSnsWrapper](#gear-initsnswrapper)
 
 #### :gear: encodeSnsAccount
 
@@ -112,6 +104,14 @@ Parameters:
 
 - `snsAccountString`: string
 
+#### :gear: initSnsWrapper
+
+Lookup for the canister ids of a Sns and initialize the wrapper to access its features.
+
+| Function         | Type             |
+| ---------------- | ---------------- |
+| `initSnsWrapper` | `InitSnsWrapper` |
+
 ### :factory: SnsGovernanceCanister
 
 #### Constructors
@@ -130,6 +130,7 @@ Parameters:
 - [listNeurons](#gear-listneurons)
 - [metadata](#gear-metadata)
 - [getNeuron](#gear-getneuron)
+- [queryNeuron](#gear-queryneuron)
 - [manageNeuron](#gear-manageneuron)
 - [addNeuronPermissions](#gear-addneuronpermissions)
 - [removeNeuronPermissions](#gear-removeneuronpermissions)
@@ -138,6 +139,8 @@ Parameters:
 - [stopDissolving](#gear-stopdissolving)
 - [setDissolveTimestamp](#gear-setdissolvetimestamp)
 - [increaseDissolveDelay](#gear-increasedissolvedelay)
+- [refreshNeuron](#gear-refreshneuron)
+- [claimNeuron](#gear-claimneuron)
 
 ##### :gear: create
 
@@ -174,6 +177,14 @@ Get the neuron of the Sns
 | Method      | Type                                                              |
 | ----------- | ----------------------------------------------------------------- |
 | `getNeuron` | `(params: SnsGetNeuronParams and QueryParams) => Promise<Neuron>` |
+
+##### :gear: queryNeuron
+
+Same as `getNeuron` but returns undefined instead of raising error when not found.
+
+| Method        | Type                                                              |
+| ------------- | ----------------------------------------------------------------- |
+| `queryNeuron` | `(params: SnsGetNeuronParams and QueryParams) => Promise<Neuron>` |
 
 ##### :gear: manageNeuron
 
@@ -238,6 +249,22 @@ Increase dissolve delay of a neuron
 | Method                  | Type                                                        |
 | ----------------------- | ----------------------------------------------------------- |
 | `increaseDissolveDelay` | `(params: SnsIncreaseDissolveDelayParams) => Promise<void>` |
+
+##### :gear: refreshNeuron
+
+Refresh neuron
+
+| Method          | Type                                    |
+| --------------- | --------------------------------------- |
+| `refreshNeuron` | `(neuronId: NeuronId) => Promise<void>` |
+
+##### :gear: claimNeuron
+
+Claim neuron
+
+| Method        | Type                                                                             |
+| ------------- | -------------------------------------------------------------------------------- |
+| `claimNeuron` | `({ memo, controller, subaccount, }: SnsClaimNeuronParams) => Promise<NeuronId>` |
 
 ### :factory: SnsLedgerCanister
 
@@ -446,9 +473,13 @@ Parameters:
 - [balance](#gear-balance)
 - [transfer](#gear-transfer)
 - [getNeuron](#gear-getneuron)
+- [queryNeuron](#gear-queryneuron)
 - [getNextNeuronAccount](#gear-getnextneuronaccount)
 - [stakeNeuron](#gear-stakeneuron)
+- [getNeuronBalance](#gear-getneuronbalance)
 - [addNeuronPermissions](#gear-addneuronpermissions)
+- [refreshNeuron](#gear-refreshneuron)
+- [claimNeuron](#gear-claimneuron)
 - [removeNeuronPermissions](#gear-removeneuronpermissions)
 - [disburse](#gear-disburse)
 - [startDissolving](#gear-startdissolving)
@@ -502,12 +533,21 @@ Parameters:
 | ----------- | -------------------------------------------------------------------- |
 | `getNeuron` | `(params: Omit<SnsGetNeuronParams, "certified">) => Promise<Neuron>` |
 
+##### :gear: queryNeuron
+
+| Method        | Type                                                                 |
+| ------------- | -------------------------------------------------------------------- |
+| `queryNeuron` | `(params: Omit<SnsGetNeuronParams, "certified">) => Promise<Neuron>` |
+
 ##### :gear: getNextNeuronAccount
 
 Returns the subaccount of the next neuron to be created.
 
 The neuron account is a subaccount of the governance canister.
 The subaccount is derived from the controller and an ascending index.
+The id of the neuron is the subaccount.
+If the neuron does not exist for that subaccount, then we use it for the next neuron.
+
 The index is used in the memo of the transfer and when claiming the neuron.
 This is how the backend can identify which neuron is being claimed.
 
@@ -525,11 +565,29 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ------------- | -------------------------------------------------------------------------------- |
 | `stakeNeuron` | `({ stakeE8s, source, controller, }: SnsStakeNeuronParams) => Promise<NeuronId>` |
 
+##### :gear: getNeuronBalance
+
+| Method             | Type                                      |
+| ------------------ | ----------------------------------------- |
+| `getNeuronBalance` | `(neuronId: NeuronId) => Promise<bigint>` |
+
 ##### :gear: addNeuronPermissions
 
 | Method                 | Type                                                    |
 | ---------------------- | ------------------------------------------------------- |
 | `addNeuronPermissions` | `(params: SnsNeuronPermissionsParams) => Promise<void>` |
+
+##### :gear: refreshNeuron
+
+| Method          | Type                                    |
+| --------------- | --------------------------------------- |
+| `refreshNeuron` | `(neuronId: NeuronId) => Promise<void>` |
+
+##### :gear: claimNeuron
+
+| Method        | Type                                                  |
+| ------------- | ----------------------------------------------------- |
+| `claimNeuron` | `(params: SnsClaimNeuronParams) => Promise<NeuronId>` |
 
 ##### :gear: removeNeuronPermissions
 

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -74,9 +74,17 @@ console.log("Summary data:", metadata, token);
 
 ### :toolbox: Functions
 
+- [initSnsWrapper](#gear-initsnswrapper)
 - [encodeSnsAccount](#gear-encodesnsaccount)
 - [decodeSnsAccount](#gear-decodesnsaccount)
-- [initSnsWrapper](#gear-initsnswrapper)
+
+#### :gear: initSnsWrapper
+
+Lookup for the canister ids of a Sns and initialize the wrapper to access its features.
+
+| Function         | Type             |
+| ---------------- | ---------------- |
+| `initSnsWrapper` | `InitSnsWrapper` |
 
 #### :gear: encodeSnsAccount
 
@@ -103,14 +111,6 @@ Formatting Reference: https://github.com/dfinity/ICRC-1/pull/55/files#diff-b3356
 Parameters:
 
 - `snsAccountString`: string
-
-#### :gear: initSnsWrapper
-
-Lookup for the canister ids of a Sns and initialize the wrapper to access its features.
-
-| Function         | Type             |
-| ---------------- | ---------------- |
-| `initSnsWrapper` | `InitSnsWrapper` |
 
 ### :factory: SnsGovernanceCanister
 

--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -6,7 +6,7 @@ import type {
   Operation,
 } from "../../candid/sns_governance";
 import type {
-  SnsClaimOrRefreshParams,
+  SnsClaimOrRefreshArgs,
   SnsDisburseNeuronParams,
   SnsIncreaseDissolveDelayParams,
   SnsNeuronPermissionsParams,
@@ -138,16 +138,16 @@ export const toIncreaseDissolveDelayRequest = ({
 
 export const toClaimOrRefreshRequest = ({
   subaccount,
-  byNeuronId,
   memo,
   controller,
-}: SnsClaimOrRefreshParams): ManageNeuron => ({
+}: SnsClaimOrRefreshArgs): ManageNeuron => ({
   subaccount,
   command: [
     {
       ClaimOrRefresh: {
         by: [
-          byNeuronId
+          // If memo is not passed, we consider it a neuronId request because the memo is mandatory for MemoAndController
+          memo === undefined
             ? { NeuronId: {} }
             : {
                 MemoAndController: { memo, controller: toNullable(controller) },

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -45,4 +45,5 @@ export type {
 } from "./types/governance.params";
 export * from "./types/ledger.responses";
 export type { QueryParams } from "./types/query.params";
+export * from "./utils/governance.utils";
 export * from "./utils/ledger.utils";

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -1,6 +1,5 @@
 import type { Principal } from "@dfinity/principal";
 import { bigIntToUint8Array, toNullable } from "@dfinity/utils";
-import { SnsNeuronId } from ".";
 import type { BlockIndex, Tokens } from "../candid/icrc1_ledger";
 import type {
   GetMetadataResponse,
@@ -165,7 +164,7 @@ export class SnsWrapper {
         owner: this.canisterIds.governanceCanisterId,
         subaccount,
       };
-      const neuronId: SnsNeuronId = { id: subaccount };
+      const neuronId: NeuronId = { id: subaccount };
       let neuron = await this.governance.queryNeuron({
         neuronId,
         certified: false,
@@ -230,7 +229,7 @@ export class SnsWrapper {
     });
   };
 
-  getNeuronBalance = async (neuronId: SnsNeuronId): Promise<Tokens> => {
+  getNeuronBalance = async (neuronId: NeuronId): Promise<Tokens> => {
     const account = {
       owner: this.canisterIds.governanceCanisterId,
       subaccount: neuronId.id,

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -1,5 +1,5 @@
 import type { Principal } from "@dfinity/principal";
-import type { Tokens } from "../../candid/icrc1_ledger";
+import type { Subaccount, Tokens } from "../../candid/icrc1_ledger";
 import type { NeuronId } from "../../candid/sns_governance";
 import type { SnsNeuronPermissionType } from "../enums/governance.enums";
 import type { E8s } from "./common";
@@ -31,12 +31,11 @@ export interface SnsStakeNeuronParams extends Omit<QueryParams, "certified"> {
   controller: Principal;
 }
 
-export interface SnsClaimOrRefreshParams
-  extends Omit<QueryParams, "certified"> {
+// Type to transform to a ClaimOrRefresh command
+export interface SnsClaimOrRefreshArgs extends Omit<QueryParams, "certified"> {
   subaccount: Uint8Array;
-  memo: bigint;
+  memo?: bigint;
   controller?: Principal;
-  byNeuronId: boolean;
 }
 
 /**
@@ -75,4 +74,10 @@ export interface SnsSetDissolveTimestampParams
 export interface SnsIncreaseDissolveDelayParams
   extends SnsNeuronManagementParams {
   additionalDissolveDelaySeconds: number;
+}
+
+export interface SnsClaimNeuronParams {
+  memo: bigint;
+  controller: Principal;
+  subaccount: Subaccount;
 }


### PR DESCRIPTION
# Motivation

Add methods to check and refresh neuron balances.

# Changes

* New methods "claimNeuron", "refreshNeuron" and "queryNeuron" in SNS Governance.
* New methods "getNeuronBalance" in SNS wrapper.
* "getNextNeuronAccount" uses "queryNeuron" instead of checking the balance. Neurons can have balance 0.

# Tests

* Tests for new methods.
* Fix broken tests after refactor.
