### PR TITLE
Chore: Support account to in sns disburse

### DIFF
--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -1,5 +1,6 @@
 import { toNullable } from "@dfinity/utils";
 import type {
+  Account,
   Command,
   ListProposals,
   ManageNeuron,
@@ -19,6 +20,7 @@ import type {
   SnsSetTopicFollowees,
   SnsSplitNeuronParams,
 } from "../types/governance.params";
+import type { SnsAccount } from "../types/ledger.responses";
 
 // Helper for building `ManageNeuron` structure
 const toManageNeuronCommand = ({
@@ -48,6 +50,14 @@ const toManageNeuronConfigureCommand = ({
       },
     },
   });
+
+export const toCandidAccount = ({
+  owner,
+  subaccount,
+}: SnsAccount): Account => ({
+  owner: toNullable(owner),
+  subaccount: subaccount === undefined ? [] : toNullable({ subaccount }),
+});
 
 export const toAddPermissionsRequest = ({
   neuronId,
@@ -97,13 +107,15 @@ export const toSplitNeuronRequest = ({
 export const toDisburseNeuronRequest = ({
   neuronId,
   amount,
+  toAccount,
 }: SnsDisburseNeuronParams): ManageNeuron =>
   toManageNeuronCommand({
     neuronId,
     command: {
       Disburse: {
         // currently there is a main account only support
-        to_account: [],
+        to_account:
+          toAccount === undefined ? [] : toNullable(toCandidAccount(toAccount)),
         amount:
           amount === undefined
             ? []

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_PROPOSALS_LIMIT,
   MAX_LIST_NEURONS_RESULTS,
 } from "./constants/governance.constants";
+import { toCandidAccount } from "./converters/governance.converters";
 import {
   SnsNeuronPermissionType,
   SnsProposalDecisionStatus,
@@ -520,11 +521,16 @@ describe("Governance canister", () => {
   });
 
   describe("disburse", () => {
+    const toAccount = {
+      owner: Principal.fromText("aaaaa-aa"),
+      subaccount: arrayOfNumberToUint8Array([0, 0, 1]),
+    };
     const params: SnsDisburseNeuronParams = {
       neuronId: {
         id: arrayOfNumberToUint8Array([1, 2, 3]),
       },
       amount: BigInt(321),
+      toAccount,
     };
 
     it("should disburse the neuron", async () => {
@@ -533,7 +539,7 @@ describe("Governance canister", () => {
         command: [
           {
             Disburse: {
-              to_account: [],
+              to_account: [toCandidAccount(toAccount)],
               amount: [
                 {
                   e8s: params.amount as bigint,

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -112,6 +112,7 @@ export interface SnsSplitNeuronParams extends SnsNeuronManagementParams {
  */
 export interface SnsDisburseNeuronParams extends SnsNeuronManagementParams {
   amount?: E8s;
+  toAccount?: SnsAccount;
 }
 
 /**


### PR DESCRIPTION
# Motivation

Add support for the param `to_account` when disbursing SNS neuron.

This is not used in the nns-dapp.

# Changes

* Add optional toAccount in SnsDisburseNeuronParams
* Add support for the extra param in toDisburseNeuronRequest
* Add new converter toCandidAccount in governance.converters. The toCandidAccount in ledger.converters can't be used because the Account type in governance and ledger canisters are different.

# Tests

* Extend current test case to check that toAccount is used.
