### PR TITLE
feat: web crypto API to generate sha256

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7152,8 +7152,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "base58-js": "^1.0.5",
-        "bech32": "^2.0.0",
-        "js-sha256": "^0.9.0"
+        "bech32": "^2.0.0"
       },
       "peerDependencies": {
         "@dfinity/agent": "^0.15.4",
@@ -7208,9 +7207,6 @@
       "name": "@dfinity/sns",
       "version": "0.0.13",
       "license": "Apache-2.0",
-      "dependencies": {
-        "js-sha256": "^0.9.0"
-      },
       "peerDependencies": {
         "@dfinity/agent": "^0.15.4",
         "@dfinity/candid": "^0.15.4",
@@ -7737,8 +7733,7 @@
       "version": "file:packages/ckbtc",
       "requires": {
         "base58-js": "^1.0.5",
-        "bech32": "^2.0.0",
-        "js-sha256": "^0.9.0"
+        "bech32": "^2.0.0"
       }
     },
     "@dfinity/cmc": {
@@ -7771,9 +7766,7 @@
     },
     "@dfinity/sns": {
       "version": "file:packages/sns",
-      "requires": {
-        "js-sha256": "^0.9.0"
-      }
+      "requires": {}
     },
     "@dfinity/utils": {
       "version": "file:packages/utils",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint --max-warnings 0 .",
     "format": "prettier --write .",
     "protoc": "bash ./scripts/update_proto.sh",
-    "test": "jest",
+    "test": "node --experimental-global-webcrypto node_modules/jest/bin/jest.js",
     "test-all": "npm ci && npm run build --workspace=packages/utils && npm run build --workspace=packages/ledger && npm run test --workspaces",
     "docs": "node scripts/docs.js && prettier --write packages/nns/README.md packages/sns/README.md packages/cmc/README.md packages/utils/README.md packages/ledger/README.md packages/ckbtc/README.md",
     "build": "npm run build --workspaces",

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -16,7 +16,7 @@
     "ts-declaration": "tsc --emitDeclarationOnly --outDir dist/types",
     "build": "npm run rmdir && mkdir -p dist && cp -R candid dist && node esbuild.mjs && npm run ts-declaration",
     "prepack": "npm run build",
-    "test": "jest"
+    "test": "node --experimental-global-webcrypto ../../node_modules/jest/bin/jest.js"
   },
   "repository": {
     "type": "git",
@@ -45,7 +45,6 @@
   },
   "dependencies": {
     "base58-js": "^1.0.5",
-    "bech32": "^2.0.0",
-    "js-sha256": "^0.9.0"
+    "bech32": "^2.0.0"
   }
 }

