### PR TITLE
Feat: Add createAt param for NNS Transfers

### DIFF
--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -439,9 +439,9 @@ Parameters:
 
 ##### :gear: stakeNeuron
 
-| Method        | Type                                                                                                                                                                              |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `stakeNeuron` | `({ stake, principal, fromSubAccount, ledgerCanister, }: { stake: bigint; principal: Principal; fromSubAccount?: number[]; ledgerCanister: LedgerCanister; }) => Promise<bigint>` |
+| Method        | Type                                                                                                                                                                                                             |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stakeNeuron` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, }: { stake: bigint; principal: Principal; fromSubAccount?: number[]; ledgerCanister: LedgerCanister; createdAt?: bigint; }) => Promise<bigint>` |
 
 ##### :gear: increaseDissolveDelay
 

--- a/packages/nns/src/canisters/ledger/ledger.request.converts.ts
+++ b/packages/nns/src/canisters/ledger/ledger.request.converts.ts
@@ -30,13 +30,15 @@ export const toTransferRawRequest = ({
   memo,
   fee,
   fromSubAccount,
+  createdAt,
 }: TransferRequest): TransferRawRequest => ({
   to: to.toUint8Array(),
   fee: e8sToTokens(fee ?? TRANSACTION_FEE),
   amount: e8sToTokens(amount),
   // Always explicitly set the memo for compatibility with ledger wallet - hardware wallet
   memo: memo ?? BigInt(0),
-  created_at_time: [],
+  created_at_time:
+    createdAt !== undefined ? [{ timestamp_nanos: createdAt }] : [],
   from_subaccount:
     fromSubAccount === undefined
       ? []

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -227,11 +227,15 @@ export class GovernanceCanister {
     principal,
     fromSubAccount,
     ledgerCanister,
+    createdAt,
   }: {
     stake: bigint;
     principal: Principal;
     fromSubAccount?: number[];
     ledgerCanister: LedgerCanister;
+    // Used for the TransferRequest parameters.
+    // Check the TransferRequest type for more information.
+    createdAt?: bigint;
   }): Promise<NeuronId> => {
     if (stake < E8S_PER_TOKEN) {
       throw new InsufficientAmountError(stake);
@@ -251,6 +255,7 @@ export class GovernanceCanister {
       amount: stake,
       fromSubAccount,
       to: accountIdentifier,
+      createdAt,
     });
 
     // Notify the governance of the transaction so that the neuron is created.

--- a/packages/nns/src/ledger.canister.spec.ts
+++ b/packages/nns/src/ledger.canister.spec.ts
@@ -197,6 +197,39 @@ describe("LedgerCanister", () => {
         });
       });
 
