### PR TITLE
feat: export a constant for the Icrc1 metadata logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@
 - ledger `v0.0.5`
 - utils `v0.0.12`
 
-## Build
+### Features
+
+- export a constant for the Icrc1 metadata logo
+
+### Build
 
 - fix `utils` as peer dependency for `cmc`
 
@@ -22,12 +26,12 @@
 - ledger `v0.0.4`
 - utils `v0.0.11`
 
-## Features
+### Features
 
 - add fee as param in SNS Stake neuron
 - extend `NnsFunction` enum with `InsertSnsWasmUpgradePathEntries`
 
-## Fix
+### Fix
 
 - encode ICRC-1 accounts
 
@@ -41,7 +45,7 @@
 - ledger `v0.0.3`
 - utils `v0.0.10`
 
-## Fix
+### Fix
 
 - `utils` was wrongly referenced as a dependency instead of peer-dependency in last release of `cmc`
 

--- a/packages/ledger/src/mocks/ledger.mock.ts
+++ b/packages/ledger/src/mocks/ledger.mock.ts
@@ -10,6 +10,10 @@ export const tokeMetadataResponseMock: [
   [IcrcMetadataResponseEntries.NAME, { Text: "Beta Test" }],
   [IcrcMetadataResponseEntries.SYMBOL, { Text: "BTA" }],
   [IcrcMetadataResponseEntries.FEE, { Nat: BigInt(1000) }],
+  [
+    IcrcMetadataResponseEntries.LOGO,
+    { Text: "data:image/svg+xml;base64,PHN2ZyB3aW..." },
+  ],
 ];
 
 export const mockPrincipalText =

--- a/packages/ledger/src/types/ledger.responses.ts
+++ b/packages/ledger/src/types/ledger.responses.ts
@@ -7,6 +7,7 @@ export enum IcrcMetadataResponseEntries {
   NAME = "icrc1:name",
   DECIMALS = "icrc1:decimals",
   FEE = "icrc1:fee",
+  LOGO = "icrc1:logo",
 }
 
 export type IcrcTokenMetadataResponse = [


### PR DESCRIPTION
# Motivation

As for other metadata, expose a constant for the Icrc1 metadata LOGO as well.