### PR TITLE
GIX-1284: New Sale lifecycle and proposal param

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ic-js
 
-A collection of library for interfacing with the Internet Computer
+A collection of library for interfacing with the Internet Computer.
 
 The libraries are still in active development, and new features will incrementally be available.
 

--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -59,6 +59,12 @@ const btcAddress = await getBtcAddress({});
 
 `public`
 
+Parameters:
+
+- `id`
+- `service`
+- `certifiedService`
+
 #### Methods
 
 - [create](#gear-create)

--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -59,12 +59,6 @@ const btcAddress = await getBtcAddress({});
 
 `public`
 
-Parameters:
-
-- `id`
-- `service`
-- `certifiedService`
-
 #### Methods
 
 - [create](#gear-create)

--- a/packages/ledger/README.md
+++ b/packages/ledger/README.md
@@ -91,6 +91,12 @@ Parameters:
 
 `public`
 
+Parameters:
+
+- `id`
+- `service`
+- `certifiedService`
+
 #### Methods
 
 - [create](#gear-create)
@@ -150,6 +156,12 @@ Parameters:
 #### Constructors
 
 `public`
+
+Parameters:
+
+- `id`
+- `service`
+- `certifiedService`
 
 #### Methods
 

--- a/packages/ledger/README.md
+++ b/packages/ledger/README.md
@@ -91,12 +91,6 @@ Parameters:
 
 `public`
 
-Parameters:
-
-- `id`
-- `service`
-- `certifiedService`
-
 #### Methods
 
 - [create](#gear-create)
@@ -156,12 +150,6 @@ Parameters:
 #### Constructors
 
 `public`
-
-Parameters:
-
-- `id`
-- `service`
-- `certifiedService`
 
 #### Methods
 

--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit c9b2f9653afc2da47e5bd527c192090b860acbf0 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit 5376a14c92f20b4bd285d7622ac5f2a8d21c0d02 'rs/nns/gtc/canister/gtc.did' by import-candid
 type AccountState = record {
   authenticated_principal_id : opt principal;
   successfully_transferred_neurons : vec TransferredNeuron;

--- a/packages/nns/candid/governance.certified.idl.js
+++ b/packages/nns/candid/governance.certified.idl.js
@@ -40,6 +40,7 @@ export const idlFactory = ({ IDL }) => {
     'community_fund_total_maturity_e8s_equivalent' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
     'not_dissolving_neurons_count' : IDL.Nat64,
+    'total_locked_e8s' : IDL.Nat64,
     'dissolved_neurons_e8s' : IDL.Nat64,
     'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
     'dissolving_neurons_count_buckets' : IDL.Vec(
@@ -90,20 +91,37 @@ export const idlFactory = ({ IDL }) => {
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
   const Ballot = IDL.Record({ 'vote' : IDL.Int32, 'voting_power' : IDL.Nat64 });
+  const CanisterStatusResultV2 = IDL.Record({
+    'status' : IDL.Opt(IDL.Int32),
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'controllers' : IDL.Vec(IDL.Principal),
+    'memory_size' : IDL.Opt(IDL.Nat64),
+    'cycles' : IDL.Opt(IDL.Nat64),
+    'idle_cycles_burned_per_day' : IDL.Opt(IDL.Nat64),
+    'module_hash' : IDL.Vec(IDL.Nat8),
+  });
+  const CanisterSummary = IDL.Record({
+    'status' : IDL.Opt(CanisterStatusResultV2),
+    'canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const SwapBackgroundInformation = IDL.Record({
+    'ledger_index_canister_summary' : IDL.Opt(CanisterSummary),
+    'fallback_controller_principal_ids' : IDL.Vec(IDL.Principal),
+    'ledger_archive_canister_summaries' : IDL.Vec(CanisterSummary),
+    'ledger_canister_summary' : IDL.Opt(CanisterSummary),
+    'swap_canister_summary' : IDL.Opt(CanisterSummary),
+    'governance_canister_summary' : IDL.Opt(CanisterSummary),
+    'root_canister_summary' : IDL.Opt(CanisterSummary),
+    'dapp_canister_summaries' : IDL.Vec(CanisterSummary),
+  });
+  const DerivedProposalInformation = IDL.Record({
+    'swap_background_information' : IDL.Opt(SwapBackgroundInformation),
+  });
   const Tally = IDL.Record({
     'no' : IDL.Nat64,
     'yes' : IDL.Nat64,
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
-  });
-  const SwapBackgroundInformation = IDL.Record({
-    'sns_root_canister_id' : IDL.Opt(IDL.Principal),
-    'dapp_canister_ids' : IDL.Vec(IDL.Principal),
-    'fallback_controller_principal_ids' : IDL.Vec(IDL.Principal),
-    'sns_ledger_archive_canister_ids' : IDL.Vec(IDL.Principal),
-    'sns_ledger_index_canister_id' : IDL.Opt(IDL.Principal),
-    'sns_ledger_canister_id' : IDL.Opt(IDL.Principal),
-    'sns_governance_canister_id' : IDL.Opt(IDL.Principal),
   });
   const KnownNeuronData = IDL.Record({
     'name' : IDL.Text,
@@ -219,6 +237,7 @@ export const idlFactory = ({ IDL }) => {
     'swap_due_timestamp_seconds' : IDL.Nat64,
     'min_participants' : IDL.Nat32,
     'sns_token_e8s' : IDL.Nat64,
+    'sale_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_participant_icp_e8s' : IDL.Nat64,
     'min_icp_e8s' : IDL.Nat64,
   });
@@ -288,10 +307,10 @@ export const idlFactory = ({ IDL }) => {
     'reward_event_round' : IDL.Nat64,
     'failed_timestamp_seconds' : IDL.Nat64,
     'reject_cost_e8s' : IDL.Nat64,
+    'derived_proposal_information' : IDL.Opt(DerivedProposalInformation),
     'latest_tally' : IDL.Opt(Tally),
     'sns_token_swap_lifecycle' : IDL.Opt(IDL.Int32),
     'decided_timestamp_seconds' : IDL.Nat64,
-    'swap_background_information' : IDL.Opt(SwapBackgroundInformation),
     'proposal' : IDL.Opt(Proposal),
     'proposer' : IDL.Opt(NeuronId),
     'wait_for_quiet_state' : IDL.Opt(WaitForQuietState),
@@ -377,6 +396,10 @@ export const idlFactory = ({ IDL }) => {
   });
   const Result_2 = IDL.Variant({ 'Ok' : Neuron, 'Err' : GovernanceError });
   const Result_3 = IDL.Variant({
+    'Ok' : GovernanceCachedMetrics,
+    'Err' : GovernanceError,
+  });
+  const Result_4 = IDL.Variant({
     'Ok' : RewardNodeProviders,
     'Err' : GovernanceError,
   });
@@ -392,8 +415,8 @@ export const idlFactory = ({ IDL }) => {
     'voting_power' : IDL.Nat64,
     'age_seconds' : IDL.Nat64,
   });
-  const Result_4 = IDL.Variant({ 'Ok' : NeuronInfo, 'Err' : GovernanceError });
-  const Result_5 = IDL.Variant({
+  const Result_5 = IDL.Variant({ 'Ok' : NeuronInfo, 'Err' : GovernanceError });
+  const Result_6 = IDL.Variant({
     'Ok' : NodeProvider,
     'Err' : GovernanceError,
   });
@@ -408,6 +431,7 @@ export const idlFactory = ({ IDL }) => {
     'deadline_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'failed_timestamp_seconds' : IDL.Nat64,
     'reject_cost_e8s' : IDL.Nat64,
+    'derived_proposal_information' : IDL.Opt(DerivedProposalInformation),
     'latest_tally' : IDL.Opt(Tally),
     'reward_status' : IDL.Int32,
     'decided_timestamp_seconds' : IDL.Nat64,
@@ -474,12 +498,12 @@ export const idlFactory = ({ IDL }) => {
   const Committed = IDL.Record({
     'sns_governance_canister_id' : IDL.Opt(IDL.Principal),
   });
-  const Result_6 = IDL.Variant({
+  const Result_7 = IDL.Variant({
     'Committed' : Committed,
     'Aborted' : IDL.Record({}),
   });
   const SettleCommunityFundParticipation = IDL.Record({
-    'result' : IDL.Opt(Result_6),
+    'result' : IDL.Opt(Result_7),
     'open_sns_token_swap_proposal_id' : IDL.Opt(IDL.Nat64),
   });
   const UpdateNodeProvider = IDL.Record({
@@ -503,7 +527,8 @@ export const idlFactory = ({ IDL }) => {
         [Result_2],
         [],
       ),
-    'get_monthly_node_provider_rewards' : IDL.Func([], [Result_3], []),
+    'get_metrics' : IDL.Func([], [Result_3], []),
+    'get_monthly_node_provider_rewards' : IDL.Func([], [Result_4], []),
     'get_most_recent_monthly_node_provider_rewards' : IDL.Func(
         [],
         [IDL.Opt(MostRecentMonthlyNodeProviderRewards)],
@@ -511,13 +536,13 @@ export const idlFactory = ({ IDL }) => {
       ),
     'get_network_economics_parameters' : IDL.Func([], [NetworkEconomics], []),
     'get_neuron_ids' : IDL.Func([], [IDL.Vec(IDL.Nat64)], []),
-    'get_neuron_info' : IDL.Func([IDL.Nat64], [Result_4], []),
+    'get_neuron_info' : IDL.Func([IDL.Nat64], [Result_5], []),
     'get_neuron_info_by_id_or_subaccount' : IDL.Func(
         [NeuronIdOrSubaccount],
-        [Result_4],
+        [Result_5],
         [],
       ),
-    'get_node_provider_by_caller' : IDL.Func([IDL.Null], [Result_5], []),
+    'get_node_provider_by_caller' : IDL.Func([IDL.Null], [Result_6], []),
     'get_pending_proposals' : IDL.Func([], [IDL.Vec(ProposalInfo)], []),
     'get_proposal_info' : IDL.Func([IDL.Nat64], [IDL.Opt(ProposalInfo)], []),
     'list_known_neurons' : IDL.Func([], [ListKnownNeuronsResponse], []),
@@ -579,6 +604,7 @@ export const init = ({ IDL }) => {
     'community_fund_total_maturity_e8s_equivalent' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
     'not_dissolving_neurons_count' : IDL.Nat64,
+    'total_locked_e8s' : IDL.Nat64,
     'dissolved_neurons_e8s' : IDL.Nat64,
     'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
     'dissolving_neurons_count_buckets' : IDL.Vec(
@@ -629,20 +655,37 @@ export const init = ({ IDL }) => {
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
   const Ballot = IDL.Record({ 'vote' : IDL.Int32, 'voting_power' : IDL.Nat64 });
+  const CanisterStatusResultV2 = IDL.Record({
+    'status' : IDL.Opt(IDL.Int32),
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'controllers' : IDL.Vec(IDL.Principal),
+    'memory_size' : IDL.Opt(IDL.Nat64),
+    'cycles' : IDL.Opt(IDL.Nat64),
+    'idle_cycles_burned_per_day' : IDL.Opt(IDL.Nat64),
+    'module_hash' : IDL.Vec(IDL.Nat8),
+  });
+  const CanisterSummary = IDL.Record({
+    'status' : IDL.Opt(CanisterStatusResultV2),
+    'canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const SwapBackgroundInformation = IDL.Record({
+    'ledger_index_canister_summary' : IDL.Opt(CanisterSummary),
+    'fallback_controller_principal_ids' : IDL.Vec(IDL.Principal),
+    'ledger_archive_canister_summaries' : IDL.Vec(CanisterSummary),
+    'ledger_canister_summary' : IDL.Opt(CanisterSummary),
+    'swap_canister_summary' : IDL.Opt(CanisterSummary),
+    'governance_canister_summary' : IDL.Opt(CanisterSummary),
+    'root_canister_summary' : IDL.Opt(CanisterSummary),
+    'dapp_canister_summaries' : IDL.Vec(CanisterSummary),
+  });
+  const DerivedProposalInformation = IDL.Record({
+    'swap_background_information' : IDL.Opt(SwapBackgroundInformation),
+  });
   const Tally = IDL.Record({
     'no' : IDL.Nat64,
     'yes' : IDL.Nat64,
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
-  });
-  const SwapBackgroundInformation = IDL.Record({
-    'sns_root_canister_id' : IDL.Opt(IDL.Principal),
-    'dapp_canister_ids' : IDL.Vec(IDL.Principal),
-    'fallback_controller_principal_ids' : IDL.Vec(IDL.Principal),
-    'sns_ledger_archive_canister_ids' : IDL.Vec(IDL.Principal),
-    'sns_ledger_index_canister_id' : IDL.Opt(IDL.Principal),
-    'sns_ledger_canister_id' : IDL.Opt(IDL.Principal),
-    'sns_governance_canister_id' : IDL.Opt(IDL.Principal),
   });
   const KnownNeuronData = IDL.Record({
     'name' : IDL.Text,
@@ -758,6 +801,7 @@ export const init = ({ IDL }) => {
     'swap_due_timestamp_seconds' : IDL.Nat64,
     'min_participants' : IDL.Nat32,
     'sns_token_e8s' : IDL.Nat64,
+    'sale_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_participant_icp_e8s' : IDL.Nat64,
     'min_icp_e8s' : IDL.Nat64,
   });
@@ -827,10 +871,10 @@ export const init = ({ IDL }) => {
     'reward_event_round' : IDL.Nat64,
     'failed_timestamp_seconds' : IDL.Nat64,
     'reject_cost_e8s' : IDL.Nat64,
+    'derived_proposal_information' : IDL.Opt(DerivedProposalInformation),
     'latest_tally' : IDL.Opt(Tally),
     'sns_token_swap_lifecycle' : IDL.Opt(IDL.Int32),
     'decided_timestamp_seconds' : IDL.Nat64,
-    'swap_background_information' : IDL.Opt(SwapBackgroundInformation),
     'proposal' : IDL.Opt(Proposal),
     'proposer' : IDL.Opt(NeuronId),
     'wait_for_quiet_state' : IDL.Opt(WaitForQuietState),

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -41,6 +41,19 @@ export type By =
   | { NeuronIdOrSubaccount: {} }
   | { MemoAndController: ClaimOrRefreshNeuronFromAccount }
   | { Memo: bigint };
+export interface CanisterStatusResultV2 {
+  status: [] | [number];
+  freezing_threshold: [] | [bigint];
+  controllers: Array<Principal>;
+  memory_size: [] | [bigint];
+  cycles: [] | [bigint];
+  idle_cycles_burned_per_day: [] | [bigint];
+  module_hash: Uint8Array;
+}
+export interface CanisterSummary {
+  status: [] | [CanisterStatusResultV2];
+  canister_id: [] | [Principal];
+}
 export interface CfNeuron {
   nns_neuron_id: bigint;
   amount_icp_e8s: bigint;
@@ -109,6 +122,9 @@ export interface Committed {
 export interface Configure {
   operation: [] | [Operation];
 }
+export interface DerivedProposalInformation {
+  swap_background_information: [] | [SwapBackgroundInformation];
+}
 export interface Disburse {
   to_account: [] | [AccountIdentifier];
   amount: [] | [Amount];
@@ -168,6 +184,7 @@ export interface GovernanceCachedMetrics {
   community_fund_total_maturity_e8s_equivalent: bigint;
   total_staked_e8s: bigint;
   not_dissolving_neurons_count: bigint;
+  total_locked_e8s: bigint;
   dissolved_neurons_e8s: bigint;
   neurons_with_less_than_6_months_dissolve_delay_e8s: bigint;
   dissolving_neurons_count_buckets: Array<[bigint, bigint]>;
@@ -338,6 +355,7 @@ export interface Params {
   swap_due_timestamp_seconds: bigint;
   min_participants: number;
   sns_token_e8s: bigint;
+  sale_delay_seconds: [] | [bigint];
   max_participant_icp_e8s: bigint;
   min_icp_e8s: bigint;
 }
@@ -356,10 +374,10 @@ export interface ProposalData {
   reward_event_round: bigint;
   failed_timestamp_seconds: bigint;
   reject_cost_e8s: bigint;
+  derived_proposal_information: [] | [DerivedProposalInformation];
   latest_tally: [] | [Tally];
   sns_token_swap_lifecycle: [] | [number];
   decided_timestamp_seconds: bigint;
-  swap_background_information: [] | [SwapBackgroundInformation];
   proposal: [] | [Proposal];
   proposer: [] | [NeuronId];
   wait_for_quiet_state: [] | [WaitForQuietState];
@@ -377,6 +395,7 @@ export interface ProposalInfo {
   deadline_timestamp_seconds: [] | [bigint];
   failed_timestamp_seconds: bigint;
   reject_cost_e8s: bigint;
+  derived_proposal_information: [] | [DerivedProposalInformation];
   latest_tally: [] | [Tally];
   reward_status: number;
   decided_timestamp_seconds: bigint;
@@ -394,10 +413,13 @@ export interface RemoveHotKey {
 export type Result = { Ok: null } | { Err: GovernanceError };
 export type Result_1 = { Error: GovernanceError } | { NeuronId: NeuronId };
 export type Result_2 = { Ok: Neuron } | { Err: GovernanceError };
-export type Result_3 = { Ok: RewardNodeProviders } | { Err: GovernanceError };
-export type Result_4 = { Ok: NeuronInfo } | { Err: GovernanceError };
-export type Result_5 = { Ok: NodeProvider } | { Err: GovernanceError };
-export type Result_6 = { Committed: Committed } | { Aborted: {} };
+export type Result_3 =
+  | { Ok: GovernanceCachedMetrics }
+  | { Err: GovernanceError };
+export type Result_4 = { Ok: RewardNodeProviders } | { Err: GovernanceError };
+export type Result_5 = { Ok: NeuronInfo } | { Err: GovernanceError };
+export type Result_6 = { Ok: NodeProvider } | { Err: GovernanceError };
+export type Result_7 = { Committed: Committed } | { Aborted: {} };
 export interface RewardEvent {
   day_after_genesis: bigint;
   actual_timestamp_seconds: bigint;
@@ -436,7 +458,7 @@ export interface SetSnsTokenSwapOpenTimeWindow {
   swap_canister_id: [] | [Principal];
 }
 export interface SettleCommunityFundParticipation {
-  result: [] | [Result_6];
+  result: [] | [Result_7];
   open_sns_token_swap_proposal_id: [] | [bigint];
 }
 export interface Spawn {
@@ -458,13 +480,14 @@ export interface StakeMaturityResponse {
   staked_maturity_e8s: bigint;
 }
 export interface SwapBackgroundInformation {
-  sns_root_canister_id: [] | [Principal];
-  dapp_canister_ids: Array<Principal>;
+  ledger_index_canister_summary: [] | [CanisterSummary];
   fallback_controller_principal_ids: Array<Principal>;
-  sns_ledger_archive_canister_ids: Array<Principal>;
-  sns_ledger_index_canister_id: [] | [Principal];
-  sns_ledger_canister_id: [] | [Principal];
-  sns_governance_canister_id: [] | [Principal];
+  ledger_archive_canister_summaries: Array<CanisterSummary>;
+  ledger_canister_summary: [] | [CanisterSummary];
+  swap_canister_summary: [] | [CanisterSummary];
+  governance_canister_summary: [] | [CanisterSummary];
+  root_canister_summary: [] | [CanisterSummary];
+  dapp_canister_summaries: Array<CanisterSummary>;
 }
 export interface Tally {
   no: bigint;
@@ -494,19 +517,20 @@ export interface _SERVICE {
     [NeuronIdOrSubaccount],
     Result_2
   >;
-  get_monthly_node_provider_rewards: ActorMethod<[], Result_3>;
+  get_metrics: ActorMethod<[], Result_3>;
+  get_monthly_node_provider_rewards: ActorMethod<[], Result_4>;
   get_most_recent_monthly_node_provider_rewards: ActorMethod<
     [],
     [] | [MostRecentMonthlyNodeProviderRewards]
   >;
   get_network_economics_parameters: ActorMethod<[], NetworkEconomics>;
   get_neuron_ids: ActorMethod<[], BigUint64Array>;
-  get_neuron_info: ActorMethod<[bigint], Result_4>;
+  get_neuron_info: ActorMethod<[bigint], Result_5>;
   get_neuron_info_by_id_or_subaccount: ActorMethod<
     [NeuronIdOrSubaccount],
-    Result_4
+    Result_5
   >;
-  get_node_provider_by_caller: ActorMethod<[null], Result_5>;
+  get_node_provider_by_caller: ActorMethod<[null], Result_6>;
   get_pending_proposals: ActorMethod<[], Array<ProposalInfo>>;
   get_proposal_info: ActorMethod<[bigint], [] | [ProposalInfo]>;
   list_known_neurons: ActorMethod<[], ListKnownNeuronsResponse>;

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit c9b2f9653afc2da47e5bd527c192090b860acbf0 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 5376a14c92f20b4bd285d7622ac5f2a8d21c0d02 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record { hash : vec nat8 };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
@@ -24,6 +24,19 @@ type By = variant {
   NeuronIdOrSubaccount : record {};
   MemoAndController : ClaimOrRefreshNeuronFromAccount;
   Memo : nat64;
+};
+type CanisterStatusResultV2 = record {
+  status : opt int32;
+  freezing_threshold : opt nat64;
+  controllers : vec principal;
+  memory_size : opt nat64;
+  cycles : opt nat64;
+  idle_cycles_burned_per_day : opt nat64;
+  module_hash : vec nat8;
+};
+type CanisterSummary = record {
+  status : opt CanisterStatusResultV2;
+  canister_id : opt principal;
 };
 type CfNeuron = record { nns_neuron_id : nat64; amount_icp_e8s : nat64 };
 type CfParticipant = record {
@@ -83,6 +96,9 @@ type Command_2 = variant {
 };
 type Committed = record { sns_governance_canister_id : opt principal };
 type Configure = record { operation : opt Operation };
+type DerivedProposalInformation = record {
+  swap_background_information : opt SwapBackgroundInformation;
+};
 type Disburse = record {
   to_account : opt AccountIdentifier;
   amount : opt Amount;
@@ -131,6 +147,7 @@ type GovernanceCachedMetrics = record {
   community_fund_total_maturity_e8s_equivalent : nat64;
   total_staked_e8s : nat64;
   not_dissolving_neurons_count : nat64;
+  total_locked_e8s : nat64;
   dissolved_neurons_e8s : nat64;
   neurons_with_less_than_6_months_dissolve_delay_e8s : nat64;
   dissolving_neurons_count_buckets : vec record { nat64; nat64 };
@@ -277,6 +294,7 @@ type Params = record {
   swap_due_timestamp_seconds : nat64;
   min_participants : nat32;
   sns_token_e8s : nat64;
+  sale_delay_seconds : opt nat64;
   max_participant_icp_e8s : nat64;
   min_icp_e8s : nat64;
 };
@@ -295,10 +313,10 @@ type ProposalData = record {
   reward_event_round : nat64;
   failed_timestamp_seconds : nat64;
   reject_cost_e8s : nat64;
+  derived_proposal_information : opt DerivedProposalInformation;
   latest_tally : opt Tally;
   sns_token_swap_lifecycle : opt int32;
   decided_timestamp_seconds : nat64;
-  swap_background_information : opt SwapBackgroundInformation;
   proposal : opt Proposal;
   proposer : opt NeuronId;
   wait_for_quiet_state : opt WaitForQuietState;
@@ -316,6 +334,7 @@ type ProposalInfo = record {
   deadline_timestamp_seconds : opt nat64;
   failed_timestamp_seconds : nat64;
   reject_cost_e8s : nat64;
+  derived_proposal_information : opt DerivedProposalInformation;
   latest_tally : opt Tally;
   reward_status : int32;
   decided_timestamp_seconds : nat64;
@@ -328,10 +347,11 @@ type RemoveHotKey = record { hot_key_to_remove : opt principal };
 type Result = variant { Ok; Err : GovernanceError };
 type Result_1 = variant { Error : GovernanceError; NeuronId : NeuronId };
 type Result_2 = variant { Ok : Neuron; Err : GovernanceError };
-type Result_3 = variant { Ok : RewardNodeProviders; Err : GovernanceError };
-type Result_4 = variant { Ok : NeuronInfo; Err : GovernanceError };
-type Result_5 = variant { Ok : NodeProvider; Err : GovernanceError };
-type Result_6 = variant { Committed : Committed; Aborted : record {} };
+type Result_3 = variant { Ok : GovernanceCachedMetrics; Err : GovernanceError };
+type Result_4 = variant { Ok : RewardNodeProviders; Err : GovernanceError };
+type Result_5 = variant { Ok : NeuronInfo; Err : GovernanceError };
+type Result_6 = variant { Ok : NodeProvider; Err : GovernanceError };
+type Result_7 = variant { Committed : Committed; Aborted : record {} };
 type RewardEvent = record {
   day_after_genesis : nat64;
   actual_timestamp_seconds : nat64;
@@ -363,7 +383,7 @@ type SetSnsTokenSwapOpenTimeWindow = record {
   swap_canister_id : opt principal;
 };
 type SettleCommunityFundParticipation = record {
-  result : opt Result_6;
+  result : opt Result_7;
   open_sns_token_swap_proposal_id : opt nat64;
 };
 type Spawn = record {
@@ -379,13 +399,14 @@ type StakeMaturityResponse = record {
   staked_maturity_e8s : nat64;
 };
 type SwapBackgroundInformation = record {
-  sns_root_canister_id : opt principal;
-  dapp_canister_ids : vec principal;
+  ledger_index_canister_summary : opt CanisterSummary;
   fallback_controller_principal_ids : vec principal;
-  sns_ledger_archive_canister_ids : vec principal;
-  sns_ledger_index_canister_id : opt principal;
-  sns_ledger_canister_id : opt principal;
-  sns_governance_canister_id : opt principal;
+  ledger_archive_canister_summaries : vec CanisterSummary;
+  ledger_canister_summary : opt CanisterSummary;
+  swap_canister_summary : opt CanisterSummary;
+  governance_canister_summary : opt CanisterSummary;
+  root_canister_summary : opt CanisterSummary;
+  dapp_canister_summaries : vec CanisterSummary;
 };
 type Tally = record {
   no : nat64;
@@ -409,17 +430,18 @@ service : (Governance) -> {
   get_full_neuron_by_id_or_subaccount : (NeuronIdOrSubaccount) -> (
       Result_2,
     ) query;
-  get_monthly_node_provider_rewards : () -> (Result_3);
+  get_metrics : () -> (Result_3) query;
+  get_monthly_node_provider_rewards : () -> (Result_4);
   get_most_recent_monthly_node_provider_rewards : () -> (
       opt MostRecentMonthlyNodeProviderRewards,
     ) query;
   get_network_economics_parameters : () -> (NetworkEconomics) query;
   get_neuron_ids : () -> (vec nat64) query;
-  get_neuron_info : (nat64) -> (Result_4) query;
+  get_neuron_info : (nat64) -> (Result_5) query;
   get_neuron_info_by_id_or_subaccount : (NeuronIdOrSubaccount) -> (
-      Result_4,
+      Result_5,
     ) query;
-  get_node_provider_by_caller : (null) -> (Result_5) query;
+  get_node_provider_by_caller : (null) -> (Result_6) query;
   get_pending_proposals : () -> (vec ProposalInfo) query;
   get_proposal_info : (nat64) -> (opt ProposalInfo) query;
   list_known_neurons : () -> (ListKnownNeuronsResponse) query;

--- a/packages/nns/candid/governance.idl.js
+++ b/packages/nns/candid/governance.idl.js
@@ -40,6 +40,7 @@ export const idlFactory = ({ IDL }) => {
     'community_fund_total_maturity_e8s_equivalent' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
     'not_dissolving_neurons_count' : IDL.Nat64,
+    'total_locked_e8s' : IDL.Nat64,
     'dissolved_neurons_e8s' : IDL.Nat64,
     'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
     'dissolving_neurons_count_buckets' : IDL.Vec(
@@ -90,20 +91,37 @@ export const idlFactory = ({ IDL }) => {
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
   const Ballot = IDL.Record({ 'vote' : IDL.Int32, 'voting_power' : IDL.Nat64 });
+  const CanisterStatusResultV2 = IDL.Record({
+    'status' : IDL.Opt(IDL.Int32),
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'controllers' : IDL.Vec(IDL.Principal),
+    'memory_size' : IDL.Opt(IDL.Nat64),
+    'cycles' : IDL.Opt(IDL.Nat64),
+    'idle_cycles_burned_per_day' : IDL.Opt(IDL.Nat64),
+    'module_hash' : IDL.Vec(IDL.Nat8),
+  });
+  const CanisterSummary = IDL.Record({
+    'status' : IDL.Opt(CanisterStatusResultV2),
+    'canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const SwapBackgroundInformation = IDL.Record({
+    'ledger_index_canister_summary' : IDL.Opt(CanisterSummary),
+    'fallback_controller_principal_ids' : IDL.Vec(IDL.Principal),
+    'ledger_archive_canister_summaries' : IDL.Vec(CanisterSummary),
+    'ledger_canister_summary' : IDL.Opt(CanisterSummary),
+    'swap_canister_summary' : IDL.Opt(CanisterSummary),
+    'governance_canister_summary' : IDL.Opt(CanisterSummary),
+    'root_canister_summary' : IDL.Opt(CanisterSummary),
+    'dapp_canister_summaries' : IDL.Vec(CanisterSummary),
+  });
+  const DerivedProposalInformation = IDL.Record({
+    'swap_background_information' : IDL.Opt(SwapBackgroundInformation),
+  });
   const Tally = IDL.Record({
     'no' : IDL.Nat64,
     'yes' : IDL.Nat64,
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
-  });
-  const SwapBackgroundInformation = IDL.Record({
-    'sns_root_canister_id' : IDL.Opt(IDL.Principal),
-    'dapp_canister_ids' : IDL.Vec(IDL.Principal),
-    'fallback_controller_principal_ids' : IDL.Vec(IDL.Principal),
-    'sns_ledger_archive_canister_ids' : IDL.Vec(IDL.Principal),
-    'sns_ledger_index_canister_id' : IDL.Opt(IDL.Principal),
-    'sns_ledger_canister_id' : IDL.Opt(IDL.Principal),
-    'sns_governance_canister_id' : IDL.Opt(IDL.Principal),
   });
   const KnownNeuronData = IDL.Record({
     'name' : IDL.Text,
@@ -219,6 +237,7 @@ export const idlFactory = ({ IDL }) => {
     'swap_due_timestamp_seconds' : IDL.Nat64,
     'min_participants' : IDL.Nat32,
     'sns_token_e8s' : IDL.Nat64,
+    'sale_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_participant_icp_e8s' : IDL.Nat64,
     'min_icp_e8s' : IDL.Nat64,
   });
@@ -288,10 +307,10 @@ export const idlFactory = ({ IDL }) => {
     'reward_event_round' : IDL.Nat64,
     'failed_timestamp_seconds' : IDL.Nat64,
     'reject_cost_e8s' : IDL.Nat64,
+    'derived_proposal_information' : IDL.Opt(DerivedProposalInformation),
     'latest_tally' : IDL.Opt(Tally),
     'sns_token_swap_lifecycle' : IDL.Opt(IDL.Int32),
     'decided_timestamp_seconds' : IDL.Nat64,
-    'swap_background_information' : IDL.Opt(SwapBackgroundInformation),
     'proposal' : IDL.Opt(Proposal),
     'proposer' : IDL.Opt(NeuronId),
     'wait_for_quiet_state' : IDL.Opt(WaitForQuietState),
@@ -377,6 +396,10 @@ export const idlFactory = ({ IDL }) => {
   });
   const Result_2 = IDL.Variant({ 'Ok' : Neuron, 'Err' : GovernanceError });
   const Result_3 = IDL.Variant({
+    'Ok' : GovernanceCachedMetrics,
+    'Err' : GovernanceError,
+  });
+  const Result_4 = IDL.Variant({
     'Ok' : RewardNodeProviders,
     'Err' : GovernanceError,
   });
@@ -392,8 +415,8 @@ export const idlFactory = ({ IDL }) => {
     'voting_power' : IDL.Nat64,
     'age_seconds' : IDL.Nat64,
   });
-  const Result_4 = IDL.Variant({ 'Ok' : NeuronInfo, 'Err' : GovernanceError });
-  const Result_5 = IDL.Variant({
+  const Result_5 = IDL.Variant({ 'Ok' : NeuronInfo, 'Err' : GovernanceError });
+  const Result_6 = IDL.Variant({
     'Ok' : NodeProvider,
     'Err' : GovernanceError,
   });
@@ -408,6 +431,7 @@ export const idlFactory = ({ IDL }) => {
     'deadline_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'failed_timestamp_seconds' : IDL.Nat64,
     'reject_cost_e8s' : IDL.Nat64,
+    'derived_proposal_information' : IDL.Opt(DerivedProposalInformation),
     'latest_tally' : IDL.Opt(Tally),
     'reward_status' : IDL.Int32,
     'decided_timestamp_seconds' : IDL.Nat64,
@@ -474,12 +498,12 @@ export const idlFactory = ({ IDL }) => {
   const Committed = IDL.Record({
     'sns_governance_canister_id' : IDL.Opt(IDL.Principal),
   });
-  const Result_6 = IDL.Variant({
+  const Result_7 = IDL.Variant({
     'Committed' : Committed,
     'Aborted' : IDL.Record({}),
   });
   const SettleCommunityFundParticipation = IDL.Record({
-    'result' : IDL.Opt(Result_6),
+    'result' : IDL.Opt(Result_7),
     'open_sns_token_swap_proposal_id' : IDL.Opt(IDL.Nat64),
   });
   const UpdateNodeProvider = IDL.Record({
@@ -503,7 +527,8 @@ export const idlFactory = ({ IDL }) => {
         [Result_2],
         ['query'],
       ),
-    'get_monthly_node_provider_rewards' : IDL.Func([], [Result_3], []),
+    'get_metrics' : IDL.Func([], [Result_3], ['query']),
+    'get_monthly_node_provider_rewards' : IDL.Func([], [Result_4], []),
     'get_most_recent_monthly_node_provider_rewards' : IDL.Func(
         [],
         [IDL.Opt(MostRecentMonthlyNodeProviderRewards)],
@@ -515,13 +540,13 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_neuron_ids' : IDL.Func([], [IDL.Vec(IDL.Nat64)], ['query']),
-    'get_neuron_info' : IDL.Func([IDL.Nat64], [Result_4], ['query']),
+    'get_neuron_info' : IDL.Func([IDL.Nat64], [Result_5], ['query']),
     'get_neuron_info_by_id_or_subaccount' : IDL.Func(
         [NeuronIdOrSubaccount],
-        [Result_4],
+        [Result_5],
         ['query'],
       ),
-    'get_node_provider_by_caller' : IDL.Func([IDL.Null], [Result_5], ['query']),
+    'get_node_provider_by_caller' : IDL.Func([IDL.Null], [Result_6], ['query']),
     'get_pending_proposals' : IDL.Func([], [IDL.Vec(ProposalInfo)], ['query']),
     'get_proposal_info' : IDL.Func(
         [IDL.Nat64],
@@ -591,6 +616,7 @@ export const init = ({ IDL }) => {
     'community_fund_total_maturity_e8s_equivalent' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
     'not_dissolving_neurons_count' : IDL.Nat64,
+    'total_locked_e8s' : IDL.Nat64,
     'dissolved_neurons_e8s' : IDL.Nat64,
     'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
     'dissolving_neurons_count_buckets' : IDL.Vec(
@@ -641,20 +667,37 @@ export const init = ({ IDL }) => {
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
   const Ballot = IDL.Record({ 'vote' : IDL.Int32, 'voting_power' : IDL.Nat64 });
+  const CanisterStatusResultV2 = IDL.Record({
+    'status' : IDL.Opt(IDL.Int32),
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'controllers' : IDL.Vec(IDL.Principal),
+    'memory_size' : IDL.Opt(IDL.Nat64),
+    'cycles' : IDL.Opt(IDL.Nat64),
+    'idle_cycles_burned_per_day' : IDL.Opt(IDL.Nat64),
+    'module_hash' : IDL.Vec(IDL.Nat8),
+  });
+  const CanisterSummary = IDL.Record({
+    'status' : IDL.Opt(CanisterStatusResultV2),
+    'canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const SwapBackgroundInformation = IDL.Record({
+    'ledger_index_canister_summary' : IDL.Opt(CanisterSummary),
+    'fallback_controller_principal_ids' : IDL.Vec(IDL.Principal),
+    'ledger_archive_canister_summaries' : IDL.Vec(CanisterSummary),
+    'ledger_canister_summary' : IDL.Opt(CanisterSummary),
+    'swap_canister_summary' : IDL.Opt(CanisterSummary),
+    'governance_canister_summary' : IDL.Opt(CanisterSummary),
+    'root_canister_summary' : IDL.Opt(CanisterSummary),
+    'dapp_canister_summaries' : IDL.Vec(CanisterSummary),
+  });
+  const DerivedProposalInformation = IDL.Record({
+    'swap_background_information' : IDL.Opt(SwapBackgroundInformation),
+  });
   const Tally = IDL.Record({
     'no' : IDL.Nat64,
     'yes' : IDL.Nat64,
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
-  });
-  const SwapBackgroundInformation = IDL.Record({
-    'sns_root_canister_id' : IDL.Opt(IDL.Principal),
-    'dapp_canister_ids' : IDL.Vec(IDL.Principal),
-    'fallback_controller_principal_ids' : IDL.Vec(IDL.Principal),
-    'sns_ledger_archive_canister_ids' : IDL.Vec(IDL.Principal),
-    'sns_ledger_index_canister_id' : IDL.Opt(IDL.Principal),
-    'sns_ledger_canister_id' : IDL.Opt(IDL.Principal),
-    'sns_governance_canister_id' : IDL.Opt(IDL.Principal),
   });
   const KnownNeuronData = IDL.Record({
     'name' : IDL.Text,
@@ -770,6 +813,7 @@ export const init = ({ IDL }) => {
     'swap_due_timestamp_seconds' : IDL.Nat64,
     'min_participants' : IDL.Nat32,
     'sns_token_e8s' : IDL.Nat64,
+    'sale_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_participant_icp_e8s' : IDL.Nat64,
     'min_icp_e8s' : IDL.Nat64,
   });
@@ -839,10 +883,10 @@ export const init = ({ IDL }) => {
     'reward_event_round' : IDL.Nat64,
     'failed_timestamp_seconds' : IDL.Nat64,
     'reject_cost_e8s' : IDL.Nat64,
+    'derived_proposal_information' : IDL.Opt(DerivedProposalInformation),
     'latest_tally' : IDL.Opt(Tally),
     'sns_token_swap_lifecycle' : IDL.Opt(IDL.Int32),
     'decided_timestamp_seconds' : IDL.Nat64,
-    'swap_background_information' : IDL.Opt(SwapBackgroundInformation),
     'proposal' : IDL.Opt(Proposal),
     'proposer' : IDL.Opt(NeuronId),
     'wait_for_quiet_state' : IDL.Opt(WaitForQuietState),

--- a/packages/nns/candid/ledger.certified.idl.js
+++ b/packages/nns/candid/ledger.certified.idl.js
@@ -21,6 +21,7 @@ export const idlFactory = ({ IDL }) => {
   const TimeStamp = IDL.Record({ 'timestamp_nanos' : IDL.Nat64 });
   const Transaction = IDL.Record({
     'memo' : Memo,
+    'icrc1_memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'operation' : IDL.Opt(Operation),
     'created_at_time' : TimeStamp,
   });

--- a/packages/nns/candid/ledger.d.ts
+++ b/packages/nns/candid/ledger.d.ts
@@ -70,6 +70,7 @@ export interface Tokens {
 }
 export interface Transaction {
   memo: Memo;
+  icrc1_memo: [] | [Uint8Array];
   operation: [] | [Operation];
   created_at_time: TimeStamp;
 }

--- a/packages/nns/candid/ledger.did
+++ b/packages/nns/candid/ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit c9b2f9653afc2da47e5bd527c192090b860acbf0 'rs/rosetta-api/icp_ledger/ledger.did' by import-candid
+// Generated from IC repo commit 5376a14c92f20b4bd285d7622ac5f2a8d21c0d02 'rs/rosetta-api/icp_ledger/ledger.did' by import-candid
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.
@@ -22,6 +22,13 @@ type SubAccount = blob;
 
 // Sequence number of a block produced by the ledger.
 type BlockIndex = nat64;
+
+type Transaction = record {
+    memo : Memo;
+    icrc1_memo: opt blob;
+    operation : opt Operation;
+    created_at_time : TimeStamp;
+};
 
 // An arbitrary number associated with a transaction.
 // The caller can set it in a `transfer` call as a correlation identifier.
@@ -108,11 +115,7 @@ type Operation = variant {
     };
 };
 
-type Transaction = record {
-    memo : Memo;
-    operation : opt Operation;
-    created_at_time : TimeStamp;
-};
+ 
 
 type Block = record {
     parent_hash : opt blob;

--- a/packages/nns/candid/ledger.idl.js
+++ b/packages/nns/candid/ledger.idl.js
@@ -24,6 +24,7 @@ export const idlFactory = ({ IDL }) => {
   const TimeStamp = IDL.Record({ 'timestamp_nanos' : IDL.Nat64 });
   const Transaction = IDL.Record({
     'memo' : Memo,
+    'icrc1_memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'operation' : IDL.Opt(Operation),
     'created_at_time' : TimeStamp,
   });

--- a/packages/nns/candid/sns_wasm.certified.idl.js
+++ b/packages/nns/candid/sns_wasm.certified.idl.js
@@ -25,6 +25,7 @@ export const idlFactory = ({ IDL }) => {
     'dissolve_delay_seconds' : IDL.Nat64,
     'memo' : IDL.Nat64,
     'stake_e8s' : IDL.Nat64,
+    'vesting_period_seconds' : IDL.Opt(IDL.Nat64),
   });
   const DeveloperDistribution = IDL.Record({
     'developer_neurons' : IDL.Vec(NeuronDistribution),
@@ -62,7 +63,6 @@ export const idlFactory = ({ IDL }) => {
     'initial_reward_rate_basis_points' : IDL.Opt(IDL.Nat64),
     'wait_for_quiet_deadline_increase_seconds' : IDL.Opt(IDL.Nat64),
     'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
-    'sns_initialization_parameters' : IDL.Opt(IDL.Text),
     'max_age_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'initial_token_distribution' : IDL.Opt(InitialTokenDistribution),
     'reward_rate_transition_duration_seconds' : IDL.Opt(IDL.Nat64),
@@ -96,6 +96,7 @@ export const idlFactory = ({ IDL }) => {
     'index_wasm_hash' : IDL.Vec(IDL.Nat8),
   });
   const GetNextSnsVersionRequest = IDL.Record({
+    'governance_canister_id' : IDL.Opt(IDL.Principal),
     'current_version' : IDL.Opt(SnsVersion),
   });
   const GetNextSnsVersionResponse = IDL.Record({
@@ -106,6 +107,17 @@ export const idlFactory = ({ IDL }) => {
   });
   const GetWasmRequest = IDL.Record({ 'hash' : IDL.Vec(IDL.Nat8) });
   const GetWasmResponse = IDL.Record({ 'wasm' : IDL.Opt(SnsWasm) });
+  const SnsUpgrade = IDL.Record({
+    'next_version' : IDL.Opt(SnsVersion),
+    'current_version' : IDL.Opt(SnsVersion),
+  });
+  const InsertUpgradePathEntriesRequest = IDL.Record({
+    'upgrade_path' : IDL.Vec(SnsUpgrade),
+    'sns_governance_canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const InsertUpgradePathEntriesResponse = IDL.Record({
+    'error' : IDL.Opt(SnsWasmError),
+  });
   const DeployedSns = IDL.Record({
     'root_canister_id' : IDL.Opt(IDL.Principal),
     'governance_canister_id' : IDL.Opt(IDL.Principal),
@@ -115,6 +127,26 @@ export const idlFactory = ({ IDL }) => {
   });
   const ListDeployedSnsesResponse = IDL.Record({
     'instances' : IDL.Vec(DeployedSns),
+  });
+  const ListUpgradeStepsRequest = IDL.Record({
+    'limit' : IDL.Nat32,
+    'starting_at' : IDL.Opt(SnsVersion),
+    'sns_governance_canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const PrettySnsVersion = IDL.Record({
+    'archive_wasm_hash' : IDL.Text,
+    'root_wasm_hash' : IDL.Text,
+    'swap_wasm_hash' : IDL.Text,
+    'ledger_wasm_hash' : IDL.Text,
+    'governance_wasm_hash' : IDL.Text,
+    'index_wasm_hash' : IDL.Text,
+  });
+  const ListUpgradeStep = IDL.Record({
+    'pretty_version' : IDL.Opt(PrettySnsVersion),
+    'version' : IDL.Opt(SnsVersion),
+  });
+  const ListUpgradeStepsResponse = IDL.Record({
+    'steps' : IDL.Vec(ListUpgradeStep),
   });
   const UpdateAllowedPrincipalsRequest = IDL.Record({
     'added_principals' : IDL.Vec(IDL.Principal),
@@ -162,9 +194,19 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'get_wasm' : IDL.Func([GetWasmRequest], [GetWasmResponse], []),
+    'insert_upgrade_path_entries' : IDL.Func(
+        [InsertUpgradePathEntriesRequest],
+        [InsertUpgradePathEntriesResponse],
+        [],
+      ),
     'list_deployed_snses' : IDL.Func(
         [IDL.Record({})],
         [ListDeployedSnsesResponse],
+        [],
+      ),
+    'list_upgrade_steps' : IDL.Func(
+        [ListUpgradeStepsRequest],
+        [ListUpgradeStepsResponse],
         [],
       ),
     'update_allowed_principals' : IDL.Func(

--- a/packages/nns/candid/sns_wasm.d.ts
+++ b/packages/nns/candid/sns_wasm.d.ts
@@ -39,6 +39,7 @@ export interface GetAllowedPrincipalsResponse {
   allowed_principals: Array<Principal>;
 }
 export interface GetNextSnsVersionRequest {
+  governance_canister_id: [] | [Principal];
   current_version: [] | [SnsVersion];
 }
 export interface GetNextSnsVersionResponse {
@@ -56,14 +57,42 @@ export interface GetWasmResponse {
 export type InitialTokenDistribution = {
   FractionalDeveloperVotingPower: FractionalDeveloperVotingPower;
 };
+export interface InsertUpgradePathEntriesRequest {
+  upgrade_path: Array<SnsUpgrade>;
+  sns_governance_canister_id: [] | [Principal];
+}
+export interface InsertUpgradePathEntriesResponse {
+  error: [] | [SnsWasmError];
+}
 export interface ListDeployedSnsesResponse {
   instances: Array<DeployedSns>;
+}
+export interface ListUpgradeStep {
+  pretty_version: [] | [PrettySnsVersion];
+  version: [] | [SnsVersion];
+}
+export interface ListUpgradeStepsRequest {
+  limit: number;
+  starting_at: [] | [SnsVersion];
+  sns_governance_canister_id: [] | [Principal];
+}
+export interface ListUpgradeStepsResponse {
+  steps: Array<ListUpgradeStep>;
 }
 export interface NeuronDistribution {
   controller: [] | [Principal];
   dissolve_delay_seconds: bigint;
   memo: bigint;
   stake_e8s: bigint;
+  vesting_period_seconds: [] | [bigint];
+}
+export interface PrettySnsVersion {
+  archive_wasm_hash: string;
+  root_wasm_hash: string;
+  swap_wasm_hash: string;
+  ledger_wasm_hash: string;
+  governance_wasm_hash: string;
+  index_wasm_hash: string;
 }
 export type Result = { Error: SnsWasmError } | { Hash: Uint8Array };
 export interface SnsCanisterIds {
@@ -90,12 +119,15 @@ export interface SnsInitPayload {
   initial_reward_rate_basis_points: [] | [bigint];
   wait_for_quiet_deadline_increase_seconds: [] | [bigint];
   transaction_fee_e8s: [] | [bigint];
-  sns_initialization_parameters: [] | [string];
   max_age_bonus_percentage: [] | [bigint];
   initial_token_distribution: [] | [InitialTokenDistribution];
   reward_rate_transition_duration_seconds: [] | [bigint];
   token_name: [] | [string];
   proposal_reject_cost_e8s: [] | [bigint];
+}
+export interface SnsUpgrade {
+  next_version: [] | [SnsVersion];
+  current_version: [] | [SnsVersion];
 }
 export interface SnsVersion {
   archive_wasm_hash: Uint8Array;
@@ -152,7 +184,15 @@ export interface _SERVICE {
   >;
   get_sns_subnet_ids: ActorMethod<[{}], GetSnsSubnetIdsResponse>;
   get_wasm: ActorMethod<[GetWasmRequest], GetWasmResponse>;
+  insert_upgrade_path_entries: ActorMethod<
+    [InsertUpgradePathEntriesRequest],
+    InsertUpgradePathEntriesResponse
+  >;
   list_deployed_snses: ActorMethod<[{}], ListDeployedSnsesResponse>;
+  list_upgrade_steps: ActorMethod<
+    [ListUpgradeStepsRequest],
+    ListUpgradeStepsResponse
+  >;
   update_allowed_principals: ActorMethod<
     [UpdateAllowedPrincipalsRequest],
     UpdateAllowedPrincipalsResponse

--- a/packages/nns/candid/sns_wasm.did
+++ b/packages/nns/candid/sns_wasm.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit c9b2f9653afc2da47e5bd527c192090b860acbf0 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit 5376a14c92f20b4bd285d7622ac5f2a8d21c0d02 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 type AddWasmRequest = record { hash : vec nat8; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
@@ -27,7 +27,10 @@ type FractionalDeveloperVotingPower = record {
 type GetAllowedPrincipalsResponse = record {
   allowed_principals : vec principal;
 };
-type GetNextSnsVersionRequest = record { current_version : opt SnsVersion };
+type GetNextSnsVersionRequest = record {
+  governance_canister_id : opt principal;
+  current_version : opt SnsVersion;
+};
 type GetNextSnsVersionResponse = record { next_version : opt SnsVersion };
 type GetSnsSubnetIdsResponse = record { sns_subnet_ids : vec principal };
 type GetWasmRequest = record { hash : vec nat8 };
@@ -35,12 +38,36 @@ type GetWasmResponse = record { wasm : opt SnsWasm };
 type InitialTokenDistribution = variant {
   FractionalDeveloperVotingPower : FractionalDeveloperVotingPower;
 };
+type InsertUpgradePathEntriesRequest = record {
+  upgrade_path : vec SnsUpgrade;
+  sns_governance_canister_id : opt principal;
+};
+type InsertUpgradePathEntriesResponse = record { error : opt SnsWasmError };
 type ListDeployedSnsesResponse = record { instances : vec DeployedSns };
+type ListUpgradeStep = record {
+  pretty_version : opt PrettySnsVersion;
+  version : opt SnsVersion;
+};
+type ListUpgradeStepsRequest = record {
+  limit : nat32;
+  starting_at : opt SnsVersion;
+  sns_governance_canister_id : opt principal;
+};
+type ListUpgradeStepsResponse = record { steps : vec ListUpgradeStep };
 type NeuronDistribution = record {
   controller : opt principal;
   dissolve_delay_seconds : nat64;
   memo : nat64;
   stake_e8s : nat64;
+  vesting_period_seconds : opt nat64;
+};
+type PrettySnsVersion = record {
+  archive_wasm_hash : text;
+  root_wasm_hash : text;
+  swap_wasm_hash : text;
+  ledger_wasm_hash : text;
+  governance_wasm_hash : text;
+  index_wasm_hash : text;
 };
 type Result = variant { Error : SnsWasmError; Hash : vec nat8 };
 type SnsCanisterIds = record {
@@ -67,12 +94,15 @@ type SnsInitPayload = record {
   initial_reward_rate_basis_points : opt nat64;
   wait_for_quiet_deadline_increase_seconds : opt nat64;
   transaction_fee_e8s : opt nat64;
-  sns_initialization_parameters : opt text;
   max_age_bonus_percentage : opt nat64;
   initial_token_distribution : opt InitialTokenDistribution;
   reward_rate_transition_duration_seconds : opt nat64;
   token_name : opt text;
   proposal_reject_cost_e8s : opt nat64;
+};
+type SnsUpgrade = record {
+  next_version : opt SnsVersion;
+  current_version : opt SnsVersion;
 };
 type SnsVersion = record {
   archive_wasm_hash : vec nat8;
@@ -120,7 +150,13 @@ service : (SnsWasmCanisterInitPayload) -> {
     ) query;
   get_sns_subnet_ids : (record {}) -> (GetSnsSubnetIdsResponse) query;
   get_wasm : (GetWasmRequest) -> (GetWasmResponse) query;
+  insert_upgrade_path_entries : (InsertUpgradePathEntriesRequest) -> (
+      InsertUpgradePathEntriesResponse,
+    );
   list_deployed_snses : (record {}) -> (ListDeployedSnsesResponse) query;
+  list_upgrade_steps : (ListUpgradeStepsRequest) -> (
+      ListUpgradeStepsResponse,
+    ) query;
   update_allowed_principals : (UpdateAllowedPrincipalsRequest) -> (
       UpdateAllowedPrincipalsResponse,
     );

--- a/packages/nns/candid/sns_wasm.idl.js
+++ b/packages/nns/candid/sns_wasm.idl.js
@@ -25,6 +25,7 @@ export const idlFactory = ({ IDL }) => {
     'dissolve_delay_seconds' : IDL.Nat64,
     'memo' : IDL.Nat64,
     'stake_e8s' : IDL.Nat64,
+    'vesting_period_seconds' : IDL.Opt(IDL.Nat64),
   });
   const DeveloperDistribution = IDL.Record({
     'developer_neurons' : IDL.Vec(NeuronDistribution),
@@ -62,7 +63,6 @@ export const idlFactory = ({ IDL }) => {
     'initial_reward_rate_basis_points' : IDL.Opt(IDL.Nat64),
     'wait_for_quiet_deadline_increase_seconds' : IDL.Opt(IDL.Nat64),
     'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
-    'sns_initialization_parameters' : IDL.Opt(IDL.Text),
     'max_age_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'initial_token_distribution' : IDL.Opt(InitialTokenDistribution),
     'reward_rate_transition_duration_seconds' : IDL.Opt(IDL.Nat64),
@@ -96,6 +96,7 @@ export const idlFactory = ({ IDL }) => {
     'index_wasm_hash' : IDL.Vec(IDL.Nat8),
   });
   const GetNextSnsVersionRequest = IDL.Record({
+    'governance_canister_id' : IDL.Opt(IDL.Principal),
     'current_version' : IDL.Opt(SnsVersion),
   });
   const GetNextSnsVersionResponse = IDL.Record({
@@ -106,6 +107,17 @@ export const idlFactory = ({ IDL }) => {
   });
   const GetWasmRequest = IDL.Record({ 'hash' : IDL.Vec(IDL.Nat8) });
   const GetWasmResponse = IDL.Record({ 'wasm' : IDL.Opt(SnsWasm) });
+  const SnsUpgrade = IDL.Record({
+    'next_version' : IDL.Opt(SnsVersion),
+    'current_version' : IDL.Opt(SnsVersion),
+  });
+  const InsertUpgradePathEntriesRequest = IDL.Record({
+    'upgrade_path' : IDL.Vec(SnsUpgrade),
+    'sns_governance_canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const InsertUpgradePathEntriesResponse = IDL.Record({
+    'error' : IDL.Opt(SnsWasmError),
+  });
   const DeployedSns = IDL.Record({
     'root_canister_id' : IDL.Opt(IDL.Principal),
     'governance_canister_id' : IDL.Opt(IDL.Principal),
@@ -115,6 +127,26 @@ export const idlFactory = ({ IDL }) => {
   });
   const ListDeployedSnsesResponse = IDL.Record({
     'instances' : IDL.Vec(DeployedSns),
+  });
+  const ListUpgradeStepsRequest = IDL.Record({
+    'limit' : IDL.Nat32,
+    'starting_at' : IDL.Opt(SnsVersion),
+    'sns_governance_canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const PrettySnsVersion = IDL.Record({
+    'archive_wasm_hash' : IDL.Text,
+    'root_wasm_hash' : IDL.Text,
+    'swap_wasm_hash' : IDL.Text,
+    'ledger_wasm_hash' : IDL.Text,
+    'governance_wasm_hash' : IDL.Text,
+    'index_wasm_hash' : IDL.Text,
+  });
+  const ListUpgradeStep = IDL.Record({
+    'pretty_version' : IDL.Opt(PrettySnsVersion),
+    'version' : IDL.Opt(SnsVersion),
+  });
+  const ListUpgradeStepsResponse = IDL.Record({
+    'steps' : IDL.Vec(ListUpgradeStep),
   });
   const UpdateAllowedPrincipalsRequest = IDL.Record({
     'added_principals' : IDL.Vec(IDL.Principal),
@@ -162,9 +194,19 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_wasm' : IDL.Func([GetWasmRequest], [GetWasmResponse], ['query']),
+    'insert_upgrade_path_entries' : IDL.Func(
+        [InsertUpgradePathEntriesRequest],
+        [InsertUpgradePathEntriesResponse],
+        [],
+      ),
     'list_deployed_snses' : IDL.Func(
         [IDL.Record({})],
         [ListDeployedSnsesResponse],
+        ['query'],
+      ),
+    'list_upgrade_steps' : IDL.Func(
+        [ListUpgradeStepsRequest],
+        [ListUpgradeStepsResponse],
         ['query'],
       ),
     'update_allowed_principals' : IDL.Func(

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -247,6 +247,7 @@ const fromAction = (action: Action): RawAction => {
                   sns_token_e8s: params.snsTokenE8s,
                   max_participant_icp_e8s: params.maxParticipantIcpE8s,
                   min_icp_e8s: params.minIcpE8s,
+                  sale_delay_seconds: toNullable(params.saleDelaySeconds),
                   neuron_basket_construction_parameters: toNullable(
                     params.neuronBasketConstructionParameters
                   ),

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -382,6 +382,7 @@ const toAction = (action: RawAction): Action => {
             snsTokenE8s: params.sns_token_e8s,
             maxParticipantIcpE8s: params.max_participant_icp_e8s,
             minIcpE8s: params.min_icp_e8s,
+            saleDelaySeconds: fromNullable(params.sale_delay_seconds),
             neuronBasketConstructionParameters: fromNullable(
               params.neuron_basket_construction_parameters
             ),

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -215,6 +215,7 @@ export interface OpenSnsTokenSwap {
     snsTokenE8s: bigint;
     maxParticipantIcpE8s: bigint;
     minIcpE8s: bigint;
+    saleDelaySeconds?: bigint;
     neuronBasketConstructionParameters?: {
       // Keep snake case to avoid having to convert back and forth.
       dissolve_delay_interval_seconds: bigint;

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -85,12 +85,6 @@ Lookup for the canister ids of a Sns and initialize the wrapper to access its fe
 
 `public`
 
-Parameters:
-
-- `id`
-- `service`
-- `certifiedService`
-
 #### Methods
 
 - [create](#gear-create)
@@ -331,12 +325,6 @@ Claim neuron
 
 `public`
 
-Parameters:
-
-- `id`
-- `service`
-- `certifiedService`
-
 #### Methods
 
 - [create](#gear-create)
@@ -363,12 +351,6 @@ Source code: https://github.com/dfinity/ic/blob/master/rs/sns/root/src/lib.rs
 #### Constructors
 
 `public`
-
-Parameters:
-
-- `id`
-- `service`
-- `certifiedService`
 
 #### Methods
 
@@ -404,9 +386,9 @@ Notify of the user participating in the swap
 
 Get user commitment
 
-| Method              | Type                                                                    |
-| ------------------- | ----------------------------------------------------------------------- |
-| `getUserCommitment` | `(params: GetBuyerStateRequest and QueryParams) => Promise<BuyerState>` |
+| Method              | Type                                   |
+| ------------------- | -------------------------------------- |
+| `getUserCommitment` | `(params: any) => Promise<BuyerState>` |
 
 ##### :gear: getLifecycle
 
@@ -512,21 +494,21 @@ Parameters:
 
 ##### :gear: transactionFee
 
-| Method           | Type                                                          |
-| ---------------- | ------------------------------------------------------------- |
-| `transactionFee` | `(params: Omit<QueryParams, "certified">) => Promise<bigint>` |
+| Method           | Type                                                              |
+| ---------------- | ----------------------------------------------------------------- |
+| `transactionFee` | `(params: Omit<QueryParams, "certified">) => Promise<IcrcTokens>` |
 
 ##### :gear: balance
 
-| Method    | Type                                                            |
-| --------- | --------------------------------------------------------------- |
-| `balance` | `(params: Omit<BalanceParams, "certified">) => Promise<bigint>` |
+| Method    | Type                                                                |
+| --------- | ------------------------------------------------------------------- |
+| `balance` | `(params: Omit<BalanceParams, "certified">) => Promise<IcrcTokens>` |
 
 ##### :gear: transfer
 
-| Method     | Type                                          |
-| ---------- | --------------------------------------------- |
-| `transfer` | `(params: TransferParams) => Promise<bigint>` |
+| Method     | Type                                                  |
+| ---------- | ----------------------------------------------------- |
+| `transfer` | `(params: TransferParams) => Promise<IcrcBlockIndex>` |
 
 ##### :gear: getNeuron
 
@@ -584,9 +566,9 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 
 ##### :gear: getNeuronBalance
 
-| Method             | Type                                      |
-| ------------------ | ----------------------------------------- |
-| `getNeuronBalance` | `(neuronId: NeuronId) => Promise<bigint>` |
+| Method             | Type                                          |
+| ------------------ | --------------------------------------------- |
+| `getNeuronBalance` | `(neuronId: NeuronId) => Promise<IcrcTokens>` |
 
 ##### :gear: addNeuronPermissions
 
@@ -686,9 +668,9 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 
 ##### :gear: getTransactions
 
-| Method            | Type                                                                 |
-| ----------------- | -------------------------------------------------------------------- |
-| `getTransactions` | `(params: GetAccountTransactionsParams) => Promise<GetTransactions>` |
+| Method            | Type                                                                     |
+| ----------------- | ------------------------------------------------------------------------ |
+| `getTransactions` | `(params: GetAccountTransactionsParams) => Promise<IcrcGetTransactions>` |
 
 ##### :gear: stakeMaturity
 

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -85,6 +85,12 @@ Lookup for the canister ids of a Sns and initialize the wrapper to access its fe
 
 `public`
 
+Parameters:
+
+- `id`
+- `service`
+- `certifiedService`
+
 #### Methods
 
 - [create](#gear-create)
@@ -325,6 +331,12 @@ Claim neuron
 
 `public`
 
+Parameters:
+
+- `id`
+- `service`
+- `certifiedService`
+
 #### Methods
 
 - [create](#gear-create)
@@ -352,12 +364,19 @@ Source code: https://github.com/dfinity/ic/blob/master/rs/sns/root/src/lib.rs
 
 `public`
 
+Parameters:
+
+- `id`
+- `service`
+- `certifiedService`
+
 #### Methods
 
 - [create](#gear-create)
 - [state](#gear-state)
 - [notifyParticipation](#gear-notifyparticipation)
 - [getUserCommitment](#gear-getusercommitment)
+- [getLifecycle](#gear-getlifecycle)
 
 ##### :gear: create
 
@@ -385,9 +404,17 @@ Notify of the user participating in the swap
 
 Get user commitment
 
-| Method              | Type                                   |
-| ------------------- | -------------------------------------- |
-| `getUserCommitment` | `(params: any) => Promise<BuyerState>` |
+| Method              | Type                                                                    |
+| ------------------- | ----------------------------------------------------------------------- |
+| `getUserCommitment` | `(params: GetBuyerStateRequest and QueryParams) => Promise<BuyerState>` |
+
+##### :gear: getLifecycle
+
+Get sale lifecycle state
+
+| Method         | Type                                                     |
+| -------------- | -------------------------------------------------------- |
+| `getLifecycle` | `(params: QueryParams) => Promise<GetLifecycleResponse>` |
 
 ### :factory: SnsWrapper
 
@@ -436,6 +463,7 @@ Parameters:
 - [swapState](#gear-swapstate)
 - [notifyParticipation](#gear-notifyparticipation)
 - [getUserCommitment](#gear-getusercommitment)
+- [getLifecycle](#gear-getlifecycle)
 - [getTransactions](#gear-gettransactions)
 - [stakeMaturity](#gear-stakematurity)
 - [autoStakeMaturity](#gear-autostakematurity)
@@ -484,21 +512,21 @@ Parameters:
 
 ##### :gear: transactionFee
 
-| Method           | Type                                                              |
-| ---------------- | ----------------------------------------------------------------- |
-| `transactionFee` | `(params: Omit<QueryParams, "certified">) => Promise<IcrcTokens>` |
+| Method           | Type                                                          |
+| ---------------- | ------------------------------------------------------------- |
+| `transactionFee` | `(params: Omit<QueryParams, "certified">) => Promise<bigint>` |
 
 ##### :gear: balance
 
-| Method    | Type                                                                |
-| --------- | ------------------------------------------------------------------- |
-| `balance` | `(params: Omit<BalanceParams, "certified">) => Promise<IcrcTokens>` |
+| Method    | Type                                                            |
+| --------- | --------------------------------------------------------------- |
+| `balance` | `(params: Omit<BalanceParams, "certified">) => Promise<bigint>` |
 
 ##### :gear: transfer
 
-| Method     | Type                                                  |
-| ---------- | ----------------------------------------------------- |
-| `transfer` | `(params: TransferParams) => Promise<IcrcBlockIndex>` |
+| Method     | Type                                          |
+| ---------- | --------------------------------------------- |
+| `transfer` | `(params: TransferParams) => Promise<bigint>` |
 
 ##### :gear: getNeuron
 
@@ -556,9 +584,9 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 
 ##### :gear: getNeuronBalance
 
-| Method             | Type                                          |
-| ------------------ | --------------------------------------------- |
-| `getNeuronBalance` | `(neuronId: NeuronId) => Promise<IcrcTokens>` |
+| Method             | Type                                      |
+| ------------------ | ----------------------------------------- |
+| `getNeuronBalance` | `(neuronId: NeuronId) => Promise<bigint>` |
 
 ##### :gear: addNeuronPermissions
 
@@ -650,11 +678,17 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ------------------- | ------------------------------------------------------- |
 | `getUserCommitment` | `(params: GetBuyerStateRequest) => Promise<BuyerState>` |
 
+##### :gear: getLifecycle
+
+| Method         | Type                                                                        |
+| -------------- | --------------------------------------------------------------------------- |
+| `getLifecycle` | `(params: Omit<QueryParams, "certified">) => Promise<GetLifecycleResponse>` |
+
 ##### :gear: getTransactions
 
-| Method            | Type                                                                     |
-| ----------------- | ------------------------------------------------------------------------ |
-| `getTransactions` | `(params: GetAccountTransactionsParams) => Promise<IcrcGetTransactions>` |
+| Method            | Type                                                                 |
+| ----------------- | -------------------------------------------------------------------- |
+| `getTransactions` | `(params: GetAccountTransactionsParams) => Promise<GetTransactions>` |
 
 ##### :gear: stakeMaturity
 

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,12 +1,14 @@
-// Generated from IC repo commit c9b2f9653afc2da47e5bd527c192090b860acbf0 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 5376a14c92f20b4bd285d7622ac5f2a8d21c0d02 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
   AddGenericNervousSystemFunction : NervousSystemFunction;
   RemoveGenericNervousSystemFunction : nat64;
   UpgradeSnsToNextVersion : record {};
+  RegisterDappCanisters : RegisterDappCanisters;
   TransferSnsTreasuryFunds : TransferSnsTreasuryFunds;
   UpgradeSnsControlledCanister : UpgradeSnsControlledCanister;
+  DeregisterDappCanisters : DeregisterDappCanisters;
   Unspecified : record {};
   ManageSnsMetadata : ManageSnsMetadata;
   ExecuteGenericNervousSystemFunction : ExecuteGenericNervousSystemFunction;
@@ -47,10 +49,10 @@ type ClaimSwapNeuronsRequest = record {
   neuron_parameters : vec NeuronParameters;
 };
 type ClaimSwapNeuronsResponse = record {
-  skipped_claims : nat32;
-  successful_claims : nat32;
-  failed_claims : nat32;
+  claim_swap_neurons_result : opt ClaimSwapNeuronsResult;
 };
+type ClaimSwapNeuronsResult = variant { Ok : ClaimedSwapNeurons; Err : int32 };
+type ClaimedSwapNeurons = record { swap_neurons : vec SwapNeuron };
 type Command = variant {
   Split : Split;
   Follow : Follow;
@@ -88,6 +90,7 @@ type Command_2 = variant {
   RegisterVote : RegisterVote;
   SyncCommand : record {};
   MakeProposal : Proposal;
+  FinalizeDisburseMaturity : FinalizeDisburseMaturity;
   ClaimOrRefreshNeuron : ClaimOrRefresh;
   RemoveNeuronPermissions : RemoveNeuronPermissions;
   AddNeuronPermissions : AddNeuronPermissions;
@@ -103,15 +106,21 @@ type DefiniteCanisterSettingsArgs = record {
   memory_allocation : nat;
   compute_allocation : nat;
 };
+type DeregisterDappCanisters = record {
+  canister_ids : vec principal;
+  new_controllers : vec principal;
+};
 type Disburse = record { to_account : opt Account; amount : opt Amount };
 type DisburseMaturity = record {
   to_account : opt Account;
   percentage_to_disburse : nat32;
 };
-type DisburseMaturityResponse = record {
-  transfer_block_height : nat64;
-  amount_disbursed_e8s : nat64;
+type DisburseMaturityInProgress = record {
+  timestamp_of_disbursement_seconds : nat64;
+  amount_e8s : nat64;
+  account_to_disburse_to : opt Account;
 };
+type DisburseMaturityResponse = record { amount_disbursed_e8s : nat64 };
 type DisburseResponse = record { transfer_block_height : nat64 };
 type DissolveState = variant {
   DissolveDelaySeconds : nat64;
@@ -120,6 +129,10 @@ type DissolveState = variant {
 type ExecuteGenericNervousSystemFunction = record {
   function_id : nat64;
   payload : vec nat8;
+};
+type FinalizeDisburseMaturity = record {
+  amount_to_be_disbursed_e8s : nat64;
+  to_account : opt Account;
 };
 type Follow = record { function_id : nat64; followees : vec NeuronId };
 type Followees = record { followees : vec NeuronId };
@@ -139,6 +152,7 @@ type GetMetadataResponse = record {
   name : opt text;
   description : opt text;
 };
+type GetModeResponse = record { mode : opt int32 };
 type GetNeuron = record { neuron_id : opt NeuronId };
 type GetNeuronResponse = record { result : opt Result };
 type GetProposal = record { proposal_id : opt ProposalId };
@@ -156,6 +170,7 @@ type Governance = record {
   metrics : opt GovernanceCachedMetrics;
   mode : int32;
   parameters : opt NervousSystemParameters;
+  is_finalizing_disburse_maturity : opt bool;
   deployed_version : opt Version;
   sns_initialization_parameters : text;
   latest_reward_event : opt RewardEvent;
@@ -261,6 +276,8 @@ type Neuron = record {
   aging_since_timestamp_seconds : nat64;
   dissolve_state : opt DissolveState;
   voting_power_percentage_multiplier : nat64;
+  vesting_period_seconds : opt nat64;
+  disburse_maturity_in_progress : vec DisburseMaturityInProgress;
   followees : vec record { nat64; Followees };
   neuron_fees_e8s : nat64;
 };
@@ -272,10 +289,11 @@ type NeuronInFlightCommand = record {
 type NeuronParameters = record {
   controller : opt principal;
   dissolve_delay_seconds : opt nat64;
-  memo : opt nat64;
   source_nns_neuron_id : opt nat64;
   stake_e8s : opt nat64;
+  followees : vec NeuronId;
   hotkey : opt principal;
+  neuron_id : opt NeuronId;
 };
 type NeuronPermission = record {
   "principal" : opt principal;
@@ -303,6 +321,7 @@ type ProposalData = record {
   ballots : vec record { text; Ballot };
   reward_event_round : nat64;
   failed_timestamp_seconds : nat64;
+  reward_event_end_timestamp_seconds : opt nat64;
   proposal_creation_timestamp_seconds : nat64;
   initial_voting_period_seconds : nat64;
   reject_cost_e8s : nat64;
@@ -316,6 +335,7 @@ type ProposalData = record {
   executed_timestamp_seconds : nat64;
 };
 type ProposalId = record { id : nat64 };
+type RegisterDappCanisters = record { canister_ids : vec principal };
 type RegisterVote = record { vote : int32; proposal : opt ProposalId };
 type RemoveNeuronPermissions = record {
   permissions_to_remove : opt NeuronPermissionList;
@@ -325,6 +345,7 @@ type Result = variant { Error : GovernanceError; Neuron : Neuron };
 type Result_1 = variant { Error : GovernanceError; Proposal : ProposalData };
 type RewardEvent = record {
   actual_timestamp_seconds : nat64;
+  end_timestamp_seconds : opt nat64;
   distributed_e8s_equivalent : nat64;
   round : nat64;
   settled_proposals : vec ProposalId;
@@ -339,6 +360,7 @@ type StakeMaturityResponse = record {
   staked_maturity_e8s : nat64;
 };
 type Subaccount = record { subaccount : vec nat8 };
+type SwapNeuron = record { id : opt NeuronId; status : int32 };
 type Tally = record {
   no : nat64;
   yes : nat64;
@@ -361,6 +383,7 @@ type UpgradeInProgress = record {
 type UpgradeSnsControlledCanister = record {
   new_canister_wasm : vec nat8;
   canister_id : opt principal;
+  canister_upgrade_arg : opt vec nat8;
 };
 type Version = record {
   archive_wasm_hash : vec nat8;
@@ -381,6 +404,7 @@ service : (Governance) -> {
   claim_swap_neurons : (ClaimSwapNeuronsRequest) -> (ClaimSwapNeuronsResponse);
   get_build_metadata : () -> (text) query;
   get_metadata : (record {}) -> (GetMetadataResponse) query;
+  get_mode : (record {}) -> (GetModeResponse) query;
   get_nervous_system_parameters : (null) -> (NervousSystemParameters) query;
   get_neuron : (GetNeuron) -> (GetNeuronResponse) query;
   get_proposal : (GetProposal) -> (GetProposalResponse) query;

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -87,6 +87,7 @@ export const idlFactory = ({ IDL }) => {
   const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
   const RewardEvent = IDL.Record({
     'actual_timestamp_seconds' : IDL.Nat64,
+    'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'distributed_e8s_equivalent' : IDL.Nat64,
     'round' : IDL.Nat64,
     'settled_proposals' : IDL.Vec(ProposalId),
@@ -112,6 +113,9 @@ export const idlFactory = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const RegisterDappCanisters = IDL.Record({
+    'canister_ids' : IDL.Vec(IDL.Principal),
+  });
   const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
   const TransferSnsTreasuryFunds = IDL.Record({
     'from_treasury' : IDL.Int32,
@@ -123,6 +127,11 @@ export const idlFactory = ({ IDL }) => {
   const UpgradeSnsControlledCanister = IDL.Record({
     'new_canister_wasm' : IDL.Vec(IDL.Nat8),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
+  const DeregisterDappCanisters = IDL.Record({
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'new_controllers' : IDL.Vec(IDL.Principal),
   });
   const ManageSnsMetadata = IDL.Record({
     'url' : IDL.Opt(IDL.Text),
@@ -140,8 +149,10 @@ export const idlFactory = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
+    'RegisterDappCanisters' : RegisterDappCanisters,
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
     'UpgradeSnsControlledCanister' : UpgradeSnsControlledCanister,
+    'DeregisterDappCanisters' : DeregisterDappCanisters,
     'Unspecified' : IDL.Record({}),
     'ManageSnsMetadata' : ManageSnsMetadata,
     'ExecuteGenericNervousSystemFunction' : ExecuteGenericNervousSystemFunction,
@@ -164,6 +175,7 @@ export const idlFactory = ({ IDL }) => {
     'ballots' : IDL.Vec(IDL.Tuple(IDL.Text, Ballot)),
     'reward_event_round' : IDL.Nat64,
     'failed_timestamp_seconds' : IDL.Nat64,
+    'reward_event_end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'proposal_creation_timestamp_seconds' : IDL.Nat64,
     'initial_voting_period_seconds' : IDL.Nat64,
     'reject_cost_e8s' : IDL.Nat64,
@@ -210,6 +222,10 @@ export const idlFactory = ({ IDL }) => {
     'vote' : IDL.Int32,
     'proposal' : IDL.Opt(ProposalId),
   });
+  const FinalizeDisburseMaturity = IDL.Record({
+    'amount_to_be_disbursed_e8s' : IDL.Nat64,
+    'to_account' : IDL.Opt(Account),
+  });
   const MemoAndController = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
     'memo' : IDL.Nat64,
@@ -241,6 +257,7 @@ export const idlFactory = ({ IDL }) => {
     'RegisterVote' : RegisterVote,
     'SyncCommand' : IDL.Record({}),
     'MakeProposal' : Proposal,
+    'FinalizeDisburseMaturity' : FinalizeDisburseMaturity,
     'ClaimOrRefreshNeuron' : ClaimOrRefresh,
     'RemoveNeuronPermissions' : RemoveNeuronPermissions,
     'AddNeuronPermissions' : AddNeuronPermissions,
@@ -259,6 +276,11 @@ export const idlFactory = ({ IDL }) => {
     'DissolveDelaySeconds' : IDL.Nat64,
     'WhenDissolvedTimestampSeconds' : IDL.Nat64,
   });
+  const DisburseMaturityInProgress = IDL.Record({
+    'timestamp_of_disbursement_seconds' : IDL.Nat64,
+    'amount_e8s' : IDL.Nat64,
+    'account_to_disburse_to' : IDL.Opt(Account),
+  });
   const Neuron = IDL.Record({
     'id' : IDL.Opt(NeuronId),
     'staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
@@ -271,6 +293,8 @@ export const idlFactory = ({ IDL }) => {
     'aging_since_timestamp_seconds' : IDL.Nat64,
     'dissolve_state' : IDL.Opt(DissolveState),
     'voting_power_percentage_multiplier' : IDL.Nat64,
+    'vesting_period_seconds' : IDL.Opt(IDL.Nat64),
+    'disburse_maturity_in_progress' : IDL.Vec(DisburseMaturityInProgress),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Nat64, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,
   });
@@ -282,6 +306,7 @@ export const idlFactory = ({ IDL }) => {
     'metrics' : IDL.Opt(GovernanceCachedMetrics),
     'mode' : IDL.Int32,
     'parameters' : IDL.Opt(NervousSystemParameters),
+    'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),
     'deployed_version' : IDL.Opt(Version),
     'sns_initialization_parameters' : IDL.Text,
     'latest_reward_event' : IDL.Opt(RewardEvent),
@@ -297,18 +322,28 @@ export const idlFactory = ({ IDL }) => {
   const NeuronParameters = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
     'dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
-    'memo' : IDL.Opt(IDL.Nat64),
     'source_nns_neuron_id' : IDL.Opt(IDL.Nat64),
     'stake_e8s' : IDL.Opt(IDL.Nat64),
+    'followees' : IDL.Vec(NeuronId),
     'hotkey' : IDL.Opt(IDL.Principal),
+    'neuron_id' : IDL.Opt(NeuronId),
   });
   const ClaimSwapNeuronsRequest = IDL.Record({
     'neuron_parameters' : IDL.Vec(NeuronParameters),
   });
+  const SwapNeuron = IDL.Record({
+    'id' : IDL.Opt(NeuronId),
+    'status' : IDL.Int32,
+  });
+  const ClaimedSwapNeurons = IDL.Record({
+    'swap_neurons' : IDL.Vec(SwapNeuron),
+  });
+  const ClaimSwapNeuronsResult = IDL.Variant({
+    'Ok' : ClaimedSwapNeurons,
+    'Err' : IDL.Int32,
+  });
   const ClaimSwapNeuronsResponse = IDL.Record({
-    'skipped_claims' : IDL.Nat32,
-    'successful_claims' : IDL.Nat32,
-    'failed_claims' : IDL.Nat32,
+    'claim_swap_neurons_result' : IDL.Opt(ClaimSwapNeuronsResult),
   });
   const GetMetadataResponse = IDL.Record({
     'url' : IDL.Opt(IDL.Text),
@@ -316,6 +351,7 @@ export const idlFactory = ({ IDL }) => {
     'name' : IDL.Opt(IDL.Text),
     'description' : IDL.Opt(IDL.Text),
   });
+  const GetModeResponse = IDL.Record({ 'mode' : IDL.Opt(IDL.Int32) });
   const GetNeuron = IDL.Record({ 'neuron_id' : IDL.Opt(NeuronId) });
   const Result = IDL.Variant({ 'Error' : GovernanceError, 'Neuron' : Neuron });
   const GetNeuronResponse = IDL.Record({ 'result' : IDL.Opt(Result) });
@@ -398,7 +434,6 @@ export const idlFactory = ({ IDL }) => {
   });
   const SplitResponse = IDL.Record({ 'created_neuron_id' : IDL.Opt(NeuronId) });
   const DisburseMaturityResponse = IDL.Record({
-    'transfer_block_height' : IDL.Nat64,
     'amount_disbursed_e8s' : IDL.Nat64,
   });
   const ClaimOrRefreshResponse = IDL.Record({
@@ -442,6 +477,7 @@ export const idlFactory = ({ IDL }) => {
         [GetMetadataResponse],
         ['query'],
       ),
+    'get_mode' : IDL.Func([IDL.Record({})], [GetModeResponse], ['query']),
     'get_nervous_system_parameters' : IDL.Func(
         [IDL.Null],
         [NervousSystemParameters],
@@ -567,6 +603,7 @@ export const init = ({ IDL }) => {
   const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
   const RewardEvent = IDL.Record({
     'actual_timestamp_seconds' : IDL.Nat64,
+    'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'distributed_e8s_equivalent' : IDL.Nat64,
     'round' : IDL.Nat64,
     'settled_proposals' : IDL.Vec(ProposalId),
@@ -592,6 +629,9 @@ export const init = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const RegisterDappCanisters = IDL.Record({
+    'canister_ids' : IDL.Vec(IDL.Principal),
+  });
   const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
   const TransferSnsTreasuryFunds = IDL.Record({
     'from_treasury' : IDL.Int32,
@@ -603,6 +643,11 @@ export const init = ({ IDL }) => {
   const UpgradeSnsControlledCanister = IDL.Record({
     'new_canister_wasm' : IDL.Vec(IDL.Nat8),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
+  const DeregisterDappCanisters = IDL.Record({
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'new_controllers' : IDL.Vec(IDL.Principal),
   });
   const ManageSnsMetadata = IDL.Record({
     'url' : IDL.Opt(IDL.Text),
@@ -620,8 +665,10 @@ export const init = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
+    'RegisterDappCanisters' : RegisterDappCanisters,
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
     'UpgradeSnsControlledCanister' : UpgradeSnsControlledCanister,
+    'DeregisterDappCanisters' : DeregisterDappCanisters,
     'Unspecified' : IDL.Record({}),
     'ManageSnsMetadata' : ManageSnsMetadata,
     'ExecuteGenericNervousSystemFunction' : ExecuteGenericNervousSystemFunction,
@@ -644,6 +691,7 @@ export const init = ({ IDL }) => {
     'ballots' : IDL.Vec(IDL.Tuple(IDL.Text, Ballot)),
     'reward_event_round' : IDL.Nat64,
     'failed_timestamp_seconds' : IDL.Nat64,
+    'reward_event_end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'proposal_creation_timestamp_seconds' : IDL.Nat64,
     'initial_voting_period_seconds' : IDL.Nat64,
     'reject_cost_e8s' : IDL.Nat64,
@@ -690,6 +738,10 @@ export const init = ({ IDL }) => {
     'vote' : IDL.Int32,
     'proposal' : IDL.Opt(ProposalId),
   });
+  const FinalizeDisburseMaturity = IDL.Record({
+    'amount_to_be_disbursed_e8s' : IDL.Nat64,
+    'to_account' : IDL.Opt(Account),
+  });
   const MemoAndController = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
     'memo' : IDL.Nat64,
@@ -721,6 +773,7 @@ export const init = ({ IDL }) => {
     'RegisterVote' : RegisterVote,
     'SyncCommand' : IDL.Record({}),
     'MakeProposal' : Proposal,
+    'FinalizeDisburseMaturity' : FinalizeDisburseMaturity,
     'ClaimOrRefreshNeuron' : ClaimOrRefresh,
     'RemoveNeuronPermissions' : RemoveNeuronPermissions,
     'AddNeuronPermissions' : AddNeuronPermissions,
@@ -739,6 +792,11 @@ export const init = ({ IDL }) => {
     'DissolveDelaySeconds' : IDL.Nat64,
     'WhenDissolvedTimestampSeconds' : IDL.Nat64,
   });
+  const DisburseMaturityInProgress = IDL.Record({
+    'timestamp_of_disbursement_seconds' : IDL.Nat64,
+    'amount_e8s' : IDL.Nat64,
+    'account_to_disburse_to' : IDL.Opt(Account),
+  });
   const Neuron = IDL.Record({
     'id' : IDL.Opt(NeuronId),
     'staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
@@ -751,6 +809,8 @@ export const init = ({ IDL }) => {
     'aging_since_timestamp_seconds' : IDL.Nat64,
     'dissolve_state' : IDL.Opt(DissolveState),
     'voting_power_percentage_multiplier' : IDL.Nat64,
+    'vesting_period_seconds' : IDL.Opt(IDL.Nat64),
+    'disburse_maturity_in_progress' : IDL.Vec(DisburseMaturityInProgress),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Nat64, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,
   });
@@ -762,6 +822,7 @@ export const init = ({ IDL }) => {
     'metrics' : IDL.Opt(GovernanceCachedMetrics),
     'mode' : IDL.Int32,
     'parameters' : IDL.Opt(NervousSystemParameters),
+    'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),
     'deployed_version' : IDL.Opt(Version),
     'sns_initialization_parameters' : IDL.Text,
     'latest_reward_event' : IDL.Opt(RewardEvent),

--- a/packages/sns/candid/sns_root.certified.idl.js
+++ b/packages/sns/candid/sns_root.certified.idl.js
@@ -2,6 +2,7 @@
 export const idlFactory = ({ IDL }) => {
   const SnsRootCanister = IDL.Record({
     'dapp_canister_ids' : IDL.Vec(IDL.Principal),
+    'testflight' : IDL.Bool,
     'latest_ledger_archive_poll_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'archive_canister_ids' : IDL.Vec(IDL.Principal),
     'governance_canister_id' : IDL.Opt(IDL.Principal),
@@ -72,7 +73,11 @@ export const idlFactory = ({ IDL }) => {
   const RegisterDappCanisterRequest = IDL.Record({
     'canister_id' : IDL.Opt(IDL.Principal),
   });
+  const RegisterDappCanistersRequest = IDL.Record({
+    'canister_ids' : IDL.Vec(IDL.Principal),
+  });
   const SetDappControllersRequest = IDL.Record({
+    'canister_ids' : IDL.Opt(RegisterDappCanistersRequest),
     'controller_principal_ids' : IDL.Vec(IDL.Principal),
   });
   const CanisterCallError = IDL.Record({
@@ -108,6 +113,11 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Record({})],
         [],
       ),
+    'register_dapp_canisters' : IDL.Func(
+        [RegisterDappCanistersRequest],
+        [IDL.Record({})],
+        [],
+      ),
     'set_dapp_controllers' : IDL.Func(
         [SetDappControllersRequest],
         [SetDappControllersResponse],
@@ -118,6 +128,7 @@ export const idlFactory = ({ IDL }) => {
 export const init = ({ IDL }) => {
   const SnsRootCanister = IDL.Record({
     'dapp_canister_ids' : IDL.Vec(IDL.Principal),
+    'testflight' : IDL.Bool,
     'latest_ledger_archive_poll_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'archive_canister_ids' : IDL.Vec(IDL.Principal),
     'governance_canister_id' : IDL.Opt(IDL.Principal),

--- a/packages/sns/candid/sns_root.d.ts
+++ b/packages/sns/candid/sns_root.d.ts
@@ -72,7 +72,11 @@ export interface ListSnsCanistersResponse {
 export interface RegisterDappCanisterRequest {
   canister_id: [] | [Principal];
 }
+export interface RegisterDappCanistersRequest {
+  canister_ids: Array<Principal>;
+}
 export interface SetDappControllersRequest {
+  canister_ids: [] | [RegisterDappCanistersRequest];
   controller_principal_ids: Array<Principal>;
 }
 export interface SetDappControllersResponse {
@@ -80,6 +84,7 @@ export interface SetDappControllersResponse {
 }
 export interface SnsRootCanister {
   dapp_canister_ids: Array<Principal>;
+  testflight: boolean;
   latest_ledger_archive_poll_timestamp_seconds: [] | [bigint];
   archive_canister_ids: Array<Principal>;
   governance_canister_id: [] | [Principal];
@@ -96,6 +101,7 @@ export interface _SERVICE {
   >;
   list_sns_canisters: ActorMethod<[{}], ListSnsCanistersResponse>;
   register_dapp_canister: ActorMethod<[RegisterDappCanisterRequest], {}>;
+  register_dapp_canisters: ActorMethod<[RegisterDappCanistersRequest], {}>;
   set_dapp_controllers: ActorMethod<
     [SetDappControllersRequest],
     SetDappControllersResponse

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit c9b2f9653afc2da47e5bd527c192090b860acbf0 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit 5376a14c92f20b4bd285d7622ac5f2a8d21c0d02 'rs/sns/root/canister/root.did' by import-candid
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterIdRecord = record { canister_id : principal };
 type CanisterStatusResult = record {
@@ -55,12 +55,15 @@ type ListSnsCanistersResponse = record {
   archives : vec principal;
 };
 type RegisterDappCanisterRequest = record { canister_id : opt principal };
+type RegisterDappCanistersRequest = record { canister_ids : vec principal };
 type SetDappControllersRequest = record {
+  canister_ids : opt RegisterDappCanistersRequest;
   controller_principal_ids : vec principal;
 };
 type SetDappControllersResponse = record { failed_updates : vec FailedUpdate };
 type SnsRootCanister = record {
   dapp_canister_ids : vec principal;
+  testflight : bool;
   latest_ledger_archive_poll_timestamp_seconds : opt nat64;
   archive_canister_ids : vec principal;
   governance_canister_id : opt principal;
@@ -76,6 +79,7 @@ service : (SnsRootCanister) -> {
     );
   list_sns_canisters : (record {}) -> (ListSnsCanistersResponse) query;
   register_dapp_canister : (RegisterDappCanisterRequest) -> (record {});
+  register_dapp_canisters : (RegisterDappCanistersRequest) -> (record {});
   set_dapp_controllers : (SetDappControllersRequest) -> (
       SetDappControllersResponse,
     );

--- a/packages/sns/candid/sns_root.idl.js
+++ b/packages/sns/candid/sns_root.idl.js
@@ -2,6 +2,7 @@
 export const idlFactory = ({ IDL }) => {
   const SnsRootCanister = IDL.Record({
     'dapp_canister_ids' : IDL.Vec(IDL.Principal),
+    'testflight' : IDL.Bool,
     'latest_ledger_archive_poll_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'archive_canister_ids' : IDL.Vec(IDL.Principal),
     'governance_canister_id' : IDL.Opt(IDL.Principal),
@@ -72,7 +73,11 @@ export const idlFactory = ({ IDL }) => {
   const RegisterDappCanisterRequest = IDL.Record({
     'canister_id' : IDL.Opt(IDL.Principal),
   });
+  const RegisterDappCanistersRequest = IDL.Record({
+    'canister_ids' : IDL.Vec(IDL.Principal),
+  });
   const SetDappControllersRequest = IDL.Record({
+    'canister_ids' : IDL.Opt(RegisterDappCanistersRequest),
     'controller_principal_ids' : IDL.Vec(IDL.Principal),
   });
   const CanisterCallError = IDL.Record({
@@ -108,6 +113,11 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Record({})],
         [],
       ),
+    'register_dapp_canisters' : IDL.Func(
+        [RegisterDappCanistersRequest],
+        [IDL.Record({})],
+        [],
+      ),
     'set_dapp_controllers' : IDL.Func(
         [SetDappControllersRequest],
         [SetDappControllersResponse],
@@ -118,6 +128,7 @@ export const idlFactory = ({ IDL }) => {
 export const init = ({ IDL }) => {
   const SnsRootCanister = IDL.Record({
     'dapp_canister_ids' : IDL.Vec(IDL.Principal),
+    'testflight' : IDL.Bool,
     'latest_ledger_archive_poll_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'archive_canister_ids' : IDL.Vec(IDL.Principal),
     'governance_canister_id' : IDL.Opt(IDL.Principal),

--- a/packages/sns/candid/sns_swap.certified.idl.js
+++ b/packages/sns/candid/sns_swap.certified.idl.js
@@ -20,23 +20,9 @@ export const idlFactory = ({ IDL }) => {
   });
   const Result = IDL.Variant({ 'Ok' : Ok, 'Err' : Err });
   const ErrorRefundIcpResponse = IDL.Record({ 'result' : IDL.Opt(Result) });
-  const GovernanceError = IDL.Record({
-    'error_message' : IDL.Text,
-    'error_type' : IDL.Int32,
-  });
-  const Response = IDL.Record({
-    'governance_error' : IDL.Opt(GovernanceError),
-  });
   const CanisterCallError = IDL.Record({
     'code' : IDL.Opt(IDL.Int32),
     'description' : IDL.Text,
-  });
-  const Possibility = IDL.Variant({
-    'Ok' : Response,
-    'Err' : CanisterCallError,
-  });
-  const SettleCommunityFundParticipationResult = IDL.Record({
-    'possibility' : IDL.Opt(Possibility),
   });
   const FailedUpdate = IDL.Record({
     'err' : IDL.Opt(CanisterCallError),
@@ -45,31 +31,51 @@ export const idlFactory = ({ IDL }) => {
   const SetDappControllersResponse = IDL.Record({
     'failed_updates' : IDL.Vec(FailedUpdate),
   });
-  const Possibility_1 = IDL.Variant({
+  const Possibility = IDL.Variant({
     'Ok' : SetDappControllersResponse,
     'Err' : CanisterCallError,
   });
   const SetDappControllersCallResult = IDL.Record({
+    'possibility' : IDL.Opt(Possibility),
+  });
+  const GovernanceError = IDL.Record({
+    'error_message' : IDL.Text,
+    'error_type' : IDL.Int32,
+  });
+  const Response = IDL.Record({
+    'governance_error' : IDL.Opt(GovernanceError),
+  });
+  const Possibility_1 = IDL.Variant({
+    'Ok' : Response,
+    'Err' : CanisterCallError,
+  });
+  const SettleCommunityFundParticipationResult = IDL.Record({
     'possibility' : IDL.Opt(Possibility_1),
   });
-  const Possibility_2 = IDL.Variant({ 'Err' : CanisterCallError });
+  const Possibility_2 = IDL.Variant({
+    'Ok' : IDL.Record({}),
+    'Err' : CanisterCallError,
+  });
   const SetModeCallResult = IDL.Record({
     'possibility' : IDL.Opt(Possibility_2),
   });
   const SweepResult = IDL.Record({
     'failure' : IDL.Nat32,
     'skipped' : IDL.Nat32,
+    'invalid' : IDL.Nat32,
     'success' : IDL.Nat32,
+    'global_failures' : IDL.Nat32,
   });
   const FinalizeSwapResponse = IDL.Record({
+    'set_dapp_controllers_call_result' : IDL.Opt(SetDappControllersCallResult),
     'settle_community_fund_participation_result' : IDL.Opt(
       SettleCommunityFundParticipationResult
     ),
-    'set_dapp_controllers_result' : IDL.Opt(SetDappControllersCallResult),
-    'sns_governance_normal_mode_enabled' : IDL.Opt(SetModeCallResult),
-    'sweep_icp' : IDL.Opt(SweepResult),
-    'sweep_sns' : IDL.Opt(SweepResult),
-    'create_neuron' : IDL.Opt(SweepResult),
+    'error_message' : IDL.Opt(IDL.Text),
+    'set_mode_call_result' : IDL.Opt(SetModeCallResult),
+    'sweep_icp_result' : IDL.Opt(SweepResult),
+    'claim_neuron_result' : IDL.Opt(SweepResult),
+    'sweep_sns_result' : IDL.Opt(SweepResult),
   });
   const GetBuyerStateRequest = IDL.Record({
     'principal_id' : IDL.Opt(IDL.Principal),
@@ -107,32 +113,29 @@ export const idlFactory = ({ IDL }) => {
     'idle_cycles_burned_per_day' : IDL.Nat,
     'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
-  const NeuronAttributes = IDL.Record({
-    'dissolve_delay_seconds' : IDL.Nat64,
-    'memo' : IDL.Nat64,
+  const GetDerivedStateResponse = IDL.Record({
+    'sns_tokens_per_icp' : IDL.Opt(IDL.Float64),
+    'buyer_total_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
-  const CfInvestment = IDL.Record({
-    'hotkey_principal' : IDL.Text,
-    'nns_neuron_id' : IDL.Nat64,
+  const GetInitResponse = IDL.Record({ 'init' : IDL.Opt(Init) });
+  const GetLifecycleResponse = IDL.Record({
+    'decentralization_sale_open_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'lifecycle' : IDL.Opt(IDL.Int32),
   });
-  const DirectInvestment = IDL.Record({ 'buyer_principal' : IDL.Text });
-  const Investor = IDL.Variant({
-    'CommunityFund' : CfInvestment,
-    'Direct' : DirectInvestment,
+  const Icrc1Account = IDL.Record({
+    'owner' : IDL.Opt(IDL.Principal),
+    'subaccount' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
-  const SnsNeuronRecipe = IDL.Record({
-    'sns' : IDL.Opt(TransferableAmount),
-    'neuron_attributes' : IDL.Opt(NeuronAttributes),
-    'investor' : IDL.Opt(Investor),
-  });
-  const CfNeuron = IDL.Record({
-    'nns_neuron_id' : IDL.Nat64,
+  const Ticket = IDL.Record({
+    'creation_time' : IDL.Nat64,
+    'ticket_id' : IDL.Nat64,
+    'account' : IDL.Opt(Icrc1Account),
     'amount_icp_e8s' : IDL.Nat64,
   });
-  const CfParticipant = IDL.Record({
-    'hotkey_principal' : IDL.Text,
-    'cf_neurons' : IDL.Vec(CfNeuron),
-  });
+  const Ok_1 = IDL.Record({ 'ticket' : IDL.Opt(Ticket) });
+  const Err_1 = IDL.Record({ 'error_type' : IDL.Opt(IDL.Int32) });
+  const Result_1 = IDL.Variant({ 'Ok' : Ok_1, 'Err' : Err_1 });
+  const GetOpenTicketResponse = IDL.Record({ 'result' : IDL.Opt(Result_1) });
   const NeuronBasketConstructionParameters = IDL.Record({
     'dissolve_delay_interval_seconds' : IDL.Nat64,
     'count' : IDL.Nat64,
@@ -146,11 +149,44 @@ export const idlFactory = ({ IDL }) => {
     'swap_due_timestamp_seconds' : IDL.Nat64,
     'min_participants' : IDL.Nat32,
     'sns_token_e8s' : IDL.Nat64,
+    'sale_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_participant_icp_e8s' : IDL.Nat64,
     'min_icp_e8s' : IDL.Nat64,
   });
+  const GetSaleParametersResponse = IDL.Record({ 'params' : IDL.Opt(Params) });
+  const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
+  const NeuronAttributes = IDL.Record({
+    'dissolve_delay_seconds' : IDL.Nat64,
+    'memo' : IDL.Nat64,
+    'followees' : IDL.Vec(NeuronId),
+  });
+  const CfInvestment = IDL.Record({
+    'hotkey_principal' : IDL.Text,
+    'nns_neuron_id' : IDL.Nat64,
+  });
+  const DirectInvestment = IDL.Record({ 'buyer_principal' : IDL.Text });
+  const Investor = IDL.Variant({
+    'CommunityFund' : CfInvestment,
+    'Direct' : DirectInvestment,
+  });
+  const SnsNeuronRecipe = IDL.Record({
+    'sns' : IDL.Opt(TransferableAmount),
+    'claimed_status' : IDL.Opt(IDL.Int32),
+    'neuron_attributes' : IDL.Opt(NeuronAttributes),
+    'investor' : IDL.Opt(Investor),
+  });
+  const CfNeuron = IDL.Record({
+    'nns_neuron_id' : IDL.Nat64,
+    'amount_icp_e8s' : IDL.Nat64,
+  });
+  const CfParticipant = IDL.Record({
+    'hotkey_principal' : IDL.Text,
+    'cf_neurons' : IDL.Vec(CfNeuron),
+  });
   const Swap = IDL.Record({
     'neuron_recipes' : IDL.Vec(SnsNeuronRecipe),
+    'decentralization_sale_open_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'finalize_swap_in_progress' : IDL.Opt(IDL.Bool),
     'cf_participants' : IDL.Vec(CfParticipant),
     'init' : IDL.Opt(Init),
     'lifecycle' : IDL.Int32,
@@ -166,6 +202,46 @@ export const idlFactory = ({ IDL }) => {
     'swap' : IDL.Opt(Swap),
     'derived' : IDL.Opt(DerivedState),
   });
+  const ListCommunityFundParticipantsRequest = IDL.Record({
+    'offset' : IDL.Opt(IDL.Nat64),
+    'limit' : IDL.Opt(IDL.Nat32),
+  });
+  const ListCommunityFundParticipantsResponse = IDL.Record({
+    'cf_participants' : IDL.Vec(CfParticipant),
+  });
+  const ListDirectParticipantsRequest = IDL.Record({
+    'offset' : IDL.Opt(IDL.Nat32),
+    'limit' : IDL.Opt(IDL.Nat32),
+  });
+  const Participant = IDL.Record({
+    'participation' : IDL.Opt(BuyerState),
+    'participant_id' : IDL.Opt(IDL.Principal),
+  });
+  const ListDirectParticipantsResponse = IDL.Record({
+    'participants' : IDL.Vec(Participant),
+  });
+  const ListSnsNeuronRecipesRequest = IDL.Record({
+    'offset' : IDL.Opt(IDL.Nat64),
+    'limit' : IDL.Opt(IDL.Nat32),
+  });
+  const ListSnsNeuronRecipesResponse = IDL.Record({
+    'sns_neuron_recipes' : IDL.Vec(SnsNeuronRecipe),
+  });
+  const NewSaleTicketRequest = IDL.Record({
+    'subaccount' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'amount_icp_e8s' : IDL.Nat64,
+  });
+  const InvalidUserAmount = IDL.Record({
+    'min_amount_icp_e8s_included' : IDL.Nat64,
+    'max_amount_icp_e8s_included' : IDL.Nat64,
+  });
+  const Err_2 = IDL.Record({
+    'invalid_user_amount' : IDL.Opt(InvalidUserAmount),
+    'existing_ticket' : IDL.Opt(Ticket),
+    'error_type' : IDL.Int32,
+  });
+  const Result_2 = IDL.Variant({ 'Ok' : Ok_1, 'Err' : Err_2 });
+  const NewSaleTicketResponse = IDL.Record({ 'result' : IDL.Opt(Result_2) });
   const OpenRequest = IDL.Record({
     'cf_participants' : IDL.Vec(CfParticipant),
     'params' : IDL.Opt(Params),
@@ -198,7 +274,40 @@ export const idlFactory = ({ IDL }) => {
         [CanisterStatusResultV2],
         [],
       ),
+    'get_derived_state' : IDL.Func(
+        [IDL.Record({})],
+        [GetDerivedStateResponse],
+        [],
+      ),
+    'get_init' : IDL.Func([IDL.Record({})], [GetInitResponse], []),
+    'get_lifecycle' : IDL.Func([IDL.Record({})], [GetLifecycleResponse], []),
+    'get_open_ticket' : IDL.Func([IDL.Record({})], [GetOpenTicketResponse], []),
+    'get_sale_parameters' : IDL.Func(
+        [IDL.Record({})],
+        [GetSaleParametersResponse],
+        [],
+      ),
     'get_state' : IDL.Func([IDL.Record({})], [GetStateResponse], []),
+    'list_community_fund_participants' : IDL.Func(
+        [ListCommunityFundParticipantsRequest],
+        [ListCommunityFundParticipantsResponse],
+        [],
+      ),
+    'list_direct_participants' : IDL.Func(
+        [ListDirectParticipantsRequest],
+        [ListDirectParticipantsResponse],
+        [],
+      ),
+    'list_sns_neuron_recipes' : IDL.Func(
+        [ListSnsNeuronRecipesRequest],
+        [ListSnsNeuronRecipesResponse],
+        [],
+      ),
+    'new_sale_ticket' : IDL.Func(
+        [NewSaleTicketRequest],
+        [NewSaleTicketResponse],
+        [],
+      ),
     'open' : IDL.Func([OpenRequest], [IDL.Record({})], []),
     'refresh_buyer_tokens' : IDL.Func(
         [RefreshBuyerTokensRequest],

--- a/packages/sns/candid/sns_swap.d.ts
+++ b/packages/sns/candid/sns_swap.d.ts
@@ -53,6 +53,14 @@ export interface Err {
   description: [] | [string];
   error_type: [] | [number];
 }
+export interface Err_1 {
+  error_type: [] | [number];
+}
+export interface Err_2 {
+  invalid_user_amount: [] | [InvalidUserAmount];
+  existing_ticket: [] | [Ticket];
+  error_type: number;
+}
 export interface ErrorRefundIcpRequest {
   source_principal_id: [] | [Principal];
 }
@@ -64,14 +72,15 @@ export interface FailedUpdate {
   dapp_canister_id: [] | [Principal];
 }
 export interface FinalizeSwapResponse {
+  set_dapp_controllers_call_result: [] | [SetDappControllersCallResult];
   settle_community_fund_participation_result:
     | []
     | [SettleCommunityFundParticipationResult];
-  set_dapp_controllers_result: [] | [SetDappControllersCallResult];
-  sns_governance_normal_mode_enabled: [] | [SetModeCallResult];
-  sweep_icp: [] | [SweepResult];
-  sweep_sns: [] | [SweepResult];
-  create_neuron: [] | [SweepResult];
+  error_message: [] | [string];
+  set_mode_call_result: [] | [SetModeCallResult];
+  sweep_icp_result: [] | [SweepResult];
+  claim_neuron_result: [] | [SweepResult];
+  sweep_sns_result: [] | [SweepResult];
 }
 export interface GetBuyerStateRequest {
   principal_id: [] | [Principal];
@@ -82,6 +91,23 @@ export interface GetBuyerStateResponse {
 export interface GetBuyersTotalResponse {
   buyers_total: bigint;
 }
+export interface GetDerivedStateResponse {
+  sns_tokens_per_icp: [] | [number];
+  buyer_total_icp_e8s: [] | [bigint];
+}
+export interface GetInitResponse {
+  init: [] | [Init];
+}
+export interface GetLifecycleResponse {
+  decentralization_sale_open_timestamp_seconds: [] | [bigint];
+  lifecycle: [] | [number];
+}
+export interface GetOpenTicketResponse {
+  result: [] | [Result_1];
+}
+export interface GetSaleParametersResponse {
+  params: [] | [Params];
+}
 export interface GetStateResponse {
   swap: [] | [Swap];
   derived: [] | [DerivedState];
@@ -89,6 +115,10 @@ export interface GetStateResponse {
 export interface GovernanceError {
   error_message: string;
   error_type: number;
+}
+export interface Icrc1Account {
+  owner: [] | [Principal];
+  subaccount: [] | [Uint8Array];
 }
 export interface Init {
   sns_root_canister_id: string;
@@ -100,19 +130,58 @@ export interface Init {
   sns_ledger_canister_id: string;
   sns_governance_canister_id: string;
 }
+export interface InvalidUserAmount {
+  min_amount_icp_e8s_included: bigint;
+  max_amount_icp_e8s_included: bigint;
+}
 export type Investor =
   | { CommunityFund: CfInvestment }
   | { Direct: DirectInvestment };
+export interface ListCommunityFundParticipantsRequest {
+  offset: [] | [bigint];
+  limit: [] | [number];
+}
+export interface ListCommunityFundParticipantsResponse {
+  cf_participants: Array<CfParticipant>;
+}
+export interface ListDirectParticipantsRequest {
+  offset: [] | [number];
+  limit: [] | [number];
+}
+export interface ListDirectParticipantsResponse {
+  participants: Array<Participant>;
+}
+export interface ListSnsNeuronRecipesRequest {
+  offset: [] | [bigint];
+  limit: [] | [number];
+}
+export interface ListSnsNeuronRecipesResponse {
+  sns_neuron_recipes: Array<SnsNeuronRecipe>;
+}
 export interface NeuronAttributes {
   dissolve_delay_seconds: bigint;
   memo: bigint;
+  followees: Array<NeuronId>;
 }
 export interface NeuronBasketConstructionParameters {
   dissolve_delay_interval_seconds: bigint;
   count: bigint;
 }
+export interface NeuronId {
+  id: Uint8Array;
+}
+export interface NewSaleTicketRequest {
+  subaccount: [] | [Uint8Array];
+  amount_icp_e8s: bigint;
+}
+export interface NewSaleTicketResponse {
+  result: [] | [Result_2];
+}
 export interface Ok {
   block_height: [] | [bigint];
+}
+export interface Ok_1 {
+  ticket: [] | [Ticket];
 }
 export interface OpenRequest {
   cf_participants: Array<CfParticipant>;
@@ -128,14 +197,19 @@ export interface Params {
   swap_due_timestamp_seconds: bigint;
   min_participants: number;
   sns_token_e8s: bigint;
+  sale_delay_seconds: [] | [bigint];
   max_participant_icp_e8s: bigint;
   min_icp_e8s: bigint;
 }
-export type Possibility = { Ok: Response } | { Err: CanisterCallError };
-export type Possibility_1 =
+export interface Participant {
+  participation: [] | [BuyerState];
+  participant_id: [] | [Principal];
+}
+export type Possibility =
   | { Ok: SetDappControllersResponse }
   | { Err: CanisterCallError };
-export type Possibility_2 = { Err: CanisterCallError };
+export type Possibility_1 = { Ok: Response } | { Err: CanisterCallError };
+export type Possibility_2 = { Ok: {} } | { Err: CanisterCallError };
 export interface RefreshBuyerTokensRequest {
   buyer: string;
 }
@@ -147,8 +221,10 @@ export interface Response {
   governance_error: [] | [GovernanceError];
 }
 export type Result = { Ok: Ok } | { Err: Err };
+export type Result_1 = { Ok: Ok_1 } | { Err: Err_1 };
+export type Result_2 = { Ok: Ok_1 } | { Err: Err_2 };
 export interface SetDappControllersCallResult {
-  possibility: [] | [Possibility_1];
+  possibility: [] | [Possibility];
 }
 export interface SetDappControllersResponse {
   failed_updates: Array<FailedUpdate>;
@@ -157,15 +233,18 @@ export interface SetModeCallResult {
   possibility: [] | [Possibility_2];
 }
 export interface SettleCommunityFundParticipationResult {
-  possibility: [] | [Possibility];
+  possibility: [] | [Possibility_1];
 }
 export interface SnsNeuronRecipe {
   sns: [] | [TransferableAmount];
+  claimed_status: [] | [number];
   neuron_attributes: [] | [NeuronAttributes];
   investor: [] | [Investor];
 }
 export interface Swap {
   neuron_recipes: Array<SnsNeuronRecipe>;
+  decentralization_sale_open_timestamp_seconds: [] | [bigint];
+  finalize_swap_in_progress: [] | [boolean];
   cf_participants: Array<CfParticipant>;
   init: [] | [Init];
   lifecycle: number;
@@ -176,7 +255,15 @@ export interface Swap {
 export interface SweepResult {
   failure: number;
   skipped: number;
+  invalid: number;
   success: number;
+  global_failures: number;
+}
+export interface Ticket {
+  creation_time: bigint;
+  ticket_id: bigint;
+  account: [] | [Icrc1Account];
+  amount_icp_e8s: bigint;
 }
 export interface TransferableAmount {
   transfer_start_timestamp_seconds: bigint;
@@ -192,7 +279,25 @@ export interface _SERVICE {
   get_buyer_state: ActorMethod<[GetBuyerStateRequest], GetBuyerStateResponse>;
   get_buyers_total: ActorMethod<[{}], GetBuyersTotalResponse>;
   get_canister_status: ActorMethod<[{}], CanisterStatusResultV2>;
+  get_derived_state: ActorMethod<[{}], GetDerivedStateResponse>;
+  get_init: ActorMethod<[{}], GetInitResponse>;
+  get_lifecycle: ActorMethod<[{}], GetLifecycleResponse>;
+  get_open_ticket: ActorMethod<[{}], GetOpenTicketResponse>;
+  get_sale_parameters: ActorMethod<[{}], GetSaleParametersResponse>;
   get_state: ActorMethod<[{}], GetStateResponse>;
+  list_community_fund_participants: ActorMethod<
+    [ListCommunityFundParticipantsRequest],
+    ListCommunityFundParticipantsResponse
+  >;
+  list_direct_participants: ActorMethod<
+    [ListDirectParticipantsRequest],
+    ListDirectParticipantsResponse
+  >;
+  list_sns_neuron_recipes: ActorMethod<
+    [ListSnsNeuronRecipesRequest],
+    ListSnsNeuronRecipesResponse
+  >;
+  new_sale_ticket: ActorMethod<[NewSaleTicketRequest], NewSaleTicketResponse>;
   open: ActorMethod<[OpenRequest], {}>;
   refresh_buyer_tokens: ActorMethod<
     [RefreshBuyerTokensRequest],

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit c9b2f9653afc2da47e5bd527c192090b860acbf0 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 5376a14c92f20b4bd285d7622ac5f2a8d21c0d02 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record { icp : opt TransferableAmount };
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterStatusResultV2 = record {
@@ -32,6 +32,12 @@ type DerivedState = record {
 };
 type DirectInvestment = record { buyer_principal : text };
 type Err = record { description : opt text; error_type : opt int32 };
+type Err_1 = record { error_type : opt int32 };
+type Err_2 = record {
+  invalid_user_amount : opt InvalidUserAmount;
+  existing_ticket : opt Ticket;
+  error_type : int32;
+};
 type ErrorRefundIcpRequest = record { source_principal_id : opt principal };
 type ErrorRefundIcpResponse = record { result : opt Result };
 type FailedUpdate = record {
@@ -39,18 +45,31 @@ type FailedUpdate = record {
   dapp_canister_id : opt principal;
 };
 type FinalizeSwapResponse = record {
+  set_dapp_controllers_call_result : opt SetDappControllersCallResult;
   settle_community_fund_participation_result : opt SettleCommunityFundParticipationResult;
-  set_dapp_controllers_result : opt SetDappControllersCallResult;
-  sns_governance_normal_mode_enabled : opt SetModeCallResult;
-  sweep_icp : opt SweepResult;
-  sweep_sns : opt SweepResult;
-  create_neuron : opt SweepResult;
+  error_message : opt text;
+  set_mode_call_result : opt SetModeCallResult;
+  sweep_icp_result : opt SweepResult;
+  claim_neuron_result : opt SweepResult;
+  sweep_sns_result : opt SweepResult;
 };
 type GetBuyerStateRequest = record { principal_id : opt principal };
 type GetBuyerStateResponse = record { buyer_state : opt BuyerState };
 type GetBuyersTotalResponse = record { buyers_total : nat64 };
+type GetDerivedStateResponse = record {
+  sns_tokens_per_icp : opt float64;
+  buyer_total_icp_e8s : opt nat64;
+};
+type GetInitResponse = record { init : opt Init };
+type GetLifecycleResponse = record {
+  decentralization_sale_open_timestamp_seconds : opt nat64;
+  lifecycle : opt int32;
+};
+type GetOpenTicketResponse = record { result : opt Result_1 };
+type GetSaleParametersResponse = record { params : opt Params };
 type GetStateResponse = record { swap : opt Swap; derived : opt DerivedState };
 type GovernanceError = record { error_message : text; error_type : int32 };
+type Icrc1Account = record { owner : opt principal; subaccount : opt vec nat8 };
 type Init = record {
   sns_root_canister_id : text;
   fallback_controller_principal_ids : vec text;
@@ -61,16 +80,50 @@ type Init = record {
   sns_ledger_canister_id : text;
   sns_governance_canister_id : text;
 };
+type InvalidUserAmount = record {
+  min_amount_icp_e8s_included : nat64;
+  max_amount_icp_e8s_included : nat64;
+};
 type Investor = variant {
   CommunityFund : CfInvestment;
   Direct : DirectInvestment;
 };
-type NeuronAttributes = record { dissolve_delay_seconds : nat64; memo : nat64 };
+type ListCommunityFundParticipantsRequest = record {
+  offset : opt nat64;
+  limit : opt nat32;
+};
+type ListCommunityFundParticipantsResponse = record {
+  cf_participants : vec CfParticipant;
+};
+type ListDirectParticipantsRequest = record {
+  offset : opt nat32;
+  limit : opt nat32;
+};
+type ListDirectParticipantsResponse = record { participants : vec Participant };
+type ListSnsNeuronRecipesRequest = record {
+  offset : opt nat64;
+  limit : opt nat32;
+};
+type ListSnsNeuronRecipesResponse = record {
+  sns_neuron_recipes : vec SnsNeuronRecipe;
+};
+type NeuronAttributes = record {
+  dissolve_delay_seconds : nat64;
+  memo : nat64;
+  followees : vec NeuronId;
+};
 type NeuronBasketConstructionParameters = record {
   dissolve_delay_interval_seconds : nat64;
   count : nat64;
 };
+type NeuronId = record { id : vec nat8 };
+type NewSaleTicketRequest = record {
+  subaccount : opt vec nat8;
+  amount_icp_e8s : nat64;
+};
+type NewSaleTicketResponse = record { result : opt Result_2 };
 type Ok = record { block_height : opt nat64 };
+type Ok_1 = record { ticket : opt Ticket };
 type OpenRequest = record {
   cf_participants : vec CfParticipant;
   params : opt Params;
@@ -83,15 +136,20 @@ type Params = record {
   swap_due_timestamp_seconds : nat64;
   min_participants : nat32;
   sns_token_e8s : nat64;
+  sale_delay_seconds : opt nat64;
   max_participant_icp_e8s : nat64;
   min_icp_e8s : nat64;
 };
-type Possibility = variant { Ok : Response; Err : CanisterCallError };
-type Possibility_1 = variant {
+type Participant = record {
+  participation : opt BuyerState;
+  participant_id : opt principal;
+};
+type Possibility = variant {
   Ok : SetDappControllersResponse;
   Err : CanisterCallError;
 };
-type Possibility_2 = variant { Err : CanisterCallError };
+type Possibility_1 = variant { Ok : Response; Err : CanisterCallError };
+type Possibility_2 = variant { Ok : record {}; Err : CanisterCallError };
 type RefreshBuyerTokensRequest = record { buyer : text };
 type RefreshBuyerTokensResponse = record {
   icp_accepted_participation_e8s : nat64;
@@ -99,19 +157,24 @@ type RefreshBuyerTokensResponse = record {
 };
 type Response = record { governance_error : opt GovernanceError };
 type Result = variant { Ok : Ok; Err : Err };
-type SetDappControllersCallResult = record { possibility : opt Possibility_1 };
+type Result_1 = variant { Ok : Ok_1; Err : Err_1 };
+type Result_2 = variant { Ok : Ok_1; Err : Err_2 };
+type SetDappControllersCallResult = record { possibility : opt Possibility };
 type SetDappControllersResponse = record { failed_updates : vec FailedUpdate };
 type SetModeCallResult = record { possibility : opt Possibility_2 };
 type SettleCommunityFundParticipationResult = record {
-  possibility : opt Possibility;
+  possibility : opt Possibility_1;
 };
 type SnsNeuronRecipe = record {
   sns : opt TransferableAmount;
+  claimed_status : opt int32;
   neuron_attributes : opt NeuronAttributes;
   investor : opt Investor;
 };
 type Swap = record {
   neuron_recipes : vec SnsNeuronRecipe;
+  decentralization_sale_open_timestamp_seconds : opt nat64;
+  finalize_swap_in_progress : opt bool;
   cf_participants : vec CfParticipant;
   init : opt Init;
   lifecycle : int32;
@@ -119,7 +182,19 @@ type Swap = record {
   params : opt Params;
   open_sns_token_swap_proposal_id : opt nat64;
 };
-type SweepResult = record { failure : nat32; skipped : nat32; success : nat32 };
+type SweepResult = record {
+  failure : nat32;
+  skipped : nat32;
+  invalid : nat32;
+  success : nat32;
+  global_failures : nat32;
+};
+type Ticket = record {
+  creation_time : nat64;
+  ticket_id : nat64;
+  account : opt Icrc1Account;
+  amount_icp_e8s : nat64;
+};
 type TransferableAmount = record {
   transfer_start_timestamp_seconds : nat64;
   amount_e8s : nat64;
@@ -131,7 +206,22 @@ service : (Init) -> {
   get_buyer_state : (GetBuyerStateRequest) -> (GetBuyerStateResponse) query;
   get_buyers_total : (record {}) -> (GetBuyersTotalResponse);
   get_canister_status : (record {}) -> (CanisterStatusResultV2);
+  get_derived_state : (record {}) -> (GetDerivedStateResponse) query;
+  get_init : (record {}) -> (GetInitResponse) query;
+  get_lifecycle : (record {}) -> (GetLifecycleResponse) query;
+  get_open_ticket : (record {}) -> (GetOpenTicketResponse) query;
+  get_sale_parameters : (record {}) -> (GetSaleParametersResponse) query;
   get_state : (record {}) -> (GetStateResponse) query;
+  list_community_fund_participants : (ListCommunityFundParticipantsRequest) -> (
+      ListCommunityFundParticipantsResponse,
+    ) query;
+  list_direct_participants : (ListDirectParticipantsRequest) -> (
+      ListDirectParticipantsResponse,
+    ) query;
+  list_sns_neuron_recipes : (ListSnsNeuronRecipesRequest) -> (
+      ListSnsNeuronRecipesResponse,
+    ) query;
+  new_sale_ticket : (NewSaleTicketRequest) -> (NewSaleTicketResponse);
   open : (OpenRequest) -> (record {});
   refresh_buyer_tokens : (RefreshBuyerTokensRequest) -> (
       RefreshBuyerTokensResponse,

--- a/packages/sns/candid/sns_swap.idl.js
+++ b/packages/sns/candid/sns_swap.idl.js
@@ -20,23 +20,9 @@ export const idlFactory = ({ IDL }) => {
   });
   const Result = IDL.Variant({ 'Ok' : Ok, 'Err' : Err });
   const ErrorRefundIcpResponse = IDL.Record({ 'result' : IDL.Opt(Result) });
-  const GovernanceError = IDL.Record({
-    'error_message' : IDL.Text,
-    'error_type' : IDL.Int32,
-  });
-  const Response = IDL.Record({
-    'governance_error' : IDL.Opt(GovernanceError),
-  });
   const CanisterCallError = IDL.Record({
     'code' : IDL.Opt(IDL.Int32),
     'description' : IDL.Text,
-  });
-  const Possibility = IDL.Variant({
-    'Ok' : Response,
-    'Err' : CanisterCallError,
-  });
-  const SettleCommunityFundParticipationResult = IDL.Record({
-    'possibility' : IDL.Opt(Possibility),
   });
   const FailedUpdate = IDL.Record({
     'err' : IDL.Opt(CanisterCallError),
@@ -45,31 +31,51 @@ export const idlFactory = ({ IDL }) => {
   const SetDappControllersResponse = IDL.Record({
     'failed_updates' : IDL.Vec(FailedUpdate),
   });
-  const Possibility_1 = IDL.Variant({
+  const Possibility = IDL.Variant({
     'Ok' : SetDappControllersResponse,
     'Err' : CanisterCallError,
   });
   const SetDappControllersCallResult = IDL.Record({
+    'possibility' : IDL.Opt(Possibility),
+  });
+  const GovernanceError = IDL.Record({
+    'error_message' : IDL.Text,
+    'error_type' : IDL.Int32,
+  });
+  const Response = IDL.Record({
+    'governance_error' : IDL.Opt(GovernanceError),
+  });
+  const Possibility_1 = IDL.Variant({
+    'Ok' : Response,
+    'Err' : CanisterCallError,
+  });
+  const SettleCommunityFundParticipationResult = IDL.Record({
     'possibility' : IDL.Opt(Possibility_1),
   });
-  const Possibility_2 = IDL.Variant({ 'Err' : CanisterCallError });
+  const Possibility_2 = IDL.Variant({
+    'Ok' : IDL.Record({}),
+    'Err' : CanisterCallError,
+  });
   const SetModeCallResult = IDL.Record({
     'possibility' : IDL.Opt(Possibility_2),
   });
   const SweepResult = IDL.Record({
     'failure' : IDL.Nat32,
     'skipped' : IDL.Nat32,
+    'invalid' : IDL.Nat32,
     'success' : IDL.Nat32,
+    'global_failures' : IDL.Nat32,
   });
   const FinalizeSwapResponse = IDL.Record({
+    'set_dapp_controllers_call_result' : IDL.Opt(SetDappControllersCallResult),
     'settle_community_fund_participation_result' : IDL.Opt(
       SettleCommunityFundParticipationResult
     ),
-    'set_dapp_controllers_result' : IDL.Opt(SetDappControllersCallResult),
-    'sns_governance_normal_mode_enabled' : IDL.Opt(SetModeCallResult),
-    'sweep_icp' : IDL.Opt(SweepResult),
-    'sweep_sns' : IDL.Opt(SweepResult),
-    'create_neuron' : IDL.Opt(SweepResult),
+    'error_message' : IDL.Opt(IDL.Text),
+    'set_mode_call_result' : IDL.Opt(SetModeCallResult),
+    'sweep_icp_result' : IDL.Opt(SweepResult),
+    'claim_neuron_result' : IDL.Opt(SweepResult),
+    'sweep_sns_result' : IDL.Opt(SweepResult),
   });
   const GetBuyerStateRequest = IDL.Record({
     'principal_id' : IDL.Opt(IDL.Principal),
@@ -107,32 +113,29 @@ export const idlFactory = ({ IDL }) => {
     'idle_cycles_burned_per_day' : IDL.Nat,
     'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
-  const NeuronAttributes = IDL.Record({
-    'dissolve_delay_seconds' : IDL.Nat64,
-    'memo' : IDL.Nat64,
+  const GetDerivedStateResponse = IDL.Record({
+    'sns_tokens_per_icp' : IDL.Opt(IDL.Float64),
+    'buyer_total_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
-  const CfInvestment = IDL.Record({
-    'hotkey_principal' : IDL.Text,
-    'nns_neuron_id' : IDL.Nat64,
+  const GetInitResponse = IDL.Record({ 'init' : IDL.Opt(Init) });
+  const GetLifecycleResponse = IDL.Record({
+    'decentralization_sale_open_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'lifecycle' : IDL.Opt(IDL.Int32),
   });
-  const DirectInvestment = IDL.Record({ 'buyer_principal' : IDL.Text });
-  const Investor = IDL.Variant({
-    'CommunityFund' : CfInvestment,
-    'Direct' : DirectInvestment,
+  const Icrc1Account = IDL.Record({
+    'owner' : IDL.Opt(IDL.Principal),
+    'subaccount' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
-  const SnsNeuronRecipe = IDL.Record({
-    'sns' : IDL.Opt(TransferableAmount),
-    'neuron_attributes' : IDL.Opt(NeuronAttributes),
-    'investor' : IDL.Opt(Investor),
-  });
-  const CfNeuron = IDL.Record({
-    'nns_neuron_id' : IDL.Nat64,
+  const Ticket = IDL.Record({
+    'creation_time' : IDL.Nat64,
+    'ticket_id' : IDL.Nat64,
+    'account' : IDL.Opt(Icrc1Account),
     'amount_icp_e8s' : IDL.Nat64,
   });
-  const CfParticipant = IDL.Record({
-    'hotkey_principal' : IDL.Text,
-    'cf_neurons' : IDL.Vec(CfNeuron),
-  });
+  const Ok_1 = IDL.Record({ 'ticket' : IDL.Opt(Ticket) });
+  const Err_1 = IDL.Record({ 'error_type' : IDL.Opt(IDL.Int32) });
+  const Result_1 = IDL.Variant({ 'Ok' : Ok_1, 'Err' : Err_1 });
+  const GetOpenTicketResponse = IDL.Record({ 'result' : IDL.Opt(Result_1) });
   const NeuronBasketConstructionParameters = IDL.Record({
     'dissolve_delay_interval_seconds' : IDL.Nat64,
     'count' : IDL.Nat64,
@@ -146,11 +149,44 @@ export const idlFactory = ({ IDL }) => {
     'swap_due_timestamp_seconds' : IDL.Nat64,
     'min_participants' : IDL.Nat32,
     'sns_token_e8s' : IDL.Nat64,
+    'sale_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_participant_icp_e8s' : IDL.Nat64,
     'min_icp_e8s' : IDL.Nat64,
   });
+  const GetSaleParametersResponse = IDL.Record({ 'params' : IDL.Opt(Params) });
+  const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
+  const NeuronAttributes = IDL.Record({
+    'dissolve_delay_seconds' : IDL.Nat64,
+    'memo' : IDL.Nat64,
+    'followees' : IDL.Vec(NeuronId),
+  });
+  const CfInvestment = IDL.Record({
+    'hotkey_principal' : IDL.Text,
+    'nns_neuron_id' : IDL.Nat64,
+  });
+  const DirectInvestment = IDL.Record({ 'buyer_principal' : IDL.Text });
+  const Investor = IDL.Variant({
+    'CommunityFund' : CfInvestment,
+    'Direct' : DirectInvestment,
+  });
+  const SnsNeuronRecipe = IDL.Record({
+    'sns' : IDL.Opt(TransferableAmount),
+    'claimed_status' : IDL.Opt(IDL.Int32),
+    'neuron_attributes' : IDL.Opt(NeuronAttributes),
+    'investor' : IDL.Opt(Investor),
+  });
+  const CfNeuron = IDL.Record({
+    'nns_neuron_id' : IDL.Nat64,
+    'amount_icp_e8s' : IDL.Nat64,
+  });
+  const CfParticipant = IDL.Record({
+    'hotkey_principal' : IDL.Text,
+    'cf_neurons' : IDL.Vec(CfNeuron),
+  });
   const Swap = IDL.Record({
     'neuron_recipes' : IDL.Vec(SnsNeuronRecipe),
+    'decentralization_sale_open_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'finalize_swap_in_progress' : IDL.Opt(IDL.Bool),
     'cf_participants' : IDL.Vec(CfParticipant),
     'init' : IDL.Opt(Init),
     'lifecycle' : IDL.Int32,
@@ -166,6 +202,46 @@ export const idlFactory = ({ IDL }) => {
     'swap' : IDL.Opt(Swap),
     'derived' : IDL.Opt(DerivedState),
   });
+  const ListCommunityFundParticipantsRequest = IDL.Record({
+    'offset' : IDL.Opt(IDL.Nat64),
+    'limit' : IDL.Opt(IDL.Nat32),
+  });
+  const ListCommunityFundParticipantsResponse = IDL.Record({
+    'cf_participants' : IDL.Vec(CfParticipant),
+  });
+  const ListDirectParticipantsRequest = IDL.Record({
+    'offset' : IDL.Opt(IDL.Nat32),
+    'limit' : IDL.Opt(IDL.Nat32),
+  });
+  const Participant = IDL.Record({
+    'participation' : IDL.Opt(BuyerState),
+    'participant_id' : IDL.Opt(IDL.Principal),
+  });
+  const ListDirectParticipantsResponse = IDL.Record({
+    'participants' : IDL.Vec(Participant),
+  });
+  const ListSnsNeuronRecipesRequest = IDL.Record({
+    'offset' : IDL.Opt(IDL.Nat64),
+    'limit' : IDL.Opt(IDL.Nat32),
+  });
+  const ListSnsNeuronRecipesResponse = IDL.Record({
+    'sns_neuron_recipes' : IDL.Vec(SnsNeuronRecipe),
+  });
+  const NewSaleTicketRequest = IDL.Record({
+    'subaccount' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'amount_icp_e8s' : IDL.Nat64,
+  });
+  const InvalidUserAmount = IDL.Record({
+    'min_amount_icp_e8s_included' : IDL.Nat64,
+    'max_amount_icp_e8s_included' : IDL.Nat64,
+  });
+  const Err_2 = IDL.Record({
+    'invalid_user_amount' : IDL.Opt(InvalidUserAmount),
+    'existing_ticket' : IDL.Opt(Ticket),
+    'error_type' : IDL.Int32,
+  });
+  const Result_2 = IDL.Variant({ 'Ok' : Ok_1, 'Err' : Err_2 });
+  const NewSaleTicketResponse = IDL.Record({ 'result' : IDL.Opt(Result_2) });
   const OpenRequest = IDL.Record({
     'cf_participants' : IDL.Vec(CfParticipant),
     'params' : IDL.Opt(Params),
@@ -198,7 +274,48 @@ export const idlFactory = ({ IDL }) => {
         [CanisterStatusResultV2],
         [],
       ),
+    'get_derived_state' : IDL.Func(
+        [IDL.Record({})],
+        [GetDerivedStateResponse],
+        ['query'],
+      ),
+    'get_init' : IDL.Func([IDL.Record({})], [GetInitResponse], ['query']),
+    'get_lifecycle' : IDL.Func(
+        [IDL.Record({})],
+        [GetLifecycleResponse],
+        ['query'],
+      ),
+    'get_open_ticket' : IDL.Func(
+        [IDL.Record({})],
+        [GetOpenTicketResponse],
+        ['query'],
+      ),
+    'get_sale_parameters' : IDL.Func(
+        [IDL.Record({})],
+        [GetSaleParametersResponse],
+        ['query'],
+      ),
     'get_state' : IDL.Func([IDL.Record({})], [GetStateResponse], ['query']),
+    'list_community_fund_participants' : IDL.Func(
+        [ListCommunityFundParticipantsRequest],
+        [ListCommunityFundParticipantsResponse],
+        ['query'],
+      ),
+    'list_direct_participants' : IDL.Func(
+        [ListDirectParticipantsRequest],
+        [ListDirectParticipantsResponse],
+        ['query'],
+      ),
+    'list_sns_neuron_recipes' : IDL.Func(
+        [ListSnsNeuronRecipesRequest],
+        [ListSnsNeuronRecipesResponse],
+        ['query'],
+      ),
+    'new_sale_ticket' : IDL.Func(
+        [NewSaleTicketRequest],
+        [NewSaleTicketResponse],
+        [],
+      ),
     'open' : IDL.Func([OpenRequest], [IDL.Record({})], []),
     'refresh_buyer_tokens' : IDL.Func(
         [RefreshBuyerTokensRequest],

--- a/packages/sns/src/enums/swap.enums.ts
+++ b/packages/sns/src/enums/swap.enums.ts
@@ -5,4 +5,5 @@ export enum SnsSwapLifecycle {
   Open = 2,
   Committed = 3,
   Aborted = 4,
+  Adopted = 5,
 }

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -20,6 +20,7 @@ export type {
   DerivedState as SnsSwapDerivedState,
   GetBuyerStateRequest as SnsGetBuyerStateRequest,
   GetBuyerStateResponse as SnsGetBuyerStateResponse,
+  GetLifecycleResponse as SnsGetLifecycleResponse,
   Init as SnsSwapInit,
   Params as SnsParams,
   SnsNeuronRecipe,

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -317,6 +317,17 @@ describe("SnsWrapper", () => {
     });
   });
 
+  it("should call getLifecycle with query and update", async () => {
+    await snsWrapper.getLifecycle({});
+    expect(mockSwapCanister.getLifecycle).toHaveBeenCalledWith({
+      certified: false,
+    });
+    await certifiedSnsWrapper.getLifecycle({});
+    expect(mockCertifiedSwapCanister.getLifecycle).toHaveBeenCalledWith({
+      certified: true,
+    });
+  });
+
   it("should call notifyParticipation", async () => {
     await snsWrapper.notifyParticipation({ buyer: "aaaaa-aa" });
     expect(mockSwapCanister.notifyParticipation).toHaveBeenCalledWith({

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -24,6 +24,7 @@ import type {
 import type {
   BuyerState,
   GetBuyerStateRequest,
+  GetLifecycleResponse,
   GetStateResponse,
   RefreshBuyerTokensRequest,
 } from "../candid/sns_swap";
@@ -376,6 +377,11 @@ export class SnsWrapper {
     params: GetBuyerStateRequest
   ): Promise<BuyerState | undefined> =>
     this.swap.getUserCommitment(this.mergeParams(params));
+
+  getLifecycle = (
+    params: Omit<QueryParams, "certified">
+  ): Promise<GetLifecycleResponse | undefined> =>
+    this.swap.getLifecycle(this.mergeParams(params));
 
   // Always certified
   getTransactions = (

--- a/packages/sns/src/swap.canister.spec.ts
+++ b/packages/sns/src/swap.canister.spec.ts
@@ -3,10 +3,12 @@ import { Principal } from "@dfinity/principal";
 import { mock } from "jest-mock-extended";
 import type {
   BuyerState,
+  GetLifecycleResponse,
   GetStateResponse,
   Swap,
   _SERVICE as SnsSwapService,
 } from "../candid/sns_swap";
+import { SnsSwapLifecycle } from "./enums/swap.enums";
 import { swapCanisterIdMock } from "./mocks/sns.mock";
 import { SnsSwapCanister } from "./swap.canister";
 
@@ -31,6 +33,23 @@ describe("Swap canister", () => {
 
     const service = mock<ActorSubclass<SnsSwapService>>();
     service.get_state.mockResolvedValue(mockResponse);
+
+    const canister = SnsSwapCanister.create({
+      canisterId: swapCanisterIdMock,
+      certifiedServiceOverride: service,
+    });
+    const res = await canister.state({});
+    expect(res).toEqual(mockResponse);
+  });
+
+  it("should return the lifecycle state of the swap canister", async () => {
+    const mockResponse: GetLifecycleResponse = {
+      decentralization_sale_open_timestamp_seconds: [BigInt(2)],
+      lifecycle: [SnsSwapLifecycle.Adopted],
+    };
+
+    const service = mock<ActorSubclass<SnsSwapService>>();
+    service.get_lifecycle.mockResolvedValue(mockResponse);
 
     const canister = SnsSwapCanister.create({
       canisterId: swapCanisterIdMock,

--- a/packages/sns/src/swap.canister.spec.ts
+++ b/packages/sns/src/swap.canister.spec.ts
@@ -55,7 +55,7 @@ describe("Swap canister", () => {
       canisterId: swapCanisterIdMock,
       certifiedServiceOverride: service,
     });
-    const res = await canister.state({});
+    const res = await canister.getLifecycle({});
     expect(res).toEqual(mockResponse);
   });
 

--- a/packages/sns/src/swap.canister.ts
+++ b/packages/sns/src/swap.canister.ts
@@ -3,6 +3,7 @@ import { Canister, createServices, fromNullable } from "@dfinity/utils";
 import type {
   BuyerState,
   GetBuyerStateRequest,
+  GetLifecycleResponse,
   GetStateResponse,
   RefreshBuyerTokensRequest,
   _SERVICE as SnsSwapService,
@@ -48,5 +49,12 @@ export class SnsSwapCanister extends Canister<SnsSwapService> {
       certified: params.certified,
     }).get_buyer_state({ principal_id: params.principal_id });
     return fromNullable(buyer_state);
+  };
+
+  /**
+   * Get sale lifecycle state
+   */
+  getLifecycle = async (params: QueryParams): Promise<GetLifecycleResponse> => {
+    return this.caller(params).get_lifecycle({});
   };
 }


### PR DESCRIPTION
# Motivation

Support new SNS Sale Lifecycle state: Adopted.

# Changes

Most of the changes are candid related.

A part from those ones, the review should focus on:
* New method `getLifecycle` in sns swap canister.
* New method `getLifecycle` in sns wrapper canister, that redirects to the sns swap canister method.
* Use new param `sale_delay_seconds` in converters.
* New SwapLifecycle "Adpted".

# Tests

* Add test for new methods.
