### PR TITLE
fix: swap.errors visibility

### DIFF
--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -30,6 +30,7 @@ export type {
 export * from "./enums/governance.enums";
 export * from "./enums/swap.enums";
 export * from "./errors/governance.errors";
+export * from "./errors/swap.errors";
 export { SnsGovernanceCanister } from "./governance.canister";
 export { SnsRootCanister } from "./root.canister";
 export * from "./sns";


### PR DESCRIPTION
# Motivation

Make swap error types visible from outside.

# Changes

- add swap.errors to index.ts
