### PR TITLE
build: add "build" cmd script shorthand to root

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "protoc": "bash ./scripts/update_proto.sh",
     "test": "jest",
     "test-all": "npm ci && npm run build --workspace=packages/utils && npm run build --workspace=packages/ledger && npm run test --workspaces",
-    "docs": "node scripts/docs.js && prettier --write packages/nns/README.md packages/sns/README.md packages/cmc/README.md packages/utils/README.md packages/ledger/README.md packages/ckbtc/README.md"
+    "docs": "node scripts/docs.js && prettier --write packages/nns/README.md packages/sns/README.md packages/cmc/README.md packages/utils/README.md packages/ledger/README.md packages/ckbtc/README.md",
+    "build": "npm run build --workspaces"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Motivation

Add a shorthand `npm run build` to root which in addition to being handy is required by the GH action to check the size (PR #309).
