### PR TITLE
GIX-1545 ic-js: Import new candid

### DIFF
--- a/packages/sns/candid/sns_governance.certified.idl.js
+++ b/packages/sns/candid/sns_governance.certified.idl.js
@@ -41,6 +41,10 @@ export const idlFactory = ({ IDL }) => {
     ),
     'timestamp_seconds' : IDL.Nat64,
   });
+  const MaturityModulation = IDL.Record({
+    'current_basis_points' : IDL.Opt(IDL.Int32),
+    'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
   const DefaultFollowees = IDL.Record({
@@ -74,6 +78,7 @@ export const idlFactory = ({ IDL }) => {
     'max_age_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'neuron_grantable_permissions' : IDL.Opt(NeuronPermissionList),
     'voting_rewards_parameters' : IDL.Opt(VotingRewardsParameters),
+    'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
     'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
   });
   const Version = IDL.Record({
@@ -86,6 +91,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
   const RewardEvent = IDL.Record({
+    'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
     'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'distributed_e8s_equivalent' : IDL.Nat64,
@@ -126,6 +132,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const UpgradeSnsControlledCanister = IDL.Record({
     'new_canister_wasm' : IDL.Vec(IDL.Nat8),
+    'mode' : IDL.Opt(IDL.Int32),
     'canister_id' : IDL.Opt(IDL.Principal),
     'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
@@ -304,6 +311,7 @@ export const idlFactory = ({ IDL }) => {
       IDL.Tuple(IDL.Nat64, NervousSystemFunction)
     ),
     'metrics' : IDL.Opt(GovernanceCachedMetrics),
+    'maturity_modulation' : IDL.Opt(MaturityModulation),
     'mode' : IDL.Int32,
     'parameters' : IDL.Opt(NervousSystemParameters),
     'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),
@@ -344,6 +352,9 @@ export const idlFactory = ({ IDL }) => {
   });
   const ClaimSwapNeuronsResponse = IDL.Record({
     'claim_swap_neurons_result' : IDL.Opt(ClaimSwapNeuronsResult),
+  });
+  const GetMaturityModulationResponse = IDL.Record({
+    'maturity_modulation' : IDL.Opt(MaturityModulation),
   });
   const GetMetadataResponse = IDL.Record({
     'url' : IDL.Opt(IDL.Text),
@@ -471,7 +482,18 @@ export const idlFactory = ({ IDL }) => {
         [ClaimSwapNeuronsResponse],
         [],
       ),
+    'fail_stuck_upgrade_in_progress' : IDL.Func(
+        [IDL.Record({})],
+        [IDL.Record({})],
+        [],
+      ),
     'get_build_metadata' : IDL.Func([], [IDL.Text], []),
+    'get_latest_reward_event' : IDL.Func([], [RewardEvent], []),
+    'get_maturity_modulation' : IDL.Func(
+        [IDL.Record({})],
+        [GetMaturityModulationResponse],
+        [],
+      ),
     'get_metadata' : IDL.Func([IDL.Record({})], [GetMetadataResponse], []),
     'get_mode' : IDL.Func([IDL.Record({})], [GetModeResponse], []),
     'get_nervous_system_parameters' : IDL.Func(
@@ -549,6 +571,10 @@ export const init = ({ IDL }) => {
     ),
     'timestamp_seconds' : IDL.Nat64,
   });
+  const MaturityModulation = IDL.Record({
+    'current_basis_points' : IDL.Opt(IDL.Int32),
+    'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
   const DefaultFollowees = IDL.Record({
@@ -582,6 +608,7 @@ export const init = ({ IDL }) => {
     'max_age_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'neuron_grantable_permissions' : IDL.Opt(NeuronPermissionList),
     'voting_rewards_parameters' : IDL.Opt(VotingRewardsParameters),
+    'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
     'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
   });
   const Version = IDL.Record({
@@ -594,6 +621,7 @@ export const init = ({ IDL }) => {
   });
   const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
   const RewardEvent = IDL.Record({
+    'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
     'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'distributed_e8s_equivalent' : IDL.Nat64,
@@ -634,6 +662,7 @@ export const init = ({ IDL }) => {
   });
   const UpgradeSnsControlledCanister = IDL.Record({
     'new_canister_wasm' : IDL.Vec(IDL.Nat8),
+    'mode' : IDL.Opt(IDL.Int32),
     'canister_id' : IDL.Opt(IDL.Principal),
     'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
@@ -812,6 +841,7 @@ export const init = ({ IDL }) => {
       IDL.Tuple(IDL.Nat64, NervousSystemFunction)
     ),
     'metrics' : IDL.Opt(GovernanceCachedMetrics),
+    'maturity_modulation' : IDL.Opt(MaturityModulation),
     'mode' : IDL.Int32,
     'parameters' : IDL.Opt(NervousSystemParameters),
     'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -175,6 +175,9 @@ export interface GenericNervousSystemFunction {
   validator_method_name: [] | [string];
   target_method_name: [] | [string];
 }
+export interface GetMaturityModulationResponse {
+  maturity_modulation: [] | [MaturityModulation];
+}
 export interface GetMetadataResponse {
   url: [] | [string];
   logo: [] | [string];
@@ -207,6 +210,7 @@ export interface Governance {
   root_canister_id: [] | [Principal];
   id_to_nervous_system_functions: Array<[bigint, NervousSystemFunction]>;
   metrics: [] | [GovernanceCachedMetrics];
+  maturity_modulation: [] | [MaturityModulation];
   mode: number;
   parameters: [] | [NervousSystemParameters];
   is_finalizing_disburse_maturity: [] | [boolean];
@@ -281,6 +285,10 @@ export interface ManageSnsMetadata {
   name: [] | [string];
   description: [] | [string];
 }
+export interface MaturityModulation {
+  current_basis_points: [] | [number];
+  updated_at_timestamp_seconds: [] | [bigint];
+}
 export interface MemoAndController {
   controller: [] | [Principal];
   memo: bigint;
@@ -320,6 +328,7 @@ export interface NervousSystemParameters {
   max_age_bonus_percentage: [] | [bigint];
   neuron_grantable_permissions: [] | [NeuronPermissionList];
   voting_rewards_parameters: [] | [VotingRewardsParameters];
+  maturity_modulation_disabled: [] | [boolean];
   max_number_of_principals_per_neuron: [] | [bigint];
 }
 export interface Neuron {
@@ -414,6 +423,7 @@ export interface RemoveNeuronPermissions {
 export type Result = { Error: GovernanceError } | { Neuron: Neuron };
 export type Result_1 = { Error: GovernanceError } | { Proposal: ProposalData };
 export interface RewardEvent {
+  rounds_since_last_distribution: [] | [bigint];
   actual_timestamp_seconds: bigint;
   end_timestamp_seconds: [] | [bigint];
   distributed_e8s_equivalent: bigint;
@@ -468,6 +478,7 @@ export interface UpgradeInProgress {
 }
 export interface UpgradeSnsControlledCanister {
   new_canister_wasm: Uint8Array;
+  mode: [] | [number];
   canister_id: [] | [Principal];
   canister_upgrade_arg: [] | [Uint8Array];
 }
@@ -493,7 +504,10 @@ export interface _SERVICE {
     [ClaimSwapNeuronsRequest],
     ClaimSwapNeuronsResponse
   >;
+  fail_stuck_upgrade_in_progress: ActorMethod<[{}], {}>;
   get_build_metadata: ActorMethod<[], string>;
+  get_latest_reward_event: ActorMethod<[], RewardEvent>;
+  get_maturity_modulation: ActorMethod<[{}], GetMaturityModulationResponse>;
   get_metadata: ActorMethod<[{}], GetMetadataResponse>;
   get_mode: ActorMethod<[{}], GetModeResponse>;
   get_nervous_system_parameters: ActorMethod<[null], NervousSystemParameters>;

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 5376a14c92f20b4bd285d7622ac5f2a8d21c0d02 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 26b480f775222265f4369bc485d502a140f15564 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
@@ -146,6 +146,9 @@ type GenericNervousSystemFunction = record {
   validator_method_name : opt text;
   target_method_name : opt text;
 };
+type GetMaturityModulationResponse = record {
+  maturity_modulation : opt MaturityModulation;
+};
 type GetMetadataResponse = record {
   url : opt text;
   logo : opt text;
@@ -168,6 +171,7 @@ type Governance = record {
   root_canister_id : opt principal;
   id_to_nervous_system_functions : vec record { nat64; NervousSystemFunction };
   metrics : opt GovernanceCachedMetrics;
+  maturity_modulation : opt MaturityModulation;
   mode : int32;
   parameters : opt NervousSystemParameters;
   is_finalizing_disburse_maturity : opt bool;
@@ -230,6 +234,10 @@ type ManageSnsMetadata = record {
   name : opt text;
   description : opt text;
 };
+type MaturityModulation = record {
+  current_basis_points : opt int32;
+  updated_at_timestamp_seconds : opt nat64;
+};
 type MemoAndController = record { controller : opt principal; memo : nat64 };
 type MergeMaturity = record { percentage_to_merge : nat32 };
 type MergeMaturityResponse = record {
@@ -262,6 +270,7 @@ type NervousSystemParameters = record {
   max_age_bonus_percentage : opt nat64;
   neuron_grantable_permissions : opt NeuronPermissionList;
   voting_rewards_parameters : opt VotingRewardsParameters;
+  maturity_modulation_disabled : opt bool;
   max_number_of_principals_per_neuron : opt nat64;
 };
 type Neuron = record {
@@ -344,6 +353,7 @@ type RemoveNeuronPermissions = record {
 type Result = variant { Error : GovernanceError; Neuron : Neuron };
 type Result_1 = variant { Error : GovernanceError; Proposal : ProposalData };
 type RewardEvent = record {
+  rounds_since_last_distribution : opt nat64;
   actual_timestamp_seconds : nat64;
   end_timestamp_seconds : opt nat64;
   distributed_e8s_equivalent : nat64;
@@ -382,6 +392,7 @@ type UpgradeInProgress = record {
 };
 type UpgradeSnsControlledCanister = record {
   new_canister_wasm : vec nat8;
+  mode : opt int32;
   canister_id : opt principal;
   canister_upgrade_arg : opt vec nat8;
 };
@@ -402,7 +413,10 @@ type VotingRewardsParameters = record {
 type WaitForQuietState = record { current_deadline_timestamp_seconds : nat64 };
 service : (Governance) -> {
   claim_swap_neurons : (ClaimSwapNeuronsRequest) -> (ClaimSwapNeuronsResponse);
+  fail_stuck_upgrade_in_progress : (record {}) -> (record {});
   get_build_metadata : () -> (text) query;
+  get_latest_reward_event : () -> (RewardEvent) query;
+  get_maturity_modulation : (record {}) -> (GetMaturityModulationResponse);
   get_metadata : (record {}) -> (GetMetadataResponse) query;
   get_mode : (record {}) -> (GetModeResponse) query;
   get_nervous_system_parameters : (null) -> (NervousSystemParameters) query;

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -41,6 +41,10 @@ export const idlFactory = ({ IDL }) => {
     ),
     'timestamp_seconds' : IDL.Nat64,
   });
+  const MaturityModulation = IDL.Record({
+    'current_basis_points' : IDL.Opt(IDL.Int32),
+    'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
   const DefaultFollowees = IDL.Record({
@@ -74,6 +78,7 @@ export const idlFactory = ({ IDL }) => {
     'max_age_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'neuron_grantable_permissions' : IDL.Opt(NeuronPermissionList),
     'voting_rewards_parameters' : IDL.Opt(VotingRewardsParameters),
+    'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
     'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
   });
   const Version = IDL.Record({
@@ -86,6 +91,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
   const RewardEvent = IDL.Record({
+    'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
     'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'distributed_e8s_equivalent' : IDL.Nat64,
@@ -126,6 +132,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const UpgradeSnsControlledCanister = IDL.Record({
     'new_canister_wasm' : IDL.Vec(IDL.Nat8),
+    'mode' : IDL.Opt(IDL.Int32),
     'canister_id' : IDL.Opt(IDL.Principal),
     'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
@@ -304,6 +311,7 @@ export const idlFactory = ({ IDL }) => {
       IDL.Tuple(IDL.Nat64, NervousSystemFunction)
     ),
     'metrics' : IDL.Opt(GovernanceCachedMetrics),
+    'maturity_modulation' : IDL.Opt(MaturityModulation),
     'mode' : IDL.Int32,
     'parameters' : IDL.Opt(NervousSystemParameters),
     'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),
@@ -344,6 +352,9 @@ export const idlFactory = ({ IDL }) => {
   });
   const ClaimSwapNeuronsResponse = IDL.Record({
     'claim_swap_neurons_result' : IDL.Opt(ClaimSwapNeuronsResult),
+  });
+  const GetMaturityModulationResponse = IDL.Record({
+    'maturity_modulation' : IDL.Opt(MaturityModulation),
   });
   const GetMetadataResponse = IDL.Record({
     'url' : IDL.Opt(IDL.Text),
@@ -471,7 +482,18 @@ export const idlFactory = ({ IDL }) => {
         [ClaimSwapNeuronsResponse],
         [],
       ),
+    'fail_stuck_upgrade_in_progress' : IDL.Func(
+        [IDL.Record({})],
+        [IDL.Record({})],
+        [],
+      ),
     'get_build_metadata' : IDL.Func([], [IDL.Text], ['query']),
+    'get_latest_reward_event' : IDL.Func([], [RewardEvent], ['query']),
+    'get_maturity_modulation' : IDL.Func(
+        [IDL.Record({})],
+        [GetMaturityModulationResponse],
+        [],
+      ),
     'get_metadata' : IDL.Func(
         [IDL.Record({})],
         [GetMetadataResponse],
@@ -557,6 +579,10 @@ export const init = ({ IDL }) => {
     ),
     'timestamp_seconds' : IDL.Nat64,
   });
+  const MaturityModulation = IDL.Record({
+    'current_basis_points' : IDL.Opt(IDL.Int32),
+    'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
   const DefaultFollowees = IDL.Record({
@@ -590,6 +616,7 @@ export const init = ({ IDL }) => {
     'max_age_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'neuron_grantable_permissions' : IDL.Opt(NeuronPermissionList),
     'voting_rewards_parameters' : IDL.Opt(VotingRewardsParameters),
+    'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
     'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
   });
   const Version = IDL.Record({
@@ -602,6 +629,7 @@ export const init = ({ IDL }) => {
   });
   const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
   const RewardEvent = IDL.Record({
+    'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
     'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'distributed_e8s_equivalent' : IDL.Nat64,
@@ -642,6 +670,7 @@ export const init = ({ IDL }) => {
   });
   const UpgradeSnsControlledCanister = IDL.Record({
     'new_canister_wasm' : IDL.Vec(IDL.Nat8),
+    'mode' : IDL.Opt(IDL.Int32),
     'canister_id' : IDL.Opt(IDL.Principal),
     'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
@@ -820,6 +849,7 @@ export const init = ({ IDL }) => {
       IDL.Tuple(IDL.Nat64, NervousSystemFunction)
     ),
     'metrics' : IDL.Opt(GovernanceCachedMetrics),
+    'maturity_modulation' : IDL.Opt(MaturityModulation),
     'mode' : IDL.Int32,
     'parameters' : IDL.Opt(NervousSystemParameters),
     'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),

--- a/packages/sns/candid/sns_root.certified.idl.js
+++ b/packages/sns/candid/sns_root.certified.idl.js
@@ -16,32 +16,27 @@ export const idlFactory = ({ IDL }) => {
     'stopping' : IDL.Null,
     'running' : IDL.Null,
   });
+  const DefiniteCanisterSettings = IDL.Record({
+    'controllers' : IDL.Vec(IDL.Principal),
+  });
   const CanisterStatusResult = IDL.Record({
     'controller' : IDL.Principal,
     'status' : CanisterStatusType,
     'memory_size' : IDL.Nat,
+    'settings' : DefiniteCanisterSettings,
     'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
   const GetSnsCanistersSummaryRequest = IDL.Record({
     'update_canister_list' : IDL.Opt(IDL.Bool),
   });
-  const CanisterStatusType_1 = IDL.Variant({
-    'stopped' : IDL.Null,
-    'stopping' : IDL.Null,
-    'running' : IDL.Null,
-  });
   const DefiniteCanisterSettingsArgs = IDL.Record({
-    'controller' : IDL.Principal,
     'freezing_threshold' : IDL.Nat,
     'controllers' : IDL.Vec(IDL.Principal),
     'memory_allocation' : IDL.Nat,
     'compute_allocation' : IDL.Nat,
   });
   const CanisterStatusResultV2 = IDL.Record({
-    'controller' : IDL.Principal,
-    'status' : CanisterStatusType_1,
-    'freezing_threshold' : IDL.Nat,
-    'balance' : IDL.Vec(IDL.Tuple(IDL.Vec(IDL.Nat8), IDL.Nat)),
+    'status' : CanisterStatusType,
     'memory_size' : IDL.Nat,
     'cycles' : IDL.Nat,
     'settings' : DefiniteCanisterSettingsArgs,

--- a/packages/sns/candid/sns_root.d.ts
+++ b/packages/sns/candid/sns_root.d.ts
@@ -12,13 +12,11 @@ export interface CanisterStatusResult {
   controller: Principal;
   status: CanisterStatusType;
   memory_size: bigint;
+  settings: DefiniteCanisterSettings;
   module_hash: [] | [Uint8Array];
 }
 export interface CanisterStatusResultV2 {
-  controller: Principal;
-  status: CanisterStatusType_1;
-  freezing_threshold: bigint;
-  balance: Array<[Uint8Array, bigint]>;
+  status: CanisterStatusType;
   memory_size: bigint;
   cycles: bigint;
   settings: DefiniteCanisterSettingsArgs;
@@ -29,16 +27,14 @@ export type CanisterStatusType =
   | { stopped: null }
   | { stopping: null }
   | { running: null };
-export type CanisterStatusType_1 =
-  | { stopped: null }
-  | { stopping: null }
-  | { running: null };
 export interface CanisterSummary {
   status: [] | [CanisterStatusResultV2];
   canister_id: [] | [Principal];
 }
+export interface DefiniteCanisterSettings {
+  controllers: Array<Principal>;
+}
 export interface DefiniteCanisterSettingsArgs {
-  controller: Principal;
   freezing_threshold: bigint;
   controllers: Array<Principal>;
   memory_allocation: bigint;

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,17 +1,15 @@
-// Generated from IC repo commit 5376a14c92f20b4bd285d7622ac5f2a8d21c0d02 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit 26b480f775222265f4369bc485d502a140f15564 'rs/sns/root/canister/root.did' by import-candid
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterIdRecord = record { canister_id : principal };
 type CanisterStatusResult = record {
   controller : principal;
   status : CanisterStatusType;
   memory_size : nat;
+  settings : DefiniteCanisterSettings;
   module_hash : opt vec nat8;
 };
 type CanisterStatusResultV2 = record {
-  controller : principal;
-  status : CanisterStatusType_1;
-  freezing_threshold : nat;
-  balance : vec record { vec nat8; nat };
+  status : CanisterStatusType;
   memory_size : nat;
   cycles : nat;
   settings : DefiniteCanisterSettingsArgs;
@@ -19,13 +17,12 @@ type CanisterStatusResultV2 = record {
   module_hash : opt vec nat8;
 };
 type CanisterStatusType = variant { stopped; stopping; running };
-type CanisterStatusType_1 = variant { stopped; stopping; running };
 type CanisterSummary = record {
   status : opt CanisterStatusResultV2;
   canister_id : opt principal;
 };
+type DefiniteCanisterSettings = record { controllers : vec principal };
 type DefiniteCanisterSettingsArgs = record {
-  controller : principal;
   freezing_threshold : nat;
   controllers : vec principal;
   memory_allocation : nat;

--- a/packages/sns/candid/sns_root.idl.js
+++ b/packages/sns/candid/sns_root.idl.js
@@ -16,32 +16,27 @@ export const idlFactory = ({ IDL }) => {
     'stopping' : IDL.Null,
     'running' : IDL.Null,
   });
+  const DefiniteCanisterSettings = IDL.Record({
+    'controllers' : IDL.Vec(IDL.Principal),
+  });
   const CanisterStatusResult = IDL.Record({
     'controller' : IDL.Principal,
     'status' : CanisterStatusType,
     'memory_size' : IDL.Nat,
+    'settings' : DefiniteCanisterSettings,
     'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
   const GetSnsCanistersSummaryRequest = IDL.Record({
     'update_canister_list' : IDL.Opt(IDL.Bool),
   });
-  const CanisterStatusType_1 = IDL.Variant({
-    'stopped' : IDL.Null,
-    'stopping' : IDL.Null,
-    'running' : IDL.Null,
-  });
   const DefiniteCanisterSettingsArgs = IDL.Record({
-    'controller' : IDL.Principal,
     'freezing_threshold' : IDL.Nat,
     'controllers' : IDL.Vec(IDL.Principal),
     'memory_allocation' : IDL.Nat,
     'compute_allocation' : IDL.Nat,
   });
   const CanisterStatusResultV2 = IDL.Record({
-    'controller' : IDL.Principal,
-    'status' : CanisterStatusType_1,
-    'freezing_threshold' : IDL.Nat,
-    'balance' : IDL.Vec(IDL.Tuple(IDL.Vec(IDL.Nat8), IDL.Nat)),
+    'status' : CanisterStatusType,
     'memory_size' : IDL.Nat,
     'cycles' : IDL.Nat,
     'settings' : DefiniteCanisterSettingsArgs,

--- a/packages/sns/candid/sns_swap.certified.idl.js
+++ b/packages/sns/candid/sns_swap.certified.idl.js
@@ -1,14 +1,17 @@
 /* Do not edit.  Compiled with ./scripts/compile-idl-js from packages/sns/candid/sns_swap.did */
 export const idlFactory = ({ IDL }) => {
+  const Countries = IDL.Record({ 'iso_codes' : IDL.Vec(IDL.Text) });
   const Init = IDL.Record({
     'sns_root_canister_id' : IDL.Text,
     'fallback_controller_principal_ids' : IDL.Vec(IDL.Text),
     'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
+    'confirmation_text' : IDL.Opt(IDL.Text),
     'nns_governance_canister_id' : IDL.Text,
     'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
     'icp_ledger_canister_id' : IDL.Text,
     'sns_ledger_canister_id' : IDL.Text,
     'sns_governance_canister_id' : IDL.Text,
+    'restricted_countries' : IDL.Opt(Countries),
   });
   const ErrorRefundIcpRequest = IDL.Record({
     'source_principal_id' : IDL.Opt(IDL.Principal),
@@ -81,8 +84,10 @@ export const idlFactory = ({ IDL }) => {
     'principal_id' : IDL.Opt(IDL.Principal),
   });
   const TransferableAmount = IDL.Record({
+    'transfer_fee_paid_e8s' : IDL.Opt(IDL.Nat64),
     'transfer_start_timestamp_seconds' : IDL.Nat64,
     'amount_e8s' : IDL.Nat64,
+    'amount_transferred_e8s' : IDL.Opt(IDL.Nat64),
     'transfer_success_timestamp_seconds' : IDL.Nat64,
   });
   const BuyerState = IDL.Record({ 'icp' : IDL.Opt(TransferableAmount) });
@@ -116,6 +121,9 @@ export const idlFactory = ({ IDL }) => {
   const GetDerivedStateResponse = IDL.Record({
     'sns_tokens_per_icp' : IDL.Opt(IDL.Float64),
     'buyer_total_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'cf_participant_count' : IDL.Opt(IDL.Nat64),
+    'direct_participant_count' : IDL.Opt(IDL.Nat64),
+    'cf_neuron_count' : IDL.Opt(IDL.Nat64),
   });
   const GetInitResponse = IDL.Record({ 'init' : IDL.Opt(Init) });
   const GetLifecycleResponse = IDL.Record({
@@ -202,6 +210,9 @@ export const idlFactory = ({ IDL }) => {
   const DerivedState = IDL.Record({
     'sns_tokens_per_icp' : IDL.Float32,
     'buyer_total_icp_e8s' : IDL.Nat64,
+    'cf_participant_count' : IDL.Opt(IDL.Nat64),
+    'direct_participant_count' : IDL.Opt(IDL.Nat64),
+    'cf_neuron_count' : IDL.Opt(IDL.Nat64),
   });
   const GetStateResponse = IDL.Record({
     'swap' : IDL.Opt(Swap),
@@ -252,7 +263,10 @@ export const idlFactory = ({ IDL }) => {
     'params' : IDL.Opt(Params),
     'open_sns_token_swap_proposal_id' : IDL.Opt(IDL.Nat64),
   });
-  const RefreshBuyerTokensRequest = IDL.Record({ 'buyer' : IDL.Text });
+  const RefreshBuyerTokensRequest = IDL.Record({
+    'confirmation_text' : IDL.Opt(IDL.Text),
+    'buyer' : IDL.Text,
+  });
   const RefreshBuyerTokensResponse = IDL.Record({
     'icp_accepted_participation_e8s' : IDL.Nat64,
     'icp_ledger_account_balance_e8s' : IDL.Nat64,
@@ -328,15 +342,18 @@ export const idlFactory = ({ IDL }) => {
   });
 };
 export const init = ({ IDL }) => {
+  const Countries = IDL.Record({ 'iso_codes' : IDL.Vec(IDL.Text) });
   const Init = IDL.Record({
     'sns_root_canister_id' : IDL.Text,
     'fallback_controller_principal_ids' : IDL.Vec(IDL.Text),
     'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
+    'confirmation_text' : IDL.Opt(IDL.Text),
     'nns_governance_canister_id' : IDL.Text,
     'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
     'icp_ledger_canister_id' : IDL.Text,
     'sns_ledger_canister_id' : IDL.Text,
     'sns_governance_canister_id' : IDL.Text,
+    'restricted_countries' : IDL.Opt(Countries),
   });
   return [Init];
 };

--- a/packages/sns/candid/sns_swap.d.ts
+++ b/packages/sns/candid/sns_swap.d.ts
@@ -35,6 +35,9 @@ export interface CfParticipant {
   hotkey_principal: string;
   cf_neurons: Array<CfNeuron>;
 }
+export interface Countries {
+  iso_codes: Array<string>;
+}
 export interface DefiniteCanisterSettingsArgs {
   controller: Principal;
   freezing_threshold: bigint;
@@ -45,6 +48,9 @@ export interface DefiniteCanisterSettingsArgs {
 export interface DerivedState {
   sns_tokens_per_icp: number;
   buyer_total_icp_e8s: bigint;
+  cf_participant_count: [] | [bigint];
+  direct_participant_count: [] | [bigint];
+  cf_neuron_count: [] | [bigint];
 }
 export interface DirectInvestment {
   buyer_principal: string;
@@ -94,6 +100,9 @@ export interface GetBuyersTotalResponse {
 export interface GetDerivedStateResponse {
   sns_tokens_per_icp: [] | [number];
   buyer_total_icp_e8s: [] | [bigint];
+  cf_participant_count: [] | [bigint];
+  direct_participant_count: [] | [bigint];
+  cf_neuron_count: [] | [bigint];
 }
 export interface GetInitResponse {
   init: [] | [Init];
@@ -124,11 +133,13 @@ export interface Init {
   sns_root_canister_id: string;
   fallback_controller_principal_ids: Array<string>;
   neuron_minimum_stake_e8s: [] | [bigint];
+  confirmation_text: [] | [string];
   nns_governance_canister_id: string;
   transaction_fee_e8s: [] | [bigint];
   icp_ledger_canister_id: string;
   sns_ledger_canister_id: string;
   sns_governance_canister_id: string;
+  restricted_countries: [] | [Countries];
 }
 export interface InvalidUserAmount {
   min_amount_icp_e8s_included: bigint;
@@ -211,6 +222,7 @@ export type Possibility =
 export type Possibility_1 = { Ok: Response } | { Err: CanisterCallError };
 export type Possibility_2 = { Ok: {} } | { Err: CanisterCallError };
 export interface RefreshBuyerTokensRequest {
+  confirmation_text: [] | [string];
   buyer: string;
 }
 export interface RefreshBuyerTokensResponse {
@@ -269,8 +281,10 @@ export interface Ticket {
   amount_icp_e8s: bigint;
 }
 export interface TransferableAmount {
+  transfer_fee_paid_e8s: [] | [bigint];
   transfer_start_timestamp_seconds: bigint;
   amount_e8s: bigint;
+  amount_transferred_e8s: [] | [bigint];
   transfer_success_timestamp_seconds: bigint;
 }
 export interface _SERVICE {

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a548beb5bc0e1be2de4162c0dd4d647ecfd4f413 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 26b480f775222265f4369bc485d502a140f15564 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record { icp : opt TransferableAmount };
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterStatusResultV2 = record {
@@ -19,6 +19,7 @@ type CfParticipant = record {
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };
+type Countries = record { iso_codes : vec text };
 type DefiniteCanisterSettingsArgs = record {
   controller : principal;
   freezing_threshold : nat;
@@ -29,6 +30,9 @@ type DefiniteCanisterSettingsArgs = record {
 type DerivedState = record {
   sns_tokens_per_icp : float32;
   buyer_total_icp_e8s : nat64;
+  cf_participant_count : opt nat64;
+  direct_participant_count : opt nat64;
+  cf_neuron_count : opt nat64;
 };
 type DirectInvestment = record { buyer_principal : text };
 type Err = record { description : opt text; error_type : opt int32 };
@@ -59,6 +63,9 @@ type GetBuyersTotalResponse = record { buyers_total : nat64 };
 type GetDerivedStateResponse = record {
   sns_tokens_per_icp : opt float64;
   buyer_total_icp_e8s : opt nat64;
+  cf_participant_count : opt nat64;
+  direct_participant_count : opt nat64;
+  cf_neuron_count : opt nat64;
 };
 type GetInitResponse = record { init : opt Init };
 type GetLifecycleResponse = record {
@@ -74,11 +81,13 @@ type Init = record {
   sns_root_canister_id : text;
   fallback_controller_principal_ids : vec text;
   neuron_minimum_stake_e8s : opt nat64;
+  confirmation_text : opt text;
   nns_governance_canister_id : text;
   transaction_fee_e8s : opt nat64;
   icp_ledger_canister_id : text;
   sns_ledger_canister_id : text;
   sns_governance_canister_id : text;
+  restricted_countries : opt Countries;
 };
 type InvalidUserAmount = record {
   min_amount_icp_e8s_included : nat64;
@@ -150,7 +159,10 @@ type Possibility = variant {
 };
 type Possibility_1 = variant { Ok : Response; Err : CanisterCallError };
 type Possibility_2 = variant { Ok : record {}; Err : CanisterCallError };
-type RefreshBuyerTokensRequest = record { buyer : text };
+type RefreshBuyerTokensRequest = record {
+  confirmation_text : opt text;
+  buyer : text;
+};
 type RefreshBuyerTokensResponse = record {
   icp_accepted_participation_e8s : nat64;
   icp_ledger_account_balance_e8s : nat64;
@@ -199,8 +211,10 @@ type Ticket = record {
   amount_icp_e8s : nat64;
 };
 type TransferableAmount = record {
+  transfer_fee_paid_e8s : opt nat64;
   transfer_start_timestamp_seconds : nat64;
   amount_e8s : nat64;
+  amount_transferred_e8s : opt nat64;
   transfer_success_timestamp_seconds : nat64;
 };
 service : (Init) -> {

--- a/packages/sns/candid/sns_swap.idl.js
+++ b/packages/sns/candid/sns_swap.idl.js
@@ -1,14 +1,17 @@
 /* Do not edit.  Compiled with ./scripts/compile-idl-js from packages/sns/candid/sns_swap.did */
 export const idlFactory = ({ IDL }) => {
+  const Countries = IDL.Record({ 'iso_codes' : IDL.Vec(IDL.Text) });
   const Init = IDL.Record({
     'sns_root_canister_id' : IDL.Text,
     'fallback_controller_principal_ids' : IDL.Vec(IDL.Text),
     'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
+    'confirmation_text' : IDL.Opt(IDL.Text),
     'nns_governance_canister_id' : IDL.Text,
     'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
     'icp_ledger_canister_id' : IDL.Text,
     'sns_ledger_canister_id' : IDL.Text,
     'sns_governance_canister_id' : IDL.Text,
+    'restricted_countries' : IDL.Opt(Countries),
   });
   const ErrorRefundIcpRequest = IDL.Record({
     'source_principal_id' : IDL.Opt(IDL.Principal),
@@ -81,8 +84,10 @@ export const idlFactory = ({ IDL }) => {
     'principal_id' : IDL.Opt(IDL.Principal),
   });
   const TransferableAmount = IDL.Record({
+    'transfer_fee_paid_e8s' : IDL.Opt(IDL.Nat64),
     'transfer_start_timestamp_seconds' : IDL.Nat64,
     'amount_e8s' : IDL.Nat64,
+    'amount_transferred_e8s' : IDL.Opt(IDL.Nat64),
     'transfer_success_timestamp_seconds' : IDL.Nat64,
   });
   const BuyerState = IDL.Record({ 'icp' : IDL.Opt(TransferableAmount) });
@@ -116,6 +121,9 @@ export const idlFactory = ({ IDL }) => {
   const GetDerivedStateResponse = IDL.Record({
     'sns_tokens_per_icp' : IDL.Opt(IDL.Float64),
     'buyer_total_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'cf_participant_count' : IDL.Opt(IDL.Nat64),
+    'direct_participant_count' : IDL.Opt(IDL.Nat64),
+    'cf_neuron_count' : IDL.Opt(IDL.Nat64),
   });
   const GetInitResponse = IDL.Record({ 'init' : IDL.Opt(Init) });
   const GetLifecycleResponse = IDL.Record({
@@ -202,6 +210,9 @@ export const idlFactory = ({ IDL }) => {
   const DerivedState = IDL.Record({
     'sns_tokens_per_icp' : IDL.Float32,
     'buyer_total_icp_e8s' : IDL.Nat64,
+    'cf_participant_count' : IDL.Opt(IDL.Nat64),
+    'direct_participant_count' : IDL.Opt(IDL.Nat64),
+    'cf_neuron_count' : IDL.Opt(IDL.Nat64),
   });
   const GetStateResponse = IDL.Record({
     'swap' : IDL.Opt(Swap),
@@ -252,7 +263,10 @@ export const idlFactory = ({ IDL }) => {
     'params' : IDL.Opt(Params),
     'open_sns_token_swap_proposal_id' : IDL.Opt(IDL.Nat64),
   });
-  const RefreshBuyerTokensRequest = IDL.Record({ 'buyer' : IDL.Text });
+  const RefreshBuyerTokensRequest = IDL.Record({
+    'confirmation_text' : IDL.Opt(IDL.Text),
+    'buyer' : IDL.Text,
+  });
   const RefreshBuyerTokensResponse = IDL.Record({
     'icp_accepted_participation_e8s' : IDL.Nat64,
     'icp_ledger_account_balance_e8s' : IDL.Nat64,
@@ -336,15 +350,18 @@ export const idlFactory = ({ IDL }) => {
   });
 };
 export const init = ({ IDL }) => {
+  const Countries = IDL.Record({ 'iso_codes' : IDL.Vec(IDL.Text) });
   const Init = IDL.Record({
     'sns_root_canister_id' : IDL.Text,
     'fallback_controller_principal_ids' : IDL.Vec(IDL.Text),
     'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
+    'confirmation_text' : IDL.Opt(IDL.Text),
     'nns_governance_canister_id' : IDL.Text,
     'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
     'icp_ledger_canister_id' : IDL.Text,
     'sns_ledger_canister_id' : IDL.Text,
     'sns_governance_canister_id' : IDL.Text,
+    'restricted_countries' : IDL.Opt(Countries),
   });
   return [Init];
 };

--- a/packages/sns/src/converters/governance.converters.spec.ts
+++ b/packages/sns/src/converters/governance.converters.spec.ts
@@ -72,6 +72,7 @@ describe("governance converters", () => {
           max_number_of_principals_per_neuron: [
             max_number_of_principals_per_neuron,
           ],
+          maturity_modulation_disabled: [false],
         },
       };
       const expectedAction: Action = {
@@ -200,11 +201,13 @@ describe("governance converters", () => {
     it("converts UpgradeSnsControlledCanister action", () => {
       const new_canister_wasm = new Uint8Array();
       const canister_id = mockPrincipal;
+      const mode = 1;
       const action: ActionCandid = {
         UpgradeSnsControlledCanister: {
           new_canister_wasm,
           canister_id: [canister_id],
           canister_upgrade_arg: [],
+          mode: [mode],
         },
       };
       const expectedAction: Action = {
@@ -212,6 +215,7 @@ describe("governance converters", () => {
           new_canister_wasm: new Uint8Array(),
           canister_id,
           canister_upgrade_arg: undefined,
+          mode,
         },
       };
       expect(fromCandidAction(action)).toEqual(expectedAction);

--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -376,6 +376,7 @@ const convertUpgradeSnsControlledCanister = (
   new_canister_wasm: params.new_canister_wasm,
   canister_id: fromNullable(params.canister_id),
   canister_upgrade_arg: fromNullable(params.canister_upgrade_arg),
+  mode: fromNullable(params.mode),
 });
 
 const convertTransferSnsTreasuryFunds = (

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -375,10 +375,10 @@ describe("SnsWrapper", () => {
   });
 
   it("should call notifyParticipation", async () => {
-    await snsWrapper.notifyParticipation({ buyer: "aaaaa-aa" });
-    expect(mockSwapCanister.notifyParticipation).toHaveBeenCalledWith({
-      buyer: "aaaaa-aa",
-    });
+    const confirmation_text: [string] = ["I agree"];
+    const params = { buyer: "aaaaa-aa", confirmation_text };
+    await snsWrapper.notifyParticipation(params);
+    expect(mockSwapCanister.notifyParticipation).toHaveBeenCalledWith(params);
   });
 
   it("should call getUserCommitment with query and update", async () => {

--- a/packages/sns/src/swap.canister.spec.ts
+++ b/packages/sns/src/swap.canister.spec.ts
@@ -177,6 +177,9 @@ describe("Swap canister", () => {
     const testResponse: GetDerivedStateResponse = {
       sns_tokens_per_icp: [2],
       buyer_total_icp_e8s: [BigInt(100_000_000)],
+      cf_participant_count: [BigInt(3)],
+      direct_participant_count: [BigInt(4)],
+      cf_neuron_count: [BigInt(6)],
     };
 
     const service = mock<ActorSubclass<SnsSwapService>>();
@@ -259,6 +262,8 @@ describe("Swap canister", () => {
           amount_e8s: BigInt(100000000),
           transfer_start_timestamp_seconds: BigInt(0),
           transfer_success_timestamp_seconds: BigInt(0),
+          transfer_fee_paid_e8s: [BigInt(100000)],
+          amount_transferred_e8s: [BigInt(99900000)],
         },
       ],
     };

--- a/packages/sns/src/types/actions.ts
+++ b/packages/sns/src/types/actions.ts
@@ -87,6 +87,7 @@ export interface UpgradeSnsControlledCanister {
   new_canister_wasm: Uint8Array;
   canister_id: Option<Principal>;
   canister_upgrade_arg: Option<Uint8Array>;
+  mode: Option<number>;
 }
 
 export interface ManageSnsMetadata {

--- a/scripts/compile-idl-js
+++ b/scripts/compile-idl-js
@@ -4,6 +4,15 @@
 
 set -euo pipefail
 
+if [ "$(didc --version)" != "didc 0.1.4" ]; then
+  {
+    echo "didc version 0.1.4 is required. To install it on Mac:"
+    echo "curl -Lf https://github.com/dfinity/candid/releases/download/2022-08-09/didc-macos -o install_didc"
+    echo "install -m 755 install_didc /$HOME/.local/bin/didc"
+  } >&2
+  exit 1
+fi
+
 did_files_to_compile_for_pkg() {
   local pkg="$1"
   local path=packages/${pkg}/candid

--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -69,7 +69,7 @@ mkdir -p packages/cmc/candid
 import_did "rs/nns/cmc/cmc.did" "cmc.did" "cmc"
 
 mkdir -p packages/ledger/candid
-import_did "rs/rosetta-api/icrc1/ledger/icrc1.did" "icrc1_ledger.did" "ledger"
+import_did "rs/rosetta-api/icrc1/ledger/ledger.did" "icrc1_ledger.did" "ledger"
 import_did "rs/rosetta-api/icrc1/index/index.did" "icrc1_index.did" "ledger"
 
 mkdir -p packages/ckbtc/candid


### PR DESCRIPTION
# Motivation

We want to use the `confirmation_text` and `restricted_countries` fields in SNS participation on NNS dapp.

**Note**: This is a breaking change. The new fields are declared as optional in Candid, but in TypeScript that results in types like `[] | [string]` which are not optional. So when upgrading the ic-js dependency those fields will be required to be at least `[]`.

# Changes

Each of these are a separate commit, which might help reviewing:

1. In `scripts/import-candid` change `icrc1.did` to `ledger.did`. The former no longer exists and has been replaced by the latter.
2. In `scripts/compile-idl-js`, require version `didc 0.1.4`. I first used `didc 0.1.6` and it caused breaking changes.
3. Run `scripts/import-candid`
4. Revert the changes in other packages than `sns`.
5. Run `scripts/compile-idl-js`
6. Fixed tests broken by the new non-optional fields.

# Tests

Tested the changes in nns-dapp as described in https://github.com/dfinity/ic-js/blob/main/HACKING.md.
The changes broke nns-dapp but I was able to fix nns-dapp by dealing with the new non-optional types.
You can see the required changes in https://github.com/dfinity/nns-dapp/pull/2529/files