### PR TITLE
Gix 1208 manage voting permissions

### DIFF
--- a/packages/sns/src/enums/governance.enums.ts
+++ b/packages/sns/src/enums/governance.enums.ts
@@ -39,4 +39,8 @@ export enum SnsNeuronPermissionType {
 
   // The principal has permission to stake the neuron's maturity.
   NEURON_PERMISSION_TYPE_STAKE_MATURITY = 9,
+
+  // The principal has permission to grant/revoke permission to vote and submit
+  // proposals on behalf of the neuron to other principals.
+  NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION = 10,
 }

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -177,6 +177,7 @@ export class SnsWrapper {
     controller: Principal
   ): Promise<{ account: SnsAccount; index: bigint }> => {
     // TODO: try parallilizing requests to improve performance
+    // OR use binary search https://dfinity.atlassian.net/browse/FOLLOW-825
     for (let index = 0; index < MAX_NEURONS_SUBACCOUNTS; index++) {
       const subaccount = neuronSubaccount({ index, controller });
 


### PR DESCRIPTION
# Motivation

Add new permission that is related to `hot keys` management. Having `ManagePrincipals` and `ManageVotingPermissions` is the only way to add or remove permissions.

[ic related PR](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/8748)

# Changes

- update permission type