### PR TITLE
Chore: Expose sns proposal action types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "packages/ckbtc"
       ],
       "devDependencies": {
+        "@babel/core": "^7.21.3",
+        "@babel/plugin-syntax-typescript": "^7.20.0",
         "@size-limit/esbuild": "^8.2.4",
         "@size-limit/preset-small-lib": "^8.2.4",
         "@types/jest": "^29.5.0",
@@ -69,34 +71,34 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.19.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.3.tgz",
-      "integrity": "sha512-prBHMK4JYYK+wDjJF1q99KK4JLL+egWS4nmNqdlMUgCExMZ+iZW0hGhyC3VEbsPjvaN0TBhW//VIFwBrk8sEiw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.0.tgz",
+      "integrity": "sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.19.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.3.tgz",
-      "integrity": "sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
+      "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
       "dev": true,
       "dependencies": {
-        "@ampproject/remapping": "^2.1.0",
+        "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.3",
-        "@babel/helper-compilation-targets": "^7.19.3",
-        "@babel/helper-module-transforms": "^7.19.0",
-        "@babel/helpers": "^7.19.0",
-        "@babel/parser": "^7.19.3",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.3",
-        "@babel/types": "^7.19.3",
+        "@babel/generator": "^7.21.3",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-module-transforms": "^7.21.2",
+        "@babel/helpers": "^7.21.0",
+        "@babel/parser": "^7.21.3",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
+        "json5": "^2.2.2",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -117,13 +119,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.19.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.3.tgz",
-      "integrity": "sha512-fqVZnmp1ncvZU757UzDheKZpfPgatqY59XtW2/j/18H7u76akb8xqvjw82f+i2UKd/ksYsSick/BCLQUUtJ/qQ==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.3.tgz",
+      "integrity": "sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.19.3",
+        "@babel/types": "^7.21.3",
         "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -145,14 +148,15 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.19.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.3.tgz",
-      "integrity": "sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.19.3",
+        "@babel/compat-data": "^7.20.5",
         "@babel/helper-validator-option": "^7.18.6",
         "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -160,6 +164,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -171,6 +184,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
     "node_modules/@babel/helper-environment-visitor": {
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
@@ -181,13 +200,13 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
+      "integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.18.10",
-        "@babel/types": "^7.19.0"
+        "@babel/template": "^7.20.7",
+        "@babel/types": "^7.21.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -218,40 +237,40 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
-      "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz",
+      "integrity": "sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-simple-access": "^7.18.6",
+        "@babel/helper-simple-access": "^7.20.2",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.0",
-        "@babel/types": "^7.19.0"
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.2",
+        "@babel/types": "^7.21.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
-      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+      "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -288,23 +307,23 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
+      "integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
-      "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.0.tgz",
+      "integrity": "sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.0",
-        "@babel/types": "^7.19.0"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.0",
+        "@babel/types": "^7.21.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -396,9 +415,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
-      "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
+      "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -585,33 +604,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-      "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/parser": "^7.18.10",
-        "@babel/types": "^7.18.10"
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.19.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.3.tgz",
-      "integrity": "sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.3.tgz",
+      "integrity": "sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.3",
+        "@babel/generator": "^7.21.3",
         "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.19.3",
-        "@babel/types": "^7.19.3",
+        "@babel/parser": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -629,9 +648,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
-      "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
+      "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -1526,9 +1545,9 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.8.tgz",
-      "integrity": "sha512-YK5G9LaddzGbcucK4c8h5tWFmMPBvRZ/uyWmN1/SbBdIvqGUdWGkJ5BAaccgs6XbzVLsqbPJrBSFwKv3kT9i7w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1548,13 +1567,13 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2605,9 +2624,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "dev": true,
       "funding": [
         {
@@ -2620,10 +2639,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2734,9 +2753,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001414",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz",
-      "integrity": "sha512-t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg==",
+      "version": "1.0.30001472",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
+      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg==",
       "dev": true,
       "funding": [
         {
@@ -2746,6 +2765,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -3035,9 +3058,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.270",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.270.tgz",
-      "integrity": "sha512-KNhIzgLiJmDDC444dj9vEOpZEgsV96ult9Iff98Vanumn+ShJHd5se8aX6KeVxdc0YQeqdrezBZv89rleDbvSg==",
+      "version": "1.4.341",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.341.tgz",
+      "integrity": "sha512-R4A8VfUBQY9WmAhuqY5tjHRf5fH2AAf6vqitBOE0y6u2PgHgqHSrhZmu78dIX3fVZtjqlwJNX1i2zwC3VpHtQQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5697,9 +5720,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -6903,9 +6926,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
-      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
       "dev": true,
       "funding": [
         {
@@ -7251,31 +7274,31 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.19.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.3.tgz",
-      "integrity": "sha512-prBHMK4JYYK+wDjJF1q99KK4JLL+egWS4nmNqdlMUgCExMZ+iZW0hGhyC3VEbsPjvaN0TBhW//VIFwBrk8sEiw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.0.tgz",
+      "integrity": "sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.19.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.3.tgz",
-      "integrity": "sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
+      "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
       "dev": true,
       "requires": {
-        "@ampproject/remapping": "^2.1.0",
+        "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.3",
-        "@babel/helper-compilation-targets": "^7.19.3",
-        "@babel/helper-module-transforms": "^7.19.0",
-        "@babel/helpers": "^7.19.0",
-        "@babel/parser": "^7.19.3",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.3",
-        "@babel/types": "^7.19.3",
+        "@babel/generator": "^7.21.3",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-module-transforms": "^7.21.2",
+        "@babel/helpers": "^7.21.0",
+        "@babel/parser": "^7.21.3",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
+        "json5": "^2.2.2",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -7288,13 +7311,14 @@
       }
     },
     "@babel/generator": {
-      "version": "7.19.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.3.tgz",
-      "integrity": "sha512-fqVZnmp1ncvZU757UzDheKZpfPgatqY59XtW2/j/18H7u76akb8xqvjw82f+i2UKd/ksYsSick/BCLQUUtJ/qQ==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.3.tgz",
+      "integrity": "sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.19.3",
+        "@babel/types": "^7.21.3",
         "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
       },
       "dependencies": {
@@ -7312,21 +7336,37 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.19.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.3.tgz",
-      "integrity": "sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.19.3",
+        "@babel/compat-data": "^7.20.5",
         "@babel/helper-validator-option": "^7.18.6",
         "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
         "semver": "^6.3.0"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true
         }
       }
@@ -7338,13 +7378,13 @@
       "dev": true
     },
     "@babel/helper-function-name": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
+      "integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.18.10",
-        "@babel/types": "^7.19.0"
+        "@babel/template": "^7.20.7",
+        "@babel/types": "^7.21.0"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -7366,34 +7406,34 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
-      "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz",
+      "integrity": "sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==",
       "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-simple-access": "^7.18.6",
+        "@babel/helper-simple-access": "^7.20.2",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.0",
-        "@babel/types": "^7.19.0"
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.2",
+        "@babel/types": "^7.21.2"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
       "dev": true
     },
     "@babel/helper-simple-access": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
-      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+      "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.20.2"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -7418,20 +7458,20 @@
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
+      "integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
-      "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.0.tgz",
+      "integrity": "sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.0",
-        "@babel/types": "^7.19.0"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.0",
+        "@babel/types": "^7.21.0"
       }
     },
     "@babel/highlight": {
@@ -7504,9 +7544,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
-      "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
+      "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -7636,30 +7676,30 @@
       }
     },
     "@babel/template": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-      "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/parser": "^7.18.10",
-        "@babel/types": "^7.18.10"
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.19.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.3.tgz",
-      "integrity": "sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.3.tgz",
+      "integrity": "sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.3",
+        "@babel/generator": "^7.21.3",
         "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.19.3",
-        "@babel/types": "^7.19.3",
+        "@babel/parser": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -7673,9 +7713,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
-      "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
+      "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -8279,9 +8319,9 @@
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.8.tgz",
-      "integrity": "sha512-YK5G9LaddzGbcucK4c8h5tWFmMPBvRZ/uyWmN1/SbBdIvqGUdWGkJ5BAaccgs6XbzVLsqbPJrBSFwKv3kT9i7w=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
@@ -8295,13 +8335,13 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
       "dev": true,
       "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "@nodelib/fs.scandir": {
@@ -9048,15 +9088,15 @@
       }
     },
     "browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
       }
     },
     "bs-logger": {
@@ -9132,9 +9172,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001414",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz",
-      "integrity": "sha512-t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg==",
+      "version": "1.0.30001472",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
+      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg==",
       "dev": true
     },
     "chalk": {
@@ -9354,9 +9394,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.270",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.270.tgz",
-      "integrity": "sha512-KNhIzgLiJmDDC444dj9vEOpZEgsV96ult9Iff98Vanumn+ShJHd5se8aX6KeVxdc0YQeqdrezBZv89rleDbvSg==",
+      "version": "1.4.341",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.341.tgz",
+      "integrity": "sha512-R4A8VfUBQY9WmAhuqY5tjHRf5fH2AAf6vqitBOE0y6u2PgHgqHSrhZmu78dIX3fVZtjqlwJNX1i2zwC3VpHtQQ==",
       "dev": true
     },
     "emittery": {
@@ -11300,9 +11340,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
       "dev": true
     },
     "normalize-path": {
@@ -12115,9 +12155,9 @@
       }
     },
     "update-browserslist-db": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