--- a/packages/ckbtc/src/utils/btc.utils.spec.ts
+++ b/packages/ckbtc/src/utils/btc.utils.spec.ts
@@ -7,10 +7,12 @@ import {
 import { parseBtcAddress } from "./btc.utils";
 
 describe("BTC utils", () => {
-  it("parse Mainnet P2PKH", () => {
+  it("parse Mainnet P2PKH", async () => {
     const address = "17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem";
 
-    expect(parseBtcAddress({ address, network: BtcNetwork.Mainnet })).toEqual({
+    expect(
+      await parseBtcAddress({ address, network: BtcNetwork.Mainnet })
+    ).toEqual({
       address,
       network: BtcNetwork.Mainnet,
       type: BtcAddressType.P2pkh,
@@ -18,10 +20,12 @@ describe("BTC utils", () => {
     });
   });
 
-  it("parse Testnet P2PKH", () => {
+  it("parse Testnet P2PKH", async () => {
     const address = "mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn";
 
-    expect(parseBtcAddress({ address, network: BtcNetwork.Testnet })).toEqual({
+    expect(
+      await parseBtcAddress({ address, network: BtcNetwork.Testnet })
+    ).toEqual({
       address,
       network: BtcNetwork.Testnet,
       type: BtcAddressType.P2pkh,
@@ -29,10 +33,12 @@ describe("BTC utils", () => {
     });
   });
 
-  it("parse Regtest P2PKH", () => {
+  it("parse Regtest P2PKH", async () => {
     const address = "mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn";
 
-    expect(parseBtcAddress({ address, network: BtcNetwork.Regtest })).toEqual({
+    expect(
+      await parseBtcAddress({ address, network: BtcNetwork.Regtest })
+    ).toEqual({
       address,
       network: BtcNetwork.Regtest,
       type: BtcAddressType.P2pkh,
@@ -40,24 +46,26 @@ describe("BTC utils", () => {
     });
   });
 
-  it("fails on invalid P2PKH", () => {
+  it("fails on invalid P2PKH", async () => {
     const address = "17VZNX1SN5NtKa8UFFxwQbFeFc3iqRYhem";
 
-    expect(() =>
+    await expect(
       parseBtcAddress({ address, network: BtcNetwork.Mainnet })
-    ).toThrow(ParseBtcAddressMalformedAddressError);
-    expect(() =>
+    ).rejects.toThrow(ParseBtcAddressMalformedAddressError);
+    await expect(
       parseBtcAddress({ address, network: BtcNetwork.Testnet })
-    ).toThrow(ParseBtcAddressMalformedAddressError);
-    expect(() =>
+    ).rejects.toThrow(ParseBtcAddressMalformedAddressError);
+    await expect(
       parseBtcAddress({ address, network: BtcNetwork.Regtest })
-    ).toThrow(ParseBtcAddressMalformedAddressError);
+    ).rejects.toThrow(ParseBtcAddressMalformedAddressError);
   });
 
-  it("parse Mainnet P2SH", () => {
+  it("parse Mainnet P2SH", async () => {
     const address = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy";
 
-    expect(parseBtcAddress({ address, network: BtcNetwork.Mainnet })).toEqual({
+    expect(
+      await parseBtcAddress({ address, network: BtcNetwork.Mainnet })
+    ).toEqual({
       address,
       network: BtcNetwork.Mainnet,
       type: BtcAddressType.P2sh,
@@ -65,10 +73,12 @@ describe("BTC utils", () => {
     });
   });
 
-  it("parse Testnet P2SH", () => {
+  it("parse Testnet P2SH", async () => {
     const address = "2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc";
 
-    expect(parseBtcAddress({ address, network: BtcNetwork.Testnet })).toEqual({
+    expect(
+      await parseBtcAddress({ address, network: BtcNetwork.Testnet })
+    ).toEqual({
       address,
       network: BtcNetwork.Testnet,
       type: BtcAddressType.P2sh,
@@ -76,10 +86,12 @@ describe("BTC utils", () => {
     });
   });
 
-  it("parse Regtest P2SH", () => {
+  it("parse Regtest P2SH", async () => {
     const address = "2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc";
 
-    expect(parseBtcAddress({ address, network: BtcNetwork.Regtest })).toEqual({
+    expect(
+      await parseBtcAddress({ address, network: BtcNetwork.Regtest })
+    ).toEqual({
       address,
       network: BtcNetwork.Regtest,
       type: BtcAddressType.P2sh,
@@ -87,18 +99,18 @@ describe("BTC utils", () => {
     });
   });
 
-  it("fails on invalid P2SH", () => {
+  it("fails on invalid P2SH", async () => {
     const address = "17VZNX1SN5NtKa8UFFxwQbFFFc3iqRYhem";
 
-    expect(() =>
+    await expect(
       parseBtcAddress({ address, network: BtcNetwork.Mainnet })
-    ).toThrow(ParseBtcAddressMalformedAddressError);
-    expect(() =>
+    ).rejects.toThrow(ParseBtcAddressMalformedAddressError);
+    await expect(
       parseBtcAddress({ address, network: BtcNetwork.Testnet })
-    ).toThrow(ParseBtcAddressMalformedAddressError);
-    expect(() =>
+    ).rejects.toThrow(ParseBtcAddressMalformedAddressError);
+    await expect(
       parseBtcAddress({ address, network: BtcNetwork.Regtest })
-    ).toThrow(ParseBtcAddressMalformedAddressError);
+    ).rejects.toThrow(ParseBtcAddressMalformedAddressError);
   });
 
   it("fails on bogus address", () => {
@@ -129,14 +141,14 @@ describe("BTC utils", () => {
     ).toThrow(ParseBtcAddressNoDataError);
   });
 
-  it("parse Mainnet Bech32 P2WPKH", () => {
+  it("parse Mainnet Bech32 P2WPKH", async () => {
     const [a, b] = [
       "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
       "bc1q973xrrgje6etkkn9q9azzsgpxeddats8ckvp5s",
     ];
 
     expect(
-      parseBtcAddress({ address: a, network: BtcNetwork.Mainnet })
+      await parseBtcAddress({ address: a, network: BtcNetwork.Mainnet })
     ).toEqual({
       address: a,
       network: BtcNetwork.Mainnet,
@@ -144,7 +156,7 @@ describe("BTC utils", () => {
       parser: "bip-173",
     });
     expect(
-      parseBtcAddress({ address: b, network: BtcNetwork.Mainnet })
+      await parseBtcAddress({ address: b, network: BtcNetwork.Mainnet })
     ).toEqual({
       address: b,
       network: BtcNetwork.Mainnet,
@@ -153,10 +165,12 @@ describe("BTC utils", () => {
     });
   });
 
-  it("parse Testnet Bech32 P2WPKH", () => {
+  it("parse Testnet Bech32 P2WPKH", async () => {
     const address = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx";
 
-    expect(parseBtcAddress({ address, network: BtcNetwork.Testnet })).toEqual({
+    expect(
+      await parseBtcAddress({ address, network: BtcNetwork.Testnet })
+    ).toEqual({
       address,
       network: BtcNetwork.Testnet,
       type: BtcAddressType.P2wpkhV0,
@@ -164,10 +178,12 @@ describe("BTC utils", () => {
     });
   });
 
-  it("parse Regtest Bech32 P2WPKH", () => {
+  it("parse Regtest Bech32 P2WPKH", async () => {
     const address = "bcrt1q6z64a43mjgkcq0ul2znwneq3spghrlau9slefp";
 
-    expect(parseBtcAddress({ address, network: BtcNetwork.Regtest })).toEqual({
+    expect(
+      await parseBtcAddress({ address, network: BtcNetwork.Regtest })
+    ).toEqual({
       address,
       network: BtcNetwork.Regtest,
       type: BtcAddressType.P2wpkhV0,
@@ -175,29 +191,29 @@ describe("BTC utils", () => {
     });
   });
 
-  it("fails on invalid Bech32", () => {
+  it("fails on invalid Bech32", async () => {
     const address = "bc1qw508d6qejxtdg4y5r3zrrvary0c5xw7kv8f3t4";
 
-    expect(() =>
+    await expect(
       parseBtcAddress({ address, network: BtcNetwork.Mainnet })
-    ).toThrow(ParseBtcAddressMalformedAddressError);
-    expect(() =>
+    ).rejects.toThrow(ParseBtcAddressMalformedAddressError);
+    await expect(
       parseBtcAddress({ address, network: BtcNetwork.Testnet })
-    ).toThrow(ParseBtcAddressMalformedAddressError);
-    expect(() =>
+    ).rejects.toThrow(ParseBtcAddressMalformedAddressError);
+    await expect(
       parseBtcAddress({ address, network: BtcNetwork.Regtest })
-    ).toThrow(ParseBtcAddressMalformedAddressError);
+    ).rejects.toThrow(ParseBtcAddressMalformedAddressError);
   });
 
   describe("minter canister samples", () => {
-    it("parse Mainnet P2wpkhV0", () => {
+    it("parse Mainnet P2wpkhV0", async () => {
       const [a, b] = [
         "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
         "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4",
       ];
 
       expect(
-        parseBtcAddress({ address: a, network: BtcNetwork.Mainnet })
+        await parseBtcAddress({ address: a, network: BtcNetwork.Mainnet })
       ).toEqual({
         address: a,
         network: BtcNetwork.Mainnet,
@@ -206,7 +222,7 @@ describe("BTC utils", () => {
       });
 
       expect(
-        parseBtcAddress({ address: b, network: BtcNetwork.Mainnet })
+        await parseBtcAddress({ address: b, network: BtcNetwork.Mainnet })
       ).toEqual({
         address: b,
         network: BtcNetwork.Mainnet,
@@ -215,41 +231,41 @@ describe("BTC utils", () => {
       });
     });
 
-    it("should throw invalid checksum", () => {
+    it("should throw invalid checksum", async () => {
       const address = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5";
 
-      expect(() => {
-        parseBtcAddress({ address, network: BtcNetwork.Regtest });
-      }).toThrow(ParseBtcAddressMalformedAddressError);
+      await expect(
+        parseBtcAddress({ address, network: BtcNetwork.Regtest })
+      ).rejects.toThrow(ParseBtcAddressMalformedAddressError);
     });
   });
 
   describe("not supported address types", () => {
-    it("fails on Mainnet Bech32 P2WSH", () => {
+    it("fails on Mainnet Bech32 P2WSH", async () => {
       const address =
         "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3";
 
-      expect(() =>
+      await expect(
         parseBtcAddress({ address, network: BtcNetwork.Mainnet })
-      ).toThrow();
+      ).rejects.toThrow();
     });
 
-    it("fails on Testnet Bech32 P2WSH", () => {
+    it("fails on Testnet Bech32 P2WSH", async () => {
       const address =
         "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7";
 
-      expect(() =>
+      await expect(
         parseBtcAddress({ address, network: BtcNetwork.Testnet })
-      ).toThrow();
+      ).rejects.toThrow();
     });
 
-    it("fails on Regtest Bech32 P2WSH", () => {
+    it("fails on Regtest Bech32 P2WSH", async () => {
       const address =
         "bcrt1q5n2k3frgpxces3dsw4qfpqk4kksv0cz96pldxdwxrrw0d5ud5hcqzzx7zt";
 
-      expect(() =>
+      await expect(
         parseBtcAddress({ address, network: BtcNetwork.Regtest })
-      ).toThrow();
+      ).rejects.toThrow();
     });
   });
 });

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -16,7 +16,7 @@
     "ts-declaration": "tsc --emitDeclarationOnly --outDir dist/types",
     "build": "npm run rmdir && mkdir -p dist && cp -R proto candid dist && node esbuild.mjs && npm run ts-declaration",
     "prepack": "npm run build",
-    "test": "jest"
+    "test": "node --experimental-global-webcrypto ../../node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "google-protobuf": "^3.21.2",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -16,7 +16,7 @@
     "ts-declaration": "tsc --emitDeclarationOnly --outDir dist/types",
     "build": "npm run rmdir && mkdir -p dist && cp -R candid dist && node esbuild.mjs && npm run ts-declaration",
     "prepack": "npm run build",
-    "test": "jest"
+    "test": "node --experimental-global-webcrypto ../../node_modules/jest/bin/jest.js"
   },
   "repository": {
     "type": "git",
@@ -41,8 +41,5 @@
     "@dfinity/ledger": "^0.0.6",
     "@dfinity/principal": "^0.15.4",
     "@dfinity/utils": "^0.0.13"
-  },
-  "dependencies": {
-    "js-sha256": "^0.9.0"
   }
 }

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -208,7 +208,7 @@ export class SnsWrapper {
     // TODO: try parallilizing requests to improve performance
     // OR use binary search https://dfinity.atlassian.net/browse/FOLLOW-825
     for (let index = 0; index < MAX_NEURONS_SUBACCOUNTS; index++) {
-      const subaccount = neuronSubaccount({ index, controller });
+      const subaccount = await neuronSubaccount({ index, controller });
 
       const neuronId: NeuronId = { id: subaccount };
       let neuron = await this.governance.queryNeuron({

--- a/packages/sns/src/utils/governance.utils.spec.ts
+++ b/packages/sns/src/utils/governance.utils.spec.ts
@@ -4,8 +4,8 @@ import { neuronSubaccount } from "./governance.utils";
 describe("governance utils", () => {
   describe("neuronSubaccount", () => {
     // Test it to make sure that if there are changes, the test will fail.
-    it("calculates the neuron subaccount based on controller and index", () => {
-      const subaccount = neuronSubaccount({
+    it("calculates the neuron subaccount based on controller and index", async () => {
+      const subaccount = await neuronSubaccount({
         controller: mockPrincipal,
         index: 4,
       });

--- a/packages/sns/src/utils/governance.utils.ts
+++ b/packages/sns/src/utils/governance.utils.ts
@@ -1,7 +1,10 @@
 import type { IcrcSubaccount } from "@dfinity/ledger";
 import type { Principal } from "@dfinity/principal";
-import { asciiStringToByteArray, numberToUint8Array } from "@dfinity/utils";
-import { sha256 } from "js-sha256";
+import {
+  asciiStringToByteArray,
+  numberToUint8Array,
+  sha256,
+} from "@dfinity/utils";
 
 /**
  * Neuron subaccount is calculated as "sha256(0x0c . “neuron-stake” . controller . i)"
@@ -11,22 +14,19 @@ import { sha256 } from "js-sha256";
  * @param {number} params.index
  * @returns
  */
-export const neuronSubaccount = ({
+export const neuronSubaccount = async ({
   index,
   controller,
 }: {
   index: number;
   controller: Principal;
-}): IcrcSubaccount => {
+}): Promise<IcrcSubaccount> => {
   const padding = asciiStringToByteArray("neuron-stake");
-  const data = [
+  const data = Uint8Array.from([
     0x0c,
     ...padding,
     ...controller.toUint8Array(),
     ...numberToUint8Array(index),
-  ];
-  // TODO(#238): Implement without library and make it compatible with NodeJS and browser
-  const shaObj = sha256.create();
-  shaObj.update(data);
-  return new Uint8Array(shaObj.array());
+  ]);
+  return sha256(data);
 };

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -48,6 +48,7 @@ npm i @dfinity/agent @dfinity/candid @dfinity/principal
 - [encodeBase32](#gear-encodebase32)
 - [decodeBase32](#gear-decodebase32)
 - [bigEndianCrc32](#gear-bigendiancrc32)
+- [sha256](#gear-sha256)
 - [debounce](#gear-debounce)
 - [isNullish](#gear-isnullish)
 - [nonNullish](#gear-nonnullish)
@@ -182,6 +183,12 @@ Parameters:
 | Function         | Type                                |
 | ---------------- | ----------------------------------- |
 | `bigEndianCrc32` | `(bytes: Uint8Array) => Uint8Array` |
+
+#### :gear: sha256
+
+| Function | Type                                        |
+| -------- | ------------------------------------------- |
+| `sha256` | `(data: Uint8Array) => Promise<Uint8Array>` |
 
 #### :gear: debounce
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,7 +16,7 @@
     "ts-declaration": "tsc --emitDeclarationOnly --outDir dist/types",
     "build": "npm run rmdir && mkdir -p dist && node esbuild.mjs && npm run ts-declaration",
     "prepack": "npm run build",
-    "test": "jest"
+    "test": "node --experimental-global-webcrypto ../../node_modules/jest/bin/jest.js"
   },
   "repository": {
     "type": "git",

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -7,6 +7,7 @@ export * from "./utils/arrays.utils";
 export * from "./utils/asserts.utils";
 export * from "./utils/base32.utils";
 export * from "./utils/crc.utils";
+export * from "./utils/crypto.utils";
 export * from "./utils/debounce.utils";
 export * from "./utils/did.utils";
 export * from "./utils/nullish.utils";

--- a/packages/utils/src/utils/crypto.utils.spec.ts
+++ b/packages/utils/src/utils/crypto.utils.spec.ts
@@ -1,5 +1,9 @@
 import { Principal } from "@dfinity/principal";
-import { asciiStringToByteArray, numberToUint8Array } from "./arrays.utils";
+import {
+  asciiStringToByteArray,
+  numberToUint8Array,
+  uint8ArrayToHexString,
+} from "./arrays.utils";
 import { sha256 } from "./crypto.utils";
 
 describe("crypto-utils", () => {
@@ -27,9 +31,7 @@ describe("crypto-utils", () => {
   it("should encode sha256 to expected hex value", async () => {
     const msgUint8 = new TextEncoder().encode("hello world #@¶$");
     const hash = await sha256(msgUint8);
-    const hashHex = Array.from(hash)
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
+    const hashHex = uint8ArrayToHexString(hash);
     expect(hashHex).toEqual(
       "559a1d0c6d7756c70361a8f69fe0df408f2d43cdd0f71f5827f7c02451fa64d6"
     );

--- a/packages/utils/src/utils/crypto.utils.spec.ts
+++ b/packages/utils/src/utils/crypto.utils.spec.ts
@@ -1,0 +1,26 @@
+import { Principal } from "@dfinity/principal";
+import { asciiStringToByteArray, numberToUint8Array } from "./arrays.utils";
+import { sha256 } from "./crypto.utils";
+
+describe("crypto-utils", () => {
+  it("should calculate sha256 of a sns neuron id", async () => {
+    const data = Uint8Array.from([
+      0x0c,
+      ...asciiStringToByteArray("neuron-stake"),
+      ...Principal.fromText(
+        "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
+      ).toUint8Array(),
+      ...numberToUint8Array(4),
+    ]);
+
+    const hash = await sha256(data);
+
+    const expected = new Uint8Array([
+      198, 112, 210, 99, 31, 205, 63, 124, 217, 206, 133, 104, 105, 140, 83,
+      167, 139, 60, 94, 58, 107, 169, 215, 12, 177, 219, 237, 24, 75, 149, 241,
+      128,
+    ]);
+
+    expect(hash).toEqual(expected);
+  });
+});

--- a/packages/utils/src/utils/crypto.utils.spec.ts
+++ b/packages/utils/src/utils/crypto.utils.spec.ts
@@ -23,4 +23,15 @@ describe("crypto-utils", () => {
 
     expect(hash).toEqual(expected);
   });
+
+  it("should encode sha256 to expected hex value", async () => {
+    const msgUint8 = new TextEncoder().encode("hello world #@¶$");
+    const hash = await sha256(msgUint8);
+    const hashHex = Array.from(hash)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+    expect(hashHex).toEqual(
+      "559a1d0c6d7756c70361a8f69fe0df408f2d43cdd0f71f5827f7c02451fa64d6"
+    );
+  });
 });

--- a/packages/utils/src/utils/crypto.utils.ts
+++ b/packages/utils/src/utils/crypto.utils.ts
@@ -1,0 +1,6 @@
+import { arrayBufferToUint8Array } from "./arrays.utils";
+
+export const sha256 = async (data: Uint8Array): Promise<Uint8Array> => {
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return arrayBufferToUint8Array(hash);
+};


### PR DESCRIPTION
# Motivation

Replace usage of `js-sha256` library with the Web Crypto API to generate sha256.

# Changes

- replace sha256 from `js-sha256` with Web Crypto API (implemented in new utils `crypto.utils`)
- use `--experimental-global-webcrypto` flag to run jest test (needed for NodeJS v18, API is stable as of v19)
