### PR TITLE
GIX-1518 Add BitcoinSetConfig to enum NnsFunction

### DIFF
--- a/packages/nns/src/enums/governance.enums.ts
+++ b/packages/nns/src/enums/governance.enums.ts
@@ -121,4 +121,5 @@ export enum NnsFunction {
   RetireReplicaVersion = 36,
   InsertSnsWasmUpgradePathEntries = 37,
   UpdateElectedReplicaVersions = 38,
+  BitcoinSetConfig = 39,
 }


### PR DESCRIPTION
# Motivation

We want to support payload rendering for BitcoinSetConfig proposals.
According to the instructions [here](https://github.com/dfinity/nns-dapp/blob/main/HOWTO.md), we need to update this enum in ic-js.
[Here](https://github.com/dfinity/ic/blob/master/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs#:~:text=BitcoinSetConfig%20=%2039) is the corresponding value from the governance canister.

# Changes

Add `BitcoinSetConfig = 39,` to `enum NnsFunction` in `packages/nns/src/enums/governance.enums.ts`

# Tests

None