-      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
       "dev": true,
       "requires": {
         "escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "url": "https://github.com/dfinity/ic-js"
   },
   "devDependencies": {
+    "@babel/core": "^7.21.3",
+    "@babel/plugin-syntax-typescript": "^7.20.0",
     "@size-limit/esbuild": "^8.2.4",
     "@size-limit/preset-small-lib": "^8.2.4",
     "@types/jest": "^29.5.0",

--- a/packages/sns/candid/sns_governance-converters.ts
+++ b/packages/sns/candid/sns_governance-converters.ts
@@ -1,0 +1,1221 @@
+import { fromNullable } from "@dfinity/utils";
+import {
+  Account,
+  AddNeuronPermissions,
+  Amount,
+  Ballot,
+  CanisterStatusResultV2,
+  ChangeAutoStakeMaturity,
+  ClaimOrRefresh,
+  ClaimOrRefreshResponse,
+  ClaimSwapNeuronsRequest,
+  ClaimSwapNeuronsResponse,
+  ClaimedSwapNeurons,
+  Configure,
+  DefaultFollowees,
+  DefiniteCanisterSettingsArgs,
+  DeregisterDappCanisters,
+  Disburse,
+  DisburseMaturity,
+  DisburseMaturityInProgress,
+  DisburseMaturityResponse,
+  DisburseResponse,
+  ExecuteGenericNervousSystemFunction,
+  FinalizeDisburseMaturity,
+  Follow,
+  Followees,
+  GenericNervousSystemFunction,
+  GetMetadataResponse,
+  GetModeResponse,
+  GetNeuron,
+  GetNeuronResponse,
+  GetProposal,
+  GetProposalResponse,
+  GetRunningSnsVersionResponse,
+  GetSnsInitializationParametersResponse,
+  Governance,
+  GovernanceCachedMetrics,
+  GovernanceError,
+  IncreaseDissolveDelay,
+  ListNervousSystemFunctionsResponse,
+  ListNeurons,
+  ListNeuronsResponse,
+  ListProposals,
+  ListProposalsResponse,
+  ManageNeuron,
+  ManageNeuronResponse,
+  ManageSnsMetadata,
+  MemoAndController,
+  MergeMaturity,
+  MergeMaturityResponse,
+  Motion,
+  NervousSystemFunction,
+  NervousSystemParameters,
+  Neuron,
+  NeuronId,
+  NeuronInFlightCommand,
+  NeuronParameters,
+  NeuronPermission,
+  NeuronPermissionList,
+  Proposal,
+  ProposalData,
+  ProposalId,
+  RegisterDappCanisters,
+  RegisterVote,
+  RemoveNeuronPermissions,
+  RewardEvent,
+  SetDissolveTimestamp,
+  SetMode,
+  Split,
+  SplitResponse,
+  StakeMaturity,
+  StakeMaturityResponse,
+  Subaccount,
+  SwapNeuron,
+  Tally,
+  TransferSnsTreasuryFunds,
+  UpgradeInProgress,
+  UpgradeSnsControlledCanister,
+  Version,
+  VotingRewardsParameters,
+  WaitForQuietState
+} from "./sns_governance";
+import type { ActorMethod } from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+export interface OptionalAccount {
+  owner: undefined | Principal;
+  subaccount: undefined | OptionalSubaccount;
+}
+export function convertAccount(account: Account | undefined): OptionalAccount | undefined {
+  return account === undefined ? undefined : {
+    owner: fromNullable(account.owner),
+    subaccount: convertSubaccount(fromNullable(account.subaccount))
+  };
+}
+export type Action = {
+  ManageNervousSystemParameters: NervousSystemParameters;
+} | {
+  AddGenericNervousSystemFunction: NervousSystemFunction;
+} | {
+  RemoveGenericNervousSystemFunction: bigint;
+} | {
+  UpgradeSnsToNextVersion: {};
+} | {
+  RegisterDappCanisters: RegisterDappCanisters;
+} | {
+  TransferSnsTreasuryFunds: TransferSnsTreasuryFunds;
+} | {
+  UpgradeSnsControlledCanister: UpgradeSnsControlledCanister;
+} | {
+  DeregisterDappCanisters: DeregisterDappCanisters;
+} | {
+  Unspecified: {};
+} | {
+  ManageSnsMetadata: ManageSnsMetadata;
+} | {
+  ExecuteGenericNervousSystemFunction: ExecuteGenericNervousSystemFunction;
+} | {
+  Motion: Motion;
+};
+export interface OptionalAddNeuronPermissions {
+  permissions_to_add: undefined | OptionalNeuronPermissionList;
+  principal_id: undefined | Principal;
+}
+export function convertAddNeuronPermissions(addNeuronPermissions: AddNeuronPermissions | undefined): OptionalAddNeuronPermissions | undefined {
+  return addNeuronPermissions === undefined ? undefined : {
+    permissions_to_add: convertNeuronPermissionList(fromNullable(addNeuronPermissions.permissions_to_add)),
+    principal_id: fromNullable(addNeuronPermissions.principal_id)
+  };
+}
+export interface OptionalAmount {
+  e8s: bigint;
+}
+export function convertAmount(amount: Amount | undefined): OptionalAmount | undefined {
+  return amount === undefined ? undefined : {
+    e8s: amount.e8s
+  };
+}
+export interface OptionalBallot {
+  vote: number;
+  cast_timestamp_seconds: bigint;
+  voting_power: bigint;
+}
+export function convertBallot(ballot: Ballot | undefined): OptionalBallot | undefined {
+  return ballot === undefined ? undefined : {
+    vote: ballot.vote,
+    cast_timestamp_seconds: ballot.cast_timestamp_seconds,
+    voting_power: ballot.voting_power
+  };
+}
+export type By = {
+  MemoAndController: MemoAndController;
+} | {
+  NeuronId: {};
+};
+export interface OptionalCanisterStatusResultV2 {
+  controller: Principal;
+  status: CanisterStatusType;
+  freezing_threshold: bigint;
+  balance: Array<[Uint8Array, bigint]>;
+  memory_size: bigint;
+  cycles: bigint;
+  settings: DefiniteCanisterSettingsArgs;
+  idle_cycles_burned_per_day: bigint;
+  module_hash: undefined | Uint8Array;
+}
+export function convertCanisterStatusResultV2(canisterStatusResultV2: CanisterStatusResultV2 | undefined): OptionalCanisterStatusResultV2 | undefined {
+  return canisterStatusResultV2 === undefined ? undefined : {
+    controller: canisterStatusResultV2.controller,
+    status: canisterStatusResultV2.status,
+    freezing_threshold: canisterStatusResultV2.freezing_threshold,
+    balance: canisterStatusResultV2.balance,
+    memory_size: canisterStatusResultV2.memory_size,
+    cycles: canisterStatusResultV2.cycles,
+    settings: canisterStatusResultV2.settings,
+    idle_cycles_burned_per_day: canisterStatusResultV2.idle_cycles_burned_per_day,
+    module_hash: fromNullable(canisterStatusResultV2.module_hash)
+  };
+}
+export type CanisterStatusType = {
+  stopped: null;
+} | {
+  stopping: null;
+} | {
+  running: null;
+};
+export interface OptionalChangeAutoStakeMaturity {
+  requested_setting_for_auto_stake_maturity: boolean;
+}
+export function convertChangeAutoStakeMaturity(changeAutoStakeMaturity: ChangeAutoStakeMaturity | undefined): OptionalChangeAutoStakeMaturity | undefined {
+  return changeAutoStakeMaturity === undefined ? undefined : {
+    requested_setting_for_auto_stake_maturity: changeAutoStakeMaturity.requested_setting_for_auto_stake_maturity
+  };
+}
+export interface OptionalClaimOrRefresh {
+  by: undefined | By;
+}
+export function convertClaimOrRefresh(claimOrRefresh: ClaimOrRefresh | undefined): OptionalClaimOrRefresh | undefined {
+  return claimOrRefresh === undefined ? undefined : {
+    by: convertBy(fromNullable(claimOrRefresh.by))
+  };
+}
+export interface OptionalClaimOrRefreshResponse {
+  refreshed_neuron_id: undefined | OptionalNeuronId;
+}
+export function convertClaimOrRefreshResponse(claimOrRefreshResponse: ClaimOrRefreshResponse | undefined): OptionalClaimOrRefreshResponse | undefined {
+  return claimOrRefreshResponse === undefined ? undefined : {
+    refreshed_neuron_id: convertNeuronId(fromNullable(claimOrRefreshResponse.refreshed_neuron_id))
+  };
+}
+export interface OptionalClaimSwapNeuronsRequest {
+  neuron_parameters: Array<NeuronParameters>;
+}
+export function convertClaimSwapNeuronsRequest(claimSwapNeuronsRequest: ClaimSwapNeuronsRequest | undefined): OptionalClaimSwapNeuronsRequest | undefined {
+  return claimSwapNeuronsRequest === undefined ? undefined : {
+    neuron_parameters: claimSwapNeuronsRequest.neuron_parameters
+  };
+}
+export interface OptionalClaimSwapNeuronsResponse {
+  claim_swap_neurons_result: undefined | ClaimSwapNeuronsResult;
+}
+export function convertClaimSwapNeuronsResponse(claimSwapNeuronsResponse: ClaimSwapNeuronsResponse | undefined): OptionalClaimSwapNeuronsResponse | undefined {
+  return claimSwapNeuronsResponse === undefined ? undefined : {
+    claim_swap_neurons_result: convertClaimSwapNeuronsResult(fromNullable(claimSwapNeuronsResponse.claim_swap_neurons_result))
+  };
+}
+export type ClaimSwapNeuronsResult = {
+  Ok: ClaimedSwapNeurons;
+} | {
+  Err: number;
+};
+export interface OptionalClaimedSwapNeurons {
+  swap_neurons: Array<SwapNeuron>;
+}
+export function convertClaimedSwapNeurons(claimedSwapNeurons: ClaimedSwapNeurons | undefined): OptionalClaimedSwapNeurons | undefined {
+  return claimedSwapNeurons === undefined ? undefined : {
+    swap_neurons: claimedSwapNeurons.swap_neurons
+  };
+}
+export type Command = {
+  Split: Split;
+} | {
+  Follow: Follow;
+} | {
+  DisburseMaturity: DisburseMaturity;
+} | {
+  ClaimOrRefresh: ClaimOrRefresh;
+} | {
+  Configure: Configure;
+} | {
+  RegisterVote: RegisterVote;
+} | {
+  MakeProposal: Proposal;
+} | {
+  StakeMaturity: StakeMaturity;
+} | {
+  RemoveNeuronPermissions: RemoveNeuronPermissions;
+} | {
+  AddNeuronPermissions: AddNeuronPermissions;
+} | {
+  MergeMaturity: MergeMaturity;
+} | {
+  Disburse: Disburse;
+};
+export type Command_1 = {
+  Error: GovernanceError;
+} | {
+  Split: SplitResponse;
+} | {
+  Follow: {};
+} | {
+  DisburseMaturity: DisburseMaturityResponse;
+} | {
+  ClaimOrRefresh: ClaimOrRefreshResponse;
+} | {
+  Configure: {};
+} | {
+  RegisterVote: {};
+} | {
+  MakeProposal: GetProposal;
+} | {
+  RemoveNeuronPermission: {};
+} | {
+  StakeMaturity: StakeMaturityResponse;
+} | {
+  MergeMaturity: MergeMaturityResponse;
+} | {
+  Disburse: DisburseResponse;
+} | {
+  AddNeuronPermission: {};
+};
+export type Command_2 = {
+  Split: Split;
+} | {
+  Follow: Follow;
+} | {
+  DisburseMaturity: DisburseMaturity;
+} | {
+  Configure: Configure;
+} | {
+  RegisterVote: RegisterVote;
+} | {
+  SyncCommand: {};
+} | {
+  MakeProposal: Proposal;
+} | {
+  FinalizeDisburseMaturity: FinalizeDisburseMaturity;
+} | {
+  ClaimOrRefreshNeuron: ClaimOrRefresh;
+} | {
+  RemoveNeuronPermissions: RemoveNeuronPermissions;
+} | {
+  AddNeuronPermissions: AddNeuronPermissions;
+} | {
+  MergeMaturity: MergeMaturity;
+} | {
+  Disburse: Disburse;
+};
+export interface OptionalConfigure {
+  operation: undefined | Operation;
+}
+export function convertConfigure(configure: Configure | undefined): OptionalConfigure | undefined {
+  return configure === undefined ? undefined : {
+    operation: convertOperation(fromNullable(configure.operation))
+  };
+}
+export interface OptionalDefaultFollowees {
+  followees: Array<[bigint, Followees]>;
+}
+export function convertDefaultFollowees(defaultFollowees: DefaultFollowees | undefined): OptionalDefaultFollowees | undefined {
+  return defaultFollowees === undefined ? undefined : {
+    followees: defaultFollowees.followees
+  };
+}
+export interface OptionalDefiniteCanisterSettingsArgs {
+  controller: Principal;
+  freezing_threshold: bigint;
+  controllers: Array<Principal>;
+  memory_allocation: bigint;
+  compute_allocation: bigint;
+}
+export function convertDefiniteCanisterSettingsArgs(definiteCanisterSettingsArgs: DefiniteCanisterSettingsArgs | undefined): OptionalDefiniteCanisterSettingsArgs | undefined {
+  return definiteCanisterSettingsArgs === undefined ? undefined : {
+    controller: definiteCanisterSettingsArgs.controller,
+    freezing_threshold: definiteCanisterSettingsArgs.freezing_threshold,
+    controllers: definiteCanisterSettingsArgs.controllers,
+    memory_allocation: definiteCanisterSettingsArgs.memory_allocation,
+    compute_allocation: definiteCanisterSettingsArgs.compute_allocation
+  };
+}
+export interface OptionalDeregisterDappCanisters {
+  canister_ids: Array<Principal>;
+  new_controllers: Array<Principal>;
+}
+export function convertDeregisterDappCanisters(deregisterDappCanisters: DeregisterDappCanisters | undefined): OptionalDeregisterDappCanisters | undefined {
+  return deregisterDappCanisters === undefined ? undefined : {
+    canister_ids: deregisterDappCanisters.canister_ids,
+    new_controllers: deregisterDappCanisters.new_controllers
+  };
+}
+export interface OptionalDisburse {
+  to_account: undefined | OptionalAccount;
+  amount: undefined | OptionalAmount;
+}
+export function convertDisburse(disburse: Disburse | undefined): OptionalDisburse | undefined {
+  return disburse === undefined ? undefined : {
+    to_account: convertAccount(fromNullable(disburse.to_account)),
+    amount: convertAmount(fromNullable(disburse.amount))
+  };
+}
+export interface OptionalDisburseMaturity {
+  to_account: undefined | OptionalAccount;
+  percentage_to_disburse: number;
+}
+export function convertDisburseMaturity(disburseMaturity: DisburseMaturity | undefined): OptionalDisburseMaturity | undefined {
+  return disburseMaturity === undefined ? undefined : {
+    to_account: convertAccount(fromNullable(disburseMaturity.to_account)),
+    percentage_to_disburse: disburseMaturity.percentage_to_disburse
+  };
+}
+export interface OptionalDisburseMaturityInProgress {
+  timestamp_of_disbursement_seconds: bigint;
+  amount_e8s: bigint;
+  account_to_disburse_to: undefined | OptionalAccount;
+}
+export function convertDisburseMaturityInProgress(disburseMaturityInProgress: DisburseMaturityInProgress | undefined): OptionalDisburseMaturityInProgress | undefined {
+  return disburseMaturityInProgress === undefined ? undefined : {
+    timestamp_of_disbursement_seconds: disburseMaturityInProgress.timestamp_of_disbursement_seconds,
+    amount_e8s: disburseMaturityInProgress.amount_e8s,
+    account_to_disburse_to: convertAccount(fromNullable(disburseMaturityInProgress.account_to_disburse_to))
+  };
+}
+export interface OptionalDisburseMaturityResponse {
+  amount_disbursed_e8s: bigint;
+}
+export function convertDisburseMaturityResponse(disburseMaturityResponse: DisburseMaturityResponse | undefined): OptionalDisburseMaturityResponse | undefined {
+  return disburseMaturityResponse === undefined ? undefined : {
+    amount_disbursed_e8s: disburseMaturityResponse.amount_disbursed_e8s
+  };
+}
+export interface OptionalDisburseResponse {
+  transfer_block_height: bigint;
+}
+export function convertDisburseResponse(disburseResponse: DisburseResponse | undefined): OptionalDisburseResponse | undefined {
+  return disburseResponse === undefined ? undefined : {
+    transfer_block_height: disburseResponse.transfer_block_height
+  };
+}
+export type DissolveState = {
+  DissolveDelaySeconds: bigint;
+} | {
+  WhenDissolvedTimestampSeconds: bigint;
+};
+export interface OptionalExecuteGenericNervousSystemFunction {
+  function_id: bigint;
+  payload: Uint8Array;
+}
+export function convertExecuteGenericNervousSystemFunction(executeGenericNervousSystemFunction: ExecuteGenericNervousSystemFunction | undefined): OptionalExecuteGenericNervousSystemFunction | undefined {
+  return executeGenericNervousSystemFunction === undefined ? undefined : {
+    function_id: executeGenericNervousSystemFunction.function_id,
+    payload: executeGenericNervousSystemFunction.payload
+  };
+}
+export interface OptionalFinalizeDisburseMaturity {
+  amount_to_be_disbursed_e8s: bigint;
+  to_account: undefined | OptionalAccount;
+}
+export function convertFinalizeDisburseMaturity(finalizeDisburseMaturity: FinalizeDisburseMaturity | undefined): OptionalFinalizeDisburseMaturity | undefined {
+  return finalizeDisburseMaturity === undefined ? undefined : {
+    amount_to_be_disbursed_e8s: finalizeDisburseMaturity.amount_to_be_disbursed_e8s,
+    to_account: convertAccount(fromNullable(finalizeDisburseMaturity.to_account))
+  };
+}
+export interface OptionalFollow {
+  function_id: bigint;
+  followees: Array<NeuronId>;
+}
+export function convertFollow(follow: Follow | undefined): OptionalFollow | undefined {
+  return follow === undefined ? undefined : {
+    function_id: follow.function_id,
+    followees: follow.followees
+  };
+}
+export interface OptionalFollowees {
+  followees: Array<NeuronId>;
+}
+export function convertFollowees(followees: Followees | undefined): OptionalFollowees | undefined {
+  return followees === undefined ? undefined : {
+    followees: followees.followees
+  };
+}
+export type FunctionType = {
+  NativeNervousSystemFunction: {};
+} | {
+  GenericNervousSystemFunction: GenericNervousSystemFunction;
+};
+export interface OptionalGenericNervousSystemFunction {
+  validator_canister_id: undefined | Principal;
+  target_canister_id: undefined | Principal;
+  validator_method_name: undefined | string;
+  target_method_name: undefined | string;
+}
+export function convertGenericNervousSystemFunction(genericNervousSystemFunction: GenericNervousSystemFunction | undefined): OptionalGenericNervousSystemFunction | undefined {
+  return genericNervousSystemFunction === undefined ? undefined : {
+    validator_canister_id: fromNullable(genericNervousSystemFunction.validator_canister_id),
+    target_canister_id: fromNullable(genericNervousSystemFunction.target_canister_id),
+    validator_method_name: fromNullable(genericNervousSystemFunction.validator_method_name),
+    target_method_name: fromNullable(genericNervousSystemFunction.target_method_name)
+  };
+}
+export interface OptionalGetMetadataResponse {
+  url: undefined | string;
+  logo: undefined | string;
+  name: undefined | string;
+  description: undefined | string;
+}
+export function convertGetMetadataResponse(getMetadataResponse: GetMetadataResponse | undefined): OptionalGetMetadataResponse | undefined {
+  return getMetadataResponse === undefined ? undefined : {
+    url: fromNullable(getMetadataResponse.url),
+    logo: fromNullable(getMetadataResponse.logo),
+    name: fromNullable(getMetadataResponse.name),
+    description: fromNullable(getMetadataResponse.description)
+  };
+}
+export interface OptionalGetModeResponse {
+  mode: undefined | number;
+}
+export function convertGetModeResponse(getModeResponse: GetModeResponse | undefined): OptionalGetModeResponse | undefined {
+  return getModeResponse === undefined ? undefined : {
+    mode: fromNullable(getModeResponse.mode)
+  };
+}
+export interface OptionalGetNeuron {
+  neuron_id: undefined | OptionalNeuronId;
+}
+export function convertGetNeuron(getNeuron: GetNeuron | undefined): OptionalGetNeuron | undefined {
+  return getNeuron === undefined ? undefined : {
+    neuron_id: convertNeuronId(fromNullable(getNeuron.neuron_id))
+  };
+}
+export interface OptionalGetNeuronResponse {
+  result: undefined | Result;
+}
+export function convertGetNeuronResponse(getNeuronResponse: GetNeuronResponse | undefined): OptionalGetNeuronResponse | undefined {
+  return getNeuronResponse === undefined ? undefined : {
+    result: convertResult(fromNullable(getNeuronResponse.result))
+  };
+}
+export interface OptionalGetProposal {
+  proposal_id: undefined | OptionalProposalId;
+}
+export function convertGetProposal(getProposal: GetProposal | undefined): OptionalGetProposal | undefined {
+  return getProposal === undefined ? undefined : {
+    proposal_id: convertProposalId(fromNullable(getProposal.proposal_id))
+  };
+}
+export interface OptionalGetProposalResponse {
+  result: undefined | Result_1;
+}
+export function convertGetProposalResponse(getProposalResponse: GetProposalResponse | undefined): OptionalGetProposalResponse | undefined {
+  return getProposalResponse === undefined ? undefined : {
+    result: convertResult_1(fromNullable(getProposalResponse.result))
+  };
+}
+export interface OptionalGetRunningSnsVersionResponse {
+  deployed_version: undefined | OptionalVersion;
+  pending_version: undefined | OptionalUpgradeInProgress;
+}
+export function convertGetRunningSnsVersionResponse(getRunningSnsVersionResponse: GetRunningSnsVersionResponse | undefined): OptionalGetRunningSnsVersionResponse | undefined {
+  return getRunningSnsVersionResponse === undefined ? undefined : {
+    deployed_version: convertVersion(fromNullable(getRunningSnsVersionResponse.deployed_version)),
+    pending_version: convertUpgradeInProgress(fromNullable(getRunningSnsVersionResponse.pending_version))
+  };
+}
+export interface OptionalGetSnsInitializationParametersResponse {
+  sns_initialization_parameters: string;
+}
+export function convertGetSnsInitializationParametersResponse(getSnsInitializationParametersResponse: GetSnsInitializationParametersResponse | undefined): OptionalGetSnsInitializationParametersResponse | undefined {
+  return getSnsInitializationParametersResponse === undefined ? undefined : {
+    sns_initialization_parameters: getSnsInitializationParametersResponse.sns_initialization_parameters
+  };
+}
+export interface OptionalGovernance {
+  root_canister_id: undefined | Principal;
+  id_to_nervous_system_functions: Array<[bigint, NervousSystemFunction]>;
+  metrics: undefined | OptionalGovernanceCachedMetrics;
+  mode: number;
+  parameters: undefined | OptionalNervousSystemParameters;
+  is_finalizing_disburse_maturity: undefined | boolean;
+  deployed_version: undefined | OptionalVersion;
+  sns_initialization_parameters: string;
+  latest_reward_event: undefined | OptionalRewardEvent;
+  pending_version: undefined | OptionalUpgradeInProgress;
+  swap_canister_id: undefined | Principal;
+  ledger_canister_id: undefined | Principal;
+  proposals: Array<[bigint, ProposalData]>;
+  in_flight_commands: Array<[string, NeuronInFlightCommand]>;
+  sns_metadata: undefined | OptionalManageSnsMetadata;
+  neurons: Array<[string, Neuron]>;
+  genesis_timestamp_seconds: bigint;
+}
+export function convertGovernance(governance: Governance | undefined): OptionalGovernance | undefined {
+  return governance === undefined ? undefined : {
+    root_canister_id: fromNullable(governance.root_canister_id),
+    id_to_nervous_system_functions: governance.id_to_nervous_system_functions,
+    metrics: convertGovernanceCachedMetrics(fromNullable(governance.metrics)),
+    mode: governance.mode,
+    parameters: convertNervousSystemParameters(fromNullable(governance.parameters)),
+    is_finalizing_disburse_maturity: fromNullable(governance.is_finalizing_disburse_maturity),
+    deployed_version: convertVersion(fromNullable(governance.deployed_version)),
+    sns_initialization_parameters: governance.sns_initialization_parameters,
+    latest_reward_event: convertRewardEvent(fromNullable(governance.latest_reward_event)),
+    pending_version: convertUpgradeInProgress(fromNullable(governance.pending_version)),
+    swap_canister_id: fromNullable(governance.swap_canister_id),
+    ledger_canister_id: fromNullable(governance.ledger_canister_id),
+    proposals: governance.proposals,
+    in_flight_commands: governance.in_flight_commands,
+    sns_metadata: convertManageSnsMetadata(fromNullable(governance.sns_metadata)),
+    neurons: governance.neurons,
+    genesis_timestamp_seconds: governance.genesis_timestamp_seconds
+  };
+}
+export interface OptionalGovernanceCachedMetrics {
+  not_dissolving_neurons_e8s_buckets: Array<[bigint, number]>;
+  garbage_collectable_neurons_count: bigint;
+  neurons_with_invalid_stake_count: bigint;
+  not_dissolving_neurons_count_buckets: Array<[bigint, bigint]>;
+  neurons_with_less_than_6_months_dissolve_delay_count: bigint;
+  dissolved_neurons_count: bigint;
+  total_staked_e8s: bigint;
+  total_supply_governance_tokens: bigint;
+  not_dissolving_neurons_count: bigint;
+  dissolved_neurons_e8s: bigint;
+  neurons_with_less_than_6_months_dissolve_delay_e8s: bigint;
+  dissolving_neurons_count_buckets: Array<[bigint, bigint]>;
+  dissolving_neurons_count: bigint;
+  dissolving_neurons_e8s_buckets: Array<[bigint, number]>;
+  timestamp_seconds: bigint;
+}
+export function convertGovernanceCachedMetrics(governanceCachedMetrics: GovernanceCachedMetrics | undefined): OptionalGovernanceCachedMetrics | undefined {
+  return governanceCachedMetrics === undefined ? undefined : {
+    not_dissolving_neurons_e8s_buckets: governanceCachedMetrics.not_dissolving_neurons_e8s_buckets,
+    garbage_collectable_neurons_count: governanceCachedMetrics.garbage_collectable_neurons_count,
+    neurons_with_invalid_stake_count: governanceCachedMetrics.neurons_with_invalid_stake_count,
+    not_dissolving_neurons_count_buckets: governanceCachedMetrics.not_dissolving_neurons_count_buckets,
+    neurons_with_less_than_6_months_dissolve_delay_count: governanceCachedMetrics.neurons_with_less_than_6_months_dissolve_delay_count,
+    dissolved_neurons_count: governanceCachedMetrics.dissolved_neurons_count,
+    total_staked_e8s: governanceCachedMetrics.total_staked_e8s,
+    total_supply_governance_tokens: governanceCachedMetrics.total_supply_governance_tokens,
+    not_dissolving_neurons_count: governanceCachedMetrics.not_dissolving_neurons_count,
+    dissolved_neurons_e8s: governanceCachedMetrics.dissolved_neurons_e8s,
+    neurons_with_less_than_6_months_dissolve_delay_e8s: governanceCachedMetrics.neurons_with_less_than_6_months_dissolve_delay_e8s,
+    dissolving_neurons_count_buckets: governanceCachedMetrics.dissolving_neurons_count_buckets,
+    dissolving_neurons_count: governanceCachedMetrics.dissolving_neurons_count,
+    dissolving_neurons_e8s_buckets: governanceCachedMetrics.dissolving_neurons_e8s_buckets,
+    timestamp_seconds: governanceCachedMetrics.timestamp_seconds
+  };
+}
+export interface OptionalGovernanceError {
+  error_message: string;
+  error_type: number;
+}
+export function convertGovernanceError(governanceError: GovernanceError | undefined): OptionalGovernanceError | undefined {
+  return governanceError === undefined ? undefined : {
+    error_message: governanceError.error_message,
+    error_type: governanceError.error_type
+  };
+}
+export interface OptionalIncreaseDissolveDelay {
+  additional_dissolve_delay_seconds: number;
+}
+export function convertIncreaseDissolveDelay(increaseDissolveDelay: IncreaseDissolveDelay | undefined): OptionalIncreaseDissolveDelay | undefined {
+  return increaseDissolveDelay === undefined ? undefined : {
+    additional_dissolve_delay_seconds: increaseDissolveDelay.additional_dissolve_delay_seconds
+  };
+}
+export interface OptionalListNervousSystemFunctionsResponse {
+  reserved_ids: BigUint64Array;
+  functions: Array<NervousSystemFunction>;
+}
+export function convertListNervousSystemFunctionsResponse(listNervousSystemFunctionsResponse: ListNervousSystemFunctionsResponse | undefined): OptionalListNervousSystemFunctionsResponse | undefined {
+  return listNervousSystemFunctionsResponse === undefined ? undefined : {
+    reserved_ids: listNervousSystemFunctionsResponse.reserved_ids,
+    functions: listNervousSystemFunctionsResponse.functions
+  };
+}
+export interface OptionalListNeurons {
+  of_principal: undefined | Principal;
+  limit: number;
+  start_page_at: undefined | OptionalNeuronId;
+}
+export function convertListNeurons(listNeurons: ListNeurons | undefined): OptionalListNeurons | undefined {
+  return listNeurons === undefined ? undefined : {
+    of_principal: fromNullable(listNeurons.of_principal),
+    limit: listNeurons.limit,
+    start_page_at: convertNeuronId(fromNullable(listNeurons.start_page_at))
+  };
+}
+export interface OptionalListNeuronsResponse {
+  neurons: Array<Neuron>;
+}
+export function convertListNeuronsResponse(listNeuronsResponse: ListNeuronsResponse | undefined): OptionalListNeuronsResponse | undefined {
+  return listNeuronsResponse === undefined ? undefined : {
+    neurons: listNeuronsResponse.neurons
+  };
+}
+export interface OptionalListProposals {
+  include_reward_status: Int32Array;
+  before_proposal: undefined | OptionalProposalId;
+  limit: number;
+  exclude_type: BigUint64Array;
+  include_status: Int32Array;
+}
+export function convertListProposals(listProposals: ListProposals | undefined): OptionalListProposals | undefined {
+  return listProposals === undefined ? undefined : {
+    include_reward_status: listProposals.include_reward_status,
+    before_proposal: convertProposalId(fromNullable(listProposals.before_proposal)),
+    limit: listProposals.limit,
+    exclude_type: listProposals.exclude_type,
+    include_status: listProposals.include_status
+  };
+}
+export interface OptionalListProposalsResponse {
+  proposals: Array<ProposalData>;
+}
+export function convertListProposalsResponse(listProposalsResponse: ListProposalsResponse | undefined): OptionalListProposalsResponse | undefined {
+  return listProposalsResponse === undefined ? undefined : {
+    proposals: listProposalsResponse.proposals
+  };
+}
+export interface OptionalManageNeuron {
+  subaccount: Uint8Array;
+  command: undefined | Command;
+}
+export function convertManageNeuron(manageNeuron: ManageNeuron | undefined): OptionalManageNeuron | undefined {
+  return manageNeuron === undefined ? undefined : {
+    subaccount: manageNeuron.subaccount,
+    command: convertCommand(fromNullable(manageNeuron.command))
+  };
+}
+export interface OptionalManageNeuronResponse {
+  command: undefined | Command_1;
+}
+export function convertManageNeuronResponse(manageNeuronResponse: ManageNeuronResponse | undefined): OptionalManageNeuronResponse | undefined {
+  return manageNeuronResponse === undefined ? undefined : {
+    command: convertCommand_1(fromNullable(manageNeuronResponse.command))
+  };
+}
+export interface OptionalManageSnsMetadata {
+  url: undefined | string;
+  logo: undefined | string;
+  name: undefined | string;
+  description: undefined | string;
+}
+export function convertManageSnsMetadata(manageSnsMetadata: ManageSnsMetadata | undefined): OptionalManageSnsMetadata | undefined {
+  return manageSnsMetadata === undefined ? undefined : {
+    url: fromNullable(manageSnsMetadata.url),
+    logo: fromNullable(manageSnsMetadata.logo),
+    name: fromNullable(manageSnsMetadata.name),
+    description: fromNullable(manageSnsMetadata.description)
+  };
+}
+export interface OptionalMemoAndController {
+  controller: undefined | Principal;
+  memo: bigint;
+}
+export function convertMemoAndController(memoAndController: MemoAndController | undefined): OptionalMemoAndController | undefined {
+  return memoAndController === undefined ? undefined : {
+    controller: fromNullable(memoAndController.controller),
+    memo: memoAndController.memo
+  };
+}
+export interface OptionalMergeMaturity {
+  percentage_to_merge: number;
+}
+export function convertMergeMaturity(mergeMaturity: MergeMaturity | undefined): OptionalMergeMaturity | undefined {
+  return mergeMaturity === undefined ? undefined : {
+    percentage_to_merge: mergeMaturity.percentage_to_merge
+  };
+}
+export interface OptionalMergeMaturityResponse {
+  merged_maturity_e8s: bigint;
+  new_stake_e8s: bigint;
+}
+export function convertMergeMaturityResponse(mergeMaturityResponse: MergeMaturityResponse | undefined): OptionalMergeMaturityResponse | undefined {
+  return mergeMaturityResponse === undefined ? undefined : {
+    merged_maturity_e8s: mergeMaturityResponse.merged_maturity_e8s,
+    new_stake_e8s: mergeMaturityResponse.new_stake_e8s
+  };
+}
+export interface OptionalMotion {
+  motion_text: string;
+}
+export function convertMotion(motion: Motion | undefined): OptionalMotion | undefined {
+  return motion === undefined ? undefined : {
+    motion_text: motion.motion_text
+  };
+}
+export interface OptionalNervousSystemFunction {
+  id: bigint;
+  name: string;
+  description: undefined | string;
+  function_type: undefined | FunctionType;
+}
+export function convertNervousSystemFunction(nervousSystemFunction: NervousSystemFunction | undefined): OptionalNervousSystemFunction | undefined {
+  return nervousSystemFunction === undefined ? undefined : {
+    id: nervousSystemFunction.id,
+    name: nervousSystemFunction.name,
+    description: fromNullable(nervousSystemFunction.description),
+    function_type: convertFunctionType(fromNullable(nervousSystemFunction.function_type))
+  };
+}
+export interface OptionalNervousSystemParameters {
+  default_followees: undefined | OptionalDefaultFollowees;
+  max_dissolve_delay_seconds: undefined | bigint;
+  max_dissolve_delay_bonus_percentage: undefined | bigint;
+  max_followees_per_function: undefined | bigint;
+  neuron_claimer_permissions: undefined | OptionalNeuronPermissionList;
+  neuron_minimum_stake_e8s: undefined | bigint;
+  max_neuron_age_for_age_bonus: undefined | bigint;
+  initial_voting_period_seconds: undefined | bigint;
+  neuron_minimum_dissolve_delay_to_vote_seconds: undefined | bigint;
+  reject_cost_e8s: undefined | bigint;
+  max_proposals_to_keep_per_action: undefined | number;
+  wait_for_quiet_deadline_increase_seconds: undefined | bigint;
+  max_number_of_neurons: undefined | bigint;
+  transaction_fee_e8s: undefined | bigint;
+  max_number_of_proposals_with_ballots: undefined | bigint;
+  max_age_bonus_percentage: undefined | bigint;
+  neuron_grantable_permissions: undefined | OptionalNeuronPermissionList;
+  voting_rewards_parameters: undefined | OptionalVotingRewardsParameters;
+  max_number_of_principals_per_neuron: undefined | bigint;
+}
+export function convertNervousSystemParameters(nervousSystemParameters: NervousSystemParameters | undefined): OptionalNervousSystemParameters | undefined {
+  return nervousSystemParameters === undefined ? undefined : {
+    default_followees: convertDefaultFollowees(fromNullable(nervousSystemParameters.default_followees)),
+    max_dissolve_delay_seconds: fromNullable(nervousSystemParameters.max_dissolve_delay_seconds),
+    max_dissolve_delay_bonus_percentage: fromNullable(nervousSystemParameters.max_dissolve_delay_bonus_percentage),
+    max_followees_per_function: fromNullable(nervousSystemParameters.max_followees_per_function),
+    neuron_claimer_permissions: convertNeuronPermissionList(fromNullable(nervousSystemParameters.neuron_claimer_permissions)),
+    neuron_minimum_stake_e8s: fromNullable(nervousSystemParameters.neuron_minimum_stake_e8s),
+    max_neuron_age_for_age_bonus: fromNullable(nervousSystemParameters.max_neuron_age_for_age_bonus),
+    initial_voting_period_seconds: fromNullable(nervousSystemParameters.initial_voting_period_seconds),
+    neuron_minimum_dissolve_delay_to_vote_seconds: fromNullable(nervousSystemParameters.neuron_minimum_dissolve_delay_to_vote_seconds),
+    reject_cost_e8s: fromNullable(nervousSystemParameters.reject_cost_e8s),
+    max_proposals_to_keep_per_action: fromNullable(nervousSystemParameters.max_proposals_to_keep_per_action),
+    wait_for_quiet_deadline_increase_seconds: fromNullable(nervousSystemParameters.wait_for_quiet_deadline_increase_seconds),
+    max_number_of_neurons: fromNullable(nervousSystemParameters.max_number_of_neurons),
+    transaction_fee_e8s: fromNullable(nervousSystemParameters.transaction_fee_e8s),
+    max_number_of_proposals_with_ballots: fromNullable(nervousSystemParameters.max_number_of_proposals_with_ballots),
+    max_age_bonus_percentage: fromNullable(nervousSystemParameters.max_age_bonus_percentage),
+    neuron_grantable_permissions: convertNeuronPermissionList(fromNullable(nervousSystemParameters.neuron_grantable_permissions)),
+    voting_rewards_parameters: convertVotingRewardsParameters(fromNullable(nervousSystemParameters.voting_rewards_parameters)),
+    max_number_of_principals_per_neuron: fromNullable(nervousSystemParameters.max_number_of_principals_per_neuron)
+  };
+}
+export interface OptionalNeuron {
+  id: undefined | OptionalNeuronId;
+  staked_maturity_e8s_equivalent: undefined | bigint;
+  permissions: Array<NeuronPermission>;
+  maturity_e8s_equivalent: bigint;
+  cached_neuron_stake_e8s: bigint;
+  created_timestamp_seconds: bigint;
+  source_nns_neuron_id: undefined | bigint;
+  auto_stake_maturity: undefined | boolean;
+  aging_since_timestamp_seconds: bigint;
+  dissolve_state: undefined | DissolveState;
+  voting_power_percentage_multiplier: bigint;
+  vesting_period_seconds: undefined | bigint;
+  disburse_maturity_in_progress: Array<DisburseMaturityInProgress>;
+  followees: Array<[bigint, Followees]>;
+  neuron_fees_e8s: bigint;
+}
+export function convertNeuron(neuron: Neuron | undefined): OptionalNeuron | undefined {
+  return neuron === undefined ? undefined : {
+    id: convertNeuronId(fromNullable(neuron.id)),
+    staked_maturity_e8s_equivalent: fromNullable(neuron.staked_maturity_e8s_equivalent),
+    permissions: neuron.permissions,
+    maturity_e8s_equivalent: neuron.maturity_e8s_equivalent,
+    cached_neuron_stake_e8s: neuron.cached_neuron_stake_e8s,
+    created_timestamp_seconds: neuron.created_timestamp_seconds,
+    source_nns_neuron_id: fromNullable(neuron.source_nns_neuron_id),
+    auto_stake_maturity: fromNullable(neuron.auto_stake_maturity),
+    aging_since_timestamp_seconds: neuron.aging_since_timestamp_seconds,
+    dissolve_state: convertDissolveState(fromNullable(neuron.dissolve_state)),
+    voting_power_percentage_multiplier: neuron.voting_power_percentage_multiplier,
+    vesting_period_seconds: fromNullable(neuron.vesting_period_seconds),
+    disburse_maturity_in_progress: neuron.disburse_maturity_in_progress,
+    followees: neuron.followees,
+    neuron_fees_e8s: neuron.neuron_fees_e8s
+  };
+}
+export interface OptionalNeuronId {
+  id: Uint8Array;
+}
+export function convertNeuronId(neuronId: NeuronId | undefined): OptionalNeuronId | undefined {
+  return neuronId === undefined ? undefined : {
+    id: neuronId.id
+  };
+}
+export interface OptionalNeuronInFlightCommand {
+  command: undefined | Command_2;
+  timestamp: bigint;
+}
+export function convertNeuronInFlightCommand(neuronInFlightCommand: NeuronInFlightCommand | undefined): OptionalNeuronInFlightCommand | undefined {
+  return neuronInFlightCommand === undefined ? undefined : {
+    command: convertCommand_2(fromNullable(neuronInFlightCommand.command)),
+    timestamp: neuronInFlightCommand.timestamp
+  };
+}
+export interface OptionalNeuronParameters {
+  controller: undefined | Principal;
+  dissolve_delay_seconds: undefined | bigint;
+  source_nns_neuron_id: undefined | bigint;
+  stake_e8s: undefined | bigint;
+  followees: Array<NeuronId>;
+  hotkey: undefined | Principal;
+  neuron_id: undefined | OptionalNeuronId;
+}
+export function convertNeuronParameters(neuronParameters: NeuronParameters | undefined): OptionalNeuronParameters | undefined {
+  return neuronParameters === undefined ? undefined : {
+    controller: fromNullable(neuronParameters.controller),
+    dissolve_delay_seconds: fromNullable(neuronParameters.dissolve_delay_seconds),
+    source_nns_neuron_id: fromNullable(neuronParameters.source_nns_neuron_id),
+    stake_e8s: fromNullable(neuronParameters.stake_e8s),
+    followees: neuronParameters.followees,
+    hotkey: fromNullable(neuronParameters.hotkey),
+    neuron_id: convertNeuronId(fromNullable(neuronParameters.neuron_id))
+  };
+}
+export interface OptionalNeuronPermission {
+  principal: undefined | Principal;
+  permission_type: Int32Array;
+}
+export function convertNeuronPermission(neuronPermission: NeuronPermission | undefined): OptionalNeuronPermission | undefined {
+  return neuronPermission === undefined ? undefined : {
+    principal: fromNullable(neuronPermission.principal),
+    permission_type: neuronPermission.permission_type
+  };
+}
+export interface OptionalNeuronPermissionList {
+  permissions: Int32Array;
+}
+export function convertNeuronPermissionList(neuronPermissionList: NeuronPermissionList | undefined): OptionalNeuronPermissionList | undefined {
+  return neuronPermissionList === undefined ? undefined : {
+    permissions: neuronPermissionList.permissions
+  };
+}
+export type Operation = {
+  ChangeAutoStakeMaturity: ChangeAutoStakeMaturity;
+} | {
+  StopDissolving: {};
+} | {
+  StartDissolving: {};
+} | {
+  IncreaseDissolveDelay: IncreaseDissolveDelay;
+} | {
+  SetDissolveTimestamp: SetDissolveTimestamp;
+};
+export interface OptionalProposal {
+  url: string;
+  title: string;
+  action: undefined | Action;
+  summary: string;
+}
+export function convertProposal(proposal: Proposal | undefined): OptionalProposal | undefined {
+  return proposal === undefined ? undefined : {
+    url: proposal.url,
+    title: proposal.title,
+    action: convertAction(fromNullable(proposal.action)),
+    summary: proposal.summary
+  };
+}
+export interface OptionalProposalData {
+  id: undefined | OptionalProposalId;
+  payload_text_rendering: undefined | string;
+  action: bigint;
+  failure_reason: undefined | OptionalGovernanceError;
+  ballots: Array<[string, Ballot]>;
+  reward_event_round: bigint;
+  failed_timestamp_seconds: bigint;
+  reward_event_end_timestamp_seconds: undefined | bigint;
+  proposal_creation_timestamp_seconds: bigint;
+  initial_voting_period_seconds: bigint;
+  reject_cost_e8s: bigint;
+  latest_tally: undefined | OptionalTally;
+  wait_for_quiet_deadline_increase_seconds: bigint;
+  decided_timestamp_seconds: bigint;
+  proposal: undefined | OptionalProposal;
+  proposer: undefined | OptionalNeuronId;
+  wait_for_quiet_state: undefined | OptionalWaitForQuietState;
+  is_eligible_for_rewards: boolean;
+  executed_timestamp_seconds: bigint;
+}
+export function convertProposalData(proposalData: ProposalData | undefined): OptionalProposalData | undefined {
+  return proposalData === undefined ? undefined : {
+    id: convertProposalId(fromNullable(proposalData.id)),
+    payload_text_rendering: fromNullable(proposalData.payload_text_rendering),
+    action: proposalData.action,
+    failure_reason: convertGovernanceError(fromNullable(proposalData.failure_reason)),
+    ballots: proposalData.ballots,
+    reward_event_round: proposalData.reward_event_round,
+    failed_timestamp_seconds: proposalData.failed_timestamp_seconds,
+    reward_event_end_timestamp_seconds: fromNullable(proposalData.reward_event_end_timestamp_seconds),
+    proposal_creation_timestamp_seconds: proposalData.proposal_creation_timestamp_seconds,
+    initial_voting_period_seconds: proposalData.initial_voting_period_seconds,
+    reject_cost_e8s: proposalData.reject_cost_e8s,
+    latest_tally: convertTally(fromNullable(proposalData.latest_tally)),
+    wait_for_quiet_deadline_increase_seconds: proposalData.wait_for_quiet_deadline_increase_seconds,
+    decided_timestamp_seconds: proposalData.decided_timestamp_seconds,
+    proposal: convertProposal(fromNullable(proposalData.proposal)),
+    proposer: convertNeuronId(fromNullable(proposalData.proposer)),
+    wait_for_quiet_state: convertWaitForQuietState(fromNullable(proposalData.wait_for_quiet_state)),
+    is_eligible_for_rewards: proposalData.is_eligible_for_rewards,
+    executed_timestamp_seconds: proposalData.executed_timestamp_seconds
+  };
+}
+export interface OptionalProposalId {
+  id: bigint;
+}
+export function convertProposalId(proposalId: ProposalId | undefined): OptionalProposalId | undefined {
+  return proposalId === undefined ? undefined : {
+    id: proposalId.id
+  };
+}
+export interface OptionalRegisterDappCanisters {
+  canister_ids: Array<Principal>;
+}
+export function convertRegisterDappCanisters(registerDappCanisters: RegisterDappCanisters | undefined): OptionalRegisterDappCanisters | undefined {
+  return registerDappCanisters === undefined ? undefined : {
+    canister_ids: registerDappCanisters.canister_ids
+  };
+}
+export interface OptionalRegisterVote {
+  vote: number;
+  proposal: undefined | OptionalProposalId;
+}
+export function convertRegisterVote(registerVote: RegisterVote | undefined): OptionalRegisterVote | undefined {
+  return registerVote === undefined ? undefined : {
+    vote: registerVote.vote,
+    proposal: convertProposalId(fromNullable(registerVote.proposal))
+  };
+}
+export interface OptionalRemoveNeuronPermissions {
+  permissions_to_remove: undefined | OptionalNeuronPermissionList;
+  principal_id: undefined | Principal;
+}
+export function convertRemoveNeuronPermissions(removeNeuronPermissions: RemoveNeuronPermissions | undefined): OptionalRemoveNeuronPermissions | undefined {
+  return removeNeuronPermissions === undefined ? undefined : {
+    permissions_to_remove: convertNeuronPermissionList(fromNullable(removeNeuronPermissions.permissions_to_remove)),
+    principal_id: fromNullable(removeNeuronPermissions.principal_id)
+  };
+}
+export type Result = {
+  Error: GovernanceError;
+} | {
+  Neuron: Neuron;
+};
+export type Result_1 = {
+  Error: GovernanceError;
+} | {
+  Proposal: ProposalData;
+};
+export interface OptionalRewardEvent {
+  actual_timestamp_seconds: bigint;
+  end_timestamp_seconds: undefined | bigint;
+  distributed_e8s_equivalent: bigint;
+  round: bigint;
+  settled_proposals: Array<ProposalId>;
+}
+export function convertRewardEvent(rewardEvent: RewardEvent | undefined): OptionalRewardEvent | undefined {
+  return rewardEvent === undefined ? undefined : {
+    actual_timestamp_seconds: rewardEvent.actual_timestamp_seconds,
+    end_timestamp_seconds: fromNullable(rewardEvent.end_timestamp_seconds),
+    distributed_e8s_equivalent: rewardEvent.distributed_e8s_equivalent,
+    round: rewardEvent.round,
+    settled_proposals: rewardEvent.settled_proposals
+  };
+}
+export interface OptionalSetDissolveTimestamp {
+  dissolve_timestamp_seconds: bigint;
+}
+export function convertSetDissolveTimestamp(setDissolveTimestamp: SetDissolveTimestamp | undefined): OptionalSetDissolveTimestamp | undefined {
+  return setDissolveTimestamp === undefined ? undefined : {
+    dissolve_timestamp_seconds: setDissolveTimestamp.dissolve_timestamp_seconds
+  };
+}
+export interface OptionalSetMode {
+  mode: number;
+}
+export function convertSetMode(setMode: SetMode | undefined): OptionalSetMode | undefined {
+  return setMode === undefined ? undefined : {
+    mode: setMode.mode
+  };
+}
+export interface OptionalSplit {
+  memo: bigint;
+  amount_e8s: bigint;
+}
+export function convertSplit(split: Split | undefined): OptionalSplit | undefined {
+  return split === undefined ? undefined : {
+    memo: split.memo,
+    amount_e8s: split.amount_e8s
+  };
+}
+export interface OptionalSplitResponse {
+  created_neuron_id: undefined | OptionalNeuronId;
+}
+export function convertSplitResponse(splitResponse: SplitResponse | undefined): OptionalSplitResponse | undefined {
+  return splitResponse === undefined ? undefined : {
+    created_neuron_id: convertNeuronId(fromNullable(splitResponse.created_neuron_id))
+  };
+}
+export interface OptionalStakeMaturity {
+  percentage_to_stake: undefined | number;
+}
+export function convertStakeMaturity(stakeMaturity: StakeMaturity | undefined): OptionalStakeMaturity | undefined {
+  return stakeMaturity === undefined ? undefined : {
+    percentage_to_stake: fromNullable(stakeMaturity.percentage_to_stake)
+  };
+}
+export interface OptionalStakeMaturityResponse {
+  maturity_e8s: bigint;
+  staked_maturity_e8s: bigint;
+}
+export function convertStakeMaturityResponse(stakeMaturityResponse: StakeMaturityResponse | undefined): OptionalStakeMaturityResponse | undefined {
+  return stakeMaturityResponse === undefined ? undefined : {
+    maturity_e8s: stakeMaturityResponse.maturity_e8s,
+    staked_maturity_e8s: stakeMaturityResponse.staked_maturity_e8s
+  };
+}
+export interface OptionalSubaccount {
+  subaccount: Uint8Array;
+}
+export function convertSubaccount(subaccount: Subaccount | undefined): OptionalSubaccount | undefined {
+  return subaccount === undefined ? undefined : {
+    subaccount: subaccount.subaccount
+  };
+}
+export interface OptionalSwapNeuron {
+  id: undefined | OptionalNeuronId;
+  status: number;
+}
+export function convertSwapNeuron(swapNeuron: SwapNeuron | undefined): OptionalSwapNeuron | undefined {
+  return swapNeuron === undefined ? undefined : {
+    id: convertNeuronId(fromNullable(swapNeuron.id)),
+    status: swapNeuron.status
+  };
+}
+export interface OptionalTally {
+  no: bigint;
+  yes: bigint;
+  total: bigint;
+  timestamp_seconds: bigint;
+}
+export function convertTally(tally: Tally | undefined): OptionalTally | undefined {
+  return tally === undefined ? undefined : {
+    no: tally.no,
+    yes: tally.yes,
+    total: tally.total,
+    timestamp_seconds: tally.timestamp_seconds
+  };
+}
+export interface OptionalTransferSnsTreasuryFunds {
+  from_treasury: number;
+  to_principal: undefined | Principal;
+  to_subaccount: undefined | OptionalSubaccount;
+  memo: undefined | bigint;
+  amount_e8s: bigint;
+}
+export function convertTransferSnsTreasuryFunds(transferSnsTreasuryFunds: TransferSnsTreasuryFunds | undefined): OptionalTransferSnsTreasuryFunds | undefined {
+  return transferSnsTreasuryFunds === undefined ? undefined : {
+    from_treasury: transferSnsTreasuryFunds.from_treasury,
+    to_principal: fromNullable(transferSnsTreasuryFunds.to_principal),
+    to_subaccount: convertSubaccount(fromNullable(transferSnsTreasuryFunds.to_subaccount)),
+    memo: fromNullable(transferSnsTreasuryFunds.memo),
+    amount_e8s: transferSnsTreasuryFunds.amount_e8s
+  };
+}
+export interface OptionalUpgradeInProgress {
+  mark_failed_at_seconds: bigint;
+  checking_upgrade_lock: bigint;
+  proposal_id: bigint;
+  target_version: undefined | OptionalVersion;
+}
+export function convertUpgradeInProgress(upgradeInProgress: UpgradeInProgress | undefined): OptionalUpgradeInProgress | undefined {
+  return upgradeInProgress === undefined ? undefined : {
+    mark_failed_at_seconds: upgradeInProgress.mark_failed_at_seconds,
+    checking_upgrade_lock: upgradeInProgress.checking_upgrade_lock,
+    proposal_id: upgradeInProgress.proposal_id,
+    target_version: convertVersion(fromNullable(upgradeInProgress.target_version))
+  };
+}
+export interface OptionalUpgradeSnsControlledCanister {
+  new_canister_wasm: Uint8Array;
+  canister_id: undefined | Principal;
+  canister_upgrade_arg: undefined | Uint8Array;
+}
+export function convertUpgradeSnsControlledCanister(upgradeSnsControlledCanister: UpgradeSnsControlledCanister | undefined): OptionalUpgradeSnsControlledCanister | undefined {
+  return upgradeSnsControlledCanister === undefined ? undefined : {
+    new_canister_wasm: upgradeSnsControlledCanister.new_canister_wasm,
+    canister_id: fromNullable(upgradeSnsControlledCanister.canister_id),
+    canister_upgrade_arg: fromNullable(upgradeSnsControlledCanister.canister_upgrade_arg)
+  };
+}
+export interface OptionalVersion {
+  archive_wasm_hash: Uint8Array;
+  root_wasm_hash: Uint8Array;
+  swap_wasm_hash: Uint8Array;
+  ledger_wasm_hash: Uint8Array;
+  governance_wasm_hash: Uint8Array;
+  index_wasm_hash: Uint8Array;
+}
+export function convertVersion(version: Version | undefined): OptionalVersion | undefined {
+  return version === undefined ? undefined : {
+    archive_wasm_hash: version.archive_wasm_hash,
+    root_wasm_hash: version.root_wasm_hash,
+    swap_wasm_hash: version.swap_wasm_hash,
+    ledger_wasm_hash: version.ledger_wasm_hash,
+    governance_wasm_hash: version.governance_wasm_hash,
+    index_wasm_hash: version.index_wasm_hash
+  };
+}
+export interface OptionalVotingRewardsParameters {
+  final_reward_rate_basis_points: undefined | bigint;
+  initial_reward_rate_basis_points: undefined | bigint;
+  reward_rate_transition_duration_seconds: undefined | bigint;
+  round_duration_seconds: undefined | bigint;
+}
+export function convertVotingRewardsParameters(votingRewardsParameters: VotingRewardsParameters | undefined): OptionalVotingRewardsParameters | undefined {
+  return votingRewardsParameters === undefined ? undefined : {
+    final_reward_rate_basis_points: fromNullable(votingRewardsParameters.final_reward_rate_basis_points),
+    initial_reward_rate_basis_points: fromNullable(votingRewardsParameters.initial_reward_rate_basis_points),
+    reward_rate_transition_duration_seconds: fromNullable(votingRewardsParameters.reward_rate_transition_duration_seconds),
+    round_duration_seconds: fromNullable(votingRewardsParameters.round_duration_seconds)
+  };
+}
+export interface OptionalWaitForQuietState {
+  current_deadline_timestamp_seconds: bigint;
+}
+export function convertWaitForQuietState(waitForQuietState: WaitForQuietState | undefined): OptionalWaitForQuietState | undefined {
+  return waitForQuietState === undefined ? undefined : {
+    current_deadline_timestamp_seconds: waitForQuietState.current_deadline_timestamp_seconds
+  };
+}
+export interface _SERVICE {
+  claim_swap_neurons: ActorMethod<[ClaimSwapNeuronsRequest], ClaimSwapNeuronsResponse>;
+  get_build_metadata: ActorMethod<[], string>;
+  get_metadata: ActorMethod<[{}], GetMetadataResponse>;
+  get_mode: ActorMethod<[{}], GetModeResponse>;
+  get_nervous_system_parameters: ActorMethod<[null], NervousSystemParameters>;
+  get_neuron: ActorMethod<[GetNeuron], GetNeuronResponse>;
+  get_proposal: ActorMethod<[GetProposal], GetProposalResponse>;
+  get_root_canister_status: ActorMethod<[null], CanisterStatusResultV2>;
+  get_running_sns_version: ActorMethod<[{}], GetRunningSnsVersionResponse>;
+  get_sns_initialization_parameters: ActorMethod<[{}], GetSnsInitializationParametersResponse>;
+  list_nervous_system_functions: ActorMethod<[], ListNervousSystemFunctionsResponse>;
+  list_neurons: ActorMethod<[ListNeurons], ListNeuronsResponse>;
+  list_proposals: ActorMethod<[ListProposals], ListProposalsResponse>;
+  manage_neuron: ActorMethod<[ManageNeuron], ManageNeuronResponse>;
+  set_mode: ActorMethod<[SetMode], {}>;
+}

--- a/packages/sns/candid/sns_governance-converters.ts
+++ b/packages/sns/candid/sns_governance-converters.ts
@@ -1,3 +1,5 @@
+import type { ActorMethod } from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
 import { fromNullable } from "@dfinity/utils";
 import {
   Account,
@@ -6,11 +8,11 @@ import {
   Ballot,
   CanisterStatusResultV2,
   ChangeAutoStakeMaturity,
+  ClaimedSwapNeurons,
   ClaimOrRefresh,
   ClaimOrRefreshResponse,
   ClaimSwapNeuronsRequest,
   ClaimSwapNeuronsResponse,
-  ClaimedSwapNeurons,
   Configure,
   DefaultFollowees,
   DefiniteCanisterSettingsArgs,
@@ -78,80 +80,110 @@ import {
   UpgradeSnsControlledCanister,
   Version,
   VotingRewardsParameters,
-  WaitForQuietState
+  WaitForQuietState,
 } from "./sns_governance";
-import type { ActorMethod } from "@dfinity/agent";
-import type { Principal } from "@dfinity/principal";
 export interface OptionalAccount {
   owner: undefined | Principal;
   subaccount: undefined | OptionalSubaccount;
 }
-export function convertAccount(account: Account | undefined): OptionalAccount | undefined {
-  return account === undefined ? undefined : {
-    owner: fromNullable(account.owner),
-    subaccount: convertSubaccount(fromNullable(account.subaccount))
-  };
+export function convertAccount(
+  account: Account | undefined
+): OptionalAccount | undefined {
+  return account === undefined
+    ? undefined
+    : {
+        owner: fromNullable(account.owner),
+        subaccount: convertSubaccount(fromNullable(account.subaccount)),
+      };
 }
-export type Action = {
-  ManageNervousSystemParameters: NervousSystemParameters;
-} | {
-  AddGenericNervousSystemFunction: NervousSystemFunction;
-} | {
-  RemoveGenericNervousSystemFunction: bigint;
-} | {
-  UpgradeSnsToNextVersion: {};
-} | {
-  RegisterDappCanisters: RegisterDappCanisters;
-} | {
-  TransferSnsTreasuryFunds: TransferSnsTreasuryFunds;
-} | {
-  UpgradeSnsControlledCanister: UpgradeSnsControlledCanister;
-} | {
-  DeregisterDappCanisters: DeregisterDappCanisters;
-} | {
-  Unspecified: {};
-} | {
-  ManageSnsMetadata: ManageSnsMetadata;
-} | {
-  ExecuteGenericNervousSystemFunction: ExecuteGenericNervousSystemFunction;
-} | {
-  Motion: Motion;
-};
+export type Action =
+  | {
+      ManageNervousSystemParameters: NervousSystemParameters;
+    }
+  | {
+      AddGenericNervousSystemFunction: NervousSystemFunction;
+    }
+  | {
+      RemoveGenericNervousSystemFunction: bigint;
+    }
+  | {
+      UpgradeSnsToNextVersion: {};
+    }
+  | {
+      RegisterDappCanisters: RegisterDappCanisters;
+    }
+  | {
+      TransferSnsTreasuryFunds: TransferSnsTreasuryFunds;
+    }
+  | {
+      UpgradeSnsControlledCanister: UpgradeSnsControlledCanister;
+    }
+  | {
+      DeregisterDappCanisters: DeregisterDappCanisters;
+    }
+  | {
+      Unspecified: {};
+    }
+  | {
+      ManageSnsMetadata: ManageSnsMetadata;
+    }
+  | {
+      ExecuteGenericNervousSystemFunction: ExecuteGenericNervousSystemFunction;
+    }
+  | {
+      Motion: Motion;
+    };
 export interface OptionalAddNeuronPermissions {
   permissions_to_add: undefined | OptionalNeuronPermissionList;
   principal_id: undefined | Principal;
 }
-export function convertAddNeuronPermissions(addNeuronPermissions: AddNeuronPermissions | undefined): OptionalAddNeuronPermissions | undefined {
-  return addNeuronPermissions === undefined ? undefined : {
-    permissions_to_add: convertNeuronPermissionList(fromNullable(addNeuronPermissions.permissions_to_add)),
-    principal_id: fromNullable(addNeuronPermissions.principal_id)
-  };
+export function convertAddNeuronPermissions(
+  addNeuronPermissions: AddNeuronPermissions | undefined
+): OptionalAddNeuronPermissions | undefined {
+  return addNeuronPermissions === undefined
+    ? undefined
+    : {
+        permissions_to_add: convertNeuronPermissionList(
+          fromNullable(addNeuronPermissions.permissions_to_add)
+        ),
+        principal_id: fromNullable(addNeuronPermissions.principal_id),
+      };
 }
 export interface OptionalAmount {
   e8s: bigint;
 }
-export function convertAmount(amount: Amount | undefined): OptionalAmount | undefined {
-  return amount === undefined ? undefined : {
-    e8s: amount.e8s
-  };
+export function convertAmount(
+  amount: Amount | undefined
+): OptionalAmount | undefined {
+  return amount === undefined
+    ? undefined
+    : {
+        e8s: amount.e8s,
+      };
 }
 export interface OptionalBallot {
   vote: number;
   cast_timestamp_seconds: bigint;
   voting_power: bigint;
 }
-export function convertBallot(ballot: Ballot | undefined): OptionalBallot | undefined {
-  return ballot === undefined ? undefined : {
-    vote: ballot.vote,
-    cast_timestamp_seconds: ballot.cast_timestamp_seconds,
-    voting_power: ballot.voting_power
-  };
+export function convertBallot(
+  ballot: Ballot | undefined
+): OptionalBallot | undefined {
+  return ballot === undefined
+    ? undefined
+    : {
+        vote: ballot.vote,
+        cast_timestamp_seconds: ballot.cast_timestamp_seconds,
+        voting_power: ballot.voting_power,
+      };
 }
-export type By = {
-  MemoAndController: MemoAndController;
-} | {
-  NeuronId: {};
-};
+export type By =
+  | {
+      MemoAndController: MemoAndController;
+    }
+  | {
+      NeuronId: {};
+    };
 export interface OptionalCanisterStatusResultV2 {
   controller: Principal;
   status: CanisterStatusType;
@@ -163,173 +195,258 @@ export interface OptionalCanisterStatusResultV2 {
   idle_cycles_burned_per_day: bigint;
   module_hash: undefined | Uint8Array;
 }
-export function convertCanisterStatusResultV2(canisterStatusResultV2: CanisterStatusResultV2 | undefined): OptionalCanisterStatusResultV2 | undefined {
-  return canisterStatusResultV2 === undefined ? undefined : {
-    controller: canisterStatusResultV2.controller,
-    status: canisterStatusResultV2.status,
-    freezing_threshold: canisterStatusResultV2.freezing_threshold,
-    balance: canisterStatusResultV2.balance,
-    memory_size: canisterStatusResultV2.memory_size,
-    cycles: canisterStatusResultV2.cycles,
-    settings: canisterStatusResultV2.settings,
-    idle_cycles_burned_per_day: canisterStatusResultV2.idle_cycles_burned_per_day,
-    module_hash: fromNullable(canisterStatusResultV2.module_hash)
-  };
+export function convertCanisterStatusResultV2(
+  canisterStatusResultV2: CanisterStatusResultV2 | undefined
+): OptionalCanisterStatusResultV2 | undefined {
+  return canisterStatusResultV2 === undefined
+    ? undefined
+    : {
+        controller: canisterStatusResultV2.controller,
+        status: canisterStatusResultV2.status,
+        freezing_threshold: canisterStatusResultV2.freezing_threshold,
+        balance: canisterStatusResultV2.balance,
+        memory_size: canisterStatusResultV2.memory_size,
+        cycles: canisterStatusResultV2.cycles,
+        settings: canisterStatusResultV2.settings,
+        idle_cycles_burned_per_day:
+          canisterStatusResultV2.idle_cycles_burned_per_day,
+        module_hash: fromNullable(canisterStatusResultV2.module_hash),
+      };
 }
-export type CanisterStatusType = {
-  stopped: null;
-} | {
-  stopping: null;
-} | {
-  running: null;
-};
+export type CanisterStatusType =
+  | {
+      stopped: null;
+    }
+  | {
+      stopping: null;
+    }
+  | {
+      running: null;
+    };
 export interface OptionalChangeAutoStakeMaturity {
   requested_setting_for_auto_stake_maturity: boolean;
 }
-export function convertChangeAutoStakeMaturity(changeAutoStakeMaturity: ChangeAutoStakeMaturity | undefined): OptionalChangeAutoStakeMaturity | undefined {
-  return changeAutoStakeMaturity === undefined ? undefined : {
-    requested_setting_for_auto_stake_maturity: changeAutoStakeMaturity.requested_setting_for_auto_stake_maturity
-  };
+export function convertChangeAutoStakeMaturity(
+  changeAutoStakeMaturity: ChangeAutoStakeMaturity | undefined
+): OptionalChangeAutoStakeMaturity | undefined {
+  return changeAutoStakeMaturity === undefined
+    ? undefined
+    : {
+        requested_setting_for_auto_stake_maturity:
+          changeAutoStakeMaturity.requested_setting_for_auto_stake_maturity,
+      };
 }
 export interface OptionalClaimOrRefresh {
   by: undefined | By;
 }
-export function convertClaimOrRefresh(claimOrRefresh: ClaimOrRefresh | undefined): OptionalClaimOrRefresh | undefined {
-  return claimOrRefresh === undefined ? undefined : {
-    by: convertBy(fromNullable(claimOrRefresh.by))
-  };
+export function convertClaimOrRefresh(
+  claimOrRefresh: ClaimOrRefresh | undefined
+): OptionalClaimOrRefresh | undefined {
+  return claimOrRefresh === undefined
+    ? undefined
+    : {
+        by: convertBy(fromNullable(claimOrRefresh.by)),
+      };
 }
 export interface OptionalClaimOrRefreshResponse {
   refreshed_neuron_id: undefined | OptionalNeuronId;
 }
-export function convertClaimOrRefreshResponse(claimOrRefreshResponse: ClaimOrRefreshResponse | undefined): OptionalClaimOrRefreshResponse | undefined {
-  return claimOrRefreshResponse === undefined ? undefined : {
-    refreshed_neuron_id: convertNeuronId(fromNullable(claimOrRefreshResponse.refreshed_neuron_id))
-  };
+export function convertClaimOrRefreshResponse(
+  claimOrRefreshResponse: ClaimOrRefreshResponse | undefined
+): OptionalClaimOrRefreshResponse | undefined {
+  return claimOrRefreshResponse === undefined
+    ? undefined
+    : {
+        refreshed_neuron_id: convertNeuronId(
+          fromNullable(claimOrRefreshResponse.refreshed_neuron_id)
+        ),
+      };
 }
 export interface OptionalClaimSwapNeuronsRequest {
   neuron_parameters: Array<NeuronParameters>;
 }
-export function convertClaimSwapNeuronsRequest(claimSwapNeuronsRequest: ClaimSwapNeuronsRequest | undefined): OptionalClaimSwapNeuronsRequest | undefined {
-  return claimSwapNeuronsRequest === undefined ? undefined : {
-    neuron_parameters: claimSwapNeuronsRequest.neuron_parameters
-  };
+export function convertClaimSwapNeuronsRequest(
+  claimSwapNeuronsRequest: ClaimSwapNeuronsRequest | undefined
+): OptionalClaimSwapNeuronsRequest | undefined {
+  return claimSwapNeuronsRequest === undefined
+    ? undefined
+    : {
+        neuron_parameters: claimSwapNeuronsRequest.neuron_parameters,
+      };
 }
 export interface OptionalClaimSwapNeuronsResponse {
   claim_swap_neurons_result: undefined | ClaimSwapNeuronsResult;
 }
-export function convertClaimSwapNeuronsResponse(claimSwapNeuronsResponse: ClaimSwapNeuronsResponse | undefined): OptionalClaimSwapNeuronsResponse | undefined {
-  return claimSwapNeuronsResponse === undefined ? undefined : {
-    claim_swap_neurons_result: convertClaimSwapNeuronsResult(fromNullable(claimSwapNeuronsResponse.claim_swap_neurons_result))
-  };
+export function convertClaimSwapNeuronsResponse(
+  claimSwapNeuronsResponse: ClaimSwapNeuronsResponse | undefined
+): OptionalClaimSwapNeuronsResponse | undefined {
+  return claimSwapNeuronsResponse === undefined
+    ? undefined
+    : {
+        claim_swap_neurons_result: convertClaimSwapNeuronsResult(
+          fromNullable(claimSwapNeuronsResponse.claim_swap_neurons_result)
+        ),
+      };
 }
-export type ClaimSwapNeuronsResult = {
-  Ok: ClaimedSwapNeurons;
-} | {
-  Err: number;
-};
+export type ClaimSwapNeuronsResult =
+  | {
+      Ok: ClaimedSwapNeurons;
+    }
+  | {
+      Err: number;
+    };
 export interface OptionalClaimedSwapNeurons {
   swap_neurons: Array<SwapNeuron>;
 }
-export function convertClaimedSwapNeurons(claimedSwapNeurons: ClaimedSwapNeurons | undefined): OptionalClaimedSwapNeurons | undefined {
-  return claimedSwapNeurons === undefined ? undefined : {
-    swap_neurons: claimedSwapNeurons.swap_neurons
-  };
+export function convertClaimedSwapNeurons(
+  claimedSwapNeurons: ClaimedSwapNeurons | undefined
+): OptionalClaimedSwapNeurons | undefined {
+  return claimedSwapNeurons === undefined
+    ? undefined
+    : {
+        swap_neurons: claimedSwapNeurons.swap_neurons,
+      };
 }
-export type Command = {
-  Split: Split;
-} | {
-  Follow: Follow;
-} | {
-  DisburseMaturity: DisburseMaturity;
-} | {
-  ClaimOrRefresh: ClaimOrRefresh;
-} | {
-  Configure: Configure;
-} | {
-  RegisterVote: RegisterVote;
-} | {
-  MakeProposal: Proposal;
-} | {
-  StakeMaturity: StakeMaturity;
-} | {
-  RemoveNeuronPermissions: RemoveNeuronPermissions;
-} | {
-  AddNeuronPermissions: AddNeuronPermissions;
-} | {
-  MergeMaturity: MergeMaturity;
-} | {
-  Disburse: Disburse;
-};
-export type Command_1 = {
-  Error: GovernanceError;
-} | {
-  Split: SplitResponse;
-} | {
-  Follow: {};
-} | {
-  DisburseMaturity: DisburseMaturityResponse;
-} | {
-  ClaimOrRefresh: ClaimOrRefreshResponse;
-} | {
-  Configure: {};
-} | {
-  RegisterVote: {};
-} | {
-  MakeProposal: GetProposal;
-} | {
-  RemoveNeuronPermission: {};
-} | {
-  StakeMaturity: StakeMaturityResponse;
-} | {
-  MergeMaturity: MergeMaturityResponse;
-} | {
-  Disburse: DisburseResponse;
-} | {
-  AddNeuronPermission: {};
-};
-export type Command_2 = {
-  Split: Split;
-} | {
-  Follow: Follow;
-} | {
-  DisburseMaturity: DisburseMaturity;
-} | {
-  Configure: Configure;
-} | {
-  RegisterVote: RegisterVote;
-} | {
-  SyncCommand: {};
-} | {
-  MakeProposal: Proposal;
-} | {
-  FinalizeDisburseMaturity: FinalizeDisburseMaturity;
-} | {
-  ClaimOrRefreshNeuron: ClaimOrRefresh;
-} | {
-  RemoveNeuronPermissions: RemoveNeuronPermissions;
-} | {
-  AddNeuronPermissions: AddNeuronPermissions;
-} | {
-  MergeMaturity: MergeMaturity;
-} | {
-  Disburse: Disburse;
-};
+export type Command =
+  | {
+      Split: Split;
+    }
+  | {
+      Follow: Follow;
+    }
+  | {
+      DisburseMaturity: DisburseMaturity;
+    }
+  | {
+      ClaimOrRefresh: ClaimOrRefresh;
+    }
+  | {
+      Configure: Configure;
+    }
+  | {
+      RegisterVote: RegisterVote;
+    }
+  | {
+      MakeProposal: Proposal;
+    }
+  | {
+      StakeMaturity: StakeMaturity;
+    }
+  | {
+      RemoveNeuronPermissions: RemoveNeuronPermissions;
+    }
+  | {
+      AddNeuronPermissions: AddNeuronPermissions;
+    }
+  | {
+      MergeMaturity: MergeMaturity;
+    }
+  | {
+      Disburse: Disburse;
+    };
+export type Command_1 =
+  | {
+      Error: GovernanceError;
+    }
+  | {
+      Split: SplitResponse;
+    }
+  | {
+      Follow: {};
+    }
+  | {
+      DisburseMaturity: DisburseMaturityResponse;
+    }
+  | {
+      ClaimOrRefresh: ClaimOrRefreshResponse;
+    }
+  | {
+      Configure: {};
+    }
+  | {
+      RegisterVote: {};
+    }
+  | {
+      MakeProposal: GetProposal;
+    }
+  | {
+      RemoveNeuronPermission: {};
+    }
+  | {
+      StakeMaturity: StakeMaturityResponse;
+    }
+  | {
+      MergeMaturity: MergeMaturityResponse;
+    }
+  | {
+      Disburse: DisburseResponse;
+    }
+  | {
+      AddNeuronPermission: {};
+    };
+export type Command_2 =
+  | {
+      Split: Split;
+    }
+  | {
+      Follow: Follow;
+    }
+  | {
+      DisburseMaturity: DisburseMaturity;
+    }
+  | {
+      Configure: Configure;
+    }
+  | {
+      RegisterVote: RegisterVote;
+    }
+  | {
+      SyncCommand: {};
+    }
+  | {
+      MakeProposal: Proposal;
+    }
+  | {
+      FinalizeDisburseMaturity: FinalizeDisburseMaturity;
+    }
+  | {
+      ClaimOrRefreshNeuron: ClaimOrRefresh;
+    }
+  | {
+      RemoveNeuronPermissions: RemoveNeuronPermissions;
+    }
+  | {
+      AddNeuronPermissions: AddNeuronPermissions;
+    }
+  | {
+      MergeMaturity: MergeMaturity;
+    }
+  | {
+      Disburse: Disburse;
+    };
 export interface OptionalConfigure {
   operation: undefined | Operation;
 }
-export function convertConfigure(configure: Configure | undefined): OptionalConfigure | undefined {
-  return configure === undefined ? undefined : {
-    operation: convertOperation(fromNullable(configure.operation))
-  };
+export function convertConfigure(
+  configure: Configure | undefined
+): OptionalConfigure | undefined {
+  return configure === undefined
+    ? undefined
+    : {
+        operation: convertOperation(fromNullable(configure.operation)),
+      };
 }
 export interface OptionalDefaultFollowees {
   followees: Array<[bigint, Followees]>;
 }
-export function convertDefaultFollowees(defaultFollowees: DefaultFollowees | undefined): OptionalDefaultFollowees | undefined {
-  return defaultFollowees === undefined ? undefined : {
-    followees: defaultFollowees.followees
-  };
+export function convertDefaultFollowees(
+  defaultFollowees: DefaultFollowees | undefined
+): OptionalDefaultFollowees | undefined {
+  return defaultFollowees === undefined
+    ? undefined
+    : {
+        followees: defaultFollowees.followees,
+      };
 }
 export interface OptionalDefiniteCanisterSettingsArgs {
   controller: Principal;
@@ -338,134 +455,202 @@ export interface OptionalDefiniteCanisterSettingsArgs {
   memory_allocation: bigint;
   compute_allocation: bigint;
 }
-export function convertDefiniteCanisterSettingsArgs(definiteCanisterSettingsArgs: DefiniteCanisterSettingsArgs | undefined): OptionalDefiniteCanisterSettingsArgs | undefined {
-  return definiteCanisterSettingsArgs === undefined ? undefined : {
-    controller: definiteCanisterSettingsArgs.controller,
-    freezing_threshold: definiteCanisterSettingsArgs.freezing_threshold,
-    controllers: definiteCanisterSettingsArgs.controllers,
-    memory_allocation: definiteCanisterSettingsArgs.memory_allocation,
-    compute_allocation: definiteCanisterSettingsArgs.compute_allocation
-  };
+export function convertDefiniteCanisterSettingsArgs(
+  definiteCanisterSettingsArgs: DefiniteCanisterSettingsArgs | undefined
+): OptionalDefiniteCanisterSettingsArgs | undefined {
+  return definiteCanisterSettingsArgs === undefined
+    ? undefined
+    : {
+        controller: definiteCanisterSettingsArgs.controller,
+        freezing_threshold: definiteCanisterSettingsArgs.freezing_threshold,
+        controllers: definiteCanisterSettingsArgs.controllers,
+        memory_allocation: definiteCanisterSettingsArgs.memory_allocation,
+        compute_allocation: definiteCanisterSettingsArgs.compute_allocation,
+      };
 }
 export interface OptionalDeregisterDappCanisters {
   canister_ids: Array<Principal>;
   new_controllers: Array<Principal>;
 }
-export function convertDeregisterDappCanisters(deregisterDappCanisters: DeregisterDappCanisters | undefined): OptionalDeregisterDappCanisters | undefined {
-  return deregisterDappCanisters === undefined ? undefined : {
-    canister_ids: deregisterDappCanisters.canister_ids,
-    new_controllers: deregisterDappCanisters.new_controllers
-  };
+export function convertDeregisterDappCanisters(
+  deregisterDappCanisters: DeregisterDappCanisters | undefined
+): OptionalDeregisterDappCanisters | undefined {
+  return deregisterDappCanisters === undefined
+    ? undefined
+    : {
+        canister_ids: deregisterDappCanisters.canister_ids,
+        new_controllers: deregisterDappCanisters.new_controllers,
+      };
 }
 export interface OptionalDisburse {
   to_account: undefined | OptionalAccount;
   amount: undefined | OptionalAmount;
 }
-export function convertDisburse(disburse: Disburse | undefined): OptionalDisburse | undefined {
-  return disburse === undefined ? undefined : {
-    to_account: convertAccount(fromNullable(disburse.to_account)),
-    amount: convertAmount(fromNullable(disburse.amount))
-  };
+export function convertDisburse(
+  disburse: Disburse | undefined
+): OptionalDisburse | undefined {
+  return disburse === undefined
+    ? undefined
+    : {
+        to_account: convertAccount(fromNullable(disburse.to_account)),
+        amount: convertAmount(fromNullable(disburse.amount)),
+      };
 }
 export interface OptionalDisburseMaturity {
   to_account: undefined | OptionalAccount;
   percentage_to_disburse: number;
 }
-export function convertDisburseMaturity(disburseMaturity: DisburseMaturity | undefined): OptionalDisburseMaturity | undefined {
-  return disburseMaturity === undefined ? undefined : {
-    to_account: convertAccount(fromNullable(disburseMaturity.to_account)),
-    percentage_to_disburse: disburseMaturity.percentage_to_disburse
-  };
+export function convertDisburseMaturity(
+  disburseMaturity: DisburseMaturity | undefined
+): OptionalDisburseMaturity | undefined {
+  return disburseMaturity === undefined
+    ? undefined
+    : {
+        to_account: convertAccount(fromNullable(disburseMaturity.to_account)),
+        percentage_to_disburse: disburseMaturity.percentage_to_disburse,
+      };
 }
 export interface OptionalDisburseMaturityInProgress {
   timestamp_of_disbursement_seconds: bigint;
   amount_e8s: bigint;
   account_to_disburse_to: undefined | OptionalAccount;
 }
-export function convertDisburseMaturityInProgress(disburseMaturityInProgress: DisburseMaturityInProgress | undefined): OptionalDisburseMaturityInProgress | undefined {
-  return disburseMaturityInProgress === undefined ? undefined : {
-    timestamp_of_disbursement_seconds: disburseMaturityInProgress.timestamp_of_disbursement_seconds,
-    amount_e8s: disburseMaturityInProgress.amount_e8s,
-    account_to_disburse_to: convertAccount(fromNullable(disburseMaturityInProgress.account_to_disburse_to))
-  };
+export function convertDisburseMaturityInProgress(
+  disburseMaturityInProgress: DisburseMaturityInProgress | undefined
+): OptionalDisburseMaturityInProgress | undefined {
+  return disburseMaturityInProgress === undefined
+    ? undefined
+    : {
+        timestamp_of_disbursement_seconds:
+          disburseMaturityInProgress.timestamp_of_disbursement_seconds,
+        amount_e8s: disburseMaturityInProgress.amount_e8s,
+        account_to_disburse_to: convertAccount(
+          fromNullable(disburseMaturityInProgress.account_to_disburse_to)
+        ),
+      };
 }
 export interface OptionalDisburseMaturityResponse {
   amount_disbursed_e8s: bigint;
 }
-export function convertDisburseMaturityResponse(disburseMaturityResponse: DisburseMaturityResponse | undefined): OptionalDisburseMaturityResponse | undefined {
-  return disburseMaturityResponse === undefined ? undefined : {
-    amount_disbursed_e8s: disburseMaturityResponse.amount_disbursed_e8s
-  };
+export function convertDisburseMaturityResponse(
+  disburseMaturityResponse: DisburseMaturityResponse | undefined
+): OptionalDisburseMaturityResponse | undefined {
+  return disburseMaturityResponse === undefined
+    ? undefined
+    : {
+        amount_disbursed_e8s: disburseMaturityResponse.amount_disbursed_e8s,
+      };
 }
 export interface OptionalDisburseResponse {
   transfer_block_height: bigint;
 }
-export function convertDisburseResponse(disburseResponse: DisburseResponse | undefined): OptionalDisburseResponse | undefined {
-  return disburseResponse === undefined ? undefined : {
-    transfer_block_height: disburseResponse.transfer_block_height
-  };
+export function convertDisburseResponse(
+  disburseResponse: DisburseResponse | undefined
+): OptionalDisburseResponse | undefined {
+  return disburseResponse === undefined
+    ? undefined
+    : {
+        transfer_block_height: disburseResponse.transfer_block_height,
+      };
 }
-export type DissolveState = {
-  DissolveDelaySeconds: bigint;
-} | {
-  WhenDissolvedTimestampSeconds: bigint;
-};
+export type DissolveState =
+  | {
+      DissolveDelaySeconds: bigint;
+    }
+  | {
+      WhenDissolvedTimestampSeconds: bigint;
+    };
 export interface OptionalExecuteGenericNervousSystemFunction {
   function_id: bigint;
   payload: Uint8Array;
 }
-export function convertExecuteGenericNervousSystemFunction(executeGenericNervousSystemFunction: ExecuteGenericNervousSystemFunction | undefined): OptionalExecuteGenericNervousSystemFunction | undefined {
-  return executeGenericNervousSystemFunction === undefined ? undefined : {
-    function_id: executeGenericNervousSystemFunction.function_id,
-    payload: executeGenericNervousSystemFunction.payload
-  };
+export function convertExecuteGenericNervousSystemFunction(
+  executeGenericNervousSystemFunction:
+    | ExecuteGenericNervousSystemFunction
+    | undefined
+): OptionalExecuteGenericNervousSystemFunction | undefined {
+  return executeGenericNervousSystemFunction === undefined
+    ? undefined
+    : {
+        function_id: executeGenericNervousSystemFunction.function_id,
+        payload: executeGenericNervousSystemFunction.payload,
+      };
 }
 export interface OptionalFinalizeDisburseMaturity {
   amount_to_be_disbursed_e8s: bigint;
   to_account: undefined | OptionalAccount;
 }
-export function convertFinalizeDisburseMaturity(finalizeDisburseMaturity: FinalizeDisburseMaturity | undefined): OptionalFinalizeDisburseMaturity | undefined {
-  return finalizeDisburseMaturity === undefined ? undefined : {
-    amount_to_be_disbursed_e8s: finalizeDisburseMaturity.amount_to_be_disbursed_e8s,
-    to_account: convertAccount(fromNullable(finalizeDisburseMaturity.to_account))
-  };
+export function convertFinalizeDisburseMaturity(
+  finalizeDisburseMaturity: FinalizeDisburseMaturity | undefined
+): OptionalFinalizeDisburseMaturity | undefined {
+  return finalizeDisburseMaturity === undefined
+    ? undefined
+    : {
+        amount_to_be_disbursed_e8s:
+          finalizeDisburseMaturity.amount_to_be_disbursed_e8s,
+        to_account: convertAccount(
+          fromNullable(finalizeDisburseMaturity.to_account)
+        ),
+      };
 }
 export interface OptionalFollow {
   function_id: bigint;
   followees: Array<NeuronId>;
 }
-export function convertFollow(follow: Follow | undefined): OptionalFollow | undefined {
-  return follow === undefined ? undefined : {
-    function_id: follow.function_id,
-    followees: follow.followees
-  };
+export function convertFollow(
+  follow: Follow | undefined
+): OptionalFollow | undefined {
+  return follow === undefined
+    ? undefined
+    : {
+        function_id: follow.function_id,
+        followees: follow.followees,
+      };
 }
 export interface OptionalFollowees {
   followees: Array<NeuronId>;
 }
-export function convertFollowees(followees: Followees | undefined): OptionalFollowees | undefined {
-  return followees === undefined ? undefined : {
-    followees: followees.followees
-  };
+export function convertFollowees(
+  followees: Followees | undefined
+): OptionalFollowees | undefined {
+  return followees === undefined
+    ? undefined
+    : {
+        followees: followees.followees,
+      };
 }
-export type FunctionType = {
-  NativeNervousSystemFunction: {};
-} | {
-  GenericNervousSystemFunction: GenericNervousSystemFunction;
-};
+export type FunctionType =
+  | {
+      NativeNervousSystemFunction: {};
+    }
+  | {
+      GenericNervousSystemFunction: GenericNervousSystemFunction;
+    };
 export interface OptionalGenericNervousSystemFunction {
   validator_canister_id: undefined | Principal;
   target_canister_id: undefined | Principal;
   validator_method_name: undefined | string;
   target_method_name: undefined | string;
 }
-export function convertGenericNervousSystemFunction(genericNervousSystemFunction: GenericNervousSystemFunction | undefined): OptionalGenericNervousSystemFunction | undefined {
-  return genericNervousSystemFunction === undefined ? undefined : {
-    validator_canister_id: fromNullable(genericNervousSystemFunction.validator_canister_id),
-    target_canister_id: fromNullable(genericNervousSystemFunction.target_canister_id),
-    validator_method_name: fromNullable(genericNervousSystemFunction.validator_method_name),
-    target_method_name: fromNullable(genericNervousSystemFunction.target_method_name)
-  };
+export function convertGenericNervousSystemFunction(
+  genericNervousSystemFunction: GenericNervousSystemFunction | undefined
+): OptionalGenericNervousSystemFunction | undefined {
+  return genericNervousSystemFunction === undefined
+    ? undefined
+    : {
+        validator_canister_id: fromNullable(
+          genericNervousSystemFunction.validator_canister_id
+        ),
+        target_canister_id: fromNullable(
+          genericNervousSystemFunction.target_canister_id
+        ),
+        validator_method_name: fromNullable(
+          genericNervousSystemFunction.validator_method_name
+        ),
+        target_method_name: fromNullable(
+          genericNervousSystemFunction.target_method_name
+        ),
+      };
 }
 export interface OptionalGetMetadataResponse {
   url: undefined | string;
@@ -473,71 +658,110 @@ export interface OptionalGetMetadataResponse {
   name: undefined | string;
   description: undefined | string;
 }
-export function convertGetMetadataResponse(getMetadataResponse: GetMetadataResponse | undefined): OptionalGetMetadataResponse | undefined {
-  return getMetadataResponse === undefined ? undefined : {
-    url: fromNullable(getMetadataResponse.url),
-    logo: fromNullable(getMetadataResponse.logo),
-    name: fromNullable(getMetadataResponse.name),
-    description: fromNullable(getMetadataResponse.description)
-  };
+export function convertGetMetadataResponse(
+  getMetadataResponse: GetMetadataResponse | undefined
+): OptionalGetMetadataResponse | undefined {
+  return getMetadataResponse === undefined
+    ? undefined
+    : {
+        url: fromNullable(getMetadataResponse.url),
+        logo: fromNullable(getMetadataResponse.logo),
+        name: fromNullable(getMetadataResponse.name),
+        description: fromNullable(getMetadataResponse.description),
+      };
 }
 export interface OptionalGetModeResponse {
   mode: undefined | number;
 }
-export function convertGetModeResponse(getModeResponse: GetModeResponse | undefined): OptionalGetModeResponse | undefined {
-  return getModeResponse === undefined ? undefined : {
-    mode: fromNullable(getModeResponse.mode)
-  };
+export function convertGetModeResponse(
+  getModeResponse: GetModeResponse | undefined
+): OptionalGetModeResponse | undefined {
+  return getModeResponse === undefined
+    ? undefined
+    : {
+        mode: fromNullable(getModeResponse.mode),
+      };
 }
 export interface OptionalGetNeuron {
   neuron_id: undefined | OptionalNeuronId;
 }
-export function convertGetNeuron(getNeuron: GetNeuron | undefined): OptionalGetNeuron | undefined {
-  return getNeuron === undefined ? undefined : {
-    neuron_id: convertNeuronId(fromNullable(getNeuron.neuron_id))
-  };
+export function convertGetNeuron(
+  getNeuron: GetNeuron | undefined
+): OptionalGetNeuron | undefined {
+  return getNeuron === undefined
+    ? undefined
+    : {
+        neuron_id: convertNeuronId(fromNullable(getNeuron.neuron_id)),
+      };
 }
 export interface OptionalGetNeuronResponse {
   result: undefined | Result;
 }
-export function convertGetNeuronResponse(getNeuronResponse: GetNeuronResponse | undefined): OptionalGetNeuronResponse | undefined {
-  return getNeuronResponse === undefined ? undefined : {
-    result: convertResult(fromNullable(getNeuronResponse.result))
-  };
+export function convertGetNeuronResponse(
+  getNeuronResponse: GetNeuronResponse | undefined
+): OptionalGetNeuronResponse | undefined {
+  return getNeuronResponse === undefined
+    ? undefined
+    : {
+        result: convertResult(fromNullable(getNeuronResponse.result)),
+      };
 }
 export interface OptionalGetProposal {
   proposal_id: undefined | OptionalProposalId;
 }
-export function convertGetProposal(getProposal: GetProposal | undefined): OptionalGetProposal | undefined {
-  return getProposal === undefined ? undefined : {
-    proposal_id: convertProposalId(fromNullable(getProposal.proposal_id))
-  };
+export function convertGetProposal(
+  getProposal: GetProposal | undefined
+): OptionalGetProposal | undefined {
+  return getProposal === undefined
+    ? undefined
+    : {
+        proposal_id: convertProposalId(fromNullable(getProposal.proposal_id)),
+      };
 }
 export interface OptionalGetProposalResponse {
   result: undefined | Result_1;
 }
-export function convertGetProposalResponse(getProposalResponse: GetProposalResponse | undefined): OptionalGetProposalResponse | undefined {
-  return getProposalResponse === undefined ? undefined : {
-    result: convertResult_1(fromNullable(getProposalResponse.result))
-  };
+export function convertGetProposalResponse(
+  getProposalResponse: GetProposalResponse | undefined
+): OptionalGetProposalResponse | undefined {
+  return getProposalResponse === undefined
+    ? undefined
+    : {
+        result: convertResult_1(fromNullable(getProposalResponse.result)),
+      };
 }
 export interface OptionalGetRunningSnsVersionResponse {
   deployed_version: undefined | OptionalVersion;
   pending_version: undefined | OptionalUpgradeInProgress;
 }
-export function convertGetRunningSnsVersionResponse(getRunningSnsVersionResponse: GetRunningSnsVersionResponse | undefined): OptionalGetRunningSnsVersionResponse | undefined {
-  return getRunningSnsVersionResponse === undefined ? undefined : {
-    deployed_version: convertVersion(fromNullable(getRunningSnsVersionResponse.deployed_version)),
-    pending_version: convertUpgradeInProgress(fromNullable(getRunningSnsVersionResponse.pending_version))
-  };
+export function convertGetRunningSnsVersionResponse(
+  getRunningSnsVersionResponse: GetRunningSnsVersionResponse | undefined
+): OptionalGetRunningSnsVersionResponse | undefined {
+  return getRunningSnsVersionResponse === undefined
+    ? undefined
+    : {
+        deployed_version: convertVersion(
+          fromNullable(getRunningSnsVersionResponse.deployed_version)
+        ),
+        pending_version: convertUpgradeInProgress(
+          fromNullable(getRunningSnsVersionResponse.pending_version)
+        ),
+      };
 }
 export interface OptionalGetSnsInitializationParametersResponse {
   sns_initialization_parameters: string;
 }
-export function convertGetSnsInitializationParametersResponse(getSnsInitializationParametersResponse: GetSnsInitializationParametersResponse | undefined): OptionalGetSnsInitializationParametersResponse | undefined {
-  return getSnsInitializationParametersResponse === undefined ? undefined : {
-    sns_initialization_parameters: getSnsInitializationParametersResponse.sns_initialization_parameters
-  };
+export function convertGetSnsInitializationParametersResponse(
+  getSnsInitializationParametersResponse:
+    | GetSnsInitializationParametersResponse
+    | undefined
+): OptionalGetSnsInitializationParametersResponse | undefined {
+  return getSnsInitializationParametersResponse === undefined
+    ? undefined
+    : {
+        sns_initialization_parameters:
+          getSnsInitializationParametersResponse.sns_initialization_parameters,
+      };
 }
 export interface OptionalGovernance {
   root_canister_id: undefined | Principal;
@@ -558,26 +782,45 @@ export interface OptionalGovernance {
   neurons: Array<[string, Neuron]>;
   genesis_timestamp_seconds: bigint;
 }
-export function convertGovernance(governance: Governance | undefined): OptionalGovernance | undefined {
-  return governance === undefined ? undefined : {
-    root_canister_id: fromNullable(governance.root_canister_id),
-    id_to_nervous_system_functions: governance.id_to_nervous_system_functions,
-    metrics: convertGovernanceCachedMetrics(fromNullable(governance.metrics)),
-    mode: governance.mode,
-    parameters: convertNervousSystemParameters(fromNullable(governance.parameters)),
-    is_finalizing_disburse_maturity: fromNullable(governance.is_finalizing_disburse_maturity),
-    deployed_version: convertVersion(fromNullable(governance.deployed_version)),
-    sns_initialization_parameters: governance.sns_initialization_parameters,
-    latest_reward_event: convertRewardEvent(fromNullable(governance.latest_reward_event)),
-    pending_version: convertUpgradeInProgress(fromNullable(governance.pending_version)),
-    swap_canister_id: fromNullable(governance.swap_canister_id),
-    ledger_canister_id: fromNullable(governance.ledger_canister_id),
-    proposals: governance.proposals,
-    in_flight_commands: governance.in_flight_commands,
-    sns_metadata: convertManageSnsMetadata(fromNullable(governance.sns_metadata)),
-    neurons: governance.neurons,
-    genesis_timestamp_seconds: governance.genesis_timestamp_seconds
-  };
+export function convertGovernance(
+  governance: Governance | undefined
+): OptionalGovernance | undefined {
+  return governance === undefined
+    ? undefined
+    : {
+        root_canister_id: fromNullable(governance.root_canister_id),
+        id_to_nervous_system_functions:
+          governance.id_to_nervous_system_functions,
+        metrics: convertGovernanceCachedMetrics(
+          fromNullable(governance.metrics)
+        ),
+        mode: governance.mode,
+        parameters: convertNervousSystemParameters(
+          fromNullable(governance.parameters)
+        ),
+        is_finalizing_disburse_maturity: fromNullable(
+          governance.is_finalizing_disburse_maturity
+        ),
+        deployed_version: convertVersion(
+          fromNullable(governance.deployed_version)
+        ),
+        sns_initialization_parameters: governance.sns_initialization_parameters,
+        latest_reward_event: convertRewardEvent(
+          fromNullable(governance.latest_reward_event)
+        ),
+        pending_version: convertUpgradeInProgress(
+          fromNullable(governance.pending_version)
+        ),
+        swap_canister_id: fromNullable(governance.swap_canister_id),
+        ledger_canister_id: fromNullable(governance.ledger_canister_id),
+        proposals: governance.proposals,
+        in_flight_commands: governance.in_flight_commands,
+        sns_metadata: convertManageSnsMetadata(
+          fromNullable(governance.sns_metadata)
+        ),
+        neurons: governance.neurons,
+        genesis_timestamp_seconds: governance.genesis_timestamp_seconds,
+      };
 }
 export interface OptionalGovernanceCachedMetrics {
   not_dissolving_neurons_e8s_buckets: Array<[bigint, number]>;
@@ -596,72 +839,111 @@ export interface OptionalGovernanceCachedMetrics {
   dissolving_neurons_e8s_buckets: Array<[bigint, number]>;
   timestamp_seconds: bigint;
 }
-export function convertGovernanceCachedMetrics(governanceCachedMetrics: GovernanceCachedMetrics | undefined): OptionalGovernanceCachedMetrics | undefined {
-  return governanceCachedMetrics === undefined ? undefined : {
-    not_dissolving_neurons_e8s_buckets: governanceCachedMetrics.not_dissolving_neurons_e8s_buckets,
-    garbage_collectable_neurons_count: governanceCachedMetrics.garbage_collectable_neurons_count,
-    neurons_with_invalid_stake_count: governanceCachedMetrics.neurons_with_invalid_stake_count,
-    not_dissolving_neurons_count_buckets: governanceCachedMetrics.not_dissolving_neurons_count_buckets,
-    neurons_with_less_than_6_months_dissolve_delay_count: governanceCachedMetrics.neurons_with_less_than_6_months_dissolve_delay_count,
-    dissolved_neurons_count: governanceCachedMetrics.dissolved_neurons_count,
-    total_staked_e8s: governanceCachedMetrics.total_staked_e8s,
-    total_supply_governance_tokens: governanceCachedMetrics.total_supply_governance_tokens,
-    not_dissolving_neurons_count: governanceCachedMetrics.not_dissolving_neurons_count,
-    dissolved_neurons_e8s: governanceCachedMetrics.dissolved_neurons_e8s,
-    neurons_with_less_than_6_months_dissolve_delay_e8s: governanceCachedMetrics.neurons_with_less_than_6_months_dissolve_delay_e8s,
-    dissolving_neurons_count_buckets: governanceCachedMetrics.dissolving_neurons_count_buckets,
-    dissolving_neurons_count: governanceCachedMetrics.dissolving_neurons_count,
-    dissolving_neurons_e8s_buckets: governanceCachedMetrics.dissolving_neurons_e8s_buckets,
-    timestamp_seconds: governanceCachedMetrics.timestamp_seconds
-  };
+export function convertGovernanceCachedMetrics(
+  governanceCachedMetrics: GovernanceCachedMetrics | undefined
+): OptionalGovernanceCachedMetrics | undefined {
+  return governanceCachedMetrics === undefined
+    ? undefined
+    : {
+        not_dissolving_neurons_e8s_buckets:
+          governanceCachedMetrics.not_dissolving_neurons_e8s_buckets,
+        garbage_collectable_neurons_count:
+          governanceCachedMetrics.garbage_collectable_neurons_count,
+        neurons_with_invalid_stake_count:
+          governanceCachedMetrics.neurons_with_invalid_stake_count,
+        not_dissolving_neurons_count_buckets:
+          governanceCachedMetrics.not_dissolving_neurons_count_buckets,
+        neurons_with_less_than_6_months_dissolve_delay_count:
+          governanceCachedMetrics.neurons_with_less_than_6_months_dissolve_delay_count,
+        dissolved_neurons_count:
+          governanceCachedMetrics.dissolved_neurons_count,
+        total_staked_e8s: governanceCachedMetrics.total_staked_e8s,
+        total_supply_governance_tokens:
+          governanceCachedMetrics.total_supply_governance_tokens,
+        not_dissolving_neurons_count:
+          governanceCachedMetrics.not_dissolving_neurons_count,
+        dissolved_neurons_e8s: governanceCachedMetrics.dissolved_neurons_e8s,
+        neurons_with_less_than_6_months_dissolve_delay_e8s:
+          governanceCachedMetrics.neurons_with_less_than_6_months_dissolve_delay_e8s,
+        dissolving_neurons_count_buckets:
+          governanceCachedMetrics.dissolving_neurons_count_buckets,
+        dissolving_neurons_count:
+          governanceCachedMetrics.dissolving_neurons_count,
+        dissolving_neurons_e8s_buckets:
+          governanceCachedMetrics.dissolving_neurons_e8s_buckets,
+        timestamp_seconds: governanceCachedMetrics.timestamp_seconds,
+      };
 }
 export interface OptionalGovernanceError {
   error_message: string;
   error_type: number;
 }
-export function convertGovernanceError(governanceError: GovernanceError | undefined): OptionalGovernanceError | undefined {
-  return governanceError === undefined ? undefined : {
-    error_message: governanceError.error_message,
-    error_type: governanceError.error_type
-  };
+export function convertGovernanceError(
+  governanceError: GovernanceError | undefined
+): OptionalGovernanceError | undefined {
+  return governanceError === undefined
+    ? undefined
+    : {
+        error_message: governanceError.error_message,
+        error_type: governanceError.error_type,
+      };
 }
 export interface OptionalIncreaseDissolveDelay {
   additional_dissolve_delay_seconds: number;
 }
-export function convertIncreaseDissolveDelay(increaseDissolveDelay: IncreaseDissolveDelay | undefined): OptionalIncreaseDissolveDelay | undefined {
-  return increaseDissolveDelay === undefined ? undefined : {
-    additional_dissolve_delay_seconds: increaseDissolveDelay.additional_dissolve_delay_seconds
-  };
+export function convertIncreaseDissolveDelay(
+  increaseDissolveDelay: IncreaseDissolveDelay | undefined
+): OptionalIncreaseDissolveDelay | undefined {
+  return increaseDissolveDelay === undefined
+    ? undefined
+    : {
+        additional_dissolve_delay_seconds:
+          increaseDissolveDelay.additional_dissolve_delay_seconds,
+      };
 }
 export interface OptionalListNervousSystemFunctionsResponse {
   reserved_ids: BigUint64Array;
   functions: Array<NervousSystemFunction>;
 }
-export function convertListNervousSystemFunctionsResponse(listNervousSystemFunctionsResponse: ListNervousSystemFunctionsResponse | undefined): OptionalListNervousSystemFunctionsResponse | undefined {
-  return listNervousSystemFunctionsResponse === undefined ? undefined : {
-    reserved_ids: listNervousSystemFunctionsResponse.reserved_ids,
-    functions: listNervousSystemFunctionsResponse.functions
-  };
+export function convertListNervousSystemFunctionsResponse(
+  listNervousSystemFunctionsResponse:
+    | ListNervousSystemFunctionsResponse
+    | undefined
+): OptionalListNervousSystemFunctionsResponse | undefined {
+  return listNervousSystemFunctionsResponse === undefined
+    ? undefined
+    : {
+        reserved_ids: listNervousSystemFunctionsResponse.reserved_ids,
+        functions: listNervousSystemFunctionsResponse.functions,
+      };
 }
 export interface OptionalListNeurons {
   of_principal: undefined | Principal;
   limit: number;
   start_page_at: undefined | OptionalNeuronId;
 }
-export function convertListNeurons(listNeurons: ListNeurons | undefined): OptionalListNeurons | undefined {
-  return listNeurons === undefined ? undefined : {
-    of_principal: fromNullable(listNeurons.of_principal),
-    limit: listNeurons.limit,
-    start_page_at: convertNeuronId(fromNullable(listNeurons.start_page_at))
-  };
+export function convertListNeurons(
+  listNeurons: ListNeurons | undefined
+): OptionalListNeurons | undefined {
+  return listNeurons === undefined
+    ? undefined
+    : {
+        of_principal: fromNullable(listNeurons.of_principal),
+        limit: listNeurons.limit,
+        start_page_at: convertNeuronId(fromNullable(listNeurons.start_page_at)),
+      };
 }
 export interface OptionalListNeuronsResponse {
   neurons: Array<Neuron>;
 }
-export function convertListNeuronsResponse(listNeuronsResponse: ListNeuronsResponse | undefined): OptionalListNeuronsResponse | undefined {
-  return listNeuronsResponse === undefined ? undefined : {
-    neurons: listNeuronsResponse.neurons
-  };
+export function convertListNeuronsResponse(
+  listNeuronsResponse: ListNeuronsResponse | undefined
+): OptionalListNeuronsResponse | undefined {
+  return listNeuronsResponse === undefined
+    ? undefined
+    : {
+        neurons: listNeuronsResponse.neurons,
+      };
 }
 export interface OptionalListProposals {
   include_reward_status: Int32Array;
@@ -670,40 +952,58 @@ export interface OptionalListProposals {
   exclude_type: BigUint64Array;
   include_status: Int32Array;
 }
-export function convertListProposals(listProposals: ListProposals | undefined): OptionalListProposals | undefined {
-  return listProposals === undefined ? undefined : {
-    include_reward_status: listProposals.include_reward_status,
-    before_proposal: convertProposalId(fromNullable(listProposals.before_proposal)),
-    limit: listProposals.limit,
-    exclude_type: listProposals.exclude_type,
-    include_status: listProposals.include_status
-  };
+export function convertListProposals(
+  listProposals: ListProposals | undefined
+): OptionalListProposals | undefined {
+  return listProposals === undefined
+    ? undefined
+    : {
+        include_reward_status: listProposals.include_reward_status,
+        before_proposal: convertProposalId(
+          fromNullable(listProposals.before_proposal)
+        ),
+        limit: listProposals.limit,
+        exclude_type: listProposals.exclude_type,
+        include_status: listProposals.include_status,
+      };
 }
 export interface OptionalListProposalsResponse {
   proposals: Array<ProposalData>;
 }
-export function convertListProposalsResponse(listProposalsResponse: ListProposalsResponse | undefined): OptionalListProposalsResponse | undefined {
-  return listProposalsResponse === undefined ? undefined : {
-    proposals: listProposalsResponse.proposals
-  };
+export function convertListProposalsResponse(
+  listProposalsResponse: ListProposalsResponse | undefined
+): OptionalListProposalsResponse | undefined {
+  return listProposalsResponse === undefined
+    ? undefined
+    : {
+        proposals: listProposalsResponse.proposals,
+      };
 }
 export interface OptionalManageNeuron {
   subaccount: Uint8Array;
   command: undefined | Command;
 }
-export function convertManageNeuron(manageNeuron: ManageNeuron | undefined): OptionalManageNeuron | undefined {
-  return manageNeuron === undefined ? undefined : {
-    subaccount: manageNeuron.subaccount,
-    command: convertCommand(fromNullable(manageNeuron.command))
-  };
+export function convertManageNeuron(
+  manageNeuron: ManageNeuron | undefined
+): OptionalManageNeuron | undefined {
+  return manageNeuron === undefined
+    ? undefined
+    : {
+        subaccount: manageNeuron.subaccount,
+        command: convertCommand(fromNullable(manageNeuron.command)),
+      };
 }
 export interface OptionalManageNeuronResponse {
   command: undefined | Command_1;
 }
-export function convertManageNeuronResponse(manageNeuronResponse: ManageNeuronResponse | undefined): OptionalManageNeuronResponse | undefined {
-  return manageNeuronResponse === undefined ? undefined : {
-    command: convertCommand_1(fromNullable(manageNeuronResponse.command))
-  };
+export function convertManageNeuronResponse(
+  manageNeuronResponse: ManageNeuronResponse | undefined
+): OptionalManageNeuronResponse | undefined {
+  return manageNeuronResponse === undefined
+    ? undefined
+    : {
+        command: convertCommand_1(fromNullable(manageNeuronResponse.command)),
+      };
 }
 export interface OptionalManageSnsMetadata {
   url: undefined | string;
@@ -711,49 +1011,69 @@ export interface OptionalManageSnsMetadata {
   name: undefined | string;
   description: undefined | string;
 }
-export function convertManageSnsMetadata(manageSnsMetadata: ManageSnsMetadata | undefined): OptionalManageSnsMetadata | undefined {
-  return manageSnsMetadata === undefined ? undefined : {
-    url: fromNullable(manageSnsMetadata.url),
-    logo: fromNullable(manageSnsMetadata.logo),
-    name: fromNullable(manageSnsMetadata.name),
-    description: fromNullable(manageSnsMetadata.description)
-  };
+export function convertManageSnsMetadata(
+  manageSnsMetadata: ManageSnsMetadata | undefined
+): OptionalManageSnsMetadata | undefined {
+  return manageSnsMetadata === undefined
+    ? undefined
+    : {
+        url: fromNullable(manageSnsMetadata.url),
+        logo: fromNullable(manageSnsMetadata.logo),
+        name: fromNullable(manageSnsMetadata.name),
+        description: fromNullable(manageSnsMetadata.description),
+      };
 }
 export interface OptionalMemoAndController {
   controller: undefined | Principal;
   memo: bigint;
 }
-export function convertMemoAndController(memoAndController: MemoAndController | undefined): OptionalMemoAndController | undefined {
-  return memoAndController === undefined ? undefined : {
-    controller: fromNullable(memoAndController.controller),
-    memo: memoAndController.memo
-  };
+export function convertMemoAndController(
+  memoAndController: MemoAndController | undefined
+): OptionalMemoAndController | undefined {
+  return memoAndController === undefined
+    ? undefined
+    : {
+        controller: fromNullable(memoAndController.controller),
+        memo: memoAndController.memo,
+      };
 }
 export interface OptionalMergeMaturity {
   percentage_to_merge: number;
 }
-export function convertMergeMaturity(mergeMaturity: MergeMaturity | undefined): OptionalMergeMaturity | undefined {
-  return mergeMaturity === undefined ? undefined : {
-    percentage_to_merge: mergeMaturity.percentage_to_merge
-  };
+export function convertMergeMaturity(
+  mergeMaturity: MergeMaturity | undefined
+): OptionalMergeMaturity | undefined {
+  return mergeMaturity === undefined
+    ? undefined
+    : {
+        percentage_to_merge: mergeMaturity.percentage_to_merge,
+      };
 }
 export interface OptionalMergeMaturityResponse {
   merged_maturity_e8s: bigint;
   new_stake_e8s: bigint;
 }
-export function convertMergeMaturityResponse(mergeMaturityResponse: MergeMaturityResponse | undefined): OptionalMergeMaturityResponse | undefined {
-  return mergeMaturityResponse === undefined ? undefined : {
-    merged_maturity_e8s: mergeMaturityResponse.merged_maturity_e8s,
-    new_stake_e8s: mergeMaturityResponse.new_stake_e8s
-  };
+export function convertMergeMaturityResponse(
+  mergeMaturityResponse: MergeMaturityResponse | undefined
+): OptionalMergeMaturityResponse | undefined {
+  return mergeMaturityResponse === undefined
+    ? undefined
+    : {
+        merged_maturity_e8s: mergeMaturityResponse.merged_maturity_e8s,
+        new_stake_e8s: mergeMaturityResponse.new_stake_e8s,
+      };
 }
 export interface OptionalMotion {
   motion_text: string;
 }
-export function convertMotion(motion: Motion | undefined): OptionalMotion | undefined {
-  return motion === undefined ? undefined : {
-    motion_text: motion.motion_text
-  };
+export function convertMotion(
+  motion: Motion | undefined
+): OptionalMotion | undefined {
+  return motion === undefined
+    ? undefined
+    : {
+        motion_text: motion.motion_text,
+      };
 }
 export interface OptionalNervousSystemFunction {
   id: bigint;
@@ -761,13 +1081,19 @@ export interface OptionalNervousSystemFunction {
   description: undefined | string;
   function_type: undefined | FunctionType;
 }
-export function convertNervousSystemFunction(nervousSystemFunction: NervousSystemFunction | undefined): OptionalNervousSystemFunction | undefined {
-  return nervousSystemFunction === undefined ? undefined : {
-    id: nervousSystemFunction.id,
-    name: nervousSystemFunction.name,
-    description: fromNullable(nervousSystemFunction.description),
-    function_type: convertFunctionType(fromNullable(nervousSystemFunction.function_type))
-  };
+export function convertNervousSystemFunction(
+  nervousSystemFunction: NervousSystemFunction | undefined
+): OptionalNervousSystemFunction | undefined {
+  return nervousSystemFunction === undefined
+    ? undefined
+    : {
+        id: nervousSystemFunction.id,
+        name: nervousSystemFunction.name,
+        description: fromNullable(nervousSystemFunction.description),
+        function_type: convertFunctionType(
+          fromNullable(nervousSystemFunction.function_type)
+        ),
+      };
 }
 export interface OptionalNervousSystemParameters {
   default_followees: undefined | OptionalDefaultFollowees;
@@ -790,28 +1116,68 @@ export interface OptionalNervousSystemParameters {
   voting_rewards_parameters: undefined | OptionalVotingRewardsParameters;
   max_number_of_principals_per_neuron: undefined | bigint;
 }
-export function convertNervousSystemParameters(nervousSystemParameters: NervousSystemParameters | undefined): OptionalNervousSystemParameters | undefined {
-  return nervousSystemParameters === undefined ? undefined : {
-    default_followees: convertDefaultFollowees(fromNullable(nervousSystemParameters.default_followees)),
-    max_dissolve_delay_seconds: fromNullable(nervousSystemParameters.max_dissolve_delay_seconds),
-    max_dissolve_delay_bonus_percentage: fromNullable(nervousSystemParameters.max_dissolve_delay_bonus_percentage),
-    max_followees_per_function: fromNullable(nervousSystemParameters.max_followees_per_function),
-    neuron_claimer_permissions: convertNeuronPermissionList(fromNullable(nervousSystemParameters.neuron_claimer_permissions)),
-    neuron_minimum_stake_e8s: fromNullable(nervousSystemParameters.neuron_minimum_stake_e8s),
-    max_neuron_age_for_age_bonus: fromNullable(nervousSystemParameters.max_neuron_age_for_age_bonus),
-    initial_voting_period_seconds: fromNullable(nervousSystemParameters.initial_voting_period_seconds),
-    neuron_minimum_dissolve_delay_to_vote_seconds: fromNullable(nervousSystemParameters.neuron_minimum_dissolve_delay_to_vote_seconds),
-    reject_cost_e8s: fromNullable(nervousSystemParameters.reject_cost_e8s),
-    max_proposals_to_keep_per_action: fromNullable(nervousSystemParameters.max_proposals_to_keep_per_action),
-    wait_for_quiet_deadline_increase_seconds: fromNullable(nervousSystemParameters.wait_for_quiet_deadline_increase_seconds),
-    max_number_of_neurons: fromNullable(nervousSystemParameters.max_number_of_neurons),
-    transaction_fee_e8s: fromNullable(nervousSystemParameters.transaction_fee_e8s),
-    max_number_of_proposals_with_ballots: fromNullable(nervousSystemParameters.max_number_of_proposals_with_ballots),
-    max_age_bonus_percentage: fromNullable(nervousSystemParameters.max_age_bonus_percentage),
-    neuron_grantable_permissions: convertNeuronPermissionList(fromNullable(nervousSystemParameters.neuron_grantable_permissions)),
-    voting_rewards_parameters: convertVotingRewardsParameters(fromNullable(nervousSystemParameters.voting_rewards_parameters)),
-    max_number_of_principals_per_neuron: fromNullable(nervousSystemParameters.max_number_of_principals_per_neuron)
-  };
+export function convertNervousSystemParameters(
+  nervousSystemParameters: NervousSystemParameters | undefined
+): OptionalNervousSystemParameters | undefined {
+  return nervousSystemParameters === undefined
+    ? undefined
+    : {
+        default_followees: convertDefaultFollowees(
+          fromNullable(nervousSystemParameters.default_followees)
+        ),
+        max_dissolve_delay_seconds: fromNullable(
+          nervousSystemParameters.max_dissolve_delay_seconds
+        ),
+        max_dissolve_delay_bonus_percentage: fromNullable(
+          nervousSystemParameters.max_dissolve_delay_bonus_percentage
+        ),
+        max_followees_per_function: fromNullable(
+          nervousSystemParameters.max_followees_per_function
+        ),
+        neuron_claimer_permissions: convertNeuronPermissionList(
+          fromNullable(nervousSystemParameters.neuron_claimer_permissions)
+        ),
+        neuron_minimum_stake_e8s: fromNullable(
+          nervousSystemParameters.neuron_minimum_stake_e8s
+        ),
+        max_neuron_age_for_age_bonus: fromNullable(
+          nervousSystemParameters.max_neuron_age_for_age_bonus
+        ),
+        initial_voting_period_seconds: fromNullable(
+          nervousSystemParameters.initial_voting_period_seconds
+        ),
+        neuron_minimum_dissolve_delay_to_vote_seconds: fromNullable(
+          nervousSystemParameters.neuron_minimum_dissolve_delay_to_vote_seconds
+        ),
+        reject_cost_e8s: fromNullable(nervousSystemParameters.reject_cost_e8s),
+        max_proposals_to_keep_per_action: fromNullable(
+          nervousSystemParameters.max_proposals_to_keep_per_action
+        ),
+        wait_for_quiet_deadline_increase_seconds: fromNullable(
+          nervousSystemParameters.wait_for_quiet_deadline_increase_seconds
+        ),
+        max_number_of_neurons: fromNullable(
+          nervousSystemParameters.max_number_of_neurons
+        ),
+        transaction_fee_e8s: fromNullable(
+          nervousSystemParameters.transaction_fee_e8s
+        ),
+        max_number_of_proposals_with_ballots: fromNullable(
+          nervousSystemParameters.max_number_of_proposals_with_ballots
+        ),
+        max_age_bonus_percentage: fromNullable(
+          nervousSystemParameters.max_age_bonus_percentage
+        ),
+        neuron_grantable_permissions: convertNeuronPermissionList(
+          fromNullable(nervousSystemParameters.neuron_grantable_permissions)
+        ),
+        voting_rewards_parameters: convertVotingRewardsParameters(
+          fromNullable(nervousSystemParameters.voting_rewards_parameters)
+        ),
+        max_number_of_principals_per_neuron: fromNullable(
+          nervousSystemParameters.max_number_of_principals_per_neuron
+        ),
+      };
 }
 export interface OptionalNeuron {
   id: undefined | OptionalNeuronId;
@@ -830,42 +1196,59 @@ export interface OptionalNeuron {
   followees: Array<[bigint, Followees]>;
   neuron_fees_e8s: bigint;
 }
-export function convertNeuron(neuron: Neuron | undefined): OptionalNeuron | undefined {
-  return neuron === undefined ? undefined : {
-    id: convertNeuronId(fromNullable(neuron.id)),
-    staked_maturity_e8s_equivalent: fromNullable(neuron.staked_maturity_e8s_equivalent),
-    permissions: neuron.permissions,
-    maturity_e8s_equivalent: neuron.maturity_e8s_equivalent,
-    cached_neuron_stake_e8s: neuron.cached_neuron_stake_e8s,
-    created_timestamp_seconds: neuron.created_timestamp_seconds,
-    source_nns_neuron_id: fromNullable(neuron.source_nns_neuron_id),
-    auto_stake_maturity: fromNullable(neuron.auto_stake_maturity),
-    aging_since_timestamp_seconds: neuron.aging_since_timestamp_seconds,
-    dissolve_state: convertDissolveState(fromNullable(neuron.dissolve_state)),
-    voting_power_percentage_multiplier: neuron.voting_power_percentage_multiplier,
-    vesting_period_seconds: fromNullable(neuron.vesting_period_seconds),
-    disburse_maturity_in_progress: neuron.disburse_maturity_in_progress,
-    followees: neuron.followees,
-    neuron_fees_e8s: neuron.neuron_fees_e8s
-  };
+export function convertNeuron(
+  neuron: Neuron | undefined
+): OptionalNeuron | undefined {
+  return neuron === undefined
+    ? undefined
+    : {
+        id: convertNeuronId(fromNullable(neuron.id)),
+        staked_maturity_e8s_equivalent: fromNullable(
+          neuron.staked_maturity_e8s_equivalent
+        ),
+        permissions: neuron.permissions,
+        maturity_e8s_equivalent: neuron.maturity_e8s_equivalent,
+        cached_neuron_stake_e8s: neuron.cached_neuron_stake_e8s,
+        created_timestamp_seconds: neuron.created_timestamp_seconds,
+        source_nns_neuron_id: fromNullable(neuron.source_nns_neuron_id),
+        auto_stake_maturity: fromNullable(neuron.auto_stake_maturity),
+        aging_since_timestamp_seconds: neuron.aging_since_timestamp_seconds,
+        dissolve_state: convertDissolveState(
+          fromNullable(neuron.dissolve_state)
+        ),
+        voting_power_percentage_multiplier:
+          neuron.voting_power_percentage_multiplier,
+        vesting_period_seconds: fromNullable(neuron.vesting_period_seconds),
+        disburse_maturity_in_progress: neuron.disburse_maturity_in_progress,
+        followees: neuron.followees,
+        neuron_fees_e8s: neuron.neuron_fees_e8s,
+      };
 }
 export interface OptionalNeuronId {
   id: Uint8Array;
 }
-export function convertNeuronId(neuronId: NeuronId | undefined): OptionalNeuronId | undefined {
-  return neuronId === undefined ? undefined : {
-    id: neuronId.id
-  };
+export function convertNeuronId(
+  neuronId: NeuronId | undefined
+): OptionalNeuronId | undefined {
+  return neuronId === undefined
+    ? undefined
+    : {
+        id: neuronId.id,
+      };
 }
 export interface OptionalNeuronInFlightCommand {
   command: undefined | Command_2;
   timestamp: bigint;
 }
-export function convertNeuronInFlightCommand(neuronInFlightCommand: NeuronInFlightCommand | undefined): OptionalNeuronInFlightCommand | undefined {
-  return neuronInFlightCommand === undefined ? undefined : {
-    command: convertCommand_2(fromNullable(neuronInFlightCommand.command)),
-    timestamp: neuronInFlightCommand.timestamp
-  };
+export function convertNeuronInFlightCommand(
+  neuronInFlightCommand: NeuronInFlightCommand | undefined
+): OptionalNeuronInFlightCommand | undefined {
+  return neuronInFlightCommand === undefined
+    ? undefined
+    : {
+        command: convertCommand_2(fromNullable(neuronInFlightCommand.command)),
+        timestamp: neuronInFlightCommand.timestamp,
+      };
 }
 export interface OptionalNeuronParameters {
   controller: undefined | Principal;
@@ -876,59 +1259,84 @@ export interface OptionalNeuronParameters {
   hotkey: undefined | Principal;
   neuron_id: undefined | OptionalNeuronId;
 }
-export function convertNeuronParameters(neuronParameters: NeuronParameters | undefined): OptionalNeuronParameters | undefined {
-  return neuronParameters === undefined ? undefined : {
-    controller: fromNullable(neuronParameters.controller),
-    dissolve_delay_seconds: fromNullable(neuronParameters.dissolve_delay_seconds),
-    source_nns_neuron_id: fromNullable(neuronParameters.source_nns_neuron_id),
-    stake_e8s: fromNullable(neuronParameters.stake_e8s),
-    followees: neuronParameters.followees,
-    hotkey: fromNullable(neuronParameters.hotkey),
-    neuron_id: convertNeuronId(fromNullable(neuronParameters.neuron_id))
-  };
+export function convertNeuronParameters(
+  neuronParameters: NeuronParameters | undefined
+): OptionalNeuronParameters | undefined {
+  return neuronParameters === undefined
+    ? undefined
+    : {
+        controller: fromNullable(neuronParameters.controller),
+        dissolve_delay_seconds: fromNullable(
+          neuronParameters.dissolve_delay_seconds
+        ),
+        source_nns_neuron_id: fromNullable(
+          neuronParameters.source_nns_neuron_id
+        ),
+        stake_e8s: fromNullable(neuronParameters.stake_e8s),
+        followees: neuronParameters.followees,
+        hotkey: fromNullable(neuronParameters.hotkey),
+        neuron_id: convertNeuronId(fromNullable(neuronParameters.neuron_id)),
+      };
 }
 export interface OptionalNeuronPermission {
   principal: undefined | Principal;
   permission_type: Int32Array;
 }
-export function convertNeuronPermission(neuronPermission: NeuronPermission | undefined): OptionalNeuronPermission | undefined {
-  return neuronPermission === undefined ? undefined : {
-    principal: fromNullable(neuronPermission.principal),
-    permission_type: neuronPermission.permission_type
-  };
+export function convertNeuronPermission(
+  neuronPermission: NeuronPermission | undefined
+): OptionalNeuronPermission | undefined {
+  return neuronPermission === undefined
+    ? undefined
+    : {
+        principal: fromNullable(neuronPermission.principal),
+        permission_type: neuronPermission.permission_type,
+      };
 }
 export interface OptionalNeuronPermissionList {
   permissions: Int32Array;
 }
-export function convertNeuronPermissionList(neuronPermissionList: NeuronPermissionList | undefined): OptionalNeuronPermissionList | undefined {
-  return neuronPermissionList === undefined ? undefined : {
-    permissions: neuronPermissionList.permissions
-  };
+export function convertNeuronPermissionList(
+  neuronPermissionList: NeuronPermissionList | undefined
+): OptionalNeuronPermissionList | undefined {
+  return neuronPermissionList === undefined
+    ? undefined
+    : {
+        permissions: neuronPermissionList.permissions,
+      };
 }
-export type Operation = {
-  ChangeAutoStakeMaturity: ChangeAutoStakeMaturity;
-} | {
-  StopDissolving: {};
-} | {
-  StartDissolving: {};
-} | {
-  IncreaseDissolveDelay: IncreaseDissolveDelay;
-} | {
-  SetDissolveTimestamp: SetDissolveTimestamp;
-};
+export type Operation =
+  | {
+      ChangeAutoStakeMaturity: ChangeAutoStakeMaturity;
+    }
+  | {
+      StopDissolving: {};
+    }
+  | {
+      StartDissolving: {};
+    }
+  | {
+      IncreaseDissolveDelay: IncreaseDissolveDelay;
+    }
+  | {
+      SetDissolveTimestamp: SetDissolveTimestamp;
+    };
 export interface OptionalProposal {
   url: string;
   title: string;
   action: undefined | Action;
   summary: string;
 }
-export function convertProposal(proposal: Proposal | undefined): OptionalProposal | undefined {
-  return proposal === undefined ? undefined : {
-    url: proposal.url,
-    title: proposal.title,
-    action: convertAction(fromNullable(proposal.action)),
-    summary: proposal.summary
-  };
+export function convertProposal(
+  proposal: Proposal | undefined
+): OptionalProposal | undefined {
+  return proposal === undefined
+    ? undefined
+    : {
+        url: proposal.url,
+        title: proposal.title,
+        action: convertAction(fromNullable(proposal.action)),
+        summary: proposal.summary,
+      };
 }
 export interface OptionalProposalData {
   id: undefined | OptionalProposalId;
@@ -951,75 +1359,112 @@ export interface OptionalProposalData {
   is_eligible_for_rewards: boolean;
   executed_timestamp_seconds: bigint;
 }
-export function convertProposalData(proposalData: ProposalData | undefined): OptionalProposalData | undefined {
-  return proposalData === undefined ? undefined : {
-    id: convertProposalId(fromNullable(proposalData.id)),
-    payload_text_rendering: fromNullable(proposalData.payload_text_rendering),
-    action: proposalData.action,
-    failure_reason: convertGovernanceError(fromNullable(proposalData.failure_reason)),
-    ballots: proposalData.ballots,
-    reward_event_round: proposalData.reward_event_round,
-    failed_timestamp_seconds: proposalData.failed_timestamp_seconds,
-    reward_event_end_timestamp_seconds: fromNullable(proposalData.reward_event_end_timestamp_seconds),
-    proposal_creation_timestamp_seconds: proposalData.proposal_creation_timestamp_seconds,
-    initial_voting_period_seconds: proposalData.initial_voting_period_seconds,
-    reject_cost_e8s: proposalData.reject_cost_e8s,
-    latest_tally: convertTally(fromNullable(proposalData.latest_tally)),
-    wait_for_quiet_deadline_increase_seconds: proposalData.wait_for_quiet_deadline_increase_seconds,
-    decided_timestamp_seconds: proposalData.decided_timestamp_seconds,
-    proposal: convertProposal(fromNullable(proposalData.proposal)),
-    proposer: convertNeuronId(fromNullable(proposalData.proposer)),
-    wait_for_quiet_state: convertWaitForQuietState(fromNullable(proposalData.wait_for_quiet_state)),
-    is_eligible_for_rewards: proposalData.is_eligible_for_rewards,
-    executed_timestamp_seconds: proposalData.executed_timestamp_seconds
-  };
+export function convertProposalData(
+  proposalData: ProposalData | undefined
+): OptionalProposalData | undefined {
+  return proposalData === undefined
+    ? undefined
+    : {
+        id: convertProposalId(fromNullable(proposalData.id)),
+        payload_text_rendering: fromNullable(
+          proposalData.payload_text_rendering
+        ),
+        action: proposalData.action,
+        failure_reason: convertGovernanceError(
+          fromNullable(proposalData.failure_reason)
+        ),
+        ballots: proposalData.ballots,
+        reward_event_round: proposalData.reward_event_round,
+        failed_timestamp_seconds: proposalData.failed_timestamp_seconds,
+        reward_event_end_timestamp_seconds: fromNullable(
+          proposalData.reward_event_end_timestamp_seconds
+        ),
+        proposal_creation_timestamp_seconds:
+          proposalData.proposal_creation_timestamp_seconds,
+        initial_voting_period_seconds:
+          proposalData.initial_voting_period_seconds,
+        reject_cost_e8s: proposalData.reject_cost_e8s,
+        latest_tally: convertTally(fromNullable(proposalData.latest_tally)),
+        wait_for_quiet_deadline_increase_seconds:
+          proposalData.wait_for_quiet_deadline_increase_seconds,
+        decided_timestamp_seconds: proposalData.decided_timestamp_seconds,
+        proposal: convertProposal(fromNullable(proposalData.proposal)),
+        proposer: convertNeuronId(fromNullable(proposalData.proposer)),
+        wait_for_quiet_state: convertWaitForQuietState(
+          fromNullable(proposalData.wait_for_quiet_state)
+        ),
+        is_eligible_for_rewards: proposalData.is_eligible_for_rewards,
+        executed_timestamp_seconds: proposalData.executed_timestamp_seconds,
+      };
 }
 export interface OptionalProposalId {
   id: bigint;
 }
-export function convertProposalId(proposalId: ProposalId | undefined): OptionalProposalId | undefined {
-  return proposalId === undefined ? undefined : {
-    id: proposalId.id
-  };
+export function convertProposalId(
+  proposalId: ProposalId | undefined
+): OptionalProposalId | undefined {
+  return proposalId === undefined
+    ? undefined
+    : {
+        id: proposalId.id,
+      };
 }
 export interface OptionalRegisterDappCanisters {
   canister_ids: Array<Principal>;
 }
-export function convertRegisterDappCanisters(registerDappCanisters: RegisterDappCanisters | undefined): OptionalRegisterDappCanisters | undefined {
-  return registerDappCanisters === undefined ? undefined : {
-    canister_ids: registerDappCanisters.canister_ids
-  };
+export function convertRegisterDappCanisters(
+  registerDappCanisters: RegisterDappCanisters | undefined
+): OptionalRegisterDappCanisters | undefined {
+  return registerDappCanisters === undefined
+    ? undefined
+    : {
+        canister_ids: registerDappCanisters.canister_ids,
+      };
 }
 export interface OptionalRegisterVote {
   vote: number;
   proposal: undefined | OptionalProposalId;
 }
-export function convertRegisterVote(registerVote: RegisterVote | undefined): OptionalRegisterVote | undefined {
-  return registerVote === undefined ? undefined : {
-    vote: registerVote.vote,
-    proposal: convertProposalId(fromNullable(registerVote.proposal))
-  };
+export function convertRegisterVote(
+  registerVote: RegisterVote | undefined
+): OptionalRegisterVote | undefined {
+  return registerVote === undefined
+    ? undefined
+    : {
+        vote: registerVote.vote,
+        proposal: convertProposalId(fromNullable(registerVote.proposal)),
+      };
 }
 export interface OptionalRemoveNeuronPermissions {
   permissions_to_remove: undefined | OptionalNeuronPermissionList;
   principal_id: undefined | Principal;
 }
-export function convertRemoveNeuronPermissions(removeNeuronPermissions: RemoveNeuronPermissions | undefined): OptionalRemoveNeuronPermissions | undefined {
-  return removeNeuronPermissions === undefined ? undefined : {
-    permissions_to_remove: convertNeuronPermissionList(fromNullable(removeNeuronPermissions.permissions_to_remove)),
-    principal_id: fromNullable(removeNeuronPermissions.principal_id)
-  };
+export function convertRemoveNeuronPermissions(
+  removeNeuronPermissions: RemoveNeuronPermissions | undefined
+): OptionalRemoveNeuronPermissions | undefined {
+  return removeNeuronPermissions === undefined
+    ? undefined
+    : {
+        permissions_to_remove: convertNeuronPermissionList(
+          fromNullable(removeNeuronPermissions.permissions_to_remove)
+        ),
+        principal_id: fromNullable(removeNeuronPermissions.principal_id),
+      };
 }
-export type Result = {
-  Error: GovernanceError;
-} | {
-  Neuron: Neuron;
-};
-export type Result_1 = {
-  Error: GovernanceError;
-} | {
-  Proposal: ProposalData;
-};
+export type Result =
+  | {
+      Error: GovernanceError;
+    }
+  | {
+      Neuron: Neuron;
+    };
+export type Result_1 =
+  | {
+      Error: GovernanceError;
+    }
+  | {
+      Proposal: ProposalData;
+    };
 export interface OptionalRewardEvent {
   actual_timestamp_seconds: bigint;
   end_timestamp_seconds: undefined | bigint;
@@ -1027,84 +1472,123 @@ export interface OptionalRewardEvent {
   round: bigint;
   settled_proposals: Array<ProposalId>;
 }
-export function convertRewardEvent(rewardEvent: RewardEvent | undefined): OptionalRewardEvent | undefined {
-  return rewardEvent === undefined ? undefined : {
-    actual_timestamp_seconds: rewardEvent.actual_timestamp_seconds,
-    end_timestamp_seconds: fromNullable(rewardEvent.end_timestamp_seconds),
-    distributed_e8s_equivalent: rewardEvent.distributed_e8s_equivalent,
-    round: rewardEvent.round,
-    settled_proposals: rewardEvent.settled_proposals
-  };
+export function convertRewardEvent(
+  rewardEvent: RewardEvent | undefined
+): OptionalRewardEvent | undefined {
+  return rewardEvent === undefined
+    ? undefined
+    : {
+        actual_timestamp_seconds: rewardEvent.actual_timestamp_seconds,
+        end_timestamp_seconds: fromNullable(rewardEvent.end_timestamp_seconds),
+        distributed_e8s_equivalent: rewardEvent.distributed_e8s_equivalent,
+        round: rewardEvent.round,
+        settled_proposals: rewardEvent.settled_proposals,
+      };
 }
 export interface OptionalSetDissolveTimestamp {
   dissolve_timestamp_seconds: bigint;
 }
-export function convertSetDissolveTimestamp(setDissolveTimestamp: SetDissolveTimestamp | undefined): OptionalSetDissolveTimestamp | undefined {
-  return setDissolveTimestamp === undefined ? undefined : {
-    dissolve_timestamp_seconds: setDissolveTimestamp.dissolve_timestamp_seconds
-  };
+export function convertSetDissolveTimestamp(
+  setDissolveTimestamp: SetDissolveTimestamp | undefined
+): OptionalSetDissolveTimestamp | undefined {
+  return setDissolveTimestamp === undefined
+    ? undefined
+    : {
+        dissolve_timestamp_seconds:
+          setDissolveTimestamp.dissolve_timestamp_seconds,
+      };
 }
 export interface OptionalSetMode {
   mode: number;
 }
-export function convertSetMode(setMode: SetMode | undefined): OptionalSetMode | undefined {
-  return setMode === undefined ? undefined : {
-    mode: setMode.mode
-  };
+export function convertSetMode(
+  setMode: SetMode | undefined
+): OptionalSetMode | undefined {
+  return setMode === undefined
+    ? undefined
+    : {
+        mode: setMode.mode,
+      };
 }
 export interface OptionalSplit {
   memo: bigint;
   amount_e8s: bigint;
 }
-export function convertSplit(split: Split | undefined): OptionalSplit | undefined {
-  return split === undefined ? undefined : {
-    memo: split.memo,
-    amount_e8s: split.amount_e8s
-  };
+export function convertSplit(
+  split: Split | undefined
+): OptionalSplit | undefined {
+  return split === undefined
+    ? undefined
+    : {
+        memo: split.memo,
+        amount_e8s: split.amount_e8s,
+      };
 }
 export interface OptionalSplitResponse {
   created_neuron_id: undefined | OptionalNeuronId;
 }
-export function convertSplitResponse(splitResponse: SplitResponse | undefined): OptionalSplitResponse | undefined {
-  return splitResponse === undefined ? undefined : {
-    created_neuron_id: convertNeuronId(fromNullable(splitResponse.created_neuron_id))
-  };
+export function convertSplitResponse(
+  splitResponse: SplitResponse | undefined
+): OptionalSplitResponse | undefined {
+  return splitResponse === undefined
+    ? undefined
+    : {
+        created_neuron_id: convertNeuronId(
+          fromNullable(splitResponse.created_neuron_id)
+        ),
+      };
 }
 export interface OptionalStakeMaturity {
   percentage_to_stake: undefined | number;
 }
-export function convertStakeMaturity(stakeMaturity: StakeMaturity | undefined): OptionalStakeMaturity | undefined {
-  return stakeMaturity === undefined ? undefined : {
-    percentage_to_stake: fromNullable(stakeMaturity.percentage_to_stake)
-  };
+export function convertStakeMaturity(
+  stakeMaturity: StakeMaturity | undefined
+): OptionalStakeMaturity | undefined {
+  return stakeMaturity === undefined
+    ? undefined
+    : {
+        percentage_to_stake: fromNullable(stakeMaturity.percentage_to_stake),
+      };
 }
 export interface OptionalStakeMaturityResponse {
   maturity_e8s: bigint;
   staked_maturity_e8s: bigint;
 }
-export function convertStakeMaturityResponse(stakeMaturityResponse: StakeMaturityResponse | undefined): OptionalStakeMaturityResponse | undefined {
-  return stakeMaturityResponse === undefined ? undefined : {
-    maturity_e8s: stakeMaturityResponse.maturity_e8s,
-    staked_maturity_e8s: stakeMaturityResponse.staked_maturity_e8s
-  };
+export function convertStakeMaturityResponse(
+  stakeMaturityResponse: StakeMaturityResponse | undefined
+): OptionalStakeMaturityResponse | undefined {
+  return stakeMaturityResponse === undefined
+    ? undefined
+    : {
+        maturity_e8s: stakeMaturityResponse.maturity_e8s,
+        staked_maturity_e8s: stakeMaturityResponse.staked_maturity_e8s,
+      };
 }
 export interface OptionalSubaccount {
   subaccount: Uint8Array;
 }
-export function convertSubaccount(subaccount: Subaccount | undefined): OptionalSubaccount | undefined {
-  return subaccount === undefined ? undefined : {
-    subaccount: subaccount.subaccount
-  };
+export function convertSubaccount(
+  subaccount: Subaccount | undefined
+): OptionalSubaccount | undefined {
+  return subaccount === undefined
+    ? undefined
+    : {
+        subaccount: subaccount.subaccount,
+      };
 }
 export interface OptionalSwapNeuron {
   id: undefined | OptionalNeuronId;
   status: number;
 }
-export function convertSwapNeuron(swapNeuron: SwapNeuron | undefined): OptionalSwapNeuron | undefined {
-  return swapNeuron === undefined ? undefined : {
-    id: convertNeuronId(fromNullable(swapNeuron.id)),
-    status: swapNeuron.status
-  };
+export function convertSwapNeuron(
+  swapNeuron: SwapNeuron | undefined
+): OptionalSwapNeuron | undefined {
+  return swapNeuron === undefined
+    ? undefined
+    : {
+        id: convertNeuronId(fromNullable(swapNeuron.id)),
+        status: swapNeuron.status,
+      };
 }
 export interface OptionalTally {
   no: bigint;
@@ -1112,13 +1596,17 @@ export interface OptionalTally {
   total: bigint;
   timestamp_seconds: bigint;
 }
-export function convertTally(tally: Tally | undefined): OptionalTally | undefined {
-  return tally === undefined ? undefined : {
-    no: tally.no,
-    yes: tally.yes,
-    total: tally.total,
-    timestamp_seconds: tally.timestamp_seconds
-  };
+export function convertTally(
+  tally: Tally | undefined
+): OptionalTally | undefined {
+  return tally === undefined
+    ? undefined
+    : {
+        no: tally.no,
+        yes: tally.yes,
+        total: tally.total,
+        timestamp_seconds: tally.timestamp_seconds,
+      };
 }
 export interface OptionalTransferSnsTreasuryFunds {
   from_treasury: number;
@@ -1127,14 +1615,20 @@ export interface OptionalTransferSnsTreasuryFunds {
   memo: undefined | bigint;
   amount_e8s: bigint;
 }
-export function convertTransferSnsTreasuryFunds(transferSnsTreasuryFunds: TransferSnsTreasuryFunds | undefined): OptionalTransferSnsTreasuryFunds | undefined {
-  return transferSnsTreasuryFunds === undefined ? undefined : {
-    from_treasury: transferSnsTreasuryFunds.from_treasury,
-    to_principal: fromNullable(transferSnsTreasuryFunds.to_principal),
-    to_subaccount: convertSubaccount(fromNullable(transferSnsTreasuryFunds.to_subaccount)),
-    memo: fromNullable(transferSnsTreasuryFunds.memo),
-    amount_e8s: transferSnsTreasuryFunds.amount_e8s
-  };
+export function convertTransferSnsTreasuryFunds(
+  transferSnsTreasuryFunds: TransferSnsTreasuryFunds | undefined
+): OptionalTransferSnsTreasuryFunds | undefined {
+  return transferSnsTreasuryFunds === undefined
+    ? undefined
+    : {
+        from_treasury: transferSnsTreasuryFunds.from_treasury,
+        to_principal: fromNullable(transferSnsTreasuryFunds.to_principal),
+        to_subaccount: convertSubaccount(
+          fromNullable(transferSnsTreasuryFunds.to_subaccount)
+        ),
+        memo: fromNullable(transferSnsTreasuryFunds.memo),
+        amount_e8s: transferSnsTreasuryFunds.amount_e8s,
+      };
 }
 export interface OptionalUpgradeInProgress {
   mark_failed_at_seconds: bigint;
@@ -1142,25 +1636,37 @@ export interface OptionalUpgradeInProgress {
   proposal_id: bigint;
   target_version: undefined | OptionalVersion;
 }
-export function convertUpgradeInProgress(upgradeInProgress: UpgradeInProgress | undefined): OptionalUpgradeInProgress | undefined {
-  return upgradeInProgress === undefined ? undefined : {
-    mark_failed_at_seconds: upgradeInProgress.mark_failed_at_seconds,
-    checking_upgrade_lock: upgradeInProgress.checking_upgrade_lock,
-    proposal_id: upgradeInProgress.proposal_id,
-    target_version: convertVersion(fromNullable(upgradeInProgress.target_version))
-  };
+export function convertUpgradeInProgress(
+  upgradeInProgress: UpgradeInProgress | undefined
+): OptionalUpgradeInProgress | undefined {
+  return upgradeInProgress === undefined
+    ? undefined
+    : {
+        mark_failed_at_seconds: upgradeInProgress.mark_failed_at_seconds,
+        checking_upgrade_lock: upgradeInProgress.checking_upgrade_lock,
+        proposal_id: upgradeInProgress.proposal_id,
+        target_version: convertVersion(
+          fromNullable(upgradeInProgress.target_version)
+        ),
+      };
 }
 export interface OptionalUpgradeSnsControlledCanister {
   new_canister_wasm: Uint8Array;
   canister_id: undefined | Principal;
   canister_upgrade_arg: undefined | Uint8Array;
 }
-export function convertUpgradeSnsControlledCanister(upgradeSnsControlledCanister: UpgradeSnsControlledCanister | undefined): OptionalUpgradeSnsControlledCanister | undefined {
-  return upgradeSnsControlledCanister === undefined ? undefined : {
-    new_canister_wasm: upgradeSnsControlledCanister.new_canister_wasm,
-    canister_id: fromNullable(upgradeSnsControlledCanister.canister_id),
-    canister_upgrade_arg: fromNullable(upgradeSnsControlledCanister.canister_upgrade_arg)
-  };
+export function convertUpgradeSnsControlledCanister(
+  upgradeSnsControlledCanister: UpgradeSnsControlledCanister | undefined
+): OptionalUpgradeSnsControlledCanister | undefined {
+  return upgradeSnsControlledCanister === undefined
+    ? undefined
+    : {
+        new_canister_wasm: upgradeSnsControlledCanister.new_canister_wasm,
+        canister_id: fromNullable(upgradeSnsControlledCanister.canister_id),
+        canister_upgrade_arg: fromNullable(
+          upgradeSnsControlledCanister.canister_upgrade_arg
+        ),
+      };
 }
 export interface OptionalVersion {
   archive_wasm_hash: Uint8Array;
@@ -1170,15 +1676,19 @@ export interface OptionalVersion {
   governance_wasm_hash: Uint8Array;
   index_wasm_hash: Uint8Array;
 }
-export function convertVersion(version: Version | undefined): OptionalVersion | undefined {
-  return version === undefined ? undefined : {
-    archive_wasm_hash: version.archive_wasm_hash,
-    root_wasm_hash: version.root_wasm_hash,
-    swap_wasm_hash: version.swap_wasm_hash,
-    ledger_wasm_hash: version.ledger_wasm_hash,
-    governance_wasm_hash: version.governance_wasm_hash,
-    index_wasm_hash: version.index_wasm_hash
-  };
+export function convertVersion(
+  version: Version | undefined
+): OptionalVersion | undefined {
+  return version === undefined
+    ? undefined
+    : {
+        archive_wasm_hash: version.archive_wasm_hash,
+        root_wasm_hash: version.root_wasm_hash,
+        swap_wasm_hash: version.swap_wasm_hash,
+        ledger_wasm_hash: version.ledger_wasm_hash,
+        governance_wasm_hash: version.governance_wasm_hash,
+        index_wasm_hash: version.index_wasm_hash,
+      };
 }
 export interface OptionalVotingRewardsParameters {
   final_reward_rate_basis_points: undefined | bigint;
@@ -1186,24 +1696,44 @@ export interface OptionalVotingRewardsParameters {
   reward_rate_transition_duration_seconds: undefined | bigint;
   round_duration_seconds: undefined | bigint;
 }
-export function convertVotingRewardsParameters(votingRewardsParameters: VotingRewardsParameters | undefined): OptionalVotingRewardsParameters | undefined {
-  return votingRewardsParameters === undefined ? undefined : {
-    final_reward_rate_basis_points: fromNullable(votingRewardsParameters.final_reward_rate_basis_points),
-    initial_reward_rate_basis_points: fromNullable(votingRewardsParameters.initial_reward_rate_basis_points),
-    reward_rate_transition_duration_seconds: fromNullable(votingRewardsParameters.reward_rate_transition_duration_seconds),
-    round_duration_seconds: fromNullable(votingRewardsParameters.round_duration_seconds)
-  };
+export function convertVotingRewardsParameters(
+  votingRewardsParameters: VotingRewardsParameters | undefined
+): OptionalVotingRewardsParameters | undefined {
+  return votingRewardsParameters === undefined
+    ? undefined
+    : {
+        final_reward_rate_basis_points: fromNullable(
+          votingRewardsParameters.final_reward_rate_basis_points
+        ),
+        initial_reward_rate_basis_points: fromNullable(
+          votingRewardsParameters.initial_reward_rate_basis_points
+        ),
+        reward_rate_transition_duration_seconds: fromNullable(
+          votingRewardsParameters.reward_rate_transition_duration_seconds
+        ),
+        round_duration_seconds: fromNullable(
+          votingRewardsParameters.round_duration_seconds
+        ),
+      };
 }
 export interface OptionalWaitForQuietState {
   current_deadline_timestamp_seconds: bigint;
 }
-export function convertWaitForQuietState(waitForQuietState: WaitForQuietState | undefined): OptionalWaitForQuietState | undefined {
-  return waitForQuietState === undefined ? undefined : {
-    current_deadline_timestamp_seconds: waitForQuietState.current_deadline_timestamp_seconds
-  };
+export function convertWaitForQuietState(
+  waitForQuietState: WaitForQuietState | undefined
+): OptionalWaitForQuietState | undefined {
+  return waitForQuietState === undefined
+    ? undefined
+    : {
+        current_deadline_timestamp_seconds:
+          waitForQuietState.current_deadline_timestamp_seconds,
+      };
 }
 export interface _SERVICE {
-  claim_swap_neurons: ActorMethod<[ClaimSwapNeuronsRequest], ClaimSwapNeuronsResponse>;
+  claim_swap_neurons: ActorMethod<
+    [ClaimSwapNeuronsRequest],
+    ClaimSwapNeuronsResponse
+  >;
   get_build_metadata: ActorMethod<[], string>;
   get_metadata: ActorMethod<[{}], GetMetadataResponse>;
   get_mode: ActorMethod<[{}], GetModeResponse>;
@@ -1212,8 +1742,14 @@ export interface _SERVICE {
   get_proposal: ActorMethod<[GetProposal], GetProposalResponse>;
   get_root_canister_status: ActorMethod<[null], CanisterStatusResultV2>;
   get_running_sns_version: ActorMethod<[{}], GetRunningSnsVersionResponse>;
-  get_sns_initialization_parameters: ActorMethod<[{}], GetSnsInitializationParametersResponse>;
-  list_nervous_system_functions: ActorMethod<[], ListNervousSystemFunctionsResponse>;
+  get_sns_initialization_parameters: ActorMethod<
+    [{}],
+    GetSnsInitializationParametersResponse
+  >;
+  list_nervous_system_functions: ActorMethod<
+    [],
+    ListNervousSystemFunctionsResponse
+  >;
   list_neurons: ActorMethod<[ListNeurons], ListNeuronsResponse>;
   list_proposals: ActorMethod<[ListProposals], ListProposalsResponse>;
   manage_neuron: ActorMethod<[ManageNeuron], ManageNeuronResponse>;

--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -2,6 +2,7 @@ import type { IcrcAccount } from "@dfinity/ledger";
 import { toNullable } from "@dfinity/utils";
 import type {
   Account,
+  Action,
   Command,
   ListProposals,
   ManageNeuron,
@@ -264,3 +265,5 @@ export const toListProposalRequest = ({
   include_status: Int32Array.from(includeStatus ?? []),
   limit: limit ?? DEFAULT_PROPOSALS_LIMIT,
 });
+
+export const toActionOptional = (action: Action): Action | undefined => {};

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -1,17 +1,24 @@
 export type {
   Action as SnsAction,
   Ballot as SnsBallot,
+  DeregisterDappCanisters,
+  ExecuteGenericNervousSystemFunction,
   GetMetadataResponse as SnsGetMetadataResponse,
   ListNervousSystemFunctionsResponse as SnsListNervousSystemFunctionsResponse,
   ManageNeuron as SnsManageNeuron,
   ManageNeuronResponse as SnsManageNeuronResponse,
+  ManageSnsMetadata,
+  Motion as SnsMotion,
   NervousSystemFunction as SnsNervousSystemFunction,
   NervousSystemParameters,
   Neuron as SnsNeuron,
   NeuronId as SnsNeuronId,
   ProposalData as SnsProposalData,
   ProposalId as SnsProposalId,
+  RegisterDappCanisters,
   Tally as SnsTally,
+  TransferSnsTreasuryFunds,
+  UpgradeSnsControlledCanister,
 } from "../candid/sns_governance";
 export type { CanisterStatusResultV2 as SnsCanisterStatus } from "../candid/sns_root";
 export type {

--- a/scripts/convert-to-optional.js
+++ b/scripts/convert-to-optional.js
@@ -1,0 +1,230 @@
+const babel = require("@babel/core");
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Identifies the `[] | [T]` pattern
+ */
+const isOptionalUnionType = (annotation) => {
+  if (annotation.typeAnnotation.type === "TSUnionType") {
+    const types = annotation.typeAnnotation.types;
+    const hasEmptyTuple = types.some(
+      (type) => type.type === "TSTupleType" && type.elementTypes.length === 0
+    );
+    const hasOneElementTyple = types.some(
+      (type) => type.type === "TSTupleType" && type.elementTypes.length === 1
+    );
+    return types.length === 2 && hasEmptyTuple && hasOneElementTyple;
+  }
+};
+
+/**
+ * Identifies wether the type is one that needs to be converted with `convertXxxx`.
+ */
+const isConvertableType = (annotation) => {
+  console.log(annotation);
+  return false;
+};
+
+const mappedInterfaces = new Map();
+
+const transformOptionalTuple = () => {
+  return {
+    visitor: {
+      TSInterfaceDeclaration: (path) => {
+        const name = path.node.id.name;
+        if (name.startsWith("Optional") || name.startsWith("_")) {
+          return;
+        }
+        const t = babel.types;
+        const convertTypeToOptional = (node) => {
+          if (node.elementTypes.length === 0) {
+            return t.tsUndefinedKeyword();
+          }
+          if (node.elementTypes.length === 1) {
+            return node.elementTypes[0];
+          }
+          throw new Error(`Unexpected tuple type ${JSON.stringify(node)}`);
+        };
+        const convertNode = (node) => {
+          const annotation = node.typeAnnotation;
+          if (isOptionalUnionType(annotation)) {
+            return t.tsPropertySignature(
+              node.key,
+              t.tsTypeAnnotation(
+                t.tsUnionType(
+                  annotation.typeAnnotation.types.map(convertTypeToOptional)
+                )
+              )
+            );
+          }
+          return node;
+        };
+        const interfaceName = path.node.id.name;
+        const newInterfaceName = `Optional${interfaceName}`;
+        const newIdentitifer = t.identifier(newInterfaceName);
+        const newBody = path.node.body.body.map(convertNode);
+        const newInterface = t.tsInterfaceDeclaration(
+          newIdentitifer,
+          null,
+          [],
+          t.tSInterfaceBody(newBody)
+        );
+
+        const parameterName =
+          interfaceName.charAt(0).toLowerCase() + interfaceName.slice(1);
+        const parameter = t.identifier(parameterName);
+        parameter.typeAnnotation = t.tsTypeAnnotation(
+          t.tsUnionType([
+            t.tsTypeReference(t.identifier(interfaceName)),
+            t.tsUndefinedKeyword(),
+          ])
+        );
+        const transformProp = (node) => {
+          const annotation = node.typeAnnotation;
+          if (isOptionalUnionType(annotation)) {
+            const call = t.callExpression(t.identifier("fromNullable"), [
+              t.memberExpression(parameter, node.key),
+            ]);
+            if (isConvertableType(annotation)) {
+              const typeName = "test";
+              return t.objectProperty(
+                node.key,
+                t.callExpression(t.identifier(`convert${typeName}`), [call])
+              );
+            }
+            return t.objectProperty(node.key, call);
+          }
+          return t.objectProperty(
+            node.key,
+            t.memberExpression(parameter, node.key)
+          );
+        };
+        const returnObject = t.objectExpression(
+          path.node.body.body.map(transformProp)
+        );
+        const ternaryStatement = t.conditionalExpression(
+          t.binaryExpression(
+            "===",
+            t.identifier(parameterName),
+            t.identifier("undefined")
+          ),
+          t.identifier("undefined"),
+          returnObject
+        );
+        const returnStatement = t.returnStatement(ternaryStatement);
+        const newFunction = t.functionDeclaration(
+          t.identifier(`convert${interfaceName}`),
+          [parameter],
+          t.blockStatement([returnStatement])
+        );
+        newFunction.returnType = t.tsTypeAnnotation(
+          t.tsUnionType([
+            t.tsTypeReference(newIdentitifer),
+            t.tsUndefinedKeyword(),
+          ])
+        );
+        const exportStatement = t.exportNamedDeclaration(newFunction);
+
+        mappedInterfaces.set(interfaceName, newInterfaceName);
+        path.insertAfter(exportStatement);
+        path.replaceWith(newInterface);
+      },
+    },
+  };
+};
+
+/**
+ * Identifies the `undefined | T` pattern
+ */
+const isOptionalType = (annotation) => {
+  if (annotation.typeAnnotation.type === "TSUnionType") {
+    const types = annotation.typeAnnotation.types;
+    const hasUndefined = types.some(
+      (type) => type.type === "TSUndefinedKeyword"
+    );
+    const hasOneElementTyple = types.some(
+      (type) => type.type === "TSTypeReference"
+    );
+    return types.length === 2 && hasUndefined && hasOneElementTyple;
+  }
+};
+
+const hasPendingTypeConvert = (annotation) => {
+  if (annotation.typeAnnotation.type === "TSUnionType") {
+    const types = annotation.typeAnnotation.types;
+    const hasMappedType = types.some(
+      (type) =>
+        type.type === "TSTypeReference" &&
+        mappedInterfaces.has(type.typeName.name)
+    );
+    return types.length === 2 && hasMappedType;
+  }
+};
+
+const transformInterfacesToOptional = () => {
+  return {
+    visitor: {
+      TSPropertySignature: (path) => {
+        const { typeAnnotation } = path.node;
+        if (typeAnnotation.typeAnnotation.type === "TSUnionType") {
+          const t = babel.types;
+          if (
+            isOptionalType(typeAnnotation) &&
+            hasPendingTypeConvert(typeAnnotation)
+          ) {
+            const renameIfOptional = (node) => {
+              if (node.type === "TSTypeReference") {
+                return t.tsTypeReference(
+                  t.identifier(mappedInterfaces.get(node.typeName.name))
+                );
+              }
+              return node;
+            };
+            const newNode = t.tsPropertySignature(
+              path.node.key,
+              t.tsTypeAnnotation(
+                t.tsUnionType(
+                  typeAnnotation.typeAnnotation.types.map(renameIfOptional)
+                )
+              )
+            );
+            path.replaceWith(newNode);
+          }
+        }
+      },
+    },
+  };
+};
+
+/**
+ * Create helpers that transform `[T] | []` to `T | undefined`
+ *
+ * @param {string} file
+ */
+const createHelpersFor = (file) => {
+  const content = fs.readFileSync(file, "utf-8");
+  const originalAst = babel.parseSync(content, {
+    plugins: ["@babel/plugin-syntax-typescript"],
+  });
+  const { code, ast } = babel.transformFromAstSync(originalAst, content, {
+    plugins: [transformOptionalTuple],
+    ast: true,
+  });
+  const { code: code2 } = babel.transformFromAstSync(ast, code, {
+    plugins: [transformInterfacesToOptional],
+  });
+  const fromNullableImport = `import { fromNullable } from "@dfinity/utils";`;
+  const typeImports = `import {\n  ${Array.from(mappedInterfaces.keys()).join(
+    ",\n  "
+  )}\n} from "./sns_governance";`;
+  const codeWithImports = `${fromNullableImport}\n${typeImports}\n${code2}`;
+
+  fs.writeFileSync(
+    path.join(".", "./packages/sns/candid/sns_governance-converters.ts"),
+    codeWithImports,
+    "utf-8"
+  );
+};
+
+createHelpersFor("./packages/sns/candid/sns_governance.d.ts");

--- a/scripts/convert-to-optional.js
+++ b/scripts/convert-to-optional.js
@@ -3,6 +3,12 @@ const fs = require("fs");
 const path = require("path");
 
 /**
+ * Reference on AST types:
+ * - Docs on babel types https://babeljs.io/docs/babel-types
+ * - Discover and play with AST https://astexplorer.net/ (select @babel/parser as parser)
+ */
+
+/**
  * Identifies the `[] | [T]` pattern
  */
 const isOptionalUnionType = (annotation) => {


### PR DESCRIPTION
# Motivation

Expose the action types of SNS proposals.

They will be used to convert the optional parameters into `T | undefined` instead of `[T] | []`.

# Changes

* Export action types in index.ts for sns-js.

# Tests

Not applicable.
