### PR TITLE
feat: not voted neurons

### DIFF
--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -66,6 +66,10 @@ await main();
 ### :toolbox: Functions
 
 - [convertStringToE8s](#gear-convertstringtoe8s)
+- [ineligibleNeurons](#gear-ineligibleneurons)
+- [votableNeurons](#gear-votableneurons)
+- [votedNeurons](#gear-votedneurons)
+- [notVotedNeurons](#gear-notvotedneurons)
 
 #### :gear: convertStringToE8s
 
@@ -78,6 +82,65 @@ Receives a string representing a number and returns the big int or error.
 Parameters:
 
 - `amount`: - in string format
+
+#### :gear: ineligibleNeurons
+
+Filter the neurons that are ineligible to vote to a proposal.
+
+This feature needs the ballots of the proposal to contains accurate data.
+If the proposal has settled, as the ballots of the proposal are emptied for archive purpose, the function might return a list of ineligible neurons that are actually neurons that have not voted but would have been eligible.
+
+Long story short, check the status of the proposal before using this function.
+
+| Function            | Type                                                                                           |
+| ------------------- | ---------------------------------------------------------------------------------------------- |
+| `ineligibleNeurons` | `({ neurons, proposal, }: { neurons: NeuronInfo[]; proposal: ProposalInfo; }) => NeuronInfo[]` |
+
+Parameters:
+
+- `params.neurons`: The neurons to filter.
+- `params.proposal`: The proposal to match against the selected neurons.
+
+#### :gear: votableNeurons
+
+Filter the neurons that can vote for a proposal - i.e. the neurons that have not voted yet and are eligible
+
+| Function         | Type                                                                                           |
+| ---------------- | ---------------------------------------------------------------------------------------------- |
+| `votableNeurons` | `({ neurons, proposal, }: { neurons: NeuronInfo[]; proposal: ProposalInfo; }) => NeuronInfo[]` |
+
+Parameters:
+
+- `params.neurons`: The neurons to filter.
+- `params.proposal`: The proposal to match against the selected neurons.
+
+#### :gear: votedNeurons
+
+Filter the neurons that have voted for a proposal.
+
+| Function       | Type                                                                                                               |
+| -------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `votedNeurons` | `({ neurons, proposal: { id: proposalId }, }: { neurons: NeuronInfo[]; proposal: ProposalInfo; }) => NeuronInfo[]` |
+
+Parameters:
+
+- `params.neurons`: The neurons to filter.
+- `params.proposal`: The proposal for which some neurons might have already voted.
+
+#### :gear: notVotedNeurons
+
+Filter the neurons that have not voted for a proposal.
+
+Note: This function returns no hints on the reason why neurons are not voted nor if some were or are ineligible.
+
+| Function          | Type                                                                                                               |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `notVotedNeurons` | `({ neurons, proposal: { id: proposalId }, }: { neurons: NeuronInfo[]; proposal: ProposalInfo; }) => NeuronInfo[]` |
+
+Parameters:
+
+- `params.neurons`: The neurons to filter.
+- `params.proposal`: The proposal for which some neurons might have not voted.
 
 ### :wrench: Constants
 

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -87,7 +87,7 @@ Parameters:
 
 Filter the neurons that are ineligible to vote to a proposal.
 
-This feature needs the ballots of the proposal to contain accurate data.
+This feature needs the ballots of the proposal to contains accurate data.
 If the proposal has settled, as the ballots of the proposal are emptied for archive purpose, the function might return a list of ineligible neurons that are actually neurons that have not voted but would have been eligible.
 
 Long story short, check the status of the proposal before using this function.

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -87,7 +87,7 @@ Parameters:
 
 Filter the neurons that are ineligible to vote to a proposal.
 
-This feature needs the ballots of the proposal to contains accurate data.
+This feature needs the ballots of the proposal to contain accurate data.
 If the proposal has settled, as the ballots of the proposal are emptied for archive purpose, the function might return a list of ineligible neurons that are actually neurons that have not voted but would have been eligible.
 
 Long story short, check the status of the proposal before using this function.

--- a/packages/nns/src/utils/neurons.utils.spec.ts
+++ b/packages/nns/src/utils/neurons.utils.spec.ts
@@ -1,7 +1,9 @@
+import { describe } from "@jest/globals";
 import { Vote } from "../enums/governance.enums";
 import { NeuronInfo, ProposalInfo } from "../types/governance_converters";
 import {
   ineligibleNeurons,
+  notVotedNeurons,
   votableNeurons,
   votedNeurons,
 } from "./neurons.utils";
@@ -157,52 +159,105 @@ describe("neurons-utils", () => {
     expect(votable.length).toEqual(3);
   });
 
-  it("should not have voted neurons because votable", () => {
-    const voted = votedNeurons({
-      proposal,
-      neurons: [
-        {
-          ...eligibleNeuronsDate[0],
-          recentBallots: [
-            {
-              proposalId: BigInt(4),
-              vote: Vote.No,
-            },
-          ],
-        },
-      ],
+  describe("voted", () => {
+    it("should not have voted neurons because votable", () => {
+      const voted = votedNeurons({
+        proposal,
+        neurons: [
+          {
+            ...eligibleNeuronsDate[0],
+            recentBallots: [
+              {
+                proposalId: BigInt(4),
+                vote: Vote.No,
+              },
+            ],
+          },
+        ],
+      });
+      expect(voted.length).toEqual(0);
     });
-    expect(voted.length).toEqual(0);
+
+    it("should not have voted neurons because never voted", () => {
+      const voted = votedNeurons({
+        proposal,
+        neurons: [
+          {
+            ...eligibleNeuronsDate[0],
+            recentBallots: [],
+          },
+        ],
+      });
+      expect(voted.length).toEqual(0);
+    });
+
+    it("should have voted neurons because has voted", () => {
+      const voted = votedNeurons({
+        proposal,
+        neurons: [
+          {
+            ...eligibleNeuronsDate[0],
+            recentBallots: [
+              {
+                proposalId,
+                vote: Vote.No,
+              },
+            ],
+          },
+        ],
+      });
+      expect(voted.length).toEqual(1);
+    });
   });
 
-  it("should not have voted neurons because never voted", () => {
-    const voted = votedNeurons({
-      proposal,
-      neurons: [
-        {
-          ...eligibleNeuronsDate[0],
-          recentBallots: [],
-        },
-      ],
+  describe("not voted", () => {
+    it("should not have voted neurons because votable", () => {
+      const voted = notVotedNeurons({
+        proposal,
+        neurons: [
+          {
+            ...eligibleNeuronsDate[0],
+            recentBallots: [
+              {
+                proposalId: BigInt(4),
+                vote: Vote.No,
+              },
+            ],
+          },
+        ],
+      });
+      expect(voted.length).toEqual(1);
     });
-    expect(voted.length).toEqual(0);
-  });
 
-  it("should have voted neurons because has voted", () => {
-    const voted = votedNeurons({
-      proposal,
-      neurons: [
-        {
-          ...eligibleNeuronsDate[0],
-          recentBallots: [
-            {
-              proposalId,
-              vote: Vote.No,
-            },
-          ],
-        },
-      ],
+    it("should not have voted neurons because never voted", () => {
+      const voted = notVotedNeurons({
+        proposal,
+        neurons: [
+          {
+            ...eligibleNeuronsDate[0],
+            recentBallots: [],
+          },
+        ],
+      });
+      expect(voted.length).toEqual(1);
     });
-    expect(voted.length).toEqual(1);
+
+    it("should have voted neurons because has voted", () => {
+      const voted = notVotedNeurons({
+        proposal,
+        neurons: [
+          {
+            ...eligibleNeuronsDate[0],
+            recentBallots: [
+              {
+                proposalId,
+                vote: Vote.No,
+              },
+            ],
+          },
+        ],
+      });
+      expect(voted.length).toEqual(0);
+    });
   });
 });

--- a/packages/nns/src/utils/neurons.utils.ts
+++ b/packages/nns/src/utils/neurons.utils.ts
@@ -70,15 +70,24 @@ export const votableNeurons = ({
 
 export const votedNeurons = ({
   neurons,
-  proposal,
+  proposal: { id: proposalId },
 }: {
   neurons: NeuronInfo[];
   proposal: ProposalInfo;
-}): NeuronInfo[] => {
-  const { id: proposalId } = proposal;
-
-  return neurons.filter(
+}): NeuronInfo[] =>
+  neurons.filter(
     ({ recentBallots }: NeuronInfo) =>
       voteForProposal({ recentBallots, proposalId }) !== undefined
   );
-};
+
+export const notVotedNeurons = ({
+  neurons,
+  proposal: { id: proposalId },
+}: {
+  neurons: NeuronInfo[];
+  proposal: ProposalInfo;
+}): NeuronInfo[] =>
+  neurons.filter(
+    ({ recentBallots }: NeuronInfo) =>
+      voteForProposal({ recentBallots, proposalId }) === undefined
+  );

--- a/packages/nns/src/utils/neurons.utils.ts
+++ b/packages/nns/src/utils/neurons.utils.ts
@@ -24,6 +24,18 @@ const voteForProposal = ({
   return ballot?.vote;
 };
 
+/**
+ * Filter the neurons that are ineligible to vote to a proposal.
+ *
+ * This feature needs the ballots of the proposal to contains accurate data.
+ * If the proposal has settled, as the ballots of the proposal are emptied for archive purpose, the function might return a list of ineligible neurons that are actually neurons that have not voted but would have been eligible.
+ *
+ * Long story short, check the status of the proposal before using this function.
+ *
+ * @param {neurons; proposal;} params
+ * @param params.neurons The neurons to filter.
+ * @param params.proposal The proposal to match against the selected neurons.
+ */
 export const ineligibleNeurons = ({
   neurons,
   proposal,
@@ -47,7 +59,11 @@ export const ineligibleNeurons = ({
 };
 
 /**
- * Neurons that can vote for the proposal (not voted, with voting power)
+ * Filter the neurons that can vote for a proposal - i.e. the neurons that have not voted yet and are eligible
+ *
+ * @param {neurons; proposal;} params
+ * @param params.neurons The neurons to filter.
+ * @param params.proposal The proposal to match against the selected neurons.
  */
 export const votableNeurons = ({
   neurons,
@@ -68,6 +84,13 @@ export const votableNeurons = ({
   );
 };
 
+/**
+ * Filter the neurons that have voted for a proposal.
+ *
+ * @param {neurons; proposal;} params
+ * @param params.neurons The neurons to filter.
+ * @param params.proposal The proposal for which some neurons might have already voted.
+ */
 export const votedNeurons = ({
   neurons,
   proposal: { id: proposalId },
@@ -80,6 +103,15 @@ export const votedNeurons = ({
       voteForProposal({ recentBallots, proposalId }) !== undefined
   );
 
+/**
+ * Filter the neurons that have not voted for a proposal.
+ *
+ * Note: This function returns no hints on the reason why neurons are not voted nor if some were or are ineligible.
+ *
+ * @param {neurons; proposal;} params
+ * @param params.neurons The neurons to filter.
+ * @param params.proposal The proposal for which some neurons might have not voted.
+ */
 export const notVotedNeurons = ({
   neurons,
   proposal: { id: proposalId },

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -10,6 +10,7 @@ const nnsInputFiles = [
   "./packages/nns/src/token.ts",
   "./packages/nns/src/ledger.canister.ts",
   "./packages/nns/src/sns_wasm.canister.ts",
+  "./packages/nns/src/utils/neurons.utils.ts",
 ];
 
 const snsInputFiles = [


### PR DESCRIPTION
# Motivation

When the reward of a proposal has settled, we need to display in NNS-dapp the list of neurons that have not participated to the vote.

# Changes

- add a new function `notVotedNeurons` that does the contrary of `votedNeurons`
