### PR TITLE
docs: generate README docs for BTC utils

### DIFF
--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -53,6 +53,27 @@ const btcAddress = await getBtcAddress({});
 
 <!-- TSDOC_START -->
 
+### :toolbox: Functions
+
+- [parseBtcAddress](#gear-parsebtcaddress)
+
+#### :gear: parseBtcAddress
+
+Parse a Bitcoin address.
+
+Parse implementation follows strategy implemented in [Minter canister](https://github.com/dfinity/ic/blob/a8da3aa23dc6f8f4708cb0cb8edce84c5bd8f225/rs/bitcoin/ckbtc/minter/src/address.rs#L54).
+
+Credits: Parts of JavaScript code and test values from [bitcoin-address-validation](https://github.com/ruigomeseu/bitcoin-address-validation).
+
+| Function          | Type                                                    |
+| ----------------- | ------------------------------------------------------- |
+| `parseBtcAddress` | `({ address, network, }: BtcAddress) => BtcAddressInfo` |
+
+Parameters:
+
+- `params`: The Bitcoin address and network to parse
+- `params.network`: Optional. Default BtcNetwork is Mainnet
+
 ### :factory: CkBTCMinterCanister
 
 #### Constructors

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -32,7 +32,10 @@ const ledgerInputFiles = [
   "./packages/ledger/src/index.canister.ts",
 ];
 
-const ckBTCInputFiles = ["./packages/ckbtc/src/minter.canister.ts"];
+const ckBTCInputFiles = [
+  "./packages/ckbtc/src/minter.canister.ts",
+  "./packages/ckbtc/src/utils/btc.utils.ts",
+];
 
 const rosettaInputFiles = ["./packages/rosetta-client/src/index.ts"];
 


### PR DESCRIPTION
# Motivation

Just noticed I forgot to add the `btc.utils` to the list of files to process to generate the ckBTC README.
