### PR TITLE
Update agent dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -668,9 +668,9 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.15.3.tgz",
-      "integrity": "sha512-yjJnAWI2CQY9kAFgavXU4TiKjb3NwaKUpu2LwCfgtJM4k6ofKlW+7q0tBJNs5WvHqRcKRDdn4d6yXKQi+ubS+w==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.15.4.tgz",
+      "integrity": "sha512-JuWaLUUtdGJx2DwHgnGrtTNwF5bC6a+izMbcHeN2M0RSaukeVNkRdYz4Bfxg7yTwdFxQRfQWcXcwvKF8/R2IEg==",
       "peer": true,
       "dependencies": {
         "base64-arraybuffer": "^0.2.0",
@@ -681,14 +681,14 @@
         "ts-node": "^10.8.2"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.15.3",
-        "@dfinity/principal": "^0.15.3"
+        "@dfinity/candid": "^0.15.4",
+        "@dfinity/principal": "^0.15.4"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.15.3.tgz",
-      "integrity": "sha512-jbfA+kr+gCrBuwxWm/j4Vpqzbnh9bsyUWu9CjopJis8xdxH3FIfNDWOzHZ/QaW7Co+6UoON1wzxMiy91/W5DQA==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.15.4.tgz",
+      "integrity": "sha512-ImoZ18i95DDstn+EXm/Y1ms7RqF1KVS7+KqZLNvpHFTlcOgfAQc5Bq8W6l1nfkOqeh7wcehDYdjFJwLxBoeTlw==",
       "peer": true,
       "dependencies": {
         "ts-node": "^10.8.2"
@@ -711,9 +711,9 @@
       "link": true
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.15.3.tgz",
-      "integrity": "sha512-XqHZVaJx/acmg6kFkF7PB156UwAquOS2WiAA753+nGKTG+TOC7OxbBXCr8vfEsd0mEzcmcLl+jLF8iUsC6Hk4w==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.15.4.tgz",
+      "integrity": "sha512-ZH0InIXaIQqXfUDgkSa0S+9VlkAduhu2JJ984KtRs3BSHUyxG32OGnRcvxfJDdm6GHXWndTWoQUraHPoA3RplQ==",
       "peer": true,
       "dependencies": {
         "js-sha256": "^0.9.0",
@@ -6914,9 +6914,9 @@
       "version": "0.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^0.15.3",
-        "@dfinity/candid": "^0.15.3",
-        "@dfinity/principal": "^0.15.3",
+        "@dfinity/agent": "^0.15.4",
+        "@dfinity/candid": "^0.15.4",
+        "@dfinity/principal": "^0.15.4",
         "@dfinity/utils": "^0.0.13"
       }
     },
@@ -6925,9 +6925,9 @@
       "version": "0.0.9",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^0.15.3",
-        "@dfinity/candid": "^0.15.3",
-        "@dfinity/principal": "^0.15.3",
+        "@dfinity/agent": "^0.15.4",
+        "@dfinity/candid": "^0.15.4",
+        "@dfinity/principal": "^0.15.4",
         "@dfinity/utils": "^0.0.13"
       }
     },
@@ -6936,9 +6936,9 @@
       "version": "0.0.6",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^0.15.3",
-        "@dfinity/candid": "^0.15.3",
-        "@dfinity/principal": "^0.15.3",
+        "@dfinity/agent": "^0.15.4",
+        "@dfinity/candid": "^0.15.4",
+        "@dfinity/principal": "^0.15.4",
         "@dfinity/utils": "^0.0.13"
       }
     },
@@ -6958,9 +6958,9 @@
         "@types/randombytes": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.15.3",
-        "@dfinity/candid": "^0.15.3",
-        "@dfinity/principal": "^0.15.3",
+        "@dfinity/agent": "^0.15.4",
+        "@dfinity/candid": "^0.15.4",
+        "@dfinity/principal": "^0.15.4",
         "@dfinity/utils": "^0.0.13"
       }
     },
@@ -7013,10 +7013,10 @@
         "js-sha256": "^0.9.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.15.3",
-        "@dfinity/candid": "^0.15.3",
+        "@dfinity/agent": "^0.15.4",
+        "@dfinity/candid": "^0.15.4",
         "@dfinity/ledger": "^0.0.6",
-        "@dfinity/principal": "^0.15.3",
+        "@dfinity/principal": "^0.15.4",
         "@dfinity/utils": "^0.0.13"
       }
     },
@@ -7024,11 +7024,10 @@
       "name": "@dfinity/utils",
       "version": "0.0.13",
       "license": "Apache-2.0",
-      "devDependencies": {},
       "peerDependencies": {
-        "@dfinity/agent": "^0.15.3",
-        "@dfinity/candid": "^0.15.3",
-        "@dfinity/principal": "^0.15.3"
+        "@dfinity/agent": "^0.15.4",
+        "@dfinity/candid": "^0.15.4",
+        "@dfinity/principal": "^0.15.4"
       }
     }
   },
@@ -7513,9 +7512,9 @@
       }
     },
     "@dfinity/agent": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.15.3.tgz",
-      "integrity": "sha512-yjJnAWI2CQY9kAFgavXU4TiKjb3NwaKUpu2LwCfgtJM4k6ofKlW+7q0tBJNs5WvHqRcKRDdn4d6yXKQi+ubS+w==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.15.4.tgz",
+      "integrity": "sha512-JuWaLUUtdGJx2DwHgnGrtTNwF5bC6a+izMbcHeN2M0RSaukeVNkRdYz4Bfxg7yTwdFxQRfQWcXcwvKF8/R2IEg==",
       "peer": true,
       "requires": {
         "base64-arraybuffer": "^0.2.0",
@@ -7527,9 +7526,9 @@
       }
     },
     "@dfinity/candid": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.15.3.tgz",
