### PR TITLE
build: check libraries size limit with GitHub actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -110,8 +110,21 @@ jobs:
       - name: Test
         run: npm run test --workspaces
 
+  size:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm ci
+      - name: Size check
+        uses: andresz1/size-limit-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
   may-merge:
-    needs: ["formatting", "build", "lint", "test"]
+    needs: ["formatting", "build", "lint", "test", "size"]
     runs-on: ubuntu-20.04
     steps:
       - name: Cleared for merging

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -116,8 +116,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install dependencies
-        run: npm ci
       - name: Size check
         uses: andresz1/size-limit-action@v1
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "packages/ckbtc"
       ],
       "devDependencies": {
+        "@size-limit/preset-small-lib": "^8.2.4",
         "@types/jest": "^29.5.0",
         "@types/node": "^18.15.5",
         "@types/text-encoding": "^0.0.36",
@@ -1613,6 +1614,50 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
+    "node_modules/@size-limit/esbuild": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@size-limit/esbuild/-/esbuild-8.2.4.tgz",
+      "integrity": "sha512-kPgNfpwUvBD98s5axlf1UciFg4Ki4AYSl/cOmSyyYBuzksHiwW7Myeu0w4mTxtV9nwBFbkrrNXqszE7b+OhFLA==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.17.7",
+        "nanoid": "^3.3.4"
+      },
+      "engines": {
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "8.2.4"
+      }
+    },
+    "node_modules/@size-limit/file": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-8.2.4.tgz",
+      "integrity": "sha512-xLuF97W7m7lxrRJvqXRlxO/4t7cpXtfxOnjml/t4aRVUCMXLdyvebRr9OM4jjoK8Fmiz8jomCbETUCI3jVhLzA==",
+      "dev": true,
+      "dependencies": {
+        "semver": "7.3.8"
+      },
+      "engines": {
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "8.2.4"
+      }
+    },
+    "node_modules/@size-limit/preset-small-lib": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@size-limit/preset-small-lib/-/preset-small-lib-8.2.4.tgz",
+      "integrity": "sha512-AL4384oBgMcDPlNblgWHreqFSSOui0J9NbgyHhegB1h8AgRyHbdVGC3yWLpEESYQXHYnKdbNrYeRE/TclsViog==",
+      "dev": true,
+      "dependencies": {
+        "@size-limit/esbuild": "8.2.4",
+        "@size-limit/file": "8.2.4"
+      },
+      "peerDependencies": {
+        "size-limit": "8.2.4"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -2508,6 +2553,16 @@
         "node": "*"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/borc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
@@ -2637,6 +2692,16 @@
         "semver": "^7.0.0"
       }
     },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -2707,6 +2772,47 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/ci-info": {
@@ -4347,6 +4453,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-boolean-object": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
@@ -5359,6 +5478,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -5499,6 +5628,34 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanospinner": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.1.0.tgz",
+      "integrity": "sha512-yFvNYMig4AthKYfHFl1sLj7B2nkHL4lzdig4osvl9/LdGbXwrdFRoqBS98gsEsOakr0yH+r5NZ/1Y9gdVB8trA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "picocolors": "^1.0.0"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -5994,6 +6151,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -6156,9 +6326,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6222,6 +6392,27 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
+    },
+    "node_modules/size-limit": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-8.2.4.tgz",
+      "integrity": "sha512-Un16nSreD1v2CYwSorattiJcHuAWqXvg4TsGgzpjnoByqQwsSfCIEQHuaD14HNStzredR8cdsO9oGH91ibypTA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "chokidar": "^3.5.3",
+        "globby": "^11.1.0",
+        "lilconfig": "^2.0.6",
+        "nanospinner": "^1.1.0",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -8245,6 +8436,35 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
+    "@size-limit/esbuild": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@size-limit/esbuild/-/esbuild-8.2.4.tgz",
+      "integrity": "sha512-kPgNfpwUvBD98s5axlf1UciFg4Ki4AYSl/cOmSyyYBuzksHiwW7Myeu0w4mTxtV9nwBFbkrrNXqszE7b+OhFLA==",
+      "dev": true,
+      "requires": {
+        "esbuild": "^0.17.7",
+        "nanoid": "^3.3.4"
+      }
+    },
+    "@size-limit/file": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-8.2.4.tgz",
+      "integrity": "sha512-xLuF97W7m7lxrRJvqXRlxO/4t7cpXtfxOnjml/t4aRVUCMXLdyvebRr9OM4jjoK8Fmiz8jomCbETUCI3jVhLzA==",
+      "dev": true,
+      "requires": {
+        "semver": "7.3.8"
+      }
+    },
+    "@size-limit/preset-small-lib": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@size-limit/preset-small-lib/-/preset-small-lib-8.2.4.tgz",
+      "integrity": "sha512-AL4384oBgMcDPlNblgWHreqFSSOui0J9NbgyHhegB1h8AgRyHbdVGC3yWLpEESYQXHYnKdbNrYeRE/TclsViog==",
+      "dev": true,
+      "requires": {
+        "@size-limit/esbuild": "8.2.4",
+        "@size-limit/file": "8.2.4"
+      }
+    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -8869,6 +9089,13 @@
       "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
       "peer": true
     },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "peer": true
