### PR TITLE
GIX-1220: Add SNS action converters

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     {
       "name": "@dfinity/sns",
       "path": "./packages/sns/dist/index.js",
-      "limit": "13 kB",
+      "limit": "14 kB",
       "ignore": [
         "@dfinity/agent",
         "@dfinity/candid",

--- a/packages/sns/src/converters/governance.converters.spec.ts
+++ b/packages/sns/src/converters/governance.converters.spec.ts
@@ -1,5 +1,8 @@
 import { Principal } from "@dfinity/principal";
-import type { Action as ActionCandid } from "../../candid/sns_governance";
+import type {
+  Action as ActionCandid,
+  DefaultFollowees,
+} from "../../candid/sns_governance";
 import type { Action } from "../types/actions";
 import { toActionOptional } from "./governance.converters";
 
@@ -8,90 +11,120 @@ describe("governance converters", () => {
     const mockPrincipal = Principal.fromText("aaaaa-aa");
 
     it("converts ManageNervousSystemParameters action", () => {
+      const default_followees: DefaultFollowees = {
+        followees: [[BigInt(20), { followees: [{ id: new Uint8Array(0) }] }]],
+      };
+      const max_dissolve_delay_seconds = BigInt(21);
+      const max_dissolve_delay_bonus_percentage = BigInt(22);
+      const max_followees_per_function = BigInt(23);
+      const neuron_claimer_permissions = { permissions: new Int32Array() };
+      const neuron_minimum_stake_e8s = BigInt(24);
+      const max_neuron_age_for_age_bonus = BigInt(25);
+      const initial_voting_period_seconds = BigInt(26);
+      const neuron_minimum_dissolve_delay_to_vote_seconds = BigInt(27);
+      const reject_cost_e8s = BigInt(28);
+      const max_proposals_to_keep_per_action = 2;
+      const max_number_of_neurons = BigInt(29);
+      const transaction_fee_e8s = BigInt(30);
+      const max_age_bonus_percentage = BigInt(31);
+      const neuron_grantable_permissions = { permissions: new Int32Array() };
+      const final_reward_rate_basis_points = BigInt(32);
+      const initial_reward_rate_basis_points = BigInt(33);
+      const reward_rate_transition_duration_seconds = BigInt(34);
+      const round_duration_seconds = BigInt(35);
+      const max_number_of_principals_per_neuron = BigInt(2);
+
       const action: ActionCandid = {
         ManageNervousSystemParameters: {
-          default_followees: [
-            {
-              followees: [
-                [BigInt(2), { followees: [{ id: new Uint8Array(0) }] }],
-              ],
-            },
+          default_followees: [default_followees],
+          max_dissolve_delay_seconds: [max_dissolve_delay_seconds],
+          max_dissolve_delay_bonus_percentage: [
+            max_dissolve_delay_bonus_percentage,
           ],
-          max_dissolve_delay_seconds: [BigInt(2)],
-          max_dissolve_delay_bonus_percentage: [BigInt(2)],
-          max_followees_per_function: [BigInt(2)],
-          neuron_claimer_permissions: [{ permissions: new Int32Array() }],
-          neuron_minimum_stake_e8s: [BigInt(2)],
-          max_neuron_age_for_age_bonus: [BigInt(2)],
-          initial_voting_period_seconds: [BigInt(2)],
-          neuron_minimum_dissolve_delay_to_vote_seconds: [BigInt(2)],
-          reject_cost_e8s: [BigInt(2)],
-          max_proposals_to_keep_per_action: [2],
+          max_followees_per_function: [max_followees_per_function],
+          neuron_claimer_permissions: [neuron_claimer_permissions],
+          neuron_minimum_stake_e8s: [neuron_minimum_stake_e8s],
+          max_neuron_age_for_age_bonus: [max_neuron_age_for_age_bonus],
+          initial_voting_period_seconds: [initial_voting_period_seconds],
+          neuron_minimum_dissolve_delay_to_vote_seconds: [
+            neuron_minimum_dissolve_delay_to_vote_seconds,
+          ],
+          reject_cost_e8s: [reject_cost_e8s],
+          max_proposals_to_keep_per_action: [max_proposals_to_keep_per_action],
           wait_for_quiet_deadline_increase_seconds: [],
-          max_number_of_neurons: [BigInt(2)],
-          transaction_fee_e8s: [BigInt(2)],
+          max_number_of_neurons: [max_number_of_neurons],
+          transaction_fee_e8s: [transaction_fee_e8s],
           max_number_of_proposals_with_ballots: [],
-          max_age_bonus_percentage: [BigInt(2)],
-          neuron_grantable_permissions: [{ permissions: new Int32Array() }],
+          max_age_bonus_percentage: [max_age_bonus_percentage],
+          neuron_grantable_permissions: [neuron_grantable_permissions],
           voting_rewards_parameters: [
             {
-              final_reward_rate_basis_points: [BigInt(3)],
-              initial_reward_rate_basis_points: [BigInt(3)],
-              reward_rate_transition_duration_seconds: [BigInt(3)],
-              round_duration_seconds: [BigInt(3)],
+              final_reward_rate_basis_points: [final_reward_rate_basis_points],
+              initial_reward_rate_basis_points: [
+                initial_reward_rate_basis_points,
+              ],
+              reward_rate_transition_duration_seconds: [
+                reward_rate_transition_duration_seconds,
+              ],
+              round_duration_seconds: [round_duration_seconds],
             },
           ],
-          max_number_of_principals_per_neuron: [BigInt(2)],
+          max_number_of_principals_per_neuron: [
+            max_number_of_principals_per_neuron,
+          ],
         },
       };
       const expectedAction: Action = {
         ManageNervousSystemParameters: {
-          default_followees: {
-            followees: [
-              [BigInt(2), { followees: [{ id: new Uint8Array(0) }] }],
-            ],
-          },
-          max_dissolve_delay_seconds: BigInt(2),
-          max_dissolve_delay_bonus_percentage: BigInt(2),
-          max_followees_per_function: BigInt(2),
-          neuron_claimer_permissions: { permissions: new Int32Array() },
-          neuron_minimum_stake_e8s: BigInt(2),
-          max_neuron_age_for_age_bonus: BigInt(2),
-          initial_voting_period_seconds: BigInt(2),
-          neuron_minimum_dissolve_delay_to_vote_seconds: BigInt(2),
-          reject_cost_e8s: BigInt(2),
+          default_followees,
+          max_dissolve_delay_seconds,
+          max_dissolve_delay_bonus_percentage,
+          max_followees_per_function,
+          neuron_claimer_permissions,
+          neuron_minimum_stake_e8s,
+          max_neuron_age_for_age_bonus,
+          initial_voting_period_seconds,
+          neuron_minimum_dissolve_delay_to_vote_seconds,
+          reject_cost_e8s,
           max_proposals_to_keep_per_action: 2,
           wait_for_quiet_deadline_increase_seconds: undefined,
-          max_number_of_neurons: BigInt(2),
-          transaction_fee_e8s: BigInt(2),
+          max_number_of_neurons,
+          transaction_fee_e8s,
           max_number_of_proposals_with_ballots: undefined,
-          max_age_bonus_percentage: BigInt(2),
-          neuron_grantable_permissions: { permissions: new Int32Array() },
+          max_age_bonus_percentage,
+          neuron_grantable_permissions,
           voting_rewards_parameters: {
-            final_reward_rate_basis_points: BigInt(3),
-            initial_reward_rate_basis_points: BigInt(3),
-            reward_rate_transition_duration_seconds: BigInt(3),
-            round_duration_seconds: BigInt(3),
+            final_reward_rate_basis_points,
+            initial_reward_rate_basis_points,
+            reward_rate_transition_duration_seconds,
+            round_duration_seconds,
           },
-          max_number_of_principals_per_neuron: BigInt(2),
+          max_number_of_principals_per_neuron,
         },
       };
       expect(toActionOptional(action)).toEqual(expectedAction);
     });
 
     it("converts AddGenericNervousSystemFunction action", () => {
+      const id = BigInt(3);
+      const name = "test function";
+      const description = "test description";
+      const validator_canister_id = mockPrincipal;
+      const target_canister_id = mockPrincipal;
+      const validator_method_name = "validator_method_name";
+      const target_method_name = "target_method_name";
       const action: ActionCandid = {
         AddGenericNervousSystemFunction: {
-          id: BigInt(3),
-          name: "test function",
-          description: ["test description"],
+          id,
+          name,
+          description: [description],
           function_type: [
             {
               GenericNervousSystemFunction: {
-                validator_canister_id: [],
-                target_canister_id: [mockPrincipal],
-                validator_method_name: ["validator_method_name"],
-                target_method_name: ["target_method_name"],
+                validator_canister_id: [validator_canister_id],
+                target_canister_id: [target_canister_id],
+                validator_method_name: [validator_method_name],
+                target_method_name: [target_method_name],
               },
             },
           ],
@@ -99,15 +132,15 @@ describe("governance converters", () => {
       };
       const expectedAction: Action = {
         AddGenericNervousSystemFunction: {
-          id: BigInt(3),
-          name: "test function",
-          description: "test description",
+          id,
+          name,
+          description,
           function_type: {
             GenericNervousSystemFunction: {
-              validator_canister_id: undefined,
-              target_canister_id: mockPrincipal,
-              validator_method_name: "validator_method_name",
-              target_method_name: "target_method_name",
+              validator_canister_id,
+              target_canister_id,
+              validator_method_name,
+              target_method_name,
             },
           },
         },
@@ -119,20 +152,14 @@ describe("governance converters", () => {
       const action: ActionCandid = {
         RemoveGenericNervousSystemFunction: BigInt(3),
       };
-      const expectedAction: Action = {
-        RemoveGenericNervousSystemFunction: BigInt(3),
-      };
-      expect(toActionOptional(action)).toEqual(expectedAction);
+      expect(toActionOptional(action)).toEqual(action);
     });
 
     it("converts UpgradeSnsToNextVersion action", () => {
       const action: ActionCandid = {
         UpgradeSnsToNextVersion: {},
       };
-      const expectedAction: Action = {
-        UpgradeSnsToNextVersion: {},
-      };
-      expect(toActionOptional(action)).toEqual(expectedAction);
+      expect(toActionOptional(action)).toEqual(action);
     });
 
     it("converts RegisterDappCanisters action", () => {
@@ -141,48 +168,49 @@ describe("governance converters", () => {
           canister_ids: [mockPrincipal],
         },
       };
-      const expectedAction: Action = {
-        RegisterDappCanisters: {
-          canister_ids: [mockPrincipal],
-        },
-      };
-      expect(toActionOptional(action)).toEqual(expectedAction);
+      expect(toActionOptional(action)).toEqual(action);
     });
 
     it("converts TransferSnsTreasuryFunds action", () => {
+      const from_treasury = 3;
+      const to_principal = mockPrincipal;
+      const memo = BigInt(3);
+      const amount_e8s = BigInt(3);
       const action: ActionCandid = {
         TransferSnsTreasuryFunds: {
-          from_treasury: 3,
-          to_principal: [mockPrincipal],
+          from_treasury,
+          to_principal: [to_principal],
           to_subaccount: [],
-          memo: [BigInt(3)],
-          amount_e8s: BigInt(3),
+          memo: [memo],
+          amount_e8s,
         },
       };
       const expectedAction: Action = {
         TransferSnsTreasuryFunds: {
-          from_treasury: 3,
-          to_principal: mockPrincipal,
+          from_treasury,
+          to_principal,
           to_subaccount: undefined,
-          memo: BigInt(3),
-          amount_e8s: BigInt(3),
+          memo,
+          amount_e8s,
         },
       };
       expect(toActionOptional(action)).toEqual(expectedAction);
     });
 
     it("converts UpgradeSnsControlledCanister action", () => {
+      const new_canister_wasm = new Uint8Array();
+      const canister_id = mockPrincipal;
       const action: ActionCandid = {
         UpgradeSnsControlledCanister: {
-          new_canister_wasm: new Uint8Array(),
-          canister_id: [mockPrincipal],
+          new_canister_wasm,
+          canister_id: [canister_id],
           canister_upgrade_arg: [],
         },
       };
       const expectedAction: Action = {
         UpgradeSnsControlledCanister: {
           new_canister_wasm: new Uint8Array(),
-          canister_id: mockPrincipal,
+          canister_id,
           canister_upgrade_arg: undefined,
         },
       };
@@ -196,39 +224,32 @@ describe("governance converters", () => {
           new_controllers: [mockPrincipal],
         },
       };
-      const expectedAction: Action = {
-        DeregisterDappCanisters: {
-          canister_ids: [mockPrincipal],
-          new_controllers: [mockPrincipal],
-        },
-      };
-      expect(toActionOptional(action)).toEqual(expectedAction);
+      expect(toActionOptional(action)).toEqual(action);
     });
 
     it("converts Unspecified action", () => {
       const action: ActionCandid = {
         Unspecified: {},
       };
-      const expectedAction: Action = {
-        Unspecified: {},
-      };
-      expect(toActionOptional(action)).toEqual(expectedAction);
+      expect(toActionOptional(action)).toEqual(action);
     });
 
     it("converts ManageSnsMetadata action", () => {
+      const url = "https://example.com";
+      const name = "New name";
       const action: ActionCandid = {
         ManageSnsMetadata: {
-          url: ["https://example.com"],
+          url: [url],
           logo: [],
-          name: ["New name"],
+          name: [name],
           description: [],
         },
       };
       const expectedAction: Action = {
         ManageSnsMetadata: {
-          url: "https://example.com",
+          url,
           logo: undefined,
-          name: "New name",
+          name,
           description: undefined,
         },
       };
@@ -242,23 +263,14 @@ describe("governance converters", () => {
           payload: new Uint8Array(),
         },
       };
-      const expectedAction: Action = {
-        ExecuteGenericNervousSystemFunction: {
-          function_id: BigInt(3),
-          payload: new Uint8Array(),
-        },
-      };
-      expect(toActionOptional(action)).toEqual(expectedAction);
+      expect(toActionOptional(action)).toEqual(action);
     });
 
     it("converts Motion action", () => {
       const action: ActionCandid = {
         Motion: { motion_text: "test motion" },
       };
-      const expectedAction: Action = {
-        Motion: { motion_text: "test motion" },
-      };
-      expect(toActionOptional(action)).toEqual(expectedAction);
+      expect(toActionOptional(action)).toEqual(action);
     });
   });
 });

--- a/packages/sns/src/converters/governance.converters.spec.ts
+++ b/packages/sns/src/converters/governance.converters.spec.ts
@@ -1,0 +1,264 @@
+import { Principal } from "@dfinity/principal";
+import type { Action as ActionCandid } from "../../candid/sns_governance";
+import type { Action } from "../types/actions";
+import { toActionOptional } from "./governance.converters";
+
+describe("governance converters", () => {
+  describe("toActionOptional", () => {
+    const mockPrincipal = Principal.fromText("aaaaa-aa");
+
+    it("converts ManageNervousSystemParameters action", () => {
+      const action: ActionCandid = {
+        ManageNervousSystemParameters: {
+          default_followees: [
+            {
+              followees: [
+                [BigInt(2), { followees: [{ id: new Uint8Array(0) }] }],
+              ],
+            },
+          ],
+          max_dissolve_delay_seconds: [BigInt(2)],
+          max_dissolve_delay_bonus_percentage: [BigInt(2)],
+          max_followees_per_function: [BigInt(2)],
+          neuron_claimer_permissions: [{ permissions: new Int32Array() }],
+          neuron_minimum_stake_e8s: [BigInt(2)],
+          max_neuron_age_for_age_bonus: [BigInt(2)],
+          initial_voting_period_seconds: [BigInt(2)],
+          neuron_minimum_dissolve_delay_to_vote_seconds: [BigInt(2)],
+          reject_cost_e8s: [BigInt(2)],
+          max_proposals_to_keep_per_action: [2],
+          wait_for_quiet_deadline_increase_seconds: [],
+          max_number_of_neurons: [BigInt(2)],
+          transaction_fee_e8s: [BigInt(2)],
+          max_number_of_proposals_with_ballots: [],
+          max_age_bonus_percentage: [BigInt(2)],
+          neuron_grantable_permissions: [{ permissions: new Int32Array() }],
+          voting_rewards_parameters: [
+            {
+              final_reward_rate_basis_points: [BigInt(3)],
+              initial_reward_rate_basis_points: [BigInt(3)],
+              reward_rate_transition_duration_seconds: [BigInt(3)],
+              round_duration_seconds: [BigInt(3)],
+            },
+          ],
+          max_number_of_principals_per_neuron: [BigInt(2)],
+        },
+      };
+      const expectedAction: Action = {
+        ManageNervousSystemParameters: {
+          default_followees: {
+            followees: [
+              [BigInt(2), { followees: [{ id: new Uint8Array(0) }] }],
+            ],
+          },
+          max_dissolve_delay_seconds: BigInt(2),
+          max_dissolve_delay_bonus_percentage: BigInt(2),
+          max_followees_per_function: BigInt(2),
+          neuron_claimer_permissions: { permissions: new Int32Array() },
+          neuron_minimum_stake_e8s: BigInt(2),
+          max_neuron_age_for_age_bonus: BigInt(2),
+          initial_voting_period_seconds: BigInt(2),
+          neuron_minimum_dissolve_delay_to_vote_seconds: BigInt(2),
+          reject_cost_e8s: BigInt(2),
+          max_proposals_to_keep_per_action: 2,
+          wait_for_quiet_deadline_increase_seconds: undefined,
+          max_number_of_neurons: BigInt(2),
+          transaction_fee_e8s: BigInt(2),
+          max_number_of_proposals_with_ballots: undefined,
+          max_age_bonus_percentage: BigInt(2),
+          neuron_grantable_permissions: { permissions: new Int32Array() },
+          voting_rewards_parameters: {
+            final_reward_rate_basis_points: BigInt(3),
+            initial_reward_rate_basis_points: BigInt(3),
+            reward_rate_transition_duration_seconds: BigInt(3),
+            round_duration_seconds: BigInt(3),
+          },
+          max_number_of_principals_per_neuron: BigInt(2),
+        },
+      };
+      expect(toActionOptional(action)).toEqual(expectedAction);
+    });
+
+    it("converts AddGenericNervousSystemFunction action", () => {
+      const action: ActionCandid = {
+        AddGenericNervousSystemFunction: {
+          id: BigInt(3),
+          name: "test function",
+          description: ["test description"],
+          function_type: [
+            {
+              GenericNervousSystemFunction: {
+                validator_canister_id: [],
+                target_canister_id: [mockPrincipal],
+                validator_method_name: ["validator_method_name"],
+                target_method_name: ["target_method_name"],
+              },
+            },
+          ],
+        },
+      };
+      const expectedAction: Action = {
+        AddGenericNervousSystemFunction: {
+          id: BigInt(3),
+          name: "test function",
+          description: "test description",
+          function_type: {
+            GenericNervousSystemFunction: {
+              validator_canister_id: undefined,
+              target_canister_id: mockPrincipal,
+              validator_method_name: "validator_method_name",
+              target_method_name: "target_method_name",
+            },
+          },
+        },
+      };
+      expect(toActionOptional(action)).toEqual(expectedAction);
+    });
+
+    it("converts RemoveGenericNervousSystemFunction action", () => {
+      const action: ActionCandid = {
+        RemoveGenericNervousSystemFunction: BigInt(3),
+      };
+      const expectedAction: Action = {
+        RemoveGenericNervousSystemFunction: BigInt(3),
+      };
+      expect(toActionOptional(action)).toEqual(expectedAction);
+    });
+
+    it("converts UpgradeSnsToNextVersion action", () => {
+      const action: ActionCandid = {
+        UpgradeSnsToNextVersion: {},
+      };
+      const expectedAction: Action = {
+        UpgradeSnsToNextVersion: {},
+      };
+      expect(toActionOptional(action)).toEqual(expectedAction);
+    });
+
+    it("converts RegisterDappCanisters action", () => {
+      const action: ActionCandid = {
+        RegisterDappCanisters: {
+          canister_ids: [mockPrincipal],
+        },
+      };
+      const expectedAction: Action = {
+        RegisterDappCanisters: {
+          canister_ids: [mockPrincipal],
+        },
+      };
+      expect(toActionOptional(action)).toEqual(expectedAction);
+    });
+
+    it("converts TransferSnsTreasuryFunds action", () => {
+      const action: ActionCandid = {
+        TransferSnsTreasuryFunds: {
+          from_treasury: 3,
+          to_principal: [mockPrincipal],
+          to_subaccount: [],
+          memo: [BigInt(3)],
+          amount_e8s: BigInt(3),
+        },
+      };
+      const expectedAction: Action = {
+        TransferSnsTreasuryFunds: {
+          from_treasury: 3,
+          to_principal: mockPrincipal,
+          to_subaccount: undefined,
+          memo: BigInt(3),
+          amount_e8s: BigInt(3),
+        },
+      };
+      expect(toActionOptional(action)).toEqual(expectedAction);
+    });
+
+    it("converts UpgradeSnsControlledCanister action", () => {
+      const action: ActionCandid = {
+        UpgradeSnsControlledCanister: {
+          new_canister_wasm: new Uint8Array(),
+          canister_id: [mockPrincipal],
+          canister_upgrade_arg: [],
+        },
+      };
+      const expectedAction: Action = {
+        UpgradeSnsControlledCanister: {
+          new_canister_wasm: new Uint8Array(),
+          canister_id: mockPrincipal,
+          canister_upgrade_arg: undefined,
+        },
+      };
+      expect(toActionOptional(action)).toEqual(expectedAction);
+    });
+
+    it("converts DeregisterDappCanisters action", () => {
+      const action: ActionCandid = {
+        DeregisterDappCanisters: {
+          canister_ids: [mockPrincipal],
+          new_controllers: [mockPrincipal],
+        },
+      };
+      const expectedAction: Action = {
+        DeregisterDappCanisters: {
+          canister_ids: [mockPrincipal],
+          new_controllers: [mockPrincipal],
+        },
+      };
+      expect(toActionOptional(action)).toEqual(expectedAction);
+    });
+
+    it("converts Unspecified action", () => {
+      const action: ActionCandid = {
+        Unspecified: {},
+      };
+      const expectedAction: Action = {
+        Unspecified: {},
+      };
+      expect(toActionOptional(action)).toEqual(expectedAction);
+    });
+
+    it("converts ManageSnsMetadata action", () => {
+      const action: ActionCandid = {
+        ManageSnsMetadata: {
+          url: ["https://example.com"],
+          logo: [],
+          name: ["New name"],
+          description: [],
+        },
+      };
+      const expectedAction: Action = {
+        ManageSnsMetadata: {
+          url: "https://example.com",
+          logo: undefined,
+          name: "New name",
+          description: undefined,
+        },
+      };
+      expect(toActionOptional(action)).toEqual(expectedAction);
+    });
+
+    it("converts ExecuteGenericNervousSystemFunction action", () => {
+      const action: ActionCandid = {
+        ExecuteGenericNervousSystemFunction: {
+          function_id: BigInt(3),
+          payload: new Uint8Array(),
+        },
+      };
+      const expectedAction: Action = {
+        ExecuteGenericNervousSystemFunction: {
+          function_id: BigInt(3),
+          payload: new Uint8Array(),
+        },
+      };
+      expect(toActionOptional(action)).toEqual(expectedAction);
+    });
+
+    it("converts Motion action", () => {
+      const action: ActionCandid = {
+        Motion: { motion_text: "test motion" },
+      };
+      const expectedAction: Action = {
+        Motion: { motion_text: "test motion" },
+      };
+      expect(toActionOptional(action)).toEqual(expectedAction);
+    });
+  });
+});

--- a/packages/sns/src/converters/governance.converters.spec.ts
+++ b/packages/sns/src/converters/governance.converters.spec.ts
@@ -86,7 +86,7 @@ describe("governance converters", () => {
           initial_voting_period_seconds,
           neuron_minimum_dissolve_delay_to_vote_seconds,
           reject_cost_e8s,
-          max_proposals_to_keep_per_action: 2,
+          max_proposals_to_keep_per_action,
           wait_for_quiet_deadline_increase_seconds: undefined,
           max_number_of_neurons,
           transaction_fee_e8s,
@@ -110,7 +110,7 @@ describe("governance converters", () => {
       const name = "test function";
       const description = "test description";
       const validator_canister_id = mockPrincipal;
-      const target_canister_id = mockPrincipal;
+      const target_canister_id = Principal.fromHex("AB");
       const validator_method_name = "validator_method_name";
       const target_method_name = "target_method_name";
       const action: ActionCandid = {
@@ -175,7 +175,7 @@ describe("governance converters", () => {
       const from_treasury = 3;
       const to_principal = mockPrincipal;
       const memo = BigInt(3);
-      const amount_e8s = BigInt(3);
+      const amount_e8s = BigInt(10_000_000_000);
       const action: ActionCandid = {
         TransferSnsTreasuryFunds: {
           from_treasury,
@@ -221,7 +221,7 @@ describe("governance converters", () => {
       const action: ActionCandid = {
         DeregisterDappCanisters: {
           canister_ids: [mockPrincipal],
-          new_controllers: [mockPrincipal],
+          new_controllers: [Principal.fromHex("AB")],
         },
       };
       expect(fromCandidAction(action)).toEqual(action);

--- a/packages/sns/src/converters/governance.converters.spec.ts
+++ b/packages/sns/src/converters/governance.converters.spec.ts
@@ -4,10 +4,10 @@ import type {
   DefaultFollowees,
 } from "../../candid/sns_governance";
 import type { Action } from "../types/actions";
-import { toActionOptional } from "./governance.converters";
+import { fromCandidAction } from "./governance.converters";
 
 describe("governance converters", () => {
-  describe("toActionOptional", () => {
+  describe("fromCandidAction", () => {
     const mockPrincipal = Principal.fromText("aaaaa-aa");
 
     it("converts ManageNervousSystemParameters action", () => {
@@ -102,7 +102,7 @@ describe("governance converters", () => {
           max_number_of_principals_per_neuron,
         },
       };
-      expect(toActionOptional(action)).toEqual(expectedAction);
+      expect(fromCandidAction(action)).toEqual(expectedAction);
     });
 
     it("converts AddGenericNervousSystemFunction action", () => {
@@ -145,21 +145,21 @@ describe("governance converters", () => {
           },
         },
       };
-      expect(toActionOptional(action)).toEqual(expectedAction);
+      expect(fromCandidAction(action)).toEqual(expectedAction);
     });
 
     it("converts RemoveGenericNervousSystemFunction action", () => {
       const action: ActionCandid = {
         RemoveGenericNervousSystemFunction: BigInt(3),
       };
-      expect(toActionOptional(action)).toEqual(action);
+      expect(fromCandidAction(action)).toEqual(action);
     });
 
     it("converts UpgradeSnsToNextVersion action", () => {
       const action: ActionCandid = {
         UpgradeSnsToNextVersion: {},
       };
-      expect(toActionOptional(action)).toEqual(action);
+      expect(fromCandidAction(action)).toEqual(action);
     });
 
     it("converts RegisterDappCanisters action", () => {
@@ -168,7 +168,7 @@ describe("governance converters", () => {
           canister_ids: [mockPrincipal],
         },
       };
-      expect(toActionOptional(action)).toEqual(action);
+      expect(fromCandidAction(action)).toEqual(action);
     });
 
     it("converts TransferSnsTreasuryFunds action", () => {
@@ -194,7 +194,7 @@ describe("governance converters", () => {
           amount_e8s,
         },
       };
-      expect(toActionOptional(action)).toEqual(expectedAction);
+      expect(fromCandidAction(action)).toEqual(expectedAction);
     });
 
     it("converts UpgradeSnsControlledCanister action", () => {
@@ -214,7 +214,7 @@ describe("governance converters", () => {
           canister_upgrade_arg: undefined,
         },
       };
-      expect(toActionOptional(action)).toEqual(expectedAction);
+      expect(fromCandidAction(action)).toEqual(expectedAction);
     });
 
     it("converts DeregisterDappCanisters action", () => {
@@ -224,14 +224,14 @@ describe("governance converters", () => {
           new_controllers: [mockPrincipal],
         },
       };
-      expect(toActionOptional(action)).toEqual(action);
+      expect(fromCandidAction(action)).toEqual(action);
     });
 
     it("converts Unspecified action", () => {
       const action: ActionCandid = {
         Unspecified: {},
       };
-      expect(toActionOptional(action)).toEqual(action);
+      expect(fromCandidAction(action)).toEqual(action);
     });
 
     it("converts ManageSnsMetadata action", () => {
@@ -253,7 +253,7 @@ describe("governance converters", () => {
           description: undefined,
         },
       };
-      expect(toActionOptional(action)).toEqual(expectedAction);
+      expect(fromCandidAction(action)).toEqual(expectedAction);
     });
 
     it("converts ExecuteGenericNervousSystemFunction action", () => {
@@ -263,14 +263,14 @@ describe("governance converters", () => {
           payload: new Uint8Array(),
         },
       };
-      expect(toActionOptional(action)).toEqual(action);
+      expect(fromCandidAction(action)).toEqual(action);
     });
 
     it("converts Motion action", () => {
       const action: ActionCandid = {
         Motion: { motion_text: "test motion" },
       };
-      expect(toActionOptional(action)).toEqual(action);
+      expect(fromCandidAction(action)).toEqual(action);
     });
   });
 });

--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -285,7 +285,7 @@ export const toListProposalRequest = ({
   limit: limit ?? DEFAULT_PROPOSALS_LIMIT,
 });
 
-export const toActionOptional = (action: ActionCandid): Action => {
+export const fromCandidAction = (action: ActionCandid): Action => {
   if ("ManageNervousSystemParameters" in action) {
     return {
       ManageNervousSystemParameters: convertNervousSystemParams(

--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -2,32 +2,32 @@ import type { IcrcAccount } from "@dfinity/ledger";
 import { fromNullable, toNullable } from "@dfinity/utils";
 import type {
   Account,
-  Action,
+  Action as ActionCandid,
   Command,
-  FunctionType,
-  GenericNervousSystemFunction,
+  FunctionType as FunctionTypeCandid,
+  GenericNervousSystemFunction as GenericNervousSystemFunctionCandid,
   ListProposals,
   ManageNeuron,
-  ManageSnsMetadata,
-  NervousSystemFunction,
-  NervousSystemParameters,
+  ManageSnsMetadata as ManageSnsMetadataCandid,
+  NervousSystemFunction as NervousSystemFunctionCandid,
+  NervousSystemParameters as NervousSystemParametersCandid,
   NeuronId,
   Operation,
-  TransferSnsTreasuryFunds,
-  UpgradeSnsControlledCanister,
-  VotingRewardsParameters,
+  TransferSnsTreasuryFunds as TransferSnsTreasuryFundsCandid,
+  UpgradeSnsControlledCanister as UpgradeSnsControlledCanisterCandid,
+  VotingRewardsParameters as VotingRewardsParametersCandid,
 } from "../../candid/sns_governance";
 import { DEFAULT_PROPOSALS_LIMIT } from "../constants/governance.constants";
 import type {
-  ActionOptional,
-  FunctionTypeOptional,
-  GenericNervousSystemFunctionOptional,
-  ManageSnsMetadataOptional,
-  NervousSystemFunctionOptional,
-  NervousSystemParametersOptional,
-  TransferSnsTreasuryFundsOptional,
-  UpgradeSnsControlledCanisterOptional,
-  VotingRewardsParametersOptional,
+  Action,
+  FunctionType,
+  GenericNervousSystemFunction,
+  ManageSnsMetadata,
+  NervousSystemFunction,
+  NervousSystemParameters,
+  TransferSnsTreasuryFunds,
+  UpgradeSnsControlledCanister,
+  VotingRewardsParameters,
 } from "../types/actions";
 import type {
   SnsClaimOrRefreshArgs,
@@ -285,7 +285,7 @@ export const toListProposalRequest = ({
   limit: limit ?? DEFAULT_PROPOSALS_LIMIT,
 });
 
-export const toActionOptional = (action: Action): ActionOptional => {
+export const toActionOptional = (action: ActionCandid): Action => {
   if ("ManageNervousSystemParameters" in action) {
     return {
       ManageNervousSystemParameters: convertNervousSystemParams(
@@ -362,8 +362,8 @@ export const toActionOptional = (action: Action): ActionOptional => {
 };
 
 const convertManageSnsMetadata = (
-  params: ManageSnsMetadata
-): ManageSnsMetadataOptional => ({
+  params: ManageSnsMetadataCandid
+): ManageSnsMetadata => ({
   url: fromNullable(params.url),
   logo: fromNullable(params.logo),
   name: fromNullable(params.name),
@@ -371,16 +371,16 @@ const convertManageSnsMetadata = (
 });
 
 const convertUpgradeSnsControlledCanister = (
-  params: UpgradeSnsControlledCanister
-): UpgradeSnsControlledCanisterOptional => ({
+  params: UpgradeSnsControlledCanisterCandid
+): UpgradeSnsControlledCanister => ({
   new_canister_wasm: params.new_canister_wasm,
   canister_id: fromNullable(params.canister_id),
   canister_upgrade_arg: fromNullable(params.canister_upgrade_arg),
 });
 
 const convertTransferSnsTreasuryFunds = (
-  params: TransferSnsTreasuryFunds
-): TransferSnsTreasuryFundsOptional => ({
+  params: TransferSnsTreasuryFundsCandid
+): TransferSnsTreasuryFunds => ({
   from_treasury: params.from_treasury,
   to_principal: fromNullable(params.to_principal),
   to_subaccount: fromNullable(params.to_subaccount),
@@ -389,8 +389,8 @@ const convertTransferSnsTreasuryFunds = (
 });
 
 const convertGenericNervousSystemFunction = (
-  params: GenericNervousSystemFunction
-): GenericNervousSystemFunctionOptional => ({
+  params: GenericNervousSystemFunctionCandid
+): GenericNervousSystemFunction => ({
   validator_canister_id: fromNullable(params.validator_canister_id),
   target_canister_id: fromNullable(params.target_canister_id),
   validator_method_name: fromNullable(params.validator_method_name),
@@ -398,8 +398,8 @@ const convertGenericNervousSystemFunction = (
 });
 
 const convertFunctionType = (
-  params: FunctionType | undefined
-): FunctionTypeOptional | undefined => {
+  params: FunctionTypeCandid | undefined
+): FunctionType | undefined => {
   if (params === undefined) {
     return undefined;
   }
@@ -420,8 +420,8 @@ const convertFunctionType = (
 };
 
 const convertNervousSystemFunction = (
-  params: NervousSystemFunction
-): NervousSystemFunctionOptional => ({
+  params: NervousSystemFunctionCandid
+): NervousSystemFunction => ({
   id: params.id,
   name: params.name,
   description: fromNullable(params.description),
@@ -429,8 +429,8 @@ const convertNervousSystemFunction = (
 });
 
 const convertVotingRewardsParameters = (
-  params: VotingRewardsParameters | undefined
-): VotingRewardsParametersOptional | undefined =>
+  params: VotingRewardsParametersCandid | undefined
+): VotingRewardsParameters | undefined =>
   params && {
     final_reward_rate_basis_points: fromNullable(
       params.final_reward_rate_basis_points
@@ -445,8 +445,8 @@ const convertVotingRewardsParameters = (
   };
 
 const convertNervousSystemParams = (
-  params: NervousSystemParameters
-): NervousSystemParametersOptional => ({
+  params: NervousSystemParametersCandid
+): NervousSystemParameters => ({
   default_followees: fromNullable(params.default_followees),
   max_dissolve_delay_seconds: fromNullable(params.max_dissolve_delay_seconds),
   max_dissolve_delay_bonus_percentage: fromNullable(

--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -1,14 +1,34 @@
 import type { IcrcAccount } from "@dfinity/ledger";
-import { toNullable } from "@dfinity/utils";
+import { fromNullable, toNullable } from "@dfinity/utils";
 import type {
   Account,
+  Action,
   Command,
+  FunctionType,
+  GenericNervousSystemFunction,
   ListProposals,
   ManageNeuron,
+  ManageSnsMetadata,
+  NervousSystemFunction,
+  NervousSystemParameters,
   NeuronId,
   Operation,
+  TransferSnsTreasuryFunds,
+  UpgradeSnsControlledCanister,
+  VotingRewardsParameters,
 } from "../../candid/sns_governance";
 import { DEFAULT_PROPOSALS_LIMIT } from "../constants/governance.constants";
+import type {
+  ActionOptional,
+  FunctionTypeOptional,
+  GenericNervousSystemFunctionOptional,
+  ManageSnsMetadataOptional,
+  NervousSystemFunctionOptional,
+  NervousSystemParametersOptional,
+  TransferSnsTreasuryFundsOptional,
+  UpgradeSnsControlledCanisterOptional,
+  VotingRewardsParametersOptional,
+} from "../types/actions";
 import type {
   SnsClaimOrRefreshArgs,
   SnsDisburseNeuronParams,
@@ -263,4 +283,207 @@ export const toListProposalRequest = ({
   include_reward_status: Int32Array.from(includeRewardStatus ?? []),
   include_status: Int32Array.from(includeStatus ?? []),
   limit: limit ?? DEFAULT_PROPOSALS_LIMIT,
+});
+
+export const toActionOptional = (action: Action): ActionOptional => {
+  if ("ManageNervousSystemParameters" in action) {
+    return {
+      ManageNervousSystemParameters: convertNervousSystemParams(
+        action.ManageNervousSystemParameters
+      ),
+    };
+  }
+
+  if ("AddGenericNervousSystemFunction" in action) {
+    return {
+      AddGenericNervousSystemFunction: convertNervousSystemFunction(
+        action.AddGenericNervousSystemFunction
+      ),
+    };
+  }
+
+  if ("RemoveGenericNervousSystemFunction" in action) {
+    return {
+      RemoveGenericNervousSystemFunction:
+        action.RemoveGenericNervousSystemFunction,
+    };
+  }
+
+  if ("UpgradeSnsToNextVersion" in action) {
+    return { UpgradeSnsToNextVersion: action.UpgradeSnsToNextVersion };
+  }
+
+  if ("RegisterDappCanisters" in action) {
+    return { RegisterDappCanisters: action.RegisterDappCanisters };
+  }
+
+  if ("TransferSnsTreasuryFunds" in action) {
+    return {
+      TransferSnsTreasuryFunds: convertTransferSnsTreasuryFunds(
+        action.TransferSnsTreasuryFunds
+      ),
+    };
+  }
+
+  if ("UpgradeSnsControlledCanister" in action) {
+    return {
+      UpgradeSnsControlledCanister: convertUpgradeSnsControlledCanister(
+        action.UpgradeSnsControlledCanister
+      ),
+    };
+  }
+
+  if ("DeregisterDappCanisters" in action) {
+    return { DeregisterDappCanisters: action.DeregisterDappCanisters };
+  }
+
+  if ("Unspecified" in action) {
+    return { Unspecified: action.Unspecified };
+  }
+
+  if ("ManageSnsMetadata" in action) {
+    return {
+      ManageSnsMetadata: convertManageSnsMetadata(action.ManageSnsMetadata),
+    };
+  }
+
+  if ("ExecuteGenericNervousSystemFunction" in action) {
+    return {
+      ExecuteGenericNervousSystemFunction:
+        action.ExecuteGenericNervousSystemFunction,
+    };
+  }
+
+  if ("Motion" in action) {
+    return { Motion: action.Motion };
+  }
+
+  throw new Error(`Unknown action type ${JSON.stringify(action)}`);
+};
+
+const convertManageSnsMetadata = (
+  params: ManageSnsMetadata
+): ManageSnsMetadataOptional => ({
+  url: fromNullable(params.url),
+  logo: fromNullable(params.logo),
+  name: fromNullable(params.name),
+  description: fromNullable(params.description),
+});
+
+const convertUpgradeSnsControlledCanister = (
+  params: UpgradeSnsControlledCanister
+): UpgradeSnsControlledCanisterOptional => ({
+  new_canister_wasm: params.new_canister_wasm,
+  canister_id: fromNullable(params.canister_id),
+  canister_upgrade_arg: fromNullable(params.canister_upgrade_arg),
+});
+
+const convertTransferSnsTreasuryFunds = (
+  params: TransferSnsTreasuryFunds
+): TransferSnsTreasuryFundsOptional => ({
+  from_treasury: params.from_treasury,
+  to_principal: fromNullable(params.to_principal),
+  to_subaccount: fromNullable(params.to_subaccount),
+  memo: fromNullable(params.memo),
+  amount_e8s: params.amount_e8s,
+});
+
+const convertGenericNervousSystemFunction = (
+  params: GenericNervousSystemFunction
+): GenericNervousSystemFunctionOptional => ({
+  validator_canister_id: fromNullable(params.validator_canister_id),
+  target_canister_id: fromNullable(params.target_canister_id),
+  validator_method_name: fromNullable(params.validator_method_name),
+  target_method_name: fromNullable(params.target_method_name),
+});
+
+const convertFunctionType = (
+  params: FunctionType | undefined
+): FunctionTypeOptional | undefined => {
+  if (params === undefined) {
+    return undefined;
+  }
+
+  if ("NativeNervousSystemFunction" in params) {
+    return { NativeNervousSystemFunction: params.NativeNervousSystemFunction };
+  }
+
+  if ("GenericNervousSystemFunction" in params) {
+    return {
+      GenericNervousSystemFunction: convertGenericNervousSystemFunction(
+        params.GenericNervousSystemFunction
+      ),
+    };
+  }
+
+  throw new Error(`Unknown FunctionType ${JSON.stringify(params)}`);
+};
+
+const convertNervousSystemFunction = (
+  params: NervousSystemFunction
+): NervousSystemFunctionOptional => ({
+  id: params.id,
+  name: params.name,
+  description: fromNullable(params.description),
+  function_type: convertFunctionType(fromNullable(params.function_type)),
+});
+
+const convertVotingRewardsParameters = (
+  params: VotingRewardsParameters | undefined
+): VotingRewardsParametersOptional | undefined =>
+  params && {
+    final_reward_rate_basis_points: fromNullable(
+      params.final_reward_rate_basis_points
+    ),
+    initial_reward_rate_basis_points: fromNullable(
+      params.initial_reward_rate_basis_points
+    ),
+    reward_rate_transition_duration_seconds: fromNullable(
+      params.reward_rate_transition_duration_seconds
+    ),
+    round_duration_seconds: fromNullable(params.round_duration_seconds),
+  };
+
+const convertNervousSystemParams = (
+  params: NervousSystemParameters
+): NervousSystemParametersOptional => ({
+  default_followees: fromNullable(params.default_followees),
+  max_dissolve_delay_seconds: fromNullable(params.max_dissolve_delay_seconds),
+  max_dissolve_delay_bonus_percentage: fromNullable(
+    params.max_dissolve_delay_bonus_percentage
+  ),
+  max_followees_per_function: fromNullable(params.max_followees_per_function),
+  neuron_claimer_permissions: fromNullable(params.neuron_claimer_permissions),
+  neuron_minimum_stake_e8s: fromNullable(params.neuron_minimum_stake_e8s),
+  max_neuron_age_for_age_bonus: fromNullable(
+    params.max_neuron_age_for_age_bonus
+  ),
+  initial_voting_period_seconds: fromNullable(
+    params.initial_voting_period_seconds
+  ),
+  neuron_minimum_dissolve_delay_to_vote_seconds: fromNullable(
+    params.neuron_minimum_dissolve_delay_to_vote_seconds
+  ),
+  reject_cost_e8s: fromNullable(params.reject_cost_e8s),
+  max_proposals_to_keep_per_action: fromNullable(
+    params.max_proposals_to_keep_per_action
+  ),
+  wait_for_quiet_deadline_increase_seconds: fromNullable(
+    params.wait_for_quiet_deadline_increase_seconds
+  ),
+  max_number_of_neurons: fromNullable(params.max_number_of_neurons),
+  transaction_fee_e8s: fromNullable(params.transaction_fee_e8s),
+  max_number_of_proposals_with_ballots: fromNullable(
+    params.max_number_of_proposals_with_ballots
+  ),
+  max_age_bonus_percentage: fromNullable(params.max_age_bonus_percentage),
+  neuron_grantable_permissions: fromNullable(
+    params.neuron_grantable_permissions
+  ),
+  voting_rewards_parameters: convertVotingRewardsParameters(
+    fromNullable(params.voting_rewards_parameters)
+  ),
+  max_number_of_principals_per_neuron: fromNullable(
+    params.max_number_of_principals_per_neuron
+  ),
 });

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -30,7 +30,7 @@ export type {
   Ticket as SnsSwapTicket,
   TransferableAmount as SnsTransferableAmount,
 } from "../candid/sns_swap";
-export { toActionOptional } from "./converters/governance.converters";
+export { fromCandidAction } from "./converters/governance.converters";
 export * from "./enums/governance.enums";
 export * from "./enums/swap.enums";
 export * from "./errors/governance.errors";

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -30,6 +30,7 @@ export type {
   Ticket as SnsSwapTicket,
   TransferableAmount as SnsTransferableAmount,
 } from "../candid/sns_swap";
+export { toActionOptional } from "./converters/governance.converters";
 export * from "./enums/governance.enums";
 export * from "./enums/swap.enums";
 export * from "./errors/governance.errors";

--- a/packages/sns/src/types/actions.ts
+++ b/packages/sns/src/types/actions.ts
@@ -10,25 +10,25 @@ import type {
 } from "../../candid/sns_governance";
 import type { Option } from "./common";
 
-export type ActionOptional =
+export type Action =
   | {
-      ManageNervousSystemParameters: NervousSystemParametersOptional;
+      ManageNervousSystemParameters: NervousSystemParameters;
     }
-  | { AddGenericNervousSystemFunction: NervousSystemFunctionOptional }
+  | { AddGenericNervousSystemFunction: NervousSystemFunction }
   | { RemoveGenericNervousSystemFunction: bigint }
   | { UpgradeSnsToNextVersion: Record<string, never> }
   | { RegisterDappCanisters: RegisterDappCanisters }
-  | { TransferSnsTreasuryFunds: TransferSnsTreasuryFundsOptional }
-  | { UpgradeSnsControlledCanister: UpgradeSnsControlledCanisterOptional }
+  | { TransferSnsTreasuryFunds: TransferSnsTreasuryFunds }
+  | { UpgradeSnsControlledCanister: UpgradeSnsControlledCanister }
   | { DeregisterDappCanisters: DeregisterDappCanisters }
   | { Unspecified: Record<string, never> }
-  | { ManageSnsMetadata: ManageSnsMetadataOptional }
+  | { ManageSnsMetadata: ManageSnsMetadata }
   | {
       ExecuteGenericNervousSystemFunction: ExecuteGenericNervousSystemFunction;
     }
   | { Motion: Motion };
 
-export interface NervousSystemParametersOptional {
+export interface NervousSystemParameters {
   default_followees: Option<DefaultFollowees>;
   max_dissolve_delay_seconds: Option<bigint>;
   max_dissolve_delay_bonus_percentage: Option<bigint>;
@@ -46,36 +46,36 @@ export interface NervousSystemParametersOptional {
   max_number_of_proposals_with_ballots: Option<bigint>;
   max_age_bonus_percentage: Option<bigint>;
   neuron_grantable_permissions: Option<NeuronPermissionList>;
-  voting_rewards_parameters: Option<VotingRewardsParametersOptional>;
+  voting_rewards_parameters: Option<VotingRewardsParameters>;
   max_number_of_principals_per_neuron: Option<bigint>;
 }
 
-export interface VotingRewardsParametersOptional {
+export interface VotingRewardsParameters {
   final_reward_rate_basis_points: Option<bigint>;
   initial_reward_rate_basis_points: Option<bigint>;
   reward_rate_transition_duration_seconds: Option<bigint>;
   round_duration_seconds: Option<bigint>;
 }
 
-export interface NervousSystemFunctionOptional {
+export interface NervousSystemFunction {
   id: bigint;
   name: string;
   description: Option<string>;
-  function_type: Option<FunctionTypeOptional>;
+  function_type: Option<FunctionType>;
 }
 
-export type FunctionTypeOptional =
+export type FunctionType =
   | { NativeNervousSystemFunction: Record<string, never> }
-  | { GenericNervousSystemFunction: GenericNervousSystemFunctionOptional };
+  | { GenericNervousSystemFunction: GenericNervousSystemFunction };
 
-export interface GenericNervousSystemFunctionOptional {
+export interface GenericNervousSystemFunction {
   validator_canister_id: Option<Principal>;
   target_canister_id: Option<Principal>;
   validator_method_name: Option<string>;
   target_method_name: Option<string>;
 }
 
-export interface TransferSnsTreasuryFundsOptional {
+export interface TransferSnsTreasuryFunds {
   from_treasury: number;
   to_principal: Option<Principal>;
   to_subaccount: Option<Subaccount>;
@@ -83,13 +83,13 @@ export interface TransferSnsTreasuryFundsOptional {
   amount_e8s: bigint;
 }
 
-export interface UpgradeSnsControlledCanisterOptional {
+export interface UpgradeSnsControlledCanister {
   new_canister_wasm: Uint8Array;
   canister_id: Option<Principal>;
   canister_upgrade_arg: Option<Uint8Array>;
 }
 
-export interface ManageSnsMetadataOptional {
+export interface ManageSnsMetadata {
   url: Option<string>;
   logo: Option<string>;
   name: Option<string>;

--- a/packages/sns/src/types/actions.ts
+++ b/packages/sns/src/types/actions.ts
@@ -1,0 +1,97 @@
+import type { Principal } from "@dfinity/principal";
+import type {
+  DefaultFollowees,
+  DeregisterDappCanisters,
+  ExecuteGenericNervousSystemFunction,
+  Motion,
+  NeuronPermissionList,
+  RegisterDappCanisters,
+  Subaccount,
+} from "../../candid/sns_governance";
+import type { Option } from "./common";
+
+export type ActionOptional =
+  | {
+      ManageNervousSystemParameters: NervousSystemParametersOptional;
+    }
+  | { AddGenericNervousSystemFunction: NervousSystemFunctionOptional }
+  | { RemoveGenericNervousSystemFunction: bigint }
+  | { UpgradeSnsToNextVersion: Record<string, never> }
+  | { RegisterDappCanisters: RegisterDappCanisters }
+  | { TransferSnsTreasuryFunds: TransferSnsTreasuryFundsOptional }
+  | { UpgradeSnsControlledCanister: UpgradeSnsControlledCanisterOptional }
+  | { DeregisterDappCanisters: DeregisterDappCanisters }
+  | { Unspecified: Record<string, never> }
+  | { ManageSnsMetadata: ManageSnsMetadataOptional }
+  | {
+      ExecuteGenericNervousSystemFunction: ExecuteGenericNervousSystemFunction;
+    }
+  | { Motion: Motion };
+
+export interface NervousSystemParametersOptional {
+  default_followees: Option<DefaultFollowees>;
+  max_dissolve_delay_seconds: Option<bigint>;
+  max_dissolve_delay_bonus_percentage: Option<bigint>;
+  max_followees_per_function: Option<bigint>;
+  neuron_claimer_permissions: Option<NeuronPermissionList>;
+  neuron_minimum_stake_e8s: Option<bigint>;
+  max_neuron_age_for_age_bonus: Option<bigint>;
+  initial_voting_period_seconds: Option<bigint>;
+  neuron_minimum_dissolve_delay_to_vote_seconds: Option<bigint>;
+  reject_cost_e8s: Option<bigint>;
+  max_proposals_to_keep_per_action: Option<number>;
+  wait_for_quiet_deadline_increase_seconds: Option<bigint>;
+  max_number_of_neurons: Option<bigint>;
+  transaction_fee_e8s: Option<bigint>;
+  max_number_of_proposals_with_ballots: Option<bigint>;
+  max_age_bonus_percentage: Option<bigint>;
+  neuron_grantable_permissions: Option<NeuronPermissionList>;
+  voting_rewards_parameters: Option<VotingRewardsParametersOptional>;
+  max_number_of_principals_per_neuron: Option<bigint>;
+}
+
+export interface VotingRewardsParametersOptional {
+  final_reward_rate_basis_points: Option<bigint>;
+  initial_reward_rate_basis_points: Option<bigint>;
+  reward_rate_transition_duration_seconds: Option<bigint>;
+  round_duration_seconds: Option<bigint>;
+}
+
+export interface NervousSystemFunctionOptional {
+  id: bigint;
+  name: string;
+  description: Option<string>;
+  function_type: Option<FunctionTypeOptional>;
+}
+
+export type FunctionTypeOptional =
+  | { NativeNervousSystemFunction: Record<string, never> }
+  | { GenericNervousSystemFunction: GenericNervousSystemFunctionOptional };
+
+export interface GenericNervousSystemFunctionOptional {
+  validator_canister_id: Option<Principal>;
+  target_canister_id: Option<Principal>;
+  validator_method_name: Option<string>;
+  target_method_name: Option<string>;
+}
+
+export interface TransferSnsTreasuryFundsOptional {
+  from_treasury: number;
+  to_principal: Option<Principal>;
+  to_subaccount: Option<Subaccount>;
+  memo: Option<bigint>;
+  amount_e8s: bigint;
+}
+
+export interface UpgradeSnsControlledCanisterOptional {
+  new_canister_wasm: Uint8Array;
+  canister_id: Option<Principal>;
+  canister_upgrade_arg: Option<Uint8Array>;
+}
+
+export interface ManageSnsMetadataOptional {
+  url: Option<string>;
+  logo: Option<string>;
+  name: Option<string>;
+  description: Option<string>;
+}

--- a/packages/sns/src/types/common.ts
+++ b/packages/sns/src/types/common.ts
@@ -1,1 +1,3 @@
 export type E8s = bigint;
+
+export type Option<T> = T | undefined;


### PR DESCRIPTION
# Motivation

Users should understand the parameters in SNS proposal actions.

For that, we don't want to show optional parameters as `[] | [T]`, instead as `undefined | T`.

# Changes

* Add converter `toActionOptional` that converts the Action of SNS proposals.
* New types to be used in the converter function above: ActionOptional, TransferSnsTreasuryFundsOptional, ... Pattern is `<Type>Optional`.

# Tests

* Test the converter with each action in the variant.
