### PR TITLE
Chore: Add fee as param in SNS Stake neuron

### DIFF
--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -558,9 +558,9 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 
 ⚠️ This feature is provided as it without warranty. It does not implement any additional checks of the validity of the payment flow - e.g. it does not handle refund nor retries claiming the neuron in case of errors.
 
-| Method        | Type                                                                                        |
-| ------------- | ------------------------------------------------------------------------------------------- |
-| `stakeNeuron` | `({ stakeE8s, source, controller, createdAt, }: SnsStakeNeuronParams) => Promise<NeuronId>` |
+| Method        | Type                                                                                             |
+| ------------- | ------------------------------------------------------------------------------------------------ |
+| `stakeNeuron` | `({ stakeE8s, source, controller, createdAt, fee, }: SnsStakeNeuronParams) => Promise<NeuronId>` |
 
 ##### :gear: increaseStakeNeuron
 

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -557,7 +557,7 @@ describe("SnsWrapper", () => {
 
         afterEach(() => jest.clearAllMocks());
 
-        it("should check balances with query call until one with 0 is found", async () => {
+        it("should check whether neuron exists with that account until one with no neuron is found", async () => {
           mockCertifiedGovernanceCanister.queryNeuron
             .mockResolvedValueOnce(neuronMock)
             .mockResolvedValueOnce(neuronMock)
@@ -567,6 +567,7 @@ describe("SnsWrapper", () => {
             stakeE8s,
             source: mockSnsAccount,
             controller: mockPrincipal,
+            fee: BigInt(10_000),
           });
 
           expect(
@@ -590,7 +591,7 @@ describe("SnsWrapper", () => {
           ).toBe(true);
         });
 
-        it("should check with update when 0 is found and continue if that is not 0", async () => {
+        it("should check query neuron with update when one is found", async () => {
           mockCertifiedGovernanceCanister.queryNeuron
             .mockResolvedValueOnce(neuronMock)
             .mockResolvedValueOnce(neuronMock)

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -242,6 +242,7 @@ export class SnsWrapper {
     source,
     controller,
     createdAt,
+    fee,
   }: SnsStakeNeuronParams): Promise<NeuronId> => {
     this.assertCertified("stakeNeuron");
     const { account: neuronAccount, index } = await this.nextNeuronAccount(
@@ -262,6 +263,7 @@ export class SnsWrapper {
       from_subaccount: source.subaccount,
       memo: bigIntToUint8Array(index),
       created_at_time: createdAt,
+      fee,
     });
     return this.governance.claimNeuron({
       memo: BigInt(index),

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -67,6 +67,7 @@ export interface SnsStakeNeuronParams extends Omit<QueryParams, "certified"> {
   controller: Principal;
   // Same as createdAt from ledger's TransferParams
   createdAt?: bigint;
+  fee?: bigint;
 }
 
 export interface SnsIncreaseStakeNeuronParams


### PR DESCRIPTION
# Motivation

Expose the optional para fee of SNS transactions also when staking SNS neuron.

# Changes

* Add "fee" in SnsStakeNeuronParams.

# Tests

* Add param in one test.
* Rewrite the description of some tests to make more concise what they are testing.