+    },
     "borc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
@@ -8959,6 +9186,13 @@
         "semver": "^7.0.0"
       }
     },
+    "bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "peer": true
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -9002,6 +9236,35 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
     },
     "ci-info": {
       "version": "3.4.0",
@@ -10197,6 +10460,16 @@
         "has-bigints": "^1.0.1"
       }
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-boolean-object": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
@@ -10946,6 +11219,13 @@
         "type-check": "~0.4.0"
       }
     },
+    "lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
+      "peer": true
+    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -11061,6 +11341,22 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true
+    },
+    "nanospinner": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.1.0.tgz",
+      "integrity": "sha512-yFvNYMig4AthKYfHFl1sLj7B2nkHL4lzdig4osvl9/LdGbXwrdFRoqBS98gsEsOakr0yH+r5NZ/1Y9gdVB8trA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "picocolors": "^1.0.0"
+      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -11389,6 +11685,16 @@
         "util-deprecate": "^1.0.1"
       }
     },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -11493,9 +11799,9 @@
       }
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -11544,6 +11850,21 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
+    },
+    "size-limit": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-8.2.4.tgz",
+      "integrity": "sha512-Un16nSreD1v2CYwSorattiJcHuAWqXvg4TsGgzpjnoByqQwsSfCIEQHuaD14HNStzredR8cdsO9oGH91ibypTA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "bytes-iec": "^3.1.1",
+        "chokidar": "^3.5.3",
+        "globby": "^11.1.0",
+        "lilconfig": "^2.0.6",
+        "nanospinner": "^1.1.0",
+        "picocolors": "^1.0.0"
+      }
     },
     "slash": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "packages/ckbtc"
       ],
       "devDependencies": {
+        "@size-limit/esbuild": "^8.2.4",
         "@size-limit/preset-small-lib": "^8.2.4",
         "@types/jest": "^29.5.0",
         "@types/node": "^18.15.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "node-fetch": "^3.3.1",
         "prettier": "^2.8.5",
         "prettier-plugin-organize-imports": "^3.2.2",
+        "size-limit": "^8.2.4",
         "text-encoding": "^0.7.0",
         "ts-jest": "^29.0.5",
         "ts-protoc-gen": "^0.15.0",
@@ -2558,7 +2559,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2697,7 +2697,6 @@
       "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
       "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2785,7 +2784,6 @@
           "url": "https://paulmillr.com/funding/"
         }
       ],
-      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -2807,7 +2805,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -4458,7 +4455,6 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -5483,7 +5479,6 @@
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
       "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -5652,7 +5647,6 @@
       "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.1.0.tgz",
       "integrity": "sha512-yFvNYMig4AthKYfHFl1sLj7B2nkHL4lzdig4osvl9/LdGbXwrdFRoqBS98gsEsOakr0yH+r5NZ/1Y9gdVB8trA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "picocolors": "^1.0.0"
       }
@@ -6156,7 +6150,6 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -6398,7 +6391,6 @@
       "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-8.2.4.tgz",
       "integrity": "sha512-Un16nSreD1v2CYwSorattiJcHuAWqXvg4TsGgzpjnoByqQwsSfCIEQHuaD14HNStzredR8cdsO9oGH91ibypTA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "bytes-iec": "^3.1.1",
         "chokidar": "^3.5.3",
@@ -9093,8 +9085,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "borc": {
       "version": "2.1.2",
@@ -9190,8 +9181,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
       "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "call-bind": {
       "version": "1.0.2",
@@ -9242,7 +9232,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -9259,7 +9248,6 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
           "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "dev": true,
-          "peer": true,
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -10465,7 +10453,6 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -11223,8 +11210,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
       "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "lines-and-columns": {
       "version": "1.2.4",
@@ -11353,7 +11339,6 @@
       "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.1.0.tgz",
       "integrity": "sha512-yFvNYMig4AthKYfHFl1sLj7B2nkHL4lzdig4osvl9/LdGbXwrdFRoqBS98gsEsOakr0yH+r5NZ/1Y9gdVB8trA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "picocolors": "^1.0.0"
       }
