### PR TITLE
GIX-1113: SNS Neuron Followee Management

### DIFF
--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -140,6 +140,7 @@ Parameters:
 - [stopDissolving](#gear-stopdissolving)
 - [setDissolveTimestamp](#gear-setdissolvetimestamp)
 - [increaseDissolveDelay](#gear-increasedissolvedelay)
+- [setTopicFollowees](#gear-settopicfollowees)
 - [refreshNeuron](#gear-refreshneuron)
 - [claimNeuron](#gear-claimneuron)
 
@@ -259,6 +260,14 @@ Increase dissolve delay of a neuron
 | Method                  | Type                                                        |
 | ----------------------- | ----------------------------------------------------------- |
 | `increaseDissolveDelay` | `(params: SnsIncreaseDissolveDelayParams) => Promise<void>` |
+
+##### :gear: setTopicFollowees
+
+Sets followees of a neuron for a specific Nervous System Function (topic)
+
+| Method              | Type                                              |
+| ------------------- | ------------------------------------------------- |
+| `setTopicFollowees` | `(params: SnsSetTopicFollowees) => Promise<void>` |
 
 ##### :gear: refreshNeuron
 
@@ -497,6 +506,7 @@ Parameters:
 - [stopDissolving](#gear-stopdissolving)
 - [setDissolveTimestamp](#gear-setdissolvetimestamp)
 - [increaseDissolveDelay](#gear-increasedissolvedelay)
+- [setTopicFollowees](#gear-settopicfollowees)
 - [swapState](#gear-swapstate)
 - [notifyParticipation](#gear-notifyparticipation)
 - [getUserCommitment](#gear-getusercommitment)
@@ -641,6 +651,12 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | Method                  | Type                                                        |
 | ----------------------- | ----------------------------------------------------------- |
 | `increaseDissolveDelay` | `(params: SnsIncreaseDissolveDelayParams) => Promise<void>` |
+
+##### :gear: setTopicFollowees
+
+| Method              | Type                                              |
+| ------------------- | ------------------------------------------------- |
+| `setTopicFollowees` | `(params: SnsSetTopicFollowees) => Promise<void>` |
 
 ##### :gear: swapState
 

--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -11,6 +11,7 @@ import type {
   SnsIncreaseDissolveDelayParams,
   SnsNeuronPermissionsParams,
   SnsSetDissolveTimestampParams,
+  SnsSetTopicFollowees,
 } from "../types/governance.params";
 
 // Helper for building `ManageNeuron` structure
@@ -135,6 +136,22 @@ export const toIncreaseDissolveDelayRequest = ({
       },
     },
   });
+
+export const toFollowRequest = ({
+  neuronId,
+  functionId,
+  followees,
+}: SnsSetTopicFollowees): ManageNeuron => ({
+  subaccount: neuronId.id,
+  command: [
+    {
+      Follow: {
+        function_id: functionId,
+        followees,
+      },
+    },
+  ],
+});
 
 export const toClaimOrRefreshRequest = ({
   subaccount,

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -562,6 +562,71 @@ describe("Governance canister", () => {
     });
   });
 
+  describe("setTopicFollowees", () => {
+    const neuronId: NeuronId = {
+      id: arrayOfNumberToUint8Array([1, 2, 3]),
+    };
+    const functionId = BigInt(222);
+    const followees = [
+      { id: arrayOfNumberToUint8Array([1, 2, 3, 4]) },
+      { id: arrayOfNumberToUint8Array([1, 2, 3, 5]) },
+    ];
+
+    it("should call manageNeuron", async () => {
+      const request: ManageNeuron = {
+        subaccount: neuronId.id,
+        command: [
+          {
+            Follow: {
+              function_id: functionId,
+              followees,
+            },
+          },
+        ],
+      };
+
+      const service = mock<ActorSubclass<SnsGovernanceService>>();
+      service.manage_neuron.mockResolvedValue({
+        command: [{ Follow: {} }],
+      });
+
+      const canister = SnsGovernanceCanister.create({
+        canisterId: rootCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+
+      await canister.setTopicFollowees({
+        neuronId,
+        functionId,
+        followees,
+      });
+
+      expect(service.manage_neuron).toBeCalled();
+      expect(service.manage_neuron).toBeCalledWith(request);
+    });
+
+    it("should raise an error", async () => {
+      const service = mock<ActorSubclass<SnsGovernanceService>>();
+      service.manage_neuron.mockResolvedValue({
+        command: [{ Error: { error_message: "test", error_type: 2 } }],
+      });
+
+      const canister = SnsGovernanceCanister.create({
+        canisterId: rootCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+      const call = () =>
+        canister.setTopicFollowees({
+          neuronId,
+          functionId,
+          followees,
+        });
+
+      await expect(call).rejects.toThrowError(SnsGovernanceError);
+      expect(service.manage_neuron).toBeCalled();
+    });
+  });
+
   describe("queryNeuron", () => {
     it("should return the neuron", async () => {
       const service = mock<ActorSubclass<SnsGovernanceService>>();

--- a/packages/sns/src/governance.canister.ts
+++ b/packages/sns/src/governance.canister.ts
@@ -16,6 +16,7 @@ import {
   toAddPermissionsRequest,
   toClaimOrRefreshRequest,
   toDisburseNeuronRequest,
+  toFollowRequest,
   toIncreaseDissolveDelayRequest,
   toRemovePermissionsRequest,
   toSetDissolveTimestampRequest,
@@ -33,6 +34,7 @@ import type {
   SnsListNeuronsParams,
   SnsNeuronPermissionsParams,
   SnsSetDissolveTimestampParams,
+  SnsSetTopicFollowees,
 } from "./types/governance.params";
 import type { QueryParams } from "./types/query.params";
 
@@ -196,6 +198,14 @@ export class SnsGovernanceCanister extends Canister<SnsGovernanceService> {
     params: SnsIncreaseDissolveDelayParams
   ): Promise<void> => {
     const request: ManageNeuron = toIncreaseDissolveDelayRequest(params);
+    await this.manageNeuron(request);
+  };
+
+  /**
+   * Sets followees of a neuron for a specific Nervous System Function (topic)
+   */
+  setTopicFollowees = async (params: SnsSetTopicFollowees): Promise<void> => {
+    const request: ManageNeuron = toFollowRequest(params);
     await this.manageNeuron(request);
   };
 

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -41,10 +41,7 @@ export { SnsIndexCanister } from "./sns-index.canister";
 export * from "./sns.wrapper";
 export { SnsSwapCanister } from "./swap.canister";
 export type { SnsCanisterOptions } from "./types/canister.options";
-export type {
-  SnsGetNeuronParams,
-  SnsListNeuronsParams,
-} from "./types/governance.params";
+export * from "./types/governance.params";
 export * from "./types/ledger.responses";
 export type { QueryParams } from "./types/query.params";
 export * from "./utils/governance.utils";

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -344,6 +344,29 @@ describe("SnsWrapper", () => {
     });
   });
 
+  it("should call setTopicFollowees", async () => {
+    const neuronId: NeuronId = {
+      id: arrayOfNumberToUint8Array([1, 2, 3]),
+    };
+    const functionId = BigInt(222);
+    const followees = [
+      { id: arrayOfNumberToUint8Array([1, 2, 3, 4]) },
+      { id: arrayOfNumberToUint8Array([1, 2, 3, 5]) },
+    ];
+
+    await snsWrapper.setTopicFollowees({
+      neuronId,
+      functionId,
+      followees,
+    });
+
+    expect(mockGovernanceCanister.setTopicFollowees).toHaveBeenCalledWith({
+      neuronId,
+      functionId,
+      followees,
+    });
+  });
+
   it("should call getTransactions in index canister", async () => {
     const owner = Principal.fromText("aaaaa-aa");
     const subaccount = arrayOfNumberToUint8Array([0, 0, 1]);

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -29,6 +29,7 @@ import type {
   SnsListNeuronsParams,
   SnsNeuronPermissionsParams,
   SnsSetDissolveTimestampParams,
+  SnsSetTopicFollowees,
   SnsStakeNeuronParams,
 } from "./types/governance.params";
 import type { BalanceParams, TransferParams } from "./types/ledger.params";
@@ -281,6 +282,10 @@ export class SnsWrapper {
   increaseDissolveDelay = (
     params: SnsIncreaseDissolveDelayParams
   ): Promise<void> => this.governance.increaseDissolveDelay(params);
+
+  // Always certified
+  setTopicFollowees = (params: SnsSetTopicFollowees): Promise<void> =>
+    this.governance.setTopicFollowees(params);
 
   swapState = (
     params: Omit<QueryParams, "certified">

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -1,7 +1,6 @@
 import type { Principal } from "@dfinity/principal";
-import { SnsNeuronId } from "..";
 import type { Subaccount, Tokens } from "../../candid/icrc1_ledger";
-import type { NeuronId } from "../../candid/sns_governance";
+import type { Neuron, NeuronId } from "../../candid/sns_governance";
 import type { SnsNeuronPermissionType } from "../enums/governance.enums";
 import type { E8s } from "./common";
 import type { SnsAccount } from "./ledger.responses";
@@ -82,7 +81,7 @@ export interface SnsIncreaseDissolveDelayParams
  */
 export interface SnsSetTopicFollowees extends SnsNeuronManagementParams {
   functionId: bigint;
-  followees: SnsNeuronId[];
+  followees: Neuron[];
 }
 
 /**

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -1,6 +1,6 @@
 import type { Principal } from "@dfinity/principal";
 import type { Subaccount, Tokens } from "../../candid/icrc1_ledger";
-import type { Neuron, NeuronId } from "../../candid/sns_governance";
+import type { NeuronId } from "../../candid/sns_governance";
 import type { SnsNeuronPermissionType } from "../enums/governance.enums";
 import type { E8s } from "./common";
 import type { SnsAccount } from "./ledger.responses";
@@ -81,7 +81,7 @@ export interface SnsIncreaseDissolveDelayParams
  */
 export interface SnsSetTopicFollowees extends SnsNeuronManagementParams {
   functionId: bigint;
-  followees: Neuron[];
+  followees: NeuronId[];
 }
 
 /**

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -1,4 +1,5 @@
 import type { Principal } from "@dfinity/principal";
+import { SnsNeuronId } from "..";
 import type { Subaccount, Tokens } from "../../candid/icrc1_ledger";
 import type { NeuronId } from "../../candid/sns_governance";
 import type { SnsNeuronPermissionType } from "../enums/governance.enums";
@@ -76,6 +77,17 @@ export interface SnsIncreaseDissolveDelayParams
   additionalDissolveDelaySeconds: number;
 }
 
+/**
+ * The parameters to increase dissolve delay
+ */
+export interface SnsSetTopicFollowees extends SnsNeuronManagementParams {
+  functionId: bigint;
+  followees: SnsNeuronId[];
+}
+
+/**
+ * The parameters to claim a neuron
+ */
 export interface SnsClaimNeuronParams {
   memo: bigint;
   controller: Principal;


### PR DESCRIPTION
# Motivation

Expose functionality to manage followees of an sns neuron.

# Changes

* Add method setTopicFollowees to sns governance.
* Add method setTopicFollowees to sns wrapper.

# Tests

* Test new sns governance method.
* Test new sns wrapper method.
