### PR TITLE
GIX-1481: Get latest reward event NNS Governance

### DIFF
--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -363,7 +363,7 @@ Returns the index of the block containing the tx if it was successful.
 - [create](#gear-create)
 - [listNeurons](#gear-listneurons)
 - [listKnownNeurons](#gear-listknownneurons)
-- [lastestRewardEvent](#gear-lastestrewardevent)
+- [getLastestRewardEvent](#gear-getLastestRewardEvent)
 - [listProposals](#gear-listproposals)
 - [stakeNeuron](#gear-stakeneuron)
 - [increaseDissolveDelay](#gear-increasedissolvedelay)
@@ -421,16 +421,16 @@ it is fetched using a query call.
 | ------------------ | ------------------------------------------------- |
 | `listKnownNeurons` | `(certified?: boolean) => Promise<KnownNeuron[]>` |
 
-##### :gear: lastestRewardEvent
+##### :gear: getLastestRewardEvent
 
 Returns the latest reward event.
 
 If `certified` is true, the request is fetched as an update call, otherwise
 it is fetched using a query call.
 
-| Method               | Type                                            |
-| -------------------- | ----------------------------------------------- |
-| `lastestRewardEvent` | `(certified?: boolean) => Promise<RewardEvent>` |
+| Method                  | Type                                            |
+| ----------------------- | ----------------------------------------------- |
+| `getLastestRewardEvent` | `(certified?: boolean) => Promise<RewardEvent>` |
 
 ##### :gear: listProposals
 

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -363,7 +363,7 @@ Returns the index of the block containing the tx if it was successful.
 - [create](#gear-create)
 - [listNeurons](#gear-listneurons)
 - [listKnownNeurons](#gear-listknownneurons)
-- [getLastestRewardEvent](#gear-getLastestRewardEvent)
+- [getLastestRewardEvent](#gear-getlastestrewardevent)
 - [listProposals](#gear-listproposals)
 - [stakeNeuron](#gear-stakeneuron)
 - [increaseDissolveDelay](#gear-increasedissolvedelay)
@@ -426,7 +426,7 @@ it is fetched using a query call.
 Returns the latest reward event.
 
 If `certified` is true, the request is fetched as an update call, otherwise
-it is fetched using a query call.
+it's fetched using a query call.
 
 | Method                  | Type                                            |
 | ----------------------- | ----------------------------------------------- |

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -363,6 +363,7 @@ Returns the index of the block containing the tx if it was successful.
 - [create](#gear-create)
 - [listNeurons](#gear-listneurons)
 - [listKnownNeurons](#gear-listknownneurons)
+- [lastestRewardEvent](#gear-lastestrewardevent)
 - [listProposals](#gear-listproposals)
 - [stakeNeuron](#gear-stakeneuron)
 - [increaseDissolveDelay](#gear-increasedissolvedelay)
@@ -419,6 +420,17 @@ it is fetched using a query call.
 | Method             | Type                                              |
 | ------------------ | ------------------------------------------------- |
 | `listKnownNeurons` | `(certified?: boolean) => Promise<KnownNeuron[]>` |
+
+##### :gear: lastestRewardEvent
+
+Returns the latest reward event.
+
+If `certified` is true, the request is fetched as an update call, otherwise
+it is fetched using a query call.
+
+| Method               | Type                                            |
+| -------------------- | ----------------------------------------------- |
+| `lastestRewardEvent` | `(certified?: boolean) => Promise<RewardEvent>` |
 
 ##### :gear: listProposals
 

--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 5376a14c92f20b4bd285d7622ac5f2a8d21c0d02 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit 241ad2c2ed1b25131c038c2390d6d212057d87ee 'rs/nns/gtc/canister/gtc.did' by import-candid
 type AccountState = record {
   authenticated_principal_id : opt principal;
   successfully_transferred_neurons : vec TransferredNeuron;

--- a/packages/nns/candid/governance.certified.idl.js
+++ b/packages/nns/candid/governance.certified.idl.js
@@ -64,8 +64,10 @@ export const idlFactory = ({ IDL }) => {
     'maximum_node_provider_rewards_e8s' : IDL.Nat64,
   });
   const RewardEvent = IDL.Record({
+    'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'day_after_genesis' : IDL.Nat64,
     'actual_timestamp_seconds' : IDL.Nat64,
+    'total_available_e8s_equivalent' : IDL.Nat64,
     'distributed_e8s_equivalent' : IDL.Nat64,
     'settled_proposals' : IDL.Vec(NeuronId),
   });
@@ -527,6 +529,7 @@ export const idlFactory = ({ IDL }) => {
         [Result_2],
         [],
       ),
+    'get_latest_reward_event' : IDL.Func([], [RewardEvent], []),
     'get_metrics' : IDL.Func([], [Result_3], []),
     'get_monthly_node_provider_rewards' : IDL.Func([], [Result_4], []),
     'get_most_recent_monthly_node_provider_rewards' : IDL.Func(
@@ -628,8 +631,10 @@ export const init = ({ IDL }) => {
     'maximum_node_provider_rewards_e8s' : IDL.Nat64,
   });
   const RewardEvent = IDL.Record({
+    'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'day_after_genesis' : IDL.Nat64,
     'actual_timestamp_seconds' : IDL.Nat64,
+    'total_available_e8s_equivalent' : IDL.Nat64,
     'distributed_e8s_equivalent' : IDL.Nat64,
     'settled_proposals' : IDL.Vec(NeuronId),
   });

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -421,8 +421,10 @@ export type Result_5 = { Ok: NeuronInfo } | { Err: GovernanceError };
 export type Result_6 = { Ok: NodeProvider } | { Err: GovernanceError };
 export type Result_7 = { Committed: Committed } | { Aborted: {} };
 export interface RewardEvent {
+  rounds_since_last_distribution: [] | [bigint];
   day_after_genesis: bigint;
   actual_timestamp_seconds: bigint;
+  total_available_e8s_equivalent: bigint;
   distributed_e8s_equivalent: bigint;
   settled_proposals: Array<NeuronId>;
 }
@@ -517,6 +519,7 @@ export interface _SERVICE {
     [NeuronIdOrSubaccount],
     Result_2
   >;
+  get_latest_reward_event: ActorMethod<[], RewardEvent>;
   get_metrics: ActorMethod<[], Result_3>;
   get_monthly_node_provider_rewards: ActorMethod<[], Result_4>;
   get_most_recent_monthly_node_provider_rewards: ActorMethod<

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 5376a14c92f20b4bd285d7622ac5f2a8d21c0d02 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 241ad2c2ed1b25131c038c2390d6d212057d87ee 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record { hash : vec nat8 };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
@@ -353,8 +353,10 @@ type Result_5 = variant { Ok : NeuronInfo; Err : GovernanceError };
 type Result_6 = variant { Ok : NodeProvider; Err : GovernanceError };
 type Result_7 = variant { Committed : Committed; Aborted : record {} };
 type RewardEvent = record {
+  rounds_since_last_distribution : opt nat64;
   day_after_genesis : nat64;
   actual_timestamp_seconds : nat64;
+  total_available_e8s_equivalent : nat64;
   distributed_e8s_equivalent : nat64;
   settled_proposals : vec NeuronId;
 };
@@ -430,6 +432,7 @@ service : (Governance) -> {
   get_full_neuron_by_id_or_subaccount : (NeuronIdOrSubaccount) -> (
       Result_2,
     ) query;
+  get_latest_reward_event : () -> (RewardEvent) query;
   get_metrics : () -> (Result_3) query;
   get_monthly_node_provider_rewards : () -> (Result_4);
   get_most_recent_monthly_node_provider_rewards : () -> (

--- a/packages/nns/candid/governance.idl.js
+++ b/packages/nns/candid/governance.idl.js
@@ -64,8 +64,10 @@ export const idlFactory = ({ IDL }) => {
     'maximum_node_provider_rewards_e8s' : IDL.Nat64,
   });
   const RewardEvent = IDL.Record({
+    'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'day_after_genesis' : IDL.Nat64,
     'actual_timestamp_seconds' : IDL.Nat64,
+    'total_available_e8s_equivalent' : IDL.Nat64,
     'distributed_e8s_equivalent' : IDL.Nat64,
     'settled_proposals' : IDL.Vec(NeuronId),
   });
@@ -527,6 +529,7 @@ export const idlFactory = ({ IDL }) => {
         [Result_2],
         ['query'],
       ),
+    'get_latest_reward_event' : IDL.Func([], [RewardEvent], ['query']),
     'get_metrics' : IDL.Func([], [Result_3], ['query']),
     'get_monthly_node_provider_rewards' : IDL.Func([], [Result_4], []),
     'get_most_recent_monthly_node_provider_rewards' : IDL.Func(
@@ -640,8 +643,10 @@ export const init = ({ IDL }) => {
     'maximum_node_provider_rewards_e8s' : IDL.Nat64,
   });
   const RewardEvent = IDL.Record({
+    'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'day_after_genesis' : IDL.Nat64,
     'actual_timestamp_seconds' : IDL.Nat64,
+    'total_available_e8s_equivalent' : IDL.Nat64,
     'distributed_e8s_equivalent' : IDL.Nat64,
     'settled_proposals' : IDL.Vec(NeuronId),
   });

--- a/packages/nns/candid/ledger.did
+++ b/packages/nns/candid/ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 87eb51bc9aab91fb17a2b4d60ee7b719dba117dc 'rs/rosetta-api/icp_ledger/ledger.did' by import-candid
+// Generated from IC repo commit 241ad2c2ed1b25131c038c2390d6d212057d87ee 'rs/rosetta-api/icp_ledger/ledger.did' by import-candid
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.

--- a/packages/nns/candid/sns_wasm.did
+++ b/packages/nns/candid/sns_wasm.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 5376a14c92f20b4bd285d7622ac5f2a8d21c0d02 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit 241ad2c2ed1b25131c038c2390d6d212057d87ee 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 type AddWasmRequest = record { hash : vec nat8; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -15,6 +15,7 @@ import type {
   ManageNeuronResponse,
   ProposalInfo as RawProposalInfo,
   Result,
+  RewardEvent,
   _SERVICE as GovernanceService,
 } from "../candid/governance";
 import { NeuronId as PbNeuronId } from "../proto/base_types_pb";
@@ -1537,6 +1538,30 @@ describe("GovernanceCanister", () => {
       });
       const call = () => governance.makeProposal(makeProposalRequest);
       expect(call).rejects.toThrow(new GovernanceError(error));
+    });
+  });
+
+  describe("lastestRewardEvent", () => {
+    const mockRewardEvent: RewardEvent = {
+      rounds_since_last_distribution: [BigInt(1_000)],
+      day_after_genesis: BigInt(365),
+      actual_timestamp_seconds: BigInt(12234455555),
+      total_available_e8s_equivalent: BigInt(20_000_000_000),
+      distributed_e8s_equivalent: BigInt(2_000_000_000),
+      settled_proposals: [],
+    };
+
+    it("gets the latest reward event", async () => {
+      const service = mock<ActorSubclass<GovernanceService>>();
+      service.get_latest_reward_event.mockResolvedValue(mockRewardEvent);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+      });
+      const rewardEvent = await governance.lastestRewardEvent(true);
+      expect(service.get_latest_reward_event).toBeCalled();
+      expect(rewardEvent).toBe(mockRewardEvent);
     });
   });
 });

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -1541,7 +1541,7 @@ describe("GovernanceCanister", () => {
     });
   });
 
-  describe("lastestRewardEvent", () => {
+  describe("getLastestRewardEvent", () => {
     const mockRewardEvent: RewardEvent = {
       rounds_since_last_distribution: [BigInt(1_000)],
       day_after_genesis: BigInt(365),
@@ -1559,7 +1559,7 @@ describe("GovernanceCanister", () => {
         certifiedServiceOverride: service,
         serviceOverride: service,
       });
-      const rewardEvent = await governance.lastestRewardEvent(true);
+      const rewardEvent = await governance.getLastestRewardEvent(true);
       expect(service.get_latest_reward_event).toBeCalled();
       expect(rewardEvent).toBe(mockRewardEvent);
     });

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -196,7 +196,7 @@ export class GovernanceCanister {
    * Returns the latest reward event.
    *
    * If `certified` is true, the request is fetched as an update call, otherwise
-   * it is fetched using a query call.
+   * it's fetched using a query call.
    */
   public lastestRewardEvent = async (
     certified = true

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -197,6 +197,7 @@ export class GovernanceCanister {
    *
    * If `certified` is true, the request is fetched as an update call, otherwise
    * it's fetched using a query call.
+   *
    */
   public getLastestRewardEvent = async (
     certified = true

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -11,6 +11,7 @@ import randomBytes from "randombytes";
 import type {
   ListProposalInfo,
   ProposalInfo as RawProposalInfo,
+  RewardEvent,
   _SERVICE as GovernanceService,
 } from "../candid/governance";
 import { idlFactory as certifiedIdlFactory } from "../candid/governance.certified.idl";
@@ -190,6 +191,19 @@ export class GovernanceCanister {
       description: n.known_neuron_data[0]?.description[0],
     }));
   };
+
+  /**
+   * Returns the latest reward event.
+   *
+   * If `certified` is true, the request is fetched as an update call, otherwise
+   * it is fetched using a query call.
+   */
+  public lastestRewardEvent = async (
+    certified = true
+  ): Promise<RewardEvent> => {
+    return this.getGovernanceService(certified).get_latest_reward_event();
+  };
+
   /**
    * Returns the list of proposals made for the community to vote on,
    * paginated and filtered by the request.

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -198,7 +198,7 @@ export class GovernanceCanister {
    * If `certified` is true, the request is fetched as an update call, otherwise
    * it's fetched using a query call.
    */
-  public lastestRewardEvent = async (
+  public getLastestRewardEvent = async (
     certified = true
   ): Promise<RewardEvent> => {
     return this.getGovernanceService(certified).get_latest_reward_event();


### PR DESCRIPTION
# Motivation

Add endpoint to get the latest reward event of the NNS Governance

# Changes

* New endpoint in NNS Governance `lastestRewardEvent`.
* Update nns-js candid interfaces. Only changes in governance canister.

# Tests

* Add test for new endpoint.