-      "integrity": "sha512-jbfA+kr+gCrBuwxWm/j4Vpqzbnh9bsyUWu9CjopJis8xdxH3FIfNDWOzHZ/QaW7Co+6UoON1wzxMiy91/W5DQA==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.15.4.tgz",
+      "integrity": "sha512-ImoZ18i95DDstn+EXm/Y1ms7RqF1KVS7+KqZLNvpHFTlcOgfAQc5Bq8W6l1nfkOqeh7wcehDYdjFJwLxBoeTlw==",
       "peer": true,
       "requires": {
         "ts-node": "^10.8.2"
@@ -7579,9 +7578,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.15.3.tgz",
-      "integrity": "sha512-XqHZVaJx/acmg6kFkF7PB156UwAquOS2WiAA753+nGKTG+TOC7OxbBXCr8vfEsd0mEzcmcLl+jLF8iUsC6Hk4w==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.15.4.tgz",
+      "integrity": "sha512-ZH0InIXaIQqXfUDgkSa0S+9VlkAduhu2JJ984KtRs3BSHUyxG32OGnRcvxfJDdm6GHXWndTWoQUraHPoA3RplQ==",
       "peer": true,
       "requires": {
         "js-sha256": "^0.9.0",

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.15.3",
-    "@dfinity/candid": "^0.15.3",
-    "@dfinity/principal": "^0.15.3",
+    "@dfinity/agent": "^0.15.4",
+    "@dfinity/candid": "^0.15.4",
+    "@dfinity/principal": "^0.15.4",
     "@dfinity/utils": "^0.0.13"
   }
 }

--- a/packages/cmc/package.json
+++ b/packages/cmc/package.json
@@ -36,9 +36,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.15.3",
-    "@dfinity/candid": "^0.15.3",
-    "@dfinity/principal": "^0.15.3",
+    "@dfinity/agent": "^0.15.4",
+    "@dfinity/candid": "^0.15.4",
+    "@dfinity/principal": "^0.15.4",
     "@dfinity/utils": "^0.0.13"
   }
 }

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -37,9 +37,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.15.3",
-    "@dfinity/candid": "^0.15.3",
-    "@dfinity/principal": "^0.15.3",
+    "@dfinity/agent": "^0.15.4",
+    "@dfinity/candid": "^0.15.4",
+    "@dfinity/principal": "^0.15.4",
     "@dfinity/utils": "^0.0.13"
   }
 }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -55,9 +55,9 @@
     "network-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^0.15.3",
-    "@dfinity/candid": "^0.15.3",
-    "@dfinity/principal": "^0.15.3",
+    "@dfinity/agent": "^0.15.4",
+    "@dfinity/candid": "^0.15.4",
+    "@dfinity/principal": "^0.15.4",
     "@dfinity/utils": "^0.0.13"
   }
 }

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -35,14 +35,14 @@
     "service-nervous-system",
     "sns"
   ],
-  "peerDependencies": {
-    "@dfinity/agent": "^0.15.3",
-    "@dfinity/candid": "^0.15.3",
-    "@dfinity/ledger": "^0.0.6",
-    "@dfinity/principal": "^0.15.3",
-    "@dfinity/utils": "^0.0.13"
-  },
   "dependencies": {
     "js-sha256": "^0.9.0"
+  },
+  "peerDependencies": {
+    "@dfinity/agent": "^0.15.4",
+    "@dfinity/candid": "^0.15.4",
+    "@dfinity/ledger": "^0.0.6",
+    "@dfinity/principal": "^0.15.4",
+    "@dfinity/utils": "^0.0.13"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -47,8 +47,8 @@
     "service-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^0.15.3",
-    "@dfinity/candid": "^0.15.3",
-    "@dfinity/principal": "^0.15.3"
+    "@dfinity/agent": "^0.15.4",
+    "@dfinity/candid": "^0.15.4",
+    "@dfinity/principal": "^0.15.4"
   }
 }


### PR DESCRIPTION
# Motivation

Agent js 0.15.4 removed some circular dependencies (https://github.com/dfinity/agent-js/pull/688, https://github.com/dfinity/agent-js/pull/691) which makes nns-dapp less likely to hit https://github.com/rollup/plugins/issues/1425 and more reproducible as a result.

# Changes

```
npm rm @dfinity/agent @dfinity/candid @dfinity/principal @dfinity/utils  --workspace=packages/ckbtc
npm i @dfinity/agent @dfinity/candid @dfinity/principal @dfinity/utils --save-peer   --workspace=packages/ckbtc
npm rm @dfinity/agent @dfinity/candid @dfinity/principal @dfinity/utils  --workspace=packages/cmc
npm i @dfinity/agent @dfinity/candid @dfinity/principal @dfinity/utils --save-peer   --workspace=packages/cmc
npm rm @dfinity/{agent,candid,principal,utils}  --workspace=packages/ledger
npm i @dfinity/{agent,candid,principal,utils} --save-peer   --workspace=packages/ledger
npm rm @dfinity/{agent,candid,principal,utils}  --workspace=packages/nns
npm i @dfinity/{agent,candid,principal,utils} --save-peer   --workspace=packages/nns
npm rm @dfinity/{agent,candid,ledger,principal,utils}  --workspace=packages/sns
npm i @dfinity/{agent,candid,ledger,principal,utils} --save-peer   --workspace=packages/sns
npm rm @dfinity/{agent,candid,principal}  --workspace=packages/utils
npm i @dfinity/{agent,candid,principal} --save-peer   --workspace=packages/utils
```

# Tests

```
npm ci
npm run test
```