### PR TITLE
GIX-1210: List Sns Proposals

### DIFF
--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -128,6 +128,7 @@ Parameters:
 
 - [create](#gear-create)
 - [listNeurons](#gear-listneurons)
+- [listProposals](#gear-listproposals)
 - [listNervousSystemFunctions](#gear-listnervoussystemfunctions)
 - [metadata](#gear-metadata)
 - [nervousSystemParameters](#gear-nervoussystemparameters)
@@ -167,6 +168,14 @@ List the neurons of the Sns
 | Method        | Type                                                  |
 | ------------- | ----------------------------------------------------- |
 | `listNeurons` | `(params: SnsListNeuronsParams) => Promise<Neuron[]>` |
+
+##### :gear: listProposals
+
+List the proposals of the Sns
+
+| Method          | Type                                                          |
+| --------------- | ------------------------------------------------------------- |
+| `listProposals` | `(params: SnsListProposalsParams) => Promise<ProposalData[]>` |
 
 ##### :gear: listNervousSystemFunctions
 
@@ -532,6 +541,7 @@ Parameters:
 #### Methods
 
 - [listNeurons](#gear-listneurons)
+- [listProposals](#gear-listproposals)
 - [listNervousSystemFunctions](#gear-listnervoussystemfunctions)
 - [metadata](#gear-metadata)
 - [nervousSystemParameters](#gear-nervoussystemparameters)
@@ -568,6 +578,12 @@ Parameters:
 | Method        | Type                                                                     |
 | ------------- | ------------------------------------------------------------------------ |
 | `listNeurons` | `(params: Omit<SnsListNeuronsParams, "certified">) => Promise<Neuron[]>` |
+
+##### :gear: listProposals
+
+| Method          | Type                                                                             |
+| --------------- | -------------------------------------------------------------------------------- |
+| `listProposals` | `(params: Omit<SnsListProposalsParams, "certified">) => Promise<ProposalData[]>` |
 
 ##### :gear: listNervousSystemFunctions
 

--- a/packages/sns/src/constants/governance.constants.ts
+++ b/packages/sns/src/constants/governance.constants.ts
@@ -5,3 +5,4 @@
  */
 export const MAX_LIST_NEURONS_RESULTS = 100;
 export const MAX_NEURONS_SUBACCOUNTS = 2 ** 16;
+export const DEFAULT_PROPOSALS_LIMIT = 10;

--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -1,14 +1,17 @@
 import { toNullable } from "@dfinity/utils";
 import type {
   Command,
+  ListProposals,
   ManageNeuron,
   NeuronId,
   Operation,
 } from "../../candid/sns_governance";
+import { DEFAULT_PROPOSALS_LIMIT } from "../constants/governance.constants";
 import type {
   SnsClaimOrRefreshArgs,
   SnsDisburseNeuronParams,
   SnsIncreaseDissolveDelayParams,
+  SnsListProposalsParams,
   SnsNeuronAutoStakeMaturityParams,
   SnsNeuronPermissionsParams,
   SnsNeuronStakeMaturityParams,
@@ -217,4 +220,18 @@ export const toClaimOrRefreshRequest = ({
       },
     },
   ],
+});
+
+export const toListProposalRequest = ({
+  excludeType,
+  beforeProposal,
+  includeRewardStatus,
+  includeStatus,
+  limit,
+}: SnsListProposalsParams): ListProposals => ({
+  exclude_type: BigUint64Array.from(excludeType ?? []),
+  before_proposal: toNullable(beforeProposal),
+  include_reward_status: Int32Array.from(includeRewardStatus ?? []),
+  include_status: Int32Array.from(includeStatus ?? []),
+  limit: limit ?? DEFAULT_PROPOSALS_LIMIT,
 });

--- a/packages/sns/src/enums/governance.enums.ts
+++ b/packages/sns/src/enums/governance.enums.ts
@@ -44,3 +44,42 @@ export enum SnsNeuronPermissionType {
   // proposals on behalf of the neuron to other principals.
   NEURON_PERMISSION_TYPE_MANAGE_VOTING_PERMISSION = 10,
 }
+
+export enum SnsProposalRewardStatus {
+  PROPOSAL_REWARD_STATUS_UNSPECIFIED = 0,
+
+  // The proposal still accepts votes, for the purpose of
+  // voting rewards. This implies nothing on the
+  // ProposalDecisionStatus, i.e., a proposal can be decided
+  // due to an absolute majority being in favor or against it,
+  // but other neuron holders can still cast their vote to get rewards.
+  PROPOSAL_REWARD_STATUS_ACCEPT_VOTES = 1,
+
+  // The proposal no longer accepts votes. It is due to settle
+  // rewards at the next reward event.
+  PROPOSAL_REWARD_STATUS_READY_TO_SETTLE = 2,
+
+  // The proposal has been taken into account in a reward event, i.e.,
+  // the associated rewards have been settled.
+  PROPOSAL_REWARD_STATUS_SETTLED = 3,
+}
+
+export enum SnsProposalDecisionStatus {
+  PROPOSAL_DECISION_STATUS_UNSPECIFIED = 0,
+
+  // The proposal is open for voting and a decision (adopt/reject) has yet to be made.
+  PROPOSAL_DECISION_STATUS_OPEN = 1,
+
+  // The proposal has been rejected.
+  PROPOSAL_DECISION_STATUS_REJECTED = 2,
+
+  // The proposal has been adopted but either execution has not yet started
+  // or it has started but its outcome is not yet known.
+  PROPOSAL_DECISION_STATUS_ADOPTED = 3,
+
+  // The proposal was adopted and successfully executed.
+  PROPOSAL_DECISION_STATUS_EXECUTED = 4,
+
+  // The proposal was adopted, but execution failed.
+  PROPOSAL_DECISION_STATUS_FAILED = 5,
+}

--- a/packages/sns/src/governance.canister.ts
+++ b/packages/sns/src/governance.canister.ts
@@ -9,6 +9,7 @@ import type {
   NervousSystemParameters,
   Neuron,
   NeuronId,
+  ProposalData,
   SplitResponse,
   _SERVICE as SnsGovernanceService,
 } from "../candid/sns_governance";
@@ -22,6 +23,7 @@ import {
   toDisburseNeuronRequest,
   toFollowRequest,
   toIncreaseDissolveDelayRequest,
+  toListProposalRequest,
   toRemovePermissionsRequest,
   toSetDissolveTimestampRequest,
   toSplitNeuronRequest,
@@ -38,6 +40,7 @@ import type {
   SnsGetNeuronParams,
   SnsIncreaseDissolveDelayParams,
   SnsListNeuronsParams,
+  SnsListProposalsParams,
   SnsNeuronAutoStakeMaturityParams,
   SnsNeuronPermissionsParams,
   SnsNeuronStakeMaturityParams,
@@ -76,6 +79,20 @@ export class SnsGovernanceCanister extends Canister<SnsGovernanceService> {
       start_page_at: toNullable<NeuronId>(beforeNeuronId),
     });
     return neurons;
+  };
+
+  /**
+   * List the proposals of the Sns
+   */
+  listProposals = async (
+    params: SnsListProposalsParams
+  ): Promise<ProposalData[]> => {
+    const { certified } = params;
+
+    const { proposals } = await this.caller({ certified }).list_proposals(
+      toListProposalRequest(params)
+    );
+    return proposals;
   };
 
   /**

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -11,6 +11,7 @@ export type {
   NervousSystemParameters,
   Neuron as SnsNeuron,
   NeuronId as SnsNeuronId,
+  ProposalData as SnsProposalData,
 } from "../candid/sns_governance";
 export type {
   Transaction as SnsTransaction,

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -3,6 +3,8 @@ export type {
   TransferError as SnsTransferVariatError,
 } from "../candid/icrc1_ledger";
 export type {
+  Action as SnsAction,
+  Ballot as SnsBallot,
   GetMetadataResponse as SnsGetMetadataResponse,
   ListNervousSystemFunctionsResponse as SnsListNervousSystemFunctionsResponse,
   ManageNeuron as SnsManageNeuron,
@@ -12,6 +14,8 @@ export type {
   Neuron as SnsNeuron,
   NeuronId as SnsNeuronId,
   ProposalData as SnsProposalData,
+  ProposalId as SnsProposalId,
+  Tally as SnsTally,
 } from "../candid/sns_governance";
 export type {
   Transaction as SnsTransaction,

--- a/packages/sns/src/mocks/governance.mock.ts
+++ b/packages/sns/src/mocks/governance.mock.ts
@@ -3,6 +3,7 @@ import type {
   GetMetadataResponse,
   Neuron,
   NeuronId,
+  ProposalData,
 } from "../../candid/sns_governance";
 
 export const neuronIdMock: NeuronId = { id: arrayOfNumberToUint8Array([1]) };
@@ -19,3 +20,9 @@ export const metadataMock: GetMetadataResponse = {
   name: ["My project"],
   description: ["Web3 for the win"],
 };
+
+export const proposalMock = {
+  id: [{ id: BigInt(12) }],
+} as ProposalData;
+
+export const proposalsMock: ProposalData[] = [proposalMock];

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -85,6 +85,17 @@ describe("SnsWrapper", () => {
     });
   });
 
+  it("should call list of proposals with query or update", async () => {
+    await snsWrapper.listProposals({});
+    expect(mockGovernanceCanister.listProposals).toHaveBeenCalledWith({
+      certified: false,
+    });
+    await certifiedSnsWrapper.listProposals({});
+    expect(mockCertifiedGovernanceCanister.listProposals).toHaveBeenCalledWith({
+      certified: true,
+    });
+  });
+
   it("should call list of nervous system functions with query or update", async () => {
     await snsWrapper.listNervousSystemFunctions({});
     expect(

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -7,6 +7,7 @@ import type {
   NervousSystemParameters,
   Neuron,
   NeuronId,
+  ProposalData,
 } from "../candid/sns_governance";
 import type { GetTransactions } from "../candid/sns_index";
 import type {
@@ -29,6 +30,7 @@ import type {
   SnsIncreaseDissolveDelayParams,
   SnsIncreaseStakeNeuronParams,
   SnsListNeuronsParams,
+  SnsListProposalsParams,
   SnsNeuronAutoStakeMaturityParams,
   SnsNeuronPermissionsParams,
   SnsNeuronStakeMaturityParams,
@@ -114,6 +116,11 @@ export class SnsWrapper {
   listNeurons = (
     params: Omit<SnsListNeuronsParams, "certified">
   ): Promise<Neuron[]> => this.governance.listNeurons(this.mergeParams(params));
+
+  listProposals = (
+    params: Omit<SnsListProposalsParams, "certified">
+  ): Promise<ProposalData[]> =>
+    this.governance.listProposals(this.mergeParams(params));
 
   listNervousSystemFunctions = (
     params: Omit<QueryParams, "certified">

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -2,9 +2,9 @@ import type { Principal } from "@dfinity/principal";
 import type { Subaccount, Tokens } from "../../candid/icrc1_ledger";
 import type { NeuronId, ProposalId } from "../../candid/sns_governance";
 import type {
-  ProposalDecisionStatus,
-  ProposalRewardStatus,
   SnsNeuronPermissionType,
+  SnsProposalDecisionStatus,
+  SnsProposalRewardStatus,
 } from "../enums/governance.enums";
 import type { E8s } from "./common";
 import type { SnsAccount } from "./ledger.responses";
@@ -30,7 +30,7 @@ export interface SnsListProposalsParams extends QueryParams {
   // that have one of the define reward statuses should be included
   // in the list.
   // If this list is empty, no restriction is applied.
-  includeRewardStatus?: ProposalRewardStatus[];
+  includeRewardStatus?: SnsProposalRewardStatus[];
   // The proposal ID specifying which proposals to return.
   // This should be set to the last proposal of the previously returned page and
   // will not be included in the current page.
@@ -45,7 +45,7 @@ export interface SnsListProposalsParams extends QueryParams {
   // that have one of the define decision statuses should be included
   // in the list.
   // If this list is empty, no restriction is applied.
-  includeStatus?: ProposalDecisionStatus[];
+  includeStatus?: SnsProposalDecisionStatus[];
 }
 
 /**

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -1,7 +1,11 @@
 import type { Principal } from "@dfinity/principal";
 import type { Subaccount, Tokens } from "../../candid/icrc1_ledger";
-import type { NeuronId } from "../../candid/sns_governance";
-import type { SnsNeuronPermissionType } from "../enums/governance.enums";
+import type { NeuronId, ProposalId } from "../../candid/sns_governance";
+import type {
+  ProposalDecisionStatus,
+  ProposalRewardStatus,
+  SnsNeuronPermissionType,
+} from "../enums/governance.enums";
 import type { E8s } from "./common";
 import type { SnsAccount } from "./ledger.responses";
 import type { QueryParams } from "./query.params";
@@ -16,6 +20,32 @@ export interface SnsListNeuronsParams extends QueryParams {
   limit?: number;
   /** Index the search to returns a list that starts after specified neuron id */
   beforeNeuronId?: NeuronId;
+}
+
+/**
+ * The parameters available to list Sns proposals
+ */
+export interface SnsListProposalsParams extends QueryParams {
+  // A list of proposal reward statuses, specifying that only proposals that
+  // that have one of the define reward statuses should be included
+  // in the list.
+  // If this list is empty, no restriction is applied.
+  includeRewardStatus?: ProposalRewardStatus[];
+  // The proposal ID specifying which proposals to return.
+  // This should be set to the last proposal of the previously returned page and
+  // will not be included in the current page.
+  beforeProposal?: ProposalId;
+  // Limit the number of Proposals returned in each page, from 1 to 100.
+  // If a value outside of this range is provided, 100 will be used.
+  limit?: number;
+  // A list of proposal types, specifying that proposals of the given
+  // types should be excluded in this list.
+  excludeType?: bigint[];
+  // A list of proposal decision statuses, specifying that only proposals that
+  // that have one of the define decision statuses should be included
+  // in the list.
+  // If this list is empty, no restriction is applied.
+  includeStatus?: ProposalDecisionStatus[];
 }
 
 /**


### PR DESCRIPTION
# Motivation

Add method in SNS Governance to fetch proposals.

# Changes

* Add "listProposals" to SNS Governance which calls "list_proposals".
* Add two new SNS enums: SnsProposalRewardStatus and SnsProposalDecisionStatus.
* Add "listProposals" to SNS Wrapper.
* New converter toListProposalRequest.

# Tests

* Add tests for new listProposals method in SNS Governance and Wrapper.