@@ -11690,7 +11675,6 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -11856,7 +11840,6 @@
       "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-8.2.4.tgz",
       "integrity": "sha512-Un16nSreD1v2CYwSorattiJcHuAWqXvg4TsGgzpjnoByqQwsSfCIEQHuaD14HNStzredR8cdsO9oGH91ibypTA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "bytes-iec": "^3.1.1",
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "protoc": "bash ./scripts/update_proto.sh",
     "test": "jest",
     "test-all": "npm ci && npm run build --workspace=packages/utils && npm run build --workspace=packages/ledger && npm run test --workspaces",
-    "docs": "node scripts/docs.js && prettier --write packages/nns/README.md packages/sns/README.md packages/cmc/README.md packages/utils/README.md packages/ledger/README.md packages/ckbtc/README.md"
+    "docs": "node scripts/docs.js && prettier --write packages/nns/README.md packages/sns/README.md packages/cmc/README.md packages/utils/README.md packages/ledger/README.md packages/ckbtc/README.md",
+    "size": "size-limit --json"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,7 @@
     "url": "https://github.com/dfinity/ic-js"
   },
   "devDependencies": {
+    "@size-limit/preset-small-lib": "^8.2.4",
     "@types/jest": "^29.5.0",
     "@types/node": "^18.15.5",
     "@types/text-encoding": "^0.0.36",
@@ -49,5 +51,37 @@
     "tsdoc-markdown": "^0.0.1",
     "typescript": "^4.9.5",
     "whatwg-fetch": "^3.6.2"
-  }
+  },
+  "size-limit": [
+    {
+      "name": "@dfinity/ckbtc",
+      "path": "./packages/ckbtc/dist/index.js",
+      "limit": "90 kB"
+    },
+    {
+      "name": "@dfinity/cmc",
+      "path": "./packages/cmc/dist/index.js",
+      "limit": "80 kB"
+    },
+    {
+      "name": "@dfinity/ledger",
+      "path": "./packages/ledger/dist/index.js",
+      "limit": "85 kB"
+    },
+    {
+      "name": "@dfinity/nns",
+      "path": "./packages/nns/dist/index.js",
+      "limit": "210 kB"
+    },
+    {
+      "name": "@dfinity/sns",
+      "path": "./packages/sns/dist/index.js",
+      "limit": "100 kB"
+    },
+    {
+      "name": "@dfinity/utils",
+      "path": "./packages/utils/dist/index.js",
+      "limit": "85 kB"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "url": "https://github.com/dfinity/ic-js"
   },
   "devDependencies": {
+    "@size-limit/esbuild": "^8.2.4",
     "@size-limit/preset-small-lib": "^8.2.4",
     "@types/jest": "^29.5.0",
     "@types/node": "^18.15.5",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     {
       "name": "@dfinity/ckbtc",
       "path": "./packages/ckbtc/dist/index.js",
-      "limit": "5 kB"
+      "limit": "90 kB"
     },
     {
       "name": "@dfinity/cmc",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "node-fetch": "^3.3.1",
     "prettier": "^2.8.5",
     "prettier-plugin-organize-imports": "^3.2.2",
+    "size-limit": "^8.2.4",
     "text-encoding": "^0.7.0",
     "ts-jest": "^29.0.5",
     "ts-protoc-gen": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     {
       "name": "@dfinity/ckbtc",
       "path": "./packages/ckbtc/dist/index.js",
-      "limit": "90 kB"
+      "limit": "5 kB"
     },
     {
       "name": "@dfinity/cmc",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test": "jest",
     "test-all": "npm ci && npm run build --workspace=packages/utils && npm run build --workspace=packages/ledger && npm run test --workspaces",
     "docs": "node scripts/docs.js && prettier --write packages/nns/README.md packages/sns/README.md packages/cmc/README.md packages/utils/README.md packages/ledger/README.md packages/ckbtc/README.md",
-    "size": "size-limit --json"
+    "size": "size-limit --json",
+    "build": "npm run build --workspaces"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Motivation

Calculate the cost of the ic-js libs when the GA checks run.

# Notes

I think the GA or `size-limit` weight also the size of the peer dependencies so it provides a result for each libraries as if it was not used together with another library.

```
@dfinity/ckbtc 86kb
@dfinity/cmc 76kb
```

which in reality is maybe something like

```
@dfinity/ckbtc 26kb
@dfinity/cmc 16kb
@dfinity/agent-js 60kb
```



# PRs

- [x] #310
- [x] #311

# Changes

- use action [andresz1/size-limit-action@v1](https://github.com/andresz1/size-limit-action) in CI
