### PR TITLE
GIX-1111: List SNS Proposal Topics

### DIFF
--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -128,6 +128,7 @@ Parameters:
 
 - [create](#gear-create)
 - [listNeurons](#gear-listneurons)
+- [listNervousSystemFunctions](#gear-listnervoussystemfunctions)
 - [metadata](#gear-metadata)
 - [getNeuron](#gear-getneuron)
 - [queryNeuron](#gear-queryneuron)
@@ -161,6 +162,15 @@ List the neurons of the Sns
 | Method        | Type                                                  |
 | ------------- | ----------------------------------------------------- |
 | `listNeurons` | `(params: SnsListNeuronsParams) => Promise<Neuron[]>` |
+
+##### :gear: listNervousSystemFunctions
+
+List Nervous System Functions
+Neurons can follow other neurons in specific Nervous System Functions.
+
+| Method                       | Type                                                                   |
+| ---------------------------- | ---------------------------------------------------------------------- |
+| `listNervousSystemFunctions` | `(params: QueryParams) => Promise<ListNervousSystemFunctionsResponse>` |
 
 ##### :gear: metadata
 
@@ -467,6 +477,7 @@ Parameters:
 #### Methods
 
 - [listNeurons](#gear-listneurons)
+- [listNervousSystemFunctions](#gear-listnervoussystemfunctions)
 - [metadata](#gear-metadata)
 - [ledgerMetadata](#gear-ledgermetadata)
 - [transactionFee](#gear-transactionfee)
@@ -496,6 +507,12 @@ Parameters:
 | Method        | Type                                                                     |
 | ------------- | ------------------------------------------------------------------------ |
 | `listNeurons` | `(params: Omit<SnsListNeuronsParams, "certified">) => Promise<Neuron[]>` |
+
+##### :gear: listNervousSystemFunctions
+
+| Method                       | Type                                                                                      |
+| ---------------------------- | ----------------------------------------------------------------------------------------- |
+| `listNervousSystemFunctions` | `(params: Omit<QueryParams, "certified">) => Promise<ListNervousSystemFunctionsResponse>` |
 
 ##### :gear: metadata
 

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -3,7 +3,9 @@ import { Principal } from "@dfinity/principal";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
 import type {
+  ListNervousSystemFunctionsResponse,
   ManageNeuron,
+  NervousSystemFunction,
   NeuronId,
   _SERVICE as SnsGovernanceService,
 } from "../candid/sns_governance";
@@ -31,6 +33,30 @@ describe("Governance canister", () => {
     });
     const res = await canister.listNeurons({});
     expect(res).toEqual(neuronsMock);
+  });
+
+  it("should return the list of nervous system functionsof the sns", async () => {
+    const service = mock<ActorSubclass<SnsGovernanceService>>();
+    const nervousSysttemFunctionMock: NervousSystemFunction = {
+      id: BigInt(30),
+      name: "Governance",
+      description: ["This is a description"],
+      function_type: [{ NativeNervousSystemFunction: {} }],
+    };
+    const nervousSystemFunctionsMock: ListNervousSystemFunctionsResponse = {
+      reserved_ids: new BigUint64Array(),
+      functions: [nervousSysttemFunctionMock],
+    };
+    service.list_nervous_system_functions.mockResolvedValue(
+      nervousSystemFunctionsMock
+    );
+
+    const canister = SnsGovernanceCanister.create({
+      canisterId: rootCanisterIdMock,
+      certifiedServiceOverride: service,
+    });
+    const res = await canister.listNervousSystemFunctions({});
+    expect(res).toEqual(nervousSystemFunctionsMock);
   });
 
   it("should call list of neurons with default param", async () => {

--- a/packages/sns/src/governance.canister.ts
+++ b/packages/sns/src/governance.canister.ts
@@ -2,6 +2,7 @@ import type { Principal } from "@dfinity/principal";
 import { createServices, fromNullable, toNullable } from "@dfinity/utils";
 import type {
   GetMetadataResponse,
+  ListNervousSystemFunctionsResponse,
   ManageNeuron,
   ManageNeuronResponse,
   Neuron,
@@ -65,6 +66,15 @@ export class SnsGovernanceCanister extends Canister<SnsGovernanceService> {
     });
     return neurons;
   };
+
+  /**
+   * List Nervous System Functions
+   * Neurons can follow other neurons in specific Nervous System Functions.
+   */
+  listNervousSystemFunctions = async (
+    params: QueryParams
+  ): Promise<ListNervousSystemFunctionsResponse> =>
+    this.caller(params).list_nervous_system_functions();
 
   /**
    * Get the Sns metadata (title, description, etc.)

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -4,8 +4,10 @@ export type {
 } from "../candid/icrc1_ledger";
 export type {
   GetMetadataResponse as SnsGetMetadataResponse,
+  ListNervousSystemFunctionsResponse as SnsListNervousSystemFunctionsResponse,
   ManageNeuron as SnsManageNeuron,
   ManageNeuronResponse as SnsManageNeuronResponse,
+  NervousSystemFunction as SnsNervousSystemFunction,
   Neuron as SnsNeuron,
   NeuronId as SnsNeuronId,
 } from "../candid/sns_governance";

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -86,13 +86,13 @@ describe("SnsWrapper", () => {
   });
 
   it("should call list of nervous system functions with query or update", async () => {
-    await snsWrapper.listNervousSystemFunctions();
+    await snsWrapper.listNervousSystemFunctions({});
     expect(
       mockGovernanceCanister.listNervousSystemFunctions
     ).toHaveBeenCalledWith({
       certified: false,
     });
-    await certifiedSnsWrapper.listNervousSystemFunctions();
+    await certifiedSnsWrapper.listNervousSystemFunctions({});
     expect(
       mockCertifiedGovernanceCanister.listNervousSystemFunctions
     ).toHaveBeenCalledWith({

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -85,6 +85,21 @@ describe("SnsWrapper", () => {
     });
   });
 
+  it("should call list of nervous system functions with query or update", async () => {
+    await snsWrapper.listNervousSystemFunctions();
+    expect(
+      mockGovernanceCanister.listNervousSystemFunctions
+    ).toHaveBeenCalledWith({
+      certified: false,
+    });
+    await certifiedSnsWrapper.listNervousSystemFunctions();
+    expect(
+      mockCertifiedGovernanceCanister.listNervousSystemFunctions
+    ).toHaveBeenCalledWith({
+      certified: true,
+    });
+  });
+
   it("should call get neuron with query or update", async () => {
     const neuronId = {
       id: arrayOfNumberToUint8Array([1, 2, 3]),

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -108,6 +108,9 @@ export class SnsWrapper {
     params: Omit<SnsListNeuronsParams, "certified">
   ): Promise<Neuron[]> => this.governance.listNeurons(this.mergeParams(params));
 
+  listNervousSystemFunctions = () =>
+    this.governance.listNervousSystemFunctions(this.mergeParams({}));
+
   metadata = (
     params: Omit<QueryParams, "certified">
   ): Promise<[GetMetadataResponse, SnsTokenMetadataResponse]> =>

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -3,6 +3,7 @@ import { bigIntToUint8Array, toNullable } from "@dfinity/utils";
 import type { BlockIndex, Tokens } from "../candid/icrc1_ledger";
 import type {
   GetMetadataResponse,
+  ListNervousSystemFunctionsResponse,
   Neuron,
   NeuronId,
 } from "../candid/sns_governance";
@@ -108,8 +109,10 @@ export class SnsWrapper {
     params: Omit<SnsListNeuronsParams, "certified">
   ): Promise<Neuron[]> => this.governance.listNeurons(this.mergeParams(params));
 
-  listNervousSystemFunctions = () =>
-    this.governance.listNervousSystemFunctions(this.mergeParams({}));
+  listNervousSystemFunctions = (
+    params: Omit<QueryParams, "certified">
+  ): Promise<ListNervousSystemFunctionsResponse> =>
+    this.governance.listNervousSystemFunctions(this.mergeParams(params));
 
   metadata = (
     params: Omit<QueryParams, "certified">


### PR DESCRIPTION
# Motivation

Add method to retrieve the Nervous System Functions from an SNS project.

Those are the "topics" that a neuron can follow.

# Changes

* Add listNervousSystemFunctions method to sns governance.
* Add listNervousSystemFunctions method to sns wrapper.
* Export ListNervousSystemFunctionsResponse and NervousSystemFunction types.

# Tests

* Test new sns wrapper method.
* Test new sns governance method.
