### PR TITLE
refactor: ledger balance params are equals to type IcrcAccount and certified

### DIFF
--- a/packages/ledger/README.md
+++ b/packages/ledger/README.md
@@ -126,9 +126,9 @@ The ledger transaction fees.
 
 Returns the balance of the given account.
 
-| Method    | Type                                         |
-| --------- | -------------------------------------------- |
-| `balance` | `(params: BalanceParams) => Promise<bigint>` |
+| Method    | Type                               |
+| --------- | ---------------------------------- |
+| `balance` | `(params: any) => Promise<bigint>` |
 
 Parameters:
 

--- a/packages/ledger/src/types/ledger.params.ts
+++ b/packages/ledger/src/types/ledger.params.ts
@@ -1,4 +1,3 @@
-import type { Principal } from "@dfinity/principal";
 import type { QueryParams } from "@dfinity/utils";
 import type {
   Account,
@@ -6,14 +5,12 @@ import type {
   Timestamp,
   Tokens,
 } from "../../candid/icrc1_ledger";
+import type { IcrcAccount } from "./ledger.responses";
 
 /**
  * Params to get the balance of an ICRC-1 account.
  */
-export interface BalanceParams extends QueryParams {
-  owner: Principal;
-  subaccount?: Subaccount;
-}
+export type BalanceParams = IcrcAccount & QueryParams;
 
 /**
  * Params to make a transfer in an ICRC-1 ledger


### PR DESCRIPTION
# Motivation

```
export interface BalanceParams extends QueryParams {
  owner: Principal;
  subaccount?: Subaccount;
}
```

is actually equals to

```
export type BalanceParams = IcrcAccount & QueryParams;
```

i.e. `IcrcAccount` represent the owner and subaccount.
