### PR TITLE
Fix: Encode ICRC-1 accounts

### DIFF
--- a/packages/ledger/src/utils/ledger.utils.spec.ts
+++ b/packages/ledger/src/utils/ledger.utils.spec.ts
@@ -26,7 +26,7 @@ describe("ledger-utils", () => {
         subaccount: subaccount,
       };
       expect(encodeIcrcAccount(account)).toEqual(
-        Principal.fromHex("040101ff").toText()
+        Principal.fromText("ozcx7-eaeae-ax6").toText()
       );
     });
   });
@@ -48,18 +48,18 @@ describe("ledger-utils", () => {
     });
 
     it("should raise an error if incorrect subaccount", () => {
-      const call1 = () => decodeIcrcAccount(Principal.fromHex("ff").toText());
+      const call1 = () => decodeIcrcAccount(Principal.fromHex("7f").toText());
       expect(call1).toThrow();
 
       const call2 = () =>
-        decodeIcrcAccount(Principal.fromHex("040001ff").toText());
+        decodeIcrcAccount(Principal.fromHex("0400017f").toText());
       expect(call2).toThrow();
 
       const call3 = () =>
-        decodeIcrcAccount(Principal.fromHex("040103ff").toText());
+        decodeIcrcAccount(Principal.fromHex("0401037f").toText());
       expect(call3).toThrow();
 
-      const call4 = () => decodeIcrcAccount(Principal.fromHex("00ff").toText());
+      const call4 = () => decodeIcrcAccount(Principal.fromHex("007f").toText());
       expect(call4).toThrow();
     });
   });

--- a/packages/ledger/src/utils/ledger.utils.ts
+++ b/packages/ledger/src/utils/ledger.utils.ts
@@ -2,7 +2,7 @@ import { Principal } from "@dfinity/principal";
 import type { IcrcAccount } from "../types/ledger.responses";
 
 // https://github.com/dfinity/ICRC-1/pull/55/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R236
-const EXTRA_BYTES = parseInt("FF", 16);
+const EXTRA_BYTES = parseInt("7F", 16);
 const MAX_ACCOUNT_BYTES_LENGTH = 32;
 
 /**
@@ -61,11 +61,11 @@ export const encodeIcrcAccount = ({
 export const decodeIcrcAccount = (accountString: string): IcrcAccount => {
   const principal = Principal.fromText(accountString);
 
-  const [ff, nonZeroLength, ...restReversed] = principal
+  const [extraBytes, nonZeroLength, ...restReversed] = principal
     .toUint8Array()
     .reverse();
 
-  if (ff !== EXTRA_BYTES) {
+  if (extraBytes !== EXTRA_BYTES) {
     return {
       owner: Principal.fromText(accountString),
     };


### PR DESCRIPTION
# Motivation

There was a bug with the encoding and decoding of ICRC-1 accounts when it involved subaccounts.

# Changes

* Change the extra bytes when encoding and decoding ICRC-1 accounts.

# Tests

* Adapt tests.
