### PR TITLE
Chore lm enable merge neurons candid

### DIFF
--- a/packages/nns/src/canisters/governance/request.proto.converters.ts
+++ b/packages/nns/src/canisters/governance/request.proto.converters.ts
@@ -11,7 +11,6 @@ import type {
   DisburseRequest,
   FollowRequest,
   MergeMaturityRequest,
-  MergeRequest,
   RemoveHotKeyRequest,
   SpawnRequest,
 } from "../../types/governance_converters";
@@ -200,19 +199,6 @@ export const fromSpawnRequest = (request: SpawnRequest): PbManageNeuron => {
   const neuronId = new PbNeuronId();
   neuronId.setId(request.neuronId.toString());
   manageNeuron.setNeuronId(neuronId);
-  return manageNeuron;
-};
-
-export const fromMergeRequest = (request: MergeRequest): PbManageNeuron => {
-  const merge = new PbManageNeuron.Merge();
-  const sourceNeuronId = new PbNeuronId();
-  sourceNeuronId.setId(request.sourceNeuronId.toString());
-  merge.setSourceNeuronId(sourceNeuronId);
-  const manageNeuron = new PbManageNeuron();
-  const neuronId = new PbNeuronId();
-  neuronId.setId(request.targetNeuronId.toString());
-  manageNeuron.setNeuronId(neuronId);
-  manageNeuron.setMerge(merge);
   return manageNeuron;
 };
 

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -1009,25 +1009,6 @@ describe("GovernanceCanister", () => {
       expect(service.manage_neuron).toBeCalled();
     });
 
-    it("successfully merges two neurons from Hardware Wallet", async () => {
-      const agent = mock<Agent>();
-      agent.call.mockResolvedValue(agentCallSuccessfulResponse);
-
-      const governance = GovernanceCanister.create({
-        agent,
-        hardwareWallet: true,
-      });
-
-      const sourceNeuronId = BigInt(10);
-      const targetNeuronId = BigInt(13);
-      await governance.mergeNeurons({
-        sourceNeuronId,
-        targetNeuronId,
-      });
-      expect(agent.call).toBeCalled();
-      expect(spyPollForResponse).toBeCalled();
-    });
-
     it("throws error if response is error", async () => {
       const sourceNeuronId = BigInt(10);
       const targetNeuronId = BigInt(13);

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -51,7 +51,6 @@ import {
   fromDisburseRequest,
   fromIncreaseDissolveDelayRequest,
   fromMergeMaturityRequest,
-  fromMergeRequest,
   fromRemoveHotKeyRequest,
   fromSpawnRequest,
   fromStartDissolvingRequest,
@@ -90,7 +89,6 @@ import type {
   ListProposalsResponse,
   MakeProposalRequest,
   MergeMaturityRequest,
-  MergeRequest,
   NeuronInfo,
   ProposalId,
   ProposalInfo,
@@ -976,12 +974,5 @@ export class GovernanceCanister {
     throw new UnrecognizedTypeError(
       `Unrecognized Spawn error in ${JSON.stringify(response)}`
     );
-  };
-
-  private mergeNeuronsHardwareWallet = async (
-    request: MergeRequest
-  ): Promise<void> => {
-    const rawRequest = fromMergeRequest(request);
-    await this.manageNeuronUpdateCall(rawRequest);
   };
 }

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -446,9 +446,6 @@ export class GovernanceCanister {
     sourceNeuronId: NeuronId;
     targetNeuronId: NeuronId;
   }): Promise<void> => {
-    if (this.hardwareWallet) {
-      return this.mergeNeuronsHardwareWallet(request);
-    }
     const rawRequest = toMergeRequest(request);
 
     return manageNeuron({


### PR DESCRIPTION
# Motivation

Enable merge neurons for HW controlled neurons

# Changes

* Support for merge neurons is in candid. Remove the redirection to the proto method.

# Tests

* Remove unnecessary test case.
