### PR TITLE
build: do not run size checker on main

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -112,6 +112,8 @@ jobs:
 
   size:
     runs-on: ubuntu-20.04
+    # The size checker should run and provide metrics only on PRs
+    if: ${{ github.ref != 'refs/heads/main' }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# Motivation

The size checker should not run on `main` as it results in error there. We want to compare the size of new code.
