### PR TITLE
feat: icp ledger operation variant

### DIFF
--- a/packages/nns/candid/ledger.certified.idl.js
+++ b/packages/nns/candid/ledger.certified.idl.js
@@ -6,9 +6,17 @@ export const idlFactory = ({ IDL }) => {
     'length' : IDL.Nat64,
   });
   const Memo = IDL.Nat64;
-  const AccountIdentifier = IDL.Vec(IDL.Nat8);
   const Tokens = IDL.Record({ 'e8s' : IDL.Nat64 });
+  const AccountIdentifier = IDL.Vec(IDL.Nat8);
+  const TimeStamp = IDL.Record({ 'timestamp_nanos' : IDL.Nat64 });
   const Operation = IDL.Variant({
+    'Approve' : IDL.Record({
+      'fee' : Tokens,
+      'from' : AccountIdentifier,
+      'allowance_e8s' : IDL.Int,
+      'expires_at' : IDL.Opt(TimeStamp),
+      'spender' : AccountIdentifier,
+    }),
     'Burn' : IDL.Record({ 'from' : AccountIdentifier, 'amount' : Tokens }),
     'Mint' : IDL.Record({ 'to' : AccountIdentifier, 'amount' : Tokens }),
     'Transfer' : IDL.Record({
@@ -17,8 +25,14 @@ export const idlFactory = ({ IDL }) => {
       'from' : AccountIdentifier,
       'amount' : Tokens,
     }),
+    'TransferFrom' : IDL.Record({
+      'to' : AccountIdentifier,
+      'fee' : Tokens,
+      'from' : AccountIdentifier,
+      'amount' : Tokens,
+      'spender' : AccountIdentifier,
+    }),
   });
-  const TimeStamp = IDL.Record({ 'timestamp_nanos' : IDL.Nat64 });
   const Transaction = IDL.Record({
     'memo' : Memo,
     'icrc1_memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),

--- a/packages/nns/candid/ledger.d.ts
+++ b/packages/nns/candid/ledger.d.ts
@@ -27,8 +27,15 @@ export interface GetBlocksArgs {
 export type Memo = bigint;
 export type Operation =
   | {
-      Burn: { from: AccountIdentifier; amount: Tokens };
+      Approve: {
+        fee: Tokens;
+        from: AccountIdentifier;
+        allowance_e8s: bigint;
+        expires_at: [] | [TimeStamp];
+        spender: AccountIdentifier;
+      };
     }
+  | { Burn: { from: AccountIdentifier; amount: Tokens } }
   | { Mint: { to: AccountIdentifier; amount: Tokens } }
   | {
       Transfer: {
@@ -36,6 +43,15 @@ export type Operation =
         fee: Tokens;
         from: AccountIdentifier;
         amount: Tokens;
+      };
+    }
+  | {
+      TransferFrom: {
+        to: AccountIdentifier;
+        fee: Tokens;
+        from: AccountIdentifier;
+        amount: Tokens;
+        spender: AccountIdentifier;
       };
     };
 export type QueryArchiveError =

--- a/packages/nns/candid/ledger.did
+++ b/packages/nns/candid/ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 5376a14c92f20b4bd285d7622ac5f2a8d21c0d02 'rs/rosetta-api/icp_ledger/ledger.did' by import-candid
+// Generated from IC repo commit 87eb51bc9aab91fb17a2b4d60ee7b719dba117dc 'rs/rosetta-api/icp_ledger/ledger.did' by import-candid
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.
@@ -110,6 +110,20 @@ type Operation = variant {
     Transfer : record {
         from : AccountIdentifier;
         to : AccountIdentifier;
+        amount : Tokens;
+        fee : Tokens;
+    };
+    Approve : record {
+        from : AccountIdentifier;
+        spender : AccountIdentifier;
+        allowance_e8s : int;
+        fee : Tokens;
+        expires_at : opt TimeStamp;
+    };
+    TransferFrom : record {
+        from : AccountIdentifier;
+        to : AccountIdentifier;
+        spender : AccountIdentifier;
         amount : Tokens;
         fee : Tokens;
     };

--- a/packages/nns/candid/ledger.idl.js
+++ b/packages/nns/candid/ledger.idl.js
@@ -11,7 +11,15 @@ export const idlFactory = ({ IDL }) => {
     'length' : IDL.Nat64,
   });
   const Memo = IDL.Nat64;
+  const TimeStamp = IDL.Record({ 'timestamp_nanos' : IDL.Nat64 });
   const Operation = IDL.Variant({
+    'Approve' : IDL.Record({
+      'fee' : Tokens,
+      'from' : AccountIdentifier,
+      'allowance_e8s' : IDL.Int,
+      'expires_at' : IDL.Opt(TimeStamp),
+      'spender' : AccountIdentifier,
+    }),
     'Burn' : IDL.Record({ 'from' : AccountIdentifier, 'amount' : Tokens }),
     'Mint' : IDL.Record({ 'to' : AccountIdentifier, 'amount' : Tokens }),
     'Transfer' : IDL.Record({
@@ -20,8 +28,14 @@ export const idlFactory = ({ IDL }) => {
       'from' : AccountIdentifier,
       'amount' : Tokens,
     }),
+    'TransferFrom' : IDL.Record({
+      'to' : AccountIdentifier,
+      'fee' : Tokens,
+      'from' : AccountIdentifier,
+      'amount' : Tokens,
+      'spender' : AccountIdentifier,
+    }),
   });
-  const TimeStamp = IDL.Record({ 'timestamp_nanos' : IDL.Nat64 });
   const Transaction = IDL.Record({
     'memo' : Memo,
     'icrc1_memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),


### PR DESCRIPTION
# Motivation

We do not used these, therefore we should be fine but additional values in the `Operation` variant have been added to the ICP ledger on mainnet. Therefore better have these in the code.

# Changes

- update candid and generate types
