### PR TITLE
feat: extend toNullable to handle null

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -44,12 +44,12 @@ npm i @dfinity/agent @dfinity/candid @dfinity/principal
 - [assertNonNullish](#gear-assertnonnullish)
 - [assertPercentageNumber](#gear-assertpercentagenumber)
 - [debounce](#gear-debounce)
-- [toNullable](#gear-tonullable)
-- [fromNullable](#gear-fromnullable)
-- [fromDefinedNullable](#gear-fromdefinednullable)
 - [isNullish](#gear-isnullish)
 - [nonNullish](#gear-nonnullish)
 - [notEmptyString](#gear-notemptystring)
+- [toNullable](#gear-tonullable)
+- [fromNullable](#gear-fromnullable)
+- [fromDefinedNullable](#gear-fromdefinednullable)
 - [principalToSubAccount](#gear-principaltosubaccount)
 - [smallerVersion](#gear-smallerversion)
 
@@ -141,24 +141,6 @@ Parameters:
 | ---------- | -------------------------------------------------------------------- |
 | `debounce` | `(func: Function, timeout?: number) => (...args: unknown[]) => void` |
 
-#### :gear: toNullable
-
-| Function     | Type                          |
-| ------------ | ----------------------------- |
-| `toNullable` | `<T>(value?: T) => [] or [T]` |
-
-#### :gear: fromNullable
-
-| Function       | Type                         |
-| -------------- | ---------------------------- |
-| `fromNullable` | `<T>(value: [] or [T]) => T` |
-
-#### :gear: fromDefinedNullable
-
-| Function              | Type                         |
-| --------------------- | ---------------------------- |
-| `fromDefinedNullable` | `<T>(value: [] or [T]) => T` |
-
 #### :gear: isNullish
 
 Is null or undefined
@@ -182,6 +164,24 @@ Not null and not undefined and not empty
 | Function         | Type                         |
 | ---------------- | ---------------------------- |
 | `notEmptyString` | `(value: string) => boolean` |
+
+#### :gear: toNullable
+
+| Function     | Type                          |
+| ------------ | ----------------------------- |
+| `toNullable` | `<T>(value?: T) => [] or [T]` |
+
+#### :gear: fromNullable
+
+| Function       | Type                         |
+| -------------- | ---------------------------- |
+| `fromNullable` | `<T>(value: [] or [T]) => T` |
+
+#### :gear: fromDefinedNullable
+
+| Function              | Type                         |
+| --------------------- | ---------------------------- |
+| `fromDefinedNullable` | `<T>(value: [] or [T]) => T` |
 
 #### :gear: principalToSubAccount
 

--- a/packages/utils/src/utils/did.utils.spec.ts
+++ b/packages/utils/src/utils/did.utils.spec.ts
@@ -15,6 +15,10 @@ describe("did-utils", () => {
     expect(toNullable(undefined)).toEqual([]);
   });
 
+  it("should convert from null to empty array", () => {
+    expect(toNullable(null)).toEqual([]);
+  });
+
   it("should convert object to array", () => {
     const test = { test: "1" };
     expect(toNullable(test)).toEqual([test]);

--- a/packages/utils/src/utils/did.utils.spec.ts
+++ b/packages/utils/src/utils/did.utils.spec.ts
@@ -29,9 +29,9 @@ describe("did-utils", () => {
     expect(toNullable(test)).toEqual([test]);
   });
 
-  it("should convert null to array", () => {
+  it("should convert null to empty array", () => {
     const test = null;
-    expect(toNullable(test)).toEqual([test]);
+    expect(toNullable(test)).toEqual([]);
   });
 
   it("should convert 0 to array", () => {

--- a/packages/utils/src/utils/did.utils.ts
+++ b/packages/utils/src/utils/did.utils.ts
@@ -1,7 +1,8 @@
 import { assertNonNullish } from "./asserts.utils";
+import { nonNullish } from "./nullish.utils";
 
-export const toNullable = <T>(value?: T): [] | [T] => {
-  return value !== undefined ? [value] : [];
+export const toNullable = <T>(value?: T | null): [] | [T] => {
+  return nonNullish(value) ? [value] : [];
 };
 
 export const fromNullable = <T>(value: [] | [T]): T | undefined => {


### PR DESCRIPTION
# Motivation

Extend `toNullable` to handle `null`.

As discussed with @lmuntaner .
