### PR TITLE
Build utils and ledger before other packages

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -22,6 +22,10 @@ To build or test a particular package - e.g. `sns`:
 npm run build/test --workspace=packages/sns
 ```
 
+Because of dependencies between the packages you need to make sure to build
+`packages/utils` and `packages/ledger` before you can build/test any of the
+other packages.
+
 ## nns-js: How-to test local changes with nns-dapp
 
 ### In this directory

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "format": "prettier --write .",
     "protoc": "bash ./scripts/update_proto.sh",
     "test": "jest",
+    "test-all": "npm ci && npm run build --workspace=packages/utils && npm run build --workspace=packages/ledger && npm run test --workspaces",
     "docs": "node scripts/docs.js && prettier --write packages/nns/README.md packages/sns/README.md packages/cmc/README.md packages/utils/README.md packages/ledger/README.md packages/ckbtc/README.md"
   },
   "repository": {


### PR DESCRIPTION
# Motivation

`npm ci && npm run test` on a clean branch gives errors because of dependencies between the packages.

# Changes

1. Add a line in HACKING.md about building `utils` and `ledger` first.
2. Add `npm run test-all` script which builds packages in the correct order before running all the tests.

# Tests

`rm -rf packages/*/dist node_modules/ && npm run test-all`