### PR TITLE
build: peer dependencies propagated to npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,11 +38,6 @@
         "tsdoc-markdown": "^0.0.1",
         "typescript": "^4.9.5",
         "whatwg-fetch": "^3.6.2"
-      },
-      "peerDependencies": {
-        "@dfinity/agent": "^0.15.3",
-        "@dfinity/candid": "^0.15.3",
-        "@dfinity/principal": "^0.15.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6919,6 +6914,9 @@
       "version": "0.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
+        "@dfinity/agent": "^0.15.3",
+        "@dfinity/candid": "^0.15.3",
+        "@dfinity/principal": "^0.15.3",
         "@dfinity/utils": "^0.0.13"
       }
     },
@@ -6927,6 +6925,9 @@
       "version": "0.0.9",
       "license": "Apache-2.0",
       "peerDependencies": {
+        "@dfinity/agent": "^0.15.3",
+        "@dfinity/candid": "^0.15.3",
+        "@dfinity/principal": "^0.15.3",
         "@dfinity/utils": "^0.0.13"
       }
     },
@@ -6935,6 +6936,9 @@
       "version": "0.0.6",
       "license": "Apache-2.0",
       "peerDependencies": {
+        "@dfinity/agent": "^0.15.3",
+        "@dfinity/candid": "^0.15.3",
+        "@dfinity/principal": "^0.15.3",
         "@dfinity/utils": "^0.0.13"
       }
     },
@@ -6954,6 +6958,9 @@
         "@types/randombytes": "^2.0.0"
       },
       "peerDependencies": {
+        "@dfinity/agent": "^0.15.3",
+        "@dfinity/candid": "^0.15.3",
+        "@dfinity/principal": "^0.15.3",
         "@dfinity/utils": "^0.0.13"
       }
     },
@@ -7006,7 +7013,10 @@
         "js-sha256": "^0.9.0"
       },
       "peerDependencies": {
+        "@dfinity/agent": "^0.15.3",
+        "@dfinity/candid": "^0.15.3",
         "@dfinity/ledger": "^0.0.6",
+        "@dfinity/principal": "^0.15.3",
         "@dfinity/utils": "^0.0.13"
       }
     },
@@ -7014,7 +7024,12 @@
       "name": "@dfinity/utils",
       "version": "0.0.13",
       "license": "Apache-2.0",
-      "devDependencies": {}
+      "devDependencies": {},
+      "peerDependencies": {
+        "@dfinity/agent": "^0.15.3",
+        "@dfinity/candid": "^0.15.3",
+        "@dfinity/principal": "^0.15.3"
+      }
     }
   },
   "dependencies": {
@@ -7580,7 +7595,8 @@
       }
     },
     "@dfinity/utils": {
-      "version": "file:packages/utils"
+      "version": "file:packages/utils",
+      "requires": {}
     },
     "@esbuild/android-arm": {
       "version": "0.17.6",

--- a/package.json
+++ b/package.json
@@ -48,10 +48,5 @@
     "tsdoc-markdown": "^0.0.1",
     "typescript": "^4.9.5",
     "whatwg-fetch": "^3.6.2"
-  },
-  "peerDependencies": {
-    "@dfinity/agent": "^0.15.3",
-    "@dfinity/candid": "^0.15.3",
-    "@dfinity/principal": "^0.15.3"
   }
 }

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -38,6 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
+    "@dfinity/agent": "^0.15.3",
+    "@dfinity/candid": "^0.15.3",
+    "@dfinity/principal": "^0.15.3",
     "@dfinity/utils": "^0.0.13"
   }
 }

--- a/packages/cmc/package.json
+++ b/packages/cmc/package.json
@@ -36,6 +36,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
+    "@dfinity/agent": "^0.15.3",
+    "@dfinity/candid": "^0.15.3",
+    "@dfinity/principal": "^0.15.3",
     "@dfinity/utils": "^0.0.13"
   }
 }

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -37,6 +37,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
+    "@dfinity/agent": "^0.15.3",
+    "@dfinity/candid": "^0.15.3",
+    "@dfinity/principal": "^0.15.3",
     "@dfinity/utils": "^0.0.13"
   }
 }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -55,6 +55,9 @@
     "network-nervous-system"
   ],
   "peerDependencies": {
+    "@dfinity/agent": "^0.15.3",
+    "@dfinity/candid": "^0.15.3",
+    "@dfinity/principal": "^0.15.3",
     "@dfinity/utils": "^0.0.13"
   }
 }

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -36,7 +36,10 @@
     "sns"
   ],
   "peerDependencies": {
+    "@dfinity/agent": "^0.15.3",
+    "@dfinity/candid": "^0.15.3",
     "@dfinity/ledger": "^0.0.6",
+    "@dfinity/principal": "^0.15.3",
     "@dfinity/utils": "^0.0.13"
   },
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,8 +18,6 @@
     "prepack": "npm run build",
     "test": "jest"
   },
-  "dependencies": {},
-  "devDependencies": {},
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dfinity/ic-js.git",
@@ -47,5 +45,10 @@
     "sns",
     "service nervous system",
     "service-nervous-system"
-  ]
+  ],
+  "peerDependencies": {
+    "@dfinity/agent": "^0.15.3",
+    "@dfinity/candid": "^0.15.3",
+    "@dfinity/principal": "^0.15.3"
+  }
 }


### PR DESCRIPTION
# Motivation

The `package.json` we publish to npm are not currently referencing the libraries peer dependencies (e.g. https://www.npmjs.com/package/@dfinity/ledger?activeTab=explore) which is not accurate.

# Changes

- `npm rm @dfinity/agent @dfinity/candid @dfinity/principal && npm i @dfinity/agent @dfinity/candid @dfinity/principal --workspaces --save-peer`

(`--workspaces` is the key here)