+      it("handles createdAt parameter", async () => {
+        const service = mock<ActorSubclass<LedgerService>>();
+        service.transfer.mockResolvedValue({
+          Ok: BigInt(1234),
+        });
+        const fee = BigInt(10_000);
+        const memo = BigInt(3456);
+        const ledger = LedgerCanister.create({
+          certifiedServiceOverride: service,
+        });
+        const createdAt = BigInt(123132223);
+        await ledger.transfer({
+          to,
+          amount,
+          fee,
+          memo,
+          createdAt,
+        });
+
+        expect(service.transfer).toBeCalledWith({
+          to: to.toUint8Array(),
+          fee: {
+            e8s: fee,
+          },
+          amount: {
+            e8s: amount,
+          },
+          memo,
+          created_at_time: [{ timestamp_nanos: createdAt }],
+          from_subaccount: [],
+        });
+      });
+
       it("handles subaccount", async () => {
         const service = mock<ActorSubclass<LedgerService>>();
         service.transfer.mockResolvedValue({

--- a/packages/nns/src/ledger.canister.ts
+++ b/packages/nns/src/ledger.canister.ts
@@ -11,6 +11,7 @@ import {
   Memo,
   Payment,
   SendRequest,
+  TimeStamp,
 } from "../proto/ledger_pb";
 import type { AccountIdentifier } from "./account_identifier";
 import {
@@ -161,6 +162,7 @@ export class LedgerCanister {
     memo,
     fee,
     fromSubAccount,
+    createdAt,
   }: TransferRequest): Promise<BlockHeight> => {
     const request = new SendRequest();
     request.setTo(to.toProto());
@@ -175,6 +177,12 @@ export class LedgerCanister {
     const requestMemo: Memo = new Memo();
     requestMemo.setMemo((memo ?? BigInt(0)).toString());
     request.setMemo(requestMemo);
+
+    if (createdAt !== undefined) {
+      const timestamp = new TimeStamp();
+      timestamp.setTimestampNanos(createdAt.toString());
+      request.setCreatedAtTime(timestamp);
+    }
 
     if (fromSubAccount !== undefined) {
       request.setFromSubaccount(subAccountNumbersToSubaccount(fromSubAccount));

--- a/packages/nns/src/types/ledger_converters.ts
+++ b/packages/nns/src/types/ledger_converters.ts
@@ -8,4 +8,6 @@ export type TransferRequest = {
   fee?: E8s;
   // TODO: If didc is updated in nns-dapp as well, this array of number will become a Uint8Array
   fromSubAccount?: number[];
+  // In nanoseconds
+  createdAt?: bigint;
 };

--- a/packages/nns/src/types/ledger_converters.ts
+++ b/packages/nns/src/types/ledger_converters.ts
@@ -8,6 +8,8 @@ export type TransferRequest = {
   fee?: E8s;
   // TODO: If didc is updated in nns-dapp as well, this array of number will become a Uint8Array
   fromSubAccount?: number[];
-  // In nanoseconds
+  // Nanoseconds since unix epoc to trigger deduplication and avoid other issues
+  // See the link for more details on deduplication
+  // https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#transaction_deduplication
   createdAt?: bigint;
 };

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -665,9 +665,9 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 
 ⚠️ This feature is provided as it without warranty. It does not implement any additional checks of the validity of the payment flow - e.g. it does not handle refund nor retries claiming the neuron in case of errors.
 
-| Method        | Type                                                                             |
-| ------------- | -------------------------------------------------------------------------------- |
-| `stakeNeuron` | `({ stakeE8s, source, controller, }: SnsStakeNeuronParams) => Promise<NeuronId>` |
+| Method        | Type                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------- |
+| `stakeNeuron` | `({ stakeE8s, source, controller, createdAt, }: SnsStakeNeuronParams) => Promise<NeuronId>` |
 
 ##### :gear: increaseStakeNeuron
 

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -231,6 +231,7 @@ export class SnsWrapper {
     stakeE8s,
     source,
     controller,
+    createdAt,
   }: SnsStakeNeuronParams): Promise<NeuronId> => {
     this.assertCertified("stakeNeuron");
     const { account: neuronAccount, index } = await this.nextNeuronAccount(
@@ -250,6 +251,7 @@ export class SnsWrapper {
       },
       from_subaccount: source.subaccount,
       memo: bigIntToUint8Array(index),
+      created_at_time: createdAt,
     });
     return this.governance.claimNeuron({
       memo: BigInt(index),

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -59,6 +59,8 @@ export interface SnsStakeNeuronParams extends Omit<QueryParams, "certified"> {
   stakeE8s: Tokens;
   source: SnsAccount;
   controller: Principal;
+  // Same as createdAt from ledger's TransferParams
+  createdAt?: bigint;
 }
 
 export interface SnsIncreaseStakeNeuronParams

--- a/packages/sns/src/types/ledger.params.ts
+++ b/packages/sns/src/types/ledger.params.ts
@@ -23,7 +23,8 @@ export interface BalanceParams extends QueryParams {
  * @param {Subaccount?} from_subaccount The subaccount to transfer tokens to.
  * @param {Uint8Array?} memo Transfer memo.
  * @param {Timestamp?} created_at_time nanoseconds since unix epoc to trigger deduplication and avoid other issues
- * See the link for more details on deduplication: https://github.com/dfinity/ICRC-1#transaction-deduplication-
+ * See the link for more details on deduplication
+ * https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#transaction_deduplication
  * @param {Tokens?} fee The fee of the transfer when it's not the default fee.
  */
 export interface TransferParams {


### PR DESCRIPTION
# Motivation

Add optional param createdAt in NNS Transfers.

This parameter is used in the NNS Ledger to identify duplicated transactions. Without it, two transfers with the same params from the same caller would be considered as two different transactions. This could happen if agent-js or the client retries the request.

If the request has the createdAt set and agent-js retries the call, the Ledger canister will consider it as a duplicated and not perform the transaction twice.

# Changes

* Add createdAt optional param to `TransferRequest` type.
* Handle the new param in transferHardwareWallet.
* Handle the new param in toTransferRawRequest.

# Tests

* Add a test to check that the new param is added in the request.
