### PR TITLE
build: publish to npm with provenance

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,26 +17,26 @@ jobs:
       - name: Set up npm
         run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
       - name: Publish utils
-        run: npm publish --tag next --workspace=packages/utils
+        run: npm publish --provenance --tag next --workspace=packages/utils
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish Ledger
-        run: npm publish --tag next --workspace=packages/ledger
+        run: npm publish --provenance --tag next --workspace=packages/ledger
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish NNS
-        run: npm publish --tag next --workspace=packages/nns
+        run: npm publish --provenance --tag next --workspace=packages/nns
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish SNS
-        run: npm publish --tag next --workspace=packages/sns
+        run: npm publish --provenance --tag next --workspace=packages/sns
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish CMC
-        run: npm publish --tag next --workspace=packages/cmc
+        run: npm publish --provenance --tag next --workspace=packages/cmc
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish ckBTC
-        run: npm publish --tag next --workspace=packages/ckbtc
+        run: npm publish --provenance --tag next --workspace=packages/ckbtc
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,26 +18,26 @@ jobs:
       - name: Set up npm
         run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
       - name: Publish utils
-        run: npm publish --workspace=packages/utils --access public
+        run: npm publish --workspace=packages/utils --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish Ledger
-        run: npm publish --workspace=packages/ledger --access public
+        run: npm publish --workspace=packages/ledger --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish NNS
-        run: npm publish --workspace=packages/nns --access public
+        run: npm publish --workspace=packages/nns --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish SNS
-        run: npm publish --workspace=packages/sns --access public
+        run: npm publish --workspace=packages/sns --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish CMC
-        run: npm publish --workspace=packages/cmc --access public
+        run: npm publish --workspace=packages/cmc --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish ckBTC
-        run: npm publish --workspace=packages/ckbtc --access public
+        run: npm publish --workspace=packages/ckbtc --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
# Motivation

Publish provenance alongside our libraries to npm.

# Source

 - https://github.blog/2023-04-19-introducing-npm-package-provenance/
 - https://github.blog/changelog/2023-04-19-npm-provenance-public-beta/

# Changes

- add flag `--provenance` next to `npm publish`
