### PR TITLE
feat: nervousSystemParameters

### DIFF
--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -130,6 +130,7 @@ Parameters:
 - [listNeurons](#gear-listneurons)
 - [listNervousSystemFunctions](#gear-listnervoussystemfunctions)
 - [metadata](#gear-metadata)
+- [nervousSystemParameters](#gear-nervoussystemparameters)
 - [getNeuron](#gear-getneuron)
 - [queryNeuron](#gear-queryneuron)
 - [manageNeuron](#gear-manageneuron)
@@ -179,6 +180,14 @@ Get the Sns metadata (title, description, etc.)
 | Method     | Type                                                    |
 | ---------- | ------------------------------------------------------- |
 | `metadata` | `(params: QueryParams) => Promise<GetMetadataResponse>` |
+
+##### :gear: nervousSystemParameters
+
+Get the Sns nervous system parameters (default followees, max dissolve delay, max number of neurons, etc.)
+
+| Method                    | Type                                                        |
+| ------------------------- | ----------------------------------------------------------- |
+| `nervousSystemParameters` | `(params: QueryParams) => Promise<NervousSystemParameters>` |
 
 ##### :gear: getNeuron
 
@@ -479,6 +488,7 @@ Parameters:
 - [listNeurons](#gear-listneurons)
 - [listNervousSystemFunctions](#gear-listnervoussystemfunctions)
 - [metadata](#gear-metadata)
+- [nervousSystemParameters](#gear-nervoussystemparameters)
 - [ledgerMetadata](#gear-ledgermetadata)
 - [transactionFee](#gear-transactionfee)
 - [balance](#gear-balance)
@@ -519,6 +529,12 @@ Parameters:
 | Method     | Type                                                                                                   |
 | ---------- | ------------------------------------------------------------------------------------------------------ |
 | `metadata` | `(params: Omit<QueryParams, "certified">) => Promise<[GetMetadataResponse, SnsTokenMetadataResponse]>` |
+
+##### :gear: nervousSystemParameters
+
+| Method                    | Type                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------ |
+| `nervousSystemParameters` | `(params: Omit<QueryParams, "certified">) => Promise<NervousSystemParameters>` |
 
 ##### :gear: ledgerMetadata
 

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -7,7 +7,7 @@ import type {
   ManageNeuron,
   NervousSystemFunction,
   NeuronId,
-  _SERVICE as SnsGovernanceService,
+  _SERVICE as SnsGovernanceService, NervousSystemParameters,
 } from "../candid/sns_governance";
 import { MAX_LIST_NEURONS_RESULTS } from "./constants/governance.constants";
 import { SnsNeuronPermissionType } from "./enums/governance.enums";
@@ -275,6 +275,22 @@ describe("Governance canister", () => {
 
       const res = await canister.metadata({});
       expect(res).toEqual(metadataMock);
+    });
+  });
+
+  describe("nervousSystemParameters", () => {
+    it("should return the parameters of the sns", async () => {
+      const mockParams = {test: true};
+      const service = mock<ActorSubclass<SnsGovernanceService>>();
+      service.get_nervous_system_parameters.mockResolvedValue(mockParams as unknown as NervousSystemParameters);
+
+      const canister = SnsGovernanceCanister.create({
+        canisterId: rootCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+
+      const res = await canister.nervousSystemParameters({});
+      expect(res).toEqual(mockParams);
     });
   });
 

--- a/packages/sns/src/governance.canister.ts
+++ b/packages/sns/src/governance.canister.ts
@@ -5,6 +5,7 @@ import type {
   ListNervousSystemFunctionsResponse,
   ManageNeuron,
   ManageNeuronResponse,
+  NervousSystemParameters,
   Neuron,
   NeuronId,
   _SERVICE as SnsGovernanceService,
@@ -81,6 +82,14 @@ export class SnsGovernanceCanister extends Canister<SnsGovernanceService> {
    */
   metadata = (params: QueryParams): Promise<GetMetadataResponse> =>
     this.caller(params).get_metadata({});
+
+  /**
+   * Get the Sns nervous system parameters (default followees, max dissolve delay, max number of neurons, etc.)
+   */
+  nervousSystemParameters = (
+    params: QueryParams
+  ): Promise<NervousSystemParameters> =>
+    this.caller(params).get_nervous_system_parameters(null);
 
   /**
    * Get the neuron of the Sns

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -169,6 +169,18 @@ describe("SnsWrapper", () => {
     });
   });
 
+  it("should collect metadata with query or update", async () => {
+    await snsWrapper.nervousSystemParameters({});
+    await certifiedSnsWrapper.nervousSystemParameters({});
+
+    expect(mockGovernanceCanister.nervousSystemParameters).toHaveBeenCalledWith({
+      certified: false,
+    });
+    expect(mockCertifiedGovernanceCanister.nervousSystemParameters).toHaveBeenCalledWith({
+      certified: true,
+    });
+  });
+
   it("should call leger transaction fee with query or update", async () => {
     await snsWrapper.transactionFee({});
     await certifiedSnsWrapper.transactionFee({});

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -4,6 +4,7 @@ import type { BlockIndex, Tokens } from "../candid/icrc1_ledger";
 import type {
   GetMetadataResponse,
   ListNervousSystemFunctionsResponse,
+  NervousSystemParameters,
   Neuron,
   NeuronId,
 } from "../candid/sns_governance";
@@ -121,6 +122,11 @@ export class SnsWrapper {
       this.governance.metadata(this.mergeParams(params)),
       this.ledger.metadata(this.mergeParams(params)),
     ]);
+
+  nervousSystemParameters = (
+    params: Omit<QueryParams, "certified">
+  ): Promise<NervousSystemParameters> =>
+    this.governance.nervousSystemParameters(this.mergeParams(params));
 
   ledgerMetadata = (
     params: Omit<QueryParams, "certified">


### PR DESCRIPTION
# Motivation

A function to get `nervousSystemParameters`:

https://github.com/dfinity/ic-js/blob/a9ed2dea58e62407b64026949692521511407384/packages/sns/candid/sns_governance.d.ts#L281

Currently needs to [calculate sns voting power](https://dfinity.atlassian.net/browse/GIX-1120).

# Changes

- sns governance canister function
- sns wrapper function

# Tests

- tests for both functions