### PR TITLE
FIx: Rename "getNextNeuronAccount" method

### DIFF
--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -474,7 +474,7 @@ Parameters:
 - [transfer](#gear-transfer)
 - [getNeuron](#gear-getneuron)
 - [queryNeuron](#gear-queryneuron)
-- [getNextNeuronAccount](#gear-getnextneuronaccount)
+- [nextNeuronAccount](#gear-nextneuronaccount)
 - [stakeNeuron](#gear-stakeneuron)
 - [getNeuronBalance](#gear-getneuronbalance)
 - [addNeuronPermissions](#gear-addneuronpermissions)
@@ -539,7 +539,7 @@ Parameters:
 | ------------- | -------------------------------------------------------------------- |
 | `queryNeuron` | `(params: Omit<SnsGetNeuronParams, "certified">) => Promise<Neuron>` |
 
-##### :gear: getNextNeuronAccount
+##### :gear: nextNeuronAccount
 
 Returns the subaccount of the next neuron to be created.
 
@@ -551,9 +551,9 @@ If the neuron does not exist for that subaccount, then we use it for the next ne
 The index is used in the memo of the transfer and when claiming the neuron.
 This is how the backend can identify which neuron is being claimed.
 
-| Method                 | Type                                                                          |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| `getNextNeuronAccount` | `(controller: Principal) => Promise<{ account: SnsAccount; index: bigint; }>` |
+| Method              | Type                                                                          |
+| ------------------- | ----------------------------------------------------------------------------- |
+| `nextNeuronAccount` | `(controller: Principal) => Promise<{ account: SnsAccount; index: bigint; }>` |
 
 ##### :gear: stakeNeuron
 

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -545,14 +545,14 @@ describe("SnsWrapper", () => {
     });
   });
 
-  describe("getNextNeuronAccount", () => {
+  describe("nextNeuronAccount", () => {
     it("should return the next account with balance 0 and the index", async () => {
       mockCertifiedGovernanceCanister.queryNeuron
         .mockResolvedValueOnce(neuronMock)
         .mockResolvedValueOnce(neuronMock)
         .mockResolvedValue(undefined);
 
-      const { account, index } = await certifiedSnsWrapper.getNextNeuronAccount(
+      const { account, index } = await certifiedSnsWrapper.nextNeuronAccount(
         mockPrincipal
       );
 
@@ -568,8 +568,7 @@ describe("SnsWrapper", () => {
     it("should raise error if max is reached", async () => {
       mockCertifiedGovernanceCanister.queryNeuron.mockResolvedValue(neuronMock);
 
-      const call = () =>
-        certifiedSnsWrapper.getNextNeuronAccount(mockPrincipal);
+      const call = () => certifiedSnsWrapper.nextNeuronAccount(mockPrincipal);
 
       await expect(call).rejects.toThrowError(
         "No more neuron accounts available"

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -37,7 +37,7 @@ import type {
 } from "./types/ledger.responses";
 import type { QueryParams } from "./types/query.params";
 import type { GetAccountTransactionsParams } from "./types/sns-index.params";
-import { getNeuronSubaccount } from "./utils/governance.utils";
+import { neuronSubaccount } from "./utils/governance.utils";
 
 interface SnsWrapperOptions {
   /** The wrapper for the "root" canister of the particular Sns */
@@ -159,7 +159,7 @@ export class SnsWrapper {
   ): Promise<{ account: SnsAccount; index: bigint }> => {
     // TODO: try parallilizing requests to improve performance
     for (let index = 0; index < MAX_NEURONS_SUBACCOUNTS; index++) {
-      const subaccount = await getNeuronSubaccount({ index, controller });
+      const subaccount = neuronSubaccount({ index, controller });
       const account = {
         owner: this.canisterIds.governanceCanisterId,
         subaccount,

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -154,7 +154,7 @@ export class SnsWrapper {
    * @param controller
    * @returns
    */
-  getNextNeuronAccount = async (
+  nextNeuronAccount = async (
     controller: Principal
   ): Promise<{ account: SnsAccount; index: bigint }> => {
     // TODO: try parallilizing requests to improve performance
@@ -204,7 +204,7 @@ export class SnsWrapper {
     controller,
   }: SnsStakeNeuronParams): Promise<NeuronId> => {
     this.assertCertified("stakeNeuron");
-    const { account: neuronAccount, index } = await this.getNextNeuronAccount(
+    const { account: neuronAccount, index } = await this.nextNeuronAccount(
       controller
     );
     // This should not happen. The neuron account is always a subaccount of the SNS governance canister.

--- a/packages/sns/src/utils/governance.utils.spec.ts
+++ b/packages/sns/src/utils/governance.utils.spec.ts
@@ -1,11 +1,11 @@
 import { mockPrincipal } from "../mocks/ledger.mock";
-import { getNeuronSubaccount } from "./governance.utils";
+import { neuronSubaccount } from "./governance.utils";
 
 describe("governance utils", () => {
-  describe("getNeuronSubaccount", () => {
+  describe("neuronSubaccount", () => {
     // Test it to make sure that if there are changes, the test will fail.
-    it("calculates the neuron subaccount based on controller and index", async () => {
-      const neuronSubaccount = await getNeuronSubaccount({
+    it("calculates the neuron subaccount based on controller and index", () => {
+      const subaccount = neuronSubaccount({
         controller: mockPrincipal,
         index: 4,
       });
@@ -14,7 +14,7 @@ describe("governance utils", () => {
         167, 139, 60, 94, 58, 107, 169, 215, 12, 177, 219, 237, 24, 75, 149,
         241, 128,
       ]);
-      expect(neuronSubaccount).toEqual(expected);
+      expect(subaccount).toEqual(expected);
     });
   });
 });

--- a/packages/sns/src/utils/governance.utils.ts
+++ b/packages/sns/src/utils/governance.utils.ts
@@ -11,7 +11,7 @@ import type { Subaccount } from "../../candid/icrc1_ledger";
  * @param {number} params.index
  * @returns
  */
-export const getNeuronSubaccount = ({
+export const neuronSubaccount = ({
   index,
   controller,
 }: {

--- a/packages/sns/src/utils/governance.utils.ts
+++ b/packages/sns/src/utils/governance.utils.ts
@@ -11,13 +11,13 @@ import type { Subaccount } from "../../candid/icrc1_ledger";
  * @param {number} params.index
  * @returns
  */
-export const getNeuronSubaccount = async ({
+export const getNeuronSubaccount = ({
   index,
   controller,
 }: {
   index: number;
   controller: Principal;
-}): Promise<Subaccount> => {
+}): Subaccount => {
   const padding = asciiStringToByteArray("neuron-stake");
   const data = [
     0x0c,


### PR DESCRIPTION
# Motivation

Renaming in SNS.

# Changes

* Rename getNextNeuronAccount to nextNeuronAccount in sns-wrapper.
* Rename getNeuronSubaccount to neuronSubaccount in sns governance utils

# Tests

Fix tests
