### PR TITLE
Gix 1373 avoid exponent format in icp amount

### DIFF
--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -74,9 +74,9 @@ await main();
 
 Receives a string representing a number and returns the big int or error.
 
-| Function             | Type                                                   |
-| -------------------- | ------------------------------------------------------ |
-| `convertStringToE8s` | `(amount: string) => bigint or FromStringToTokenError` |
+| Function             | Type                                                  |
+| -------------------- | ----------------------------------------------------- |
+| `convertStringToE8s` | `(value: string) => bigint or FromStringToTokenError` |
 
 Parameters:
 

--- a/packages/nns/src/token.spec.ts
+++ b/packages/nns/src/token.spec.ts
@@ -112,8 +112,12 @@ describe("ICP", () => {
     ).toBe(FromStringToTokenError.InvalidFormat);
 
     const callToNumber = () =>
-      TokenAmount.fromNumber({ token: ICPToken, amount: 0.0000000001 });
-    expect(callToNumber).toThrow();
+      TokenAmount.fromNumber({ token: ICPToken, amount: 1e-9 });
+    expect(callToNumber).toThrow(
+      expect.objectContaining({
+        message: "Number 1e-9 has more than 8 decimals",
+      })
+    );
   });
 
   it("rejects negative numbers", () => {

--- a/packages/nns/src/token.spec.ts
+++ b/packages/nns/src/token.spec.ts
@@ -95,6 +95,9 @@ describe("ICP", () => {
     ).toEqual(
       TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1234500000001) })
     );
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "1e-8" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1) })
+    );
   });
 
   it("returns an error on invalid formats", () => {

--- a/packages/nns/src/token.ts
+++ b/packages/nns/src/token.ts
@@ -16,7 +16,7 @@ export const convertStringToE8s = (
   let amount = value.includes("e")
     ? Number(value).toLocaleString("en", {
         useGrouping: false,
-        maximumFractionDigits: 8,
+        maximumFractionDigits: 20,
       })
     : value;
 

--- a/packages/nns/src/token.ts
+++ b/packages/nns/src/token.ts
@@ -9,8 +9,17 @@ import { FromStringToTokenError } from "./enums/token.enums";
  * @returns bigint | FromStringToTokenError
  */
 export const convertStringToE8s = (
-  amount: string
+  value: string
 ): bigint | FromStringToTokenError => {
+  // replace exponential format (1e-4) with plain (0.0001)
+  // doesn't support decimals for values >= ~1e16
+  let amount = value.includes("e")
+    ? Number(value).toLocaleString("en", {
+        useGrouping: false,
+        maximumFractionDigits: 8,
+      })
+    : value;
+
   // Remove all instances of "," and "'".
   amount = amount.trim().replace(/[,']/g, "");
 


### PR DESCRIPTION
# Motivation

Avoid throwing error on exponential formatted numbers
https://dfinity.atlassian.net/browse/GIX-1373

# Changes

- apply `toLocaleString` on exponential number strings

# Tests

- update test to be more precise

# Screenshots

before
![Screen Recording 2023-03-03 at 19 13 20](https://user-images.githubusercontent.com/98811342/222796599-3069472d-07d3-4168-9a40-f13b9f16d121.gif)

after
![Screen Recording 2023-03-03 at 17 12 41](https://user-images.githubusercontent.com/98811342/222796834-f30ab265-77f9-44d5-97b8-b5ab8599b98a.gif)


