### PR TITLE
GIX-1381: Add total tokens supply endpoint

### DIFF
--- a/packages/ledger/README.md
+++ b/packages/ledger/README.md
@@ -98,6 +98,7 @@ Parameters:
 - [transactionFee](#gear-transactionfee)
 - [balance](#gear-balance)
 - [transfer](#gear-transfer)
+- [totalTokensSupply](#gear-totaltokenssupply)
 
 ##### :gear: create
 
@@ -144,6 +145,14 @@ Transfers tokens from the sender to the given account.
 Parameters:
 
 - `params`: The parameters to transfer tokens.
+
+##### :gear: totalTokensSupply
+
+Returns the total supply of tokens.
+
+| Method              | Type                                       |
+| ------------------- | ------------------------------------------ |
+| `totalTokensSupply` | `(params: QueryParams) => Promise<bigint>` |
 
 ### :factory: IcrcIndexCanister
 

--- a/packages/ledger/src/ledger.canister.spec.ts
+++ b/packages/ledger/src/ledger.canister.spec.ts
@@ -42,6 +42,20 @@ describe("Ledger canister", () => {
     expect(res).toEqual(fee);
   });
 
+  it("should return the total tokens supply", async () => {
+    const service = mock<ActorSubclass<IcrcLedgerService>>();
+    const totalTokens = BigInt(1000_000_000_000);
+    service.icrc1_total_supply.mockResolvedValue(totalTokens);
+
+    const canister = IcrcLedgerCanister.create({
+      canisterId: ledgerCanisterIdMock,
+      certifiedServiceOverride: service,
+    });
+
+    const res = await canister.totalTokensSupply({});
+    expect(res).toEqual(totalTokens);
+  });
+
   describe("balance", () => {
     it("should return the balance of main account", async () => {
       const service = mock<ActorSubclass<IcrcLedgerService>>();

--- a/packages/ledger/src/ledger.canister.ts
+++ b/packages/ledger/src/ledger.canister.ts
@@ -70,4 +70,11 @@ export class IcrcLedgerCanister extends Canister<IcrcLedgerService> {
     }
     return response.Ok;
   };
+
+  /**
+   * Returns the total supply of tokens.
+   */
+  totalTokensSupply = (params: QueryParams): Promise<Tokens> => {
+    return this.caller(params).icrc1_total_supply();
+  };
 }

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -467,6 +467,7 @@ Parameters:
 - [nervousSystemParameters](#gear-nervoussystemparameters)
 - [ledgerMetadata](#gear-ledgermetadata)
 - [transactionFee](#gear-transactionfee)
+- [totalTokensSupply](#gear-totaltokenssupply)
 - [balance](#gear-balance)
 - [transfer](#gear-transfer)
 - [getNeuron](#gear-getneuron)
@@ -547,6 +548,12 @@ Parameters:
 | Method           | Type                                                              |
 | ---------------- | ----------------------------------------------------------------- |
 | `transactionFee` | `(params: Omit<QueryParams, "certified">) => Promise<IcrcTokens>` |
+
+##### :gear: totalTokensSupply
+
+| Method              | Type                                                              |
+| ------------------- | ----------------------------------------------------------------- |
+| `totalTokensSupply` | `(params: Omit<QueryParams, "certified">) => Promise<IcrcTokens>` |
 
 ##### :gear: balance
 

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -42,6 +42,8 @@ describe("SnsWrapper", () => {
   });
   const mockLedgerCanister = mock<IcrcLedgerCanister>();
   mockLedgerCanister.metadata.mockResolvedValue(tokenMetadataResponseMock);
+  const tokensSupply = BigInt(1_000_000_000_000);
+  mockLedgerCanister.totalTokensSupply.mockResolvedValue(tokensSupply);
 
   const mockCertifiedLedgerCanister = mock<IcrcLedgerCanister>();
   mockCertifiedLedgerCanister.metadata.mockResolvedValue(
@@ -306,6 +308,21 @@ describe("SnsWrapper", () => {
     expect(mockCertifiedLedgerCanister.metadata).toHaveBeenCalledWith({
       certified: true,
     });
+  });
+
+  it("should call leger totalTokensSupply with query or update", async () => {
+    await snsWrapper.totalTokensSupply({});
+    expect(mockLedgerCanister.totalTokensSupply).toHaveBeenCalledWith({
+      certified: false,
+    });
+
+    await certifiedSnsWrapper.totalTokensSupply({});
+    expect(mockCertifiedLedgerCanister.totalTokensSupply).toHaveBeenCalledWith({
+      certified: true,
+    });
+
+    expect(mockLedgerCanister.totalTokensSupply).toBeCalledTimes(1);
+    expect(mockCertifiedLedgerCanister.totalTokensSupply).toBeCalledTimes(1);
   });
 
   it("should call swapState with query and update", async () => {

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -165,6 +165,11 @@ export class SnsWrapper {
   ): Promise<IcrcTokens> =>
     this.ledger.transactionFee(this.mergeParams(params));
 
+  totalTokensSupply = (
+    params: Omit<QueryParams, "certified">
+  ): Promise<IcrcTokens> =>
+    this.ledger.totalTokensSupply(this.mergeParams(params));
+
   balance = (params: Omit<BalanceParams, "certified">): Promise<IcrcTokens> =>
     this.ledger.balance(this.mergeParams(params));
 


### PR DESCRIPTION
# Motivation

Show important data like total tokens supply in the Project Detail page in the nns dapp.

Therefore, we expose the ledger endpoint `icrc1_total_supply` to use it in nns dapp and others to get this important data.

# Changes

* Add new endpoint `totalTokensSupply` to IcrcLedgerCanister.
* Add new endpoint `totalTokensSupply` to Sns Wrapper.

# Tests

* Test new endpoint in IcrcLedgerCanister
* Test new endpoint in SNS Wrapper
