### PR TITLE
docs: fix sample in readme

### DIFF
--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -51,7 +51,7 @@ const main = async () => {
 
   const balance = await ledger.accountBalance({ accountIdentifier });
 
-  console.log(`Balance: ${balance.toE8s()}`);
+  console.log(`Balance: ${balance}`);
 };
 
 await main();


### PR DESCRIPTION
# Motivation

A developer reported on [Discord](https://discord.com/channels/748416164832608337/1104349948440490066/1104349948440490066) an issue with NNS `accountBalance`.

Turned out the issue was the sample in the readme as the function returns already a `bigint` and therefore do not need to be caster `.toE8s`.
