### PR TITLE
build: ignore peer dependencies in size limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,32 +59,68 @@
     {
       "name": "@dfinity/ckbtc",
       "path": "./packages/ckbtc/dist/index.js",
-      "limit": "90 kB"
+      "limit": "90 kB",
+      "ignore": [
+        "@dfinity/agent",
+        "@dfinity/candid",
+        "@dfinity/principal",
+        "@dfinity/utils"
+      ]
     },
     {
       "name": "@dfinity/cmc",
       "path": "./packages/cmc/dist/index.js",
-      "limit": "80 kB"
+      "limit": "80 kB",
+      "ignore": [
+        "@dfinity/agent",
+        "@dfinity/candid",
+        "@dfinity/principal",
+        "@dfinity/utils"
+      ]
     },
     {
       "name": "@dfinity/ledger",
       "path": "./packages/ledger/dist/index.js",
-      "limit": "85 kB"
+      "limit": "85 kB",
+      "ignore": [
+        "@dfinity/agent",
+        "@dfinity/candid",
+        "@dfinity/principal",
+        "@dfinity/utils"
+      ]
     },
     {
       "name": "@dfinity/nns",
       "path": "./packages/nns/dist/index.js",
-      "limit": "210 kB"
+      "limit": "210 kB",
+      "ignore": [
+        "@dfinity/agent",
+        "@dfinity/candid",
+        "@dfinity/principal",
+        "@dfinity/utils"
+      ]
     },
     {
       "name": "@dfinity/sns",
       "path": "./packages/sns/dist/index.js",
-      "limit": "100 kB"
+      "limit": "100 kB",
+      "ignore": [
+        "@dfinity/agent",
+        "@dfinity/candid",
+        "@dfinity/principal",
+        "@dfinity/utils",
+        "@dfinity/ledger"
+      ]
     },
     {
       "name": "@dfinity/utils",
       "path": "./packages/utils/dist/index.js",
-      "limit": "85 kB"
+      "limit": "85 kB",
+      "ignore": [
+        "@dfinity/agent",
+        "@dfinity/candid",
+        "@dfinity/principal"
+      ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     {
       "name": "@dfinity/ledger",
       "path": "./packages/ledger/dist/index.js",
-      "limit": "2 kB",
+      "limit": "3 kB",
       "ignore": [
         "@dfinity/agent",
         "@dfinity/candid",
@@ -92,7 +92,7 @@
     {
       "name": "@dfinity/nns",
       "path": "./packages/nns/dist/index.js",
-      "limit": "121 kB",
+      "limit": "125 kB",
       "ignore": [
         "@dfinity/agent",
         "@dfinity/candid",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     {
       "name": "@dfinity/ckbtc",
       "path": "./packages/ckbtc/dist/index.js",
-      "limit": "90 kB",
+      "limit": "8 kB",
       "ignore": [
         "@dfinity/agent",
         "@dfinity/candid",
@@ -70,7 +70,7 @@
     {
       "name": "@dfinity/cmc",
       "path": "./packages/cmc/dist/index.js",
-      "limit": "80 kB",
+      "limit": "1 kB",
       "ignore": [
         "@dfinity/agent",
         "@dfinity/candid",
@@ -81,7 +81,7 @@
     {
       "name": "@dfinity/ledger",
       "path": "./packages/ledger/dist/index.js",
-      "limit": "85 kB",
+      "limit": "2 kB",
       "ignore": [
         "@dfinity/agent",
         "@dfinity/candid",
@@ -92,7 +92,7 @@
     {
       "name": "@dfinity/nns",
       "path": "./packages/nns/dist/index.js",
-      "limit": "210 kB",
+      "limit": "121 kB",
       "ignore": [
         "@dfinity/agent",
         "@dfinity/candid",
@@ -103,7 +103,7 @@
     {
       "name": "@dfinity/sns",
       "path": "./packages/sns/dist/index.js",
-      "limit": "100 kB",
+      "limit": "13 kB",
       "ignore": [
         "@dfinity/agent",
         "@dfinity/candid",
@@ -115,7 +115,7 @@
     {
       "name": "@dfinity/utils",
       "path": "./packages/utils/dist/index.js",
-      "limit": "85 kB",
+      "limit": "2 kB",
       "ignore": [
         "@dfinity/agent",
         "@dfinity/candid",


### PR DESCRIPTION
# Motivation

Ignore peer dependencies (agent-js, utils and ledger) in size comparison.

# Changes

- add `ignore` patterns to `package.json`
