### PR TITLE
Fix: TokenAmount.fromNumber problems

### DIFF
--- a/packages/nns/src/token.spec.ts
+++ b/packages/nns/src/token.spec.ts
@@ -57,6 +57,9 @@ describe("ICP", () => {
       TokenAmount.fromString({ token: ICPToken, amount: "45.1231" })
     ).toEqual(TokenAmount.fromNumber({ token: ICPToken, amount: 45.1231 }));
     expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "0.3319" })
+    ).toEqual(TokenAmount.fromNumber({ token: ICPToken, amount: 0.3319 }));
+    expect(
       TokenAmount.fromString({ token: ICPToken, amount: "0.0001" })
     ).toEqual(TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(10000) }));
     expect(
@@ -65,9 +68,6 @@ describe("ICP", () => {
     expect(
       TokenAmount.fromString({ token: ICPToken, amount: "0.0000000001" })
     ).toEqual(FromStringToTokenError.FractionalMoreThan8Decimals);
-    expect(
-      TokenAmount.fromNumber({ token: ICPToken, amount: 0.0000000001 })
-    ).toEqual(TokenAmount.fromNumber({ token: ICPToken, amount: 0 }));
     expect(TokenAmount.fromString({ token: ICPToken, amount: ".01" })).toEqual(
       TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1000000) })
     );
@@ -110,6 +110,10 @@ describe("ICP", () => {
     expect(
       TokenAmount.fromString({ token: ICPToken, amount: "123asdf$#@~!" })
     ).toBe(FromStringToTokenError.InvalidFormat);
+
+    const callToNumber = () =>
+      TokenAmount.fromNumber({ token: ICPToken, amount: 0.0000000001 });
+    expect(callToNumber).toThrow();
   });
 
   it("rejects negative numbers", () => {

--- a/packages/nns/src/token.ts
+++ b/packages/nns/src/token.ts
@@ -124,11 +124,19 @@ export class TokenAmount {
     amount: number;
     token: Token;
   }): TokenAmount {
-    const e8s = BigInt(Math.floor(amount * Number(E8S_PER_TOKEN)));
-    return TokenAmount.fromE8s({
-      amount: e8s,
+    const tokenAmount = TokenAmount.fromString({
+      amount: amount.toString(),
       token,
     });
+    if (tokenAmount instanceof TokenAmount) {
+      return tokenAmount;
+    }
+    if (tokenAmount === FromStringToTokenError.FractionalMoreThan8Decimals) {
+      throw new Error(`Number ${amount} has more than 8 decimals`);
+    }
+
+    // This should never happen
+    throw new Error(`Invalid number ${amount}`);
   }
 
   /**


### PR DESCRIPTION
# Motivation

An issue was found when converting the number "0.3319" to an ICP amount. There was a rounding error.

# Changes

* TokenAmount.fromNumber uses fromString. Raises error if number has more than 8 decimals.

# Tests

* Changed tests to adapt to new raised error.
* Add the test for the specific bug.
