### PR TITLE
Fix: ToNullable checks only undefined

### DIFF
--- a/packages/utils/src/utils/did.utils.spec.ts
+++ b/packages/utils/src/utils/did.utils.spec.ts
@@ -20,6 +20,21 @@ describe("did-utils", () => {
     expect(toNullable(test)).toEqual([test]);
   });
 
+  it("should convert boolean to array", () => {
+    const test = false;
+    expect(toNullable(test)).toEqual([test]);
+  });
+
+  it("should convert null to array", () => {
+    const test = null;
+    expect(toNullable(test)).toEqual([test]);
+  });
+
+  it("should convert 0 to array", () => {
+    const test = 0;
+    expect(toNullable(test)).toEqual([test]);
+  });
+
   describe("fromDefinedNullable", () => {
     it("should convert from array to object", () => {
       const test = { test: "1" };

--- a/packages/utils/src/utils/did.utils.ts
+++ b/packages/utils/src/utils/did.utils.ts
@@ -1,7 +1,7 @@
 import { assertNonNullish } from "./asserts.utils";
 
 export const toNullable = <T>(value?: T): [] | [T] => {
-  return value ? [value] : [];
+  return value !== undefined ? [value] : [];
 };
 
 export const fromNullable = <T>(value: [] | [T]): T | undefined => {


### PR DESCRIPTION
# Motivation

`toNullable` checks only `undefined` to add array or not.

Candid uses `[] | [T]` for optional parameteres. `T` can also be a falsy value like `null`, `false` or `0`.

# Changes

* Change `toNullable` implementation.

# Tests

* Add tests to cover falsy cases.
