### PR TITLE
feat: ckbtc estimate fee renamed and get deposit fee added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ## Features
 
 - new utils moved from NNS-dapp: `isNullish`, `nonNullish`, `notEmptyString` and `debounce`
-- added ckBTC `updateBalance`, `getWithdrawalAccount` and `retrieveBtc` functions
+- added ckBTC `updateBalance`, `getWithdrawalAccount`, `retrieveBtc`, `estimateWithdrawalFee` and `getDepositFee` functions
 
 ## Build
 

--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -139,7 +139,7 @@ Parameters:
 
 ##### :gear: estimateWithdrawalFee
 
-Returns an estimation of the user's fee (in Satoshi) for a retrieve_btc request based on the current status of the Bitcoin network and those related to the minter.
+Returns an estimation of the user's fee (in Satoshi) for a retrieve_btc request based on the current status of the Bitcoin network and the fee related to the minter.
 
 | Method                  | Type                                                              |
 | ----------------------- | ----------------------------------------------------------------- |

--- a/packages/ckbtc/candid/minter.certified.idl.js
+++ b/packages/ckbtc/candid/minter.certified.idl.js
@@ -7,10 +7,12 @@ export const idlFactory = ({ IDL }) => {
     'GeneralAvailability' : IDL.Null,
   });
   const UpgradeArgs = IDL.Record({
+    'kyt_principal' : IDL.Opt(IDL.Principal),
     'mode' : IDL.Opt(Mode),
     'retrieve_btc_min_amount' : IDL.Opt(IDL.Nat64),
     'max_time_in_queue_nanos' : IDL.Opt(IDL.Nat64),
     'min_confirmations' : IDL.Opt(IDL.Nat32),
+    'kyt_fee' : IDL.Opt(IDL.Nat64),
   });
   const BtcNetwork = IDL.Variant({
     'Mainnet' : IDL.Null,
@@ -26,6 +28,7 @@ export const idlFactory = ({ IDL }) => {
     'max_time_in_queue_nanos' : IDL.Nat64,
     'btc_network' : BtcNetwork,
     'min_confirmations' : IDL.Opt(IDL.Nat32),
+    'kyt_fee' : IDL.Opt(IDL.Nat64),
   });
   const MinterArg = IDL.Variant({
     'Upgrade' : IDL.Opt(UpgradeArgs),
@@ -124,9 +127,9 @@ export const idlFactory = ({ IDL }) => {
     }),
   });
   return IDL.Service({
-    'estimate_fee' : IDL.Func(
+    'estimate_withdrawal_fee' : IDL.Func(
         [IDL.Record({ 'amount' : IDL.Opt(IDL.Nat64) })],
-        [IDL.Nat64],
+        [IDL.Record({ 'minter_fee' : IDL.Nat64, 'bitcoin_fee' : IDL.Nat64 })],
         [],
       ),
     'get_btc_address' : IDL.Func(
@@ -139,6 +142,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Text],
         [],
       ),
+    'get_deposit_fee' : IDL.Func([], [IDL.Nat64], []),
     'get_events' : IDL.Func(
         [IDL.Record({ 'start' : IDL.Nat64, 'length' : IDL.Nat64 })],
         [IDL.Vec(Event)],
@@ -180,10 +184,12 @@ export const init = ({ IDL }) => {
     'GeneralAvailability' : IDL.Null,
   });
   const UpgradeArgs = IDL.Record({
+    'kyt_principal' : IDL.Opt(IDL.Principal),
     'mode' : IDL.Opt(Mode),
     'retrieve_btc_min_amount' : IDL.Opt(IDL.Nat64),
     'max_time_in_queue_nanos' : IDL.Opt(IDL.Nat64),
     'min_confirmations' : IDL.Opt(IDL.Nat32),
+    'kyt_fee' : IDL.Opt(IDL.Nat64),
   });
   const BtcNetwork = IDL.Variant({
     'Mainnet' : IDL.Null,
@@ -199,6 +205,7 @@ export const init = ({ IDL }) => {
     'max_time_in_queue_nanos' : IDL.Nat64,
     'btc_network' : BtcNetwork,
     'min_confirmations' : IDL.Opt(IDL.Nat32),
+    'kyt_fee' : IDL.Opt(IDL.Nat64),
   });
   const MinterArg = IDL.Variant({
     'Upgrade' : IDL.Opt(UpgradeArgs),

--- a/packages/ckbtc/candid/minter.d.ts
+++ b/packages/ckbtc/candid/minter.d.ts
@@ -49,6 +49,7 @@ export interface InitArgs {
   max_time_in_queue_nanos: bigint;
   btc_network: BtcNetwork;
   min_confirmations: [] | [number];
+  kyt_fee: [] | [bigint];
 }
 export type MinterArg = { Upgrade: [] | [UpgradeArgs] } | { Init: InitArgs };
 export type Mode =
@@ -91,10 +92,12 @@ export type UpdateBalanceError =
       };
     };
 export interface UpgradeArgs {
+  kyt_principal: [] | [Principal];
   mode: [] | [Mode];
   retrieve_btc_min_amount: [] | [bigint];
   max_time_in_queue_nanos: [] | [bigint];
   min_confirmations: [] | [number];
+  kyt_fee: [] | [bigint];
 }
 export interface Utxo {
   height: number;
@@ -113,11 +116,15 @@ export type UtxoStatus =
     }
   | { Checked: Utxo };
 export interface _SERVICE {
-  estimate_fee: ActorMethod<[{ amount: [] | [bigint] }], bigint>;
+  estimate_withdrawal_fee: ActorMethod<
+    [{ amount: [] | [bigint] }],
+    { minter_fee: bigint; bitcoin_fee: bigint }
+  >;
   get_btc_address: ActorMethod<
     [{ owner: [] | [Principal]; subaccount: [] | [Uint8Array] }],
     string
   >;
+  get_deposit_fee: ActorMethod<[], bigint>;
   get_events: ActorMethod<[{ start: bigint; length: bigint }], Array<Event>>;
   get_withdrawal_account: ActorMethod<[], Account>;
   retrieve_btc: ActorMethod<

--- a/packages/ckbtc/candid/minter.did
+++ b/packages/ckbtc/candid/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit cd8058402b0f65c9fd502f9bb19dff114592ff03 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
+// Generated from IC repo commit 078de6d2b8d15cccb09fcfe2483fddabe6c39457 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
 // Represents an account on the ckBTC ledger.
 type Account = record { owner : principal; subaccount : opt blob };
 
@@ -121,6 +121,9 @@ type InitArgs = record {
     /// The minter's operation mode.
     mode : Mode;
 
+    /// The fee paid per check by the KYT cansiter.
+    kyt_fee : opt nat64;
+
     /// The canister id of the KYT canister.
     kyt_principal: opt principal;
 };
@@ -140,6 +143,12 @@ type UpgradeArgs = record {
 
     /// If set, overrides the current minter's operation mode.
     mode : opt Mode;
+
+    /// The fee per check by the KYT cansiter.
+    kyt_fee : opt nat64;
+
+    /// The principal of the KYT canister.
+    kyt_principal : opt principal;
 };
 
 type RetrieveBtcStatus = variant {
@@ -243,7 +252,10 @@ service : (minter_arg : MinterArg) -> {
 
     /// Returns an estimate of the user's fee (in Satoshi) for a
     /// retrieve_btc request based on the current status of the Bitcoin network.
-    estimate_fee : (record { amount : opt nat64 }) -> (nat64) query;
+    estimate_withdrawal_fee : (record { amount : opt nat64 }) -> (record { bitcoin_fee: nat64; minter_fee: nat64;}) query;
+
+    /// Returns the fee that the minter will charge for a bitcoin deposit.
+    get_deposit_fee: () -> (nat64) query;
 
     // Returns the account to which the caller should deposit ckBTC
     // before withdrawing BTC using the [retrieve_btc] endpoint.

--- a/packages/ckbtc/candid/minter.idl.js
+++ b/packages/ckbtc/candid/minter.idl.js
@@ -7,10 +7,12 @@ export const idlFactory = ({ IDL }) => {
     'GeneralAvailability' : IDL.Null,
   });
   const UpgradeArgs = IDL.Record({
+    'kyt_principal' : IDL.Opt(IDL.Principal),
     'mode' : IDL.Opt(Mode),
     'retrieve_btc_min_amount' : IDL.Opt(IDL.Nat64),
     'max_time_in_queue_nanos' : IDL.Opt(IDL.Nat64),
     'min_confirmations' : IDL.Opt(IDL.Nat32),
+    'kyt_fee' : IDL.Opt(IDL.Nat64),
   });
   const BtcNetwork = IDL.Variant({
     'Mainnet' : IDL.Null,
@@ -26,6 +28,7 @@ export const idlFactory = ({ IDL }) => {
     'max_time_in_queue_nanos' : IDL.Nat64,
     'btc_network' : BtcNetwork,
     'min_confirmations' : IDL.Opt(IDL.Nat32),
+    'kyt_fee' : IDL.Opt(IDL.Nat64),
   });
   const MinterArg = IDL.Variant({
     'Upgrade' : IDL.Opt(UpgradeArgs),
@@ -124,9 +127,9 @@ export const idlFactory = ({ IDL }) => {
     }),
   });
   return IDL.Service({
-    'estimate_fee' : IDL.Func(
+    'estimate_withdrawal_fee' : IDL.Func(
         [IDL.Record({ 'amount' : IDL.Opt(IDL.Nat64) })],
-        [IDL.Nat64],
+        [IDL.Record({ 'minter_fee' : IDL.Nat64, 'bitcoin_fee' : IDL.Nat64 })],
         ['query'],
       ),
     'get_btc_address' : IDL.Func(
@@ -139,6 +142,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Text],
         [],
       ),
+    'get_deposit_fee' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_events' : IDL.Func(
         [IDL.Record({ 'start' : IDL.Nat64, 'length' : IDL.Nat64 })],
         [IDL.Vec(Event)],
@@ -180,10 +184,12 @@ export const init = ({ IDL }) => {
     'GeneralAvailability' : IDL.Null,
   });
   const UpgradeArgs = IDL.Record({
+    'kyt_principal' : IDL.Opt(IDL.Principal),
     'mode' : IDL.Opt(Mode),
     'retrieve_btc_min_amount' : IDL.Opt(IDL.Nat64),
     'max_time_in_queue_nanos' : IDL.Opt(IDL.Nat64),
     'min_confirmations' : IDL.Opt(IDL.Nat32),
+    'kyt_fee' : IDL.Opt(IDL.Nat64),
   });
   const BtcNetwork = IDL.Variant({
     'Mainnet' : IDL.Null,
@@ -199,6 +205,7 @@ export const init = ({ IDL }) => {
     'max_time_in_queue_nanos' : IDL.Nat64,
     'btc_network' : BtcNetwork,
     'min_confirmations' : IDL.Opt(IDL.Nat32),
+    'kyt_fee' : IDL.Opt(IDL.Nat64),
   });
   const MinterArg = IDL.Variant({
     'Upgrade' : IDL.Opt(UpgradeArgs),

--- a/packages/ckbtc/src/minter.canister.spec.ts
+++ b/packages/ckbtc/src/minter.canister.spec.ts
@@ -407,34 +407,34 @@ describe("ckBTC minter canister", () => {
     });
   });
 
-  describe("Estimate Fee", () => {
+  describe("Estimate Withdrawal Fee", () => {
     it("should return estimated fee", async () => {
-      const result = 123789n;
+      const result = { minter_fee: 123n, bitcoin_fee: 456n };
 
       const service = mock<ActorSubclass<CkBTCMinterService>>();
-      service.estimate_fee.mockResolvedValue(result);
+      service.estimate_withdrawal_fee.mockResolvedValue(result);
 
       const canister = minter(service);
 
-      const res = await canister.estimateFee({
+      const res = await canister.estimateWithdrawalFee({
         certified: true,
         amount: undefined,
       });
 
-      expect(service.estimate_fee).toBeCalled();
+      expect(service.estimate_withdrawal_fee).toBeCalled();
       expect(res).toEqual(result);
     });
 
     it("should bubble errors", () => {
       const service = mock<ActorSubclass<CkBTCMinterService>>();
-      service.estimate_fee.mockImplementation(() => {
+      service.estimate_withdrawal_fee.mockImplementation(() => {
         throw new Error();
       });
 
       const canister = minter(service);
 
       expect(() =>
-        canister.estimateFee({ certified: true, amount: undefined })
+        canister.estimateWithdrawalFee({ certified: true, amount: undefined })
       ).rejects.toThrowError();
     });
   });

--- a/packages/ckbtc/src/minter.canister.spec.ts
+++ b/packages/ckbtc/src/minter.canister.spec.ts
@@ -438,4 +438,35 @@ describe("ckBTC minter canister", () => {
       ).rejects.toThrowError();
     });
   });
+
+  describe("Deposit Fee", () => {
+    it("should return deposit fee", async () => {
+      const result = 123789n;
+
+      const service = mock<ActorSubclass<CkBTCMinterService>>();
+      service.get_deposit_fee.mockResolvedValue(result);
+
+      const canister = minter(service);
+
+      const res = await canister.getDepositFee({
+        certified: true,
+      });
+
+      expect(service.get_deposit_fee).toBeCalled();
+      expect(res).toEqual(result);
+    });
+
+    it("should bubble errors", () => {
+      const service = mock<ActorSubclass<CkBTCMinterService>>();
+      service.get_deposit_fee.mockImplementation(() => {
+        throw new Error();
+      });
+
+      const canister = minter(service);
+
+      expect(() =>
+        canister.getDepositFee({ certified: true })
+      ).rejects.toThrowError();
+    });
+  });
 });

--- a/packages/ckbtc/src/minter.canister.ts
+++ b/packages/ckbtc/src/minter.canister.ts
@@ -17,7 +17,7 @@ import {
 } from "./errors/minter.errors";
 import type { CkBTCMinterCanisterOptions } from "./types/canister.options";
 import type {
-  EstimateFeeParams,
+  EstimateWithdrawalFeeParams,
   GetBTCAddressParams,
   RetrieveBtcParams,
   UpdateBalanceParams,
@@ -134,7 +134,7 @@ export class CkBTCMinterCanister extends Canister<CkBTCMinterService> {
   estimateWithdrawalFee = async ({
     certified,
     amount,
-  }: EstimateFeeParams): Promise<EstimateWithdrawalFee> =>
+  }: EstimateWithdrawalFeeParams): Promise<EstimateWithdrawalFee> =>
     this.caller({
       certified,
     }).estimate_withdrawal_fee({ amount: toNullable(amount) });

--- a/packages/ckbtc/src/minter.canister.ts
+++ b/packages/ckbtc/src/minter.canister.ts
@@ -142,7 +142,7 @@ export class CkBTCMinterCanister extends Canister<CkBTCMinterService> {
   /**
    * Returns the fee that the minter will charge for a bitcoin deposit.
    *
-   * @param {RetrieveBtcParams} params The parameters to get the deposit fee.
+   * @param {QueryParams} params The parameters to get the deposit fee.
    * @param {boolean} params.certified query or update call
    */
   getDepositFee = async ({ certified }: QueryParams): Promise<bigint> =>

--- a/packages/ckbtc/src/minter.canister.ts
+++ b/packages/ckbtc/src/minter.canister.ts
@@ -22,6 +22,7 @@ import type {
   UpdateBalanceOk,
   UpdateBalanceResponse,
 } from "./types/minter.responses";
+import type { EstimateWithdrawalFee } from "./types/minter.responses";
 
 export class CkBTCMinterCanister extends Canister<CkBTCMinterService> {
   static create(options: CkBTCMinterCanisterOptions<CkBTCMinterService>) {
@@ -119,17 +120,17 @@ export class CkBTCMinterCanister extends Canister<CkBTCMinterService> {
   };
 
   /**
-   * Returns an estimation of the user's fee (in Satoshi) for a retrieve_btc request based on the current status of the Bitcoin network.
+   * Returns an estimation of the user's fee (in Satoshi) for a retrieve_btc request based on the current status of the Bitcoin network and those related to the minter.
    *
    * @param {RetrieveBtcParams} params The parameters to estimate the fee.
    * @param {boolean} params.certified query or update call
    * @param {bigint | undefined} params.amount The optional amount for which the fee should be estimated.
    */
-  estimateFee = async ({
+  estimateWithdrawalFee = async ({
     certified,
     amount,
-  }: EstimateFeeParams): Promise<bigint> =>
+  }: EstimateFeeParams): Promise<EstimateWithdrawalFee> =>
     this.caller({
       certified,
-    }).estimate_fee({ amount: toNullable(amount) });
+    }).estimate_withdrawal_fee({ amount: toNullable(amount) });
 }

--- a/packages/ckbtc/src/minter.canister.ts
+++ b/packages/ckbtc/src/minter.canister.ts
@@ -1,7 +1,7 @@
 import {
   Canister,
   createServices,
-  QueryParams,
+  type QueryParams,
   toNullable,
 } from "@dfinity/utils";
 import type {

--- a/packages/ckbtc/src/minter.canister.ts
+++ b/packages/ckbtc/src/minter.canister.ts
@@ -1,8 +1,8 @@
 import {
   Canister,
   createServices,
-  type QueryParams,
   toNullable,
+  type QueryParams,
 } from "@dfinity/utils";
 import type {
   Account as WithdrawalAccount,

--- a/packages/ckbtc/src/minter.canister.ts
+++ b/packages/ckbtc/src/minter.canister.ts
@@ -125,7 +125,7 @@ export class CkBTCMinterCanister extends Canister<CkBTCMinterService> {
   };
 
   /**
-   * Returns an estimation of the user's fee (in Satoshi) for a retrieve_btc request based on the current status of the Bitcoin network and those related to the minter.
+   * Returns an estimation of the user's fee (in Satoshi) for a retrieve_btc request based on the current status of the Bitcoin network and the fee related to the minter.
    *
    * @param {RetrieveBtcParams} params The parameters to estimate the fee.
    * @param {boolean} params.certified query or update call

--- a/packages/ckbtc/src/minter.canister.ts
+++ b/packages/ckbtc/src/minter.canister.ts
@@ -1,4 +1,9 @@
-import { Canister, createServices, toNullable } from "@dfinity/utils";
+import {
+  Canister,
+  createServices,
+  QueryParams,
+  toNullable,
+} from "@dfinity/utils";
 import type {
   Account as WithdrawalAccount,
   RetrieveBtcOk,
@@ -18,11 +23,11 @@ import type {
   UpdateBalanceParams,
 } from "./types/minter.params";
 import type {
+  EstimateWithdrawalFee,
   RetrieveBtcResponse,
   UpdateBalanceOk,
   UpdateBalanceResponse,
 } from "./types/minter.responses";
-import type { EstimateWithdrawalFee } from "./types/minter.responses";
 
 export class CkBTCMinterCanister extends Canister<CkBTCMinterService> {
   static create(options: CkBTCMinterCanisterOptions<CkBTCMinterService>) {
@@ -133,4 +138,15 @@ export class CkBTCMinterCanister extends Canister<CkBTCMinterService> {
     this.caller({
       certified,
     }).estimate_withdrawal_fee({ amount: toNullable(amount) });
+
+  /**
+   * Returns the fee that the minter will charge for a bitcoin deposit.
+   *
+   * @param {RetrieveBtcParams} params The parameters to get the deposit fee.
+   * @param {boolean} params.certified query or update call
+   */
+  getDepositFee = async ({ certified }: QueryParams): Promise<bigint> =>
+    this.caller({
+      certified,
+    }).get_deposit_fee();
 }

--- a/packages/ckbtc/src/types/minter.params.ts
+++ b/packages/ckbtc/src/types/minter.params.ts
@@ -27,4 +27,4 @@ export type RetrieveBtcParams = RetrieveBtcArgs &
 /**
  * Params to estimate the fee of the Bitcoin network.
  */
-export type EstimateFeeParams = QueryParams & { amount: bigint | undefined };
+export type EstimateWithdrawalFeeParams = QueryParams & { amount: bigint | undefined };

--- a/packages/ckbtc/src/types/minter.params.ts
+++ b/packages/ckbtc/src/types/minter.params.ts
@@ -27,4 +27,6 @@ export type RetrieveBtcParams = RetrieveBtcArgs &
 /**
  * Params to estimate the fee of the Bitcoin network.
  */
-export type EstimateWithdrawalFeeParams = QueryParams & { amount: bigint | undefined };
+export type EstimateWithdrawalFeeParams = QueryParams & {
+  amount: bigint | undefined;
+};

--- a/packages/ckbtc/src/types/minter.responses.ts
+++ b/packages/ckbtc/src/types/minter.responses.ts
@@ -14,3 +14,5 @@ export type UpdateBalanceResponse =
 export type RetrieveBtcResponse =
   | { Ok: RetrieveBtcOk }
   | { Err: RetrieveBtcError };
+
+export type EstimateWithdrawalFee = { minter_fee: bigint; bitcoin_fee: bigint };


### PR DESCRIPTION
# Motivation

Update ckBTC for last canister implementation.

# Changes

- `estimate_fee` renamed to `estimate_withdrawal_fee`
- new endpoint `get_deposit_fee` added
