### PR TITLE
Import candid for nns package

### DIFF
--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 9aac7d457a14a4cd89efcfa07d4eb9bf8079297c 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit b9fc66eafca530e997313aa68aaac31d41e6a875 'rs/nns/gtc/canister/gtc.did' by import-candid
 type AccountState = record {
   authenticated_principal_id : opt principal;
   successfully_transferred_neurons : vec TransferredNeuron;

--- a/packages/nns/candid/governance.certified.idl.js
+++ b/packages/nns/candid/governance.certified.idl.js
@@ -260,10 +260,10 @@ export const idlFactory = ({ IDL }) => {
     'neuron_basket_construction_parameters' : IDL.Opt(
       NeuronBasketConstructionParameters
     ),
-    'maximum_participant_icp' : IDL.Opt(IDL.Nat64),
-    'minimum_icp' : IDL.Opt(IDL.Nat64),
-    'minimum_participant_icp' : IDL.Opt(IDL.Nat64),
-    'maximum_icp' : IDL.Opt(IDL.Nat64),
+    'maximum_participant_icp' : IDL.Opt(Tokens),
+    'minimum_icp' : IDL.Opt(Tokens),
+    'minimum_participant_icp' : IDL.Opt(Tokens),
+    'maximum_icp' : IDL.Opt(Tokens),
   });
   const SwapDistribution = IDL.Record({ 'total' : IDL.Opt(Tokens) });
   const NeuronDistribution = IDL.Record({
@@ -541,6 +541,12 @@ export const idlFactory = ({ IDL }) => {
   const ClaimOrRefreshResponse = IDL.Record({
     'refreshed_neuron_id' : IDL.Opt(NeuronId),
   });
+  const MergeResponse = IDL.Record({
+    'target_neuron' : IDL.Opt(Neuron),
+    'source_neuron' : IDL.Opt(Neuron),
+    'target_neuron_info' : IDL.Opt(NeuronInfo),
+    'source_neuron_info' : IDL.Opt(NeuronInfo),
+  });
   const MakeProposalResponse = IDL.Record({
     'proposal_id' : IDL.Opt(NeuronId),
   });
@@ -561,7 +567,7 @@ export const idlFactory = ({ IDL }) => {
     'ClaimOrRefresh' : ClaimOrRefreshResponse,
     'Configure' : IDL.Record({}),
     'RegisterVote' : IDL.Record({}),
-    'Merge' : IDL.Record({}),
+    'Merge' : MergeResponse,
     'DisburseToNeuron' : SpawnResponse,
     'MakeProposal' : MakeProposalResponse,
     'StakeMaturity' : StakeMaturityResponse,
@@ -632,6 +638,11 @@ export const idlFactory = ({ IDL }) => {
     'settle_community_fund_participation' : IDL.Func(
         [SettleCommunityFundParticipation],
         [Result],
+        [],
+      ),
+    'simulate_manage_neuron' : IDL.Func(
+        [ManageNeuron],
+        [ManageNeuronResponse],
         [],
       ),
     'transfer_gtc_neuron' : IDL.Func([NeuronId, NeuronId], [Result], []),
@@ -899,10 +910,10 @@ export const init = ({ IDL }) => {
     'neuron_basket_construction_parameters' : IDL.Opt(
       NeuronBasketConstructionParameters
     ),
-    'maximum_participant_icp' : IDL.Opt(IDL.Nat64),
-    'minimum_icp' : IDL.Opt(IDL.Nat64),
-    'minimum_participant_icp' : IDL.Opt(IDL.Nat64),
-    'maximum_icp' : IDL.Opt(IDL.Nat64),
+    'maximum_participant_icp' : IDL.Opt(Tokens),
+    'minimum_icp' : IDL.Opt(Tokens),
+    'minimum_participant_icp' : IDL.Opt(Tokens),
+    'maximum_icp' : IDL.Opt(Tokens),
   });
   const SwapDistribution = IDL.Record({ 'total' : IDL.Opt(Tokens) });
   const NeuronDistribution = IDL.Record({

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -104,7 +104,7 @@ export type Command_1 =
   | { ClaimOrRefresh: ClaimOrRefreshResponse }
   | { Configure: {} }
   | { RegisterVote: {} }
-  | { Merge: {} }
+  | { Merge: MergeResponse }
   | { DisburseToNeuron: SpawnResponse }
   | { MakeProposal: MakeProposalResponse }
   | { StakeMaturity: StakeMaturityResponse }
@@ -300,6 +300,12 @@ export interface MergeMaturity {
 export interface MergeMaturityResponse {
   merged_maturity_e8s: bigint;
   new_stake_e8s: bigint;
+}
+export interface MergeResponse {
+  target_neuron: [] | [Neuron];
+  source_neuron: [] | [Neuron];
+  target_neuron_info: [] | [NeuronInfo];
+  source_neuron_info: [] | [NeuronInfo];
 }
 export interface MostRecentMonthlyNodeProviderRewards {
   timestamp: bigint;
@@ -562,10 +568,10 @@ export interface SwapParameters {
   neuron_basket_construction_parameters:
     | []
     | [NeuronBasketConstructionParameters];
-  maximum_participant_icp: [] | [bigint];
-  minimum_icp: [] | [bigint];
-  minimum_participant_icp: [] | [bigint];
-  maximum_icp: [] | [bigint];
+  maximum_participant_icp: [] | [Tokens];
+  minimum_icp: [] | [Tokens];
+  minimum_participant_icp: [] | [Tokens];
+  maximum_icp: [] | [Tokens];
 }
 export interface Tally {
   no: bigint;
@@ -629,6 +635,7 @@ export interface _SERVICE {
     [SettleCommunityFundParticipation],
     Result
   >;
+  simulate_manage_neuron: ActorMethod<[ManageNeuron], ManageNeuronResponse>;
   transfer_gtc_neuron: ActorMethod<[NeuronId, NeuronId], Result>;
   update_node_provider: ActorMethod<[UpdateNodeProvider], Result>;
 }

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 9aac7d457a14a4cd89efcfa07d4eb9bf8079297c 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit b9fc66eafca530e997313aa68aaac31d41e6a875 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record { hash : vec nat8 };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
@@ -78,7 +78,7 @@ type Command_1 = variant {
   ClaimOrRefresh : ClaimOrRefreshResponse;
   Configure : record {};
   RegisterVote : record {};
-  Merge : record {};
+  Merge : MergeResponse;
   DisburseToNeuron : SpawnResponse;
   MakeProposal : MakeProposalResponse;
   StakeMaturity : StakeMaturityResponse;
@@ -237,6 +237,12 @@ type MergeMaturity = record { percentage_to_merge : nat32 };
 type MergeMaturityResponse = record {
   merged_maturity_e8s : nat64;
   new_stake_e8s : nat64;
+};
+type MergeResponse = record {
+  target_neuron : opt Neuron;
+  source_neuron : opt Neuron;
+  target_neuron_info : opt NeuronInfo;
+  source_neuron_info : opt NeuronInfo;
 };
 type MostRecentMonthlyNodeProviderRewards = record {
   timestamp : nat64;
@@ -469,10 +475,10 @@ type SwapDistribution = record { total : opt Tokens };
 type SwapParameters = record {
   minimum_participants : opt nat64;
   neuron_basket_construction_parameters : opt NeuronBasketConstructionParameters;
-  maximum_participant_icp : opt nat64;
-  minimum_icp : opt nat64;
-  minimum_participant_icp : opt nat64;
-  maximum_icp : opt nat64;
+  maximum_participant_icp : opt Tokens;
+  minimum_icp : opt Tokens;
+  minimum_participant_icp : opt Tokens;
+  maximum_icp : opt Tokens;
 };
 type Tally = record {
   no : nat64;
@@ -525,6 +531,7 @@ service : (Governance) -> {
   settle_community_fund_participation : (SettleCommunityFundParticipation) -> (
       Result,
     );
+  simulate_manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
   transfer_gtc_neuron : (NeuronId, NeuronId) -> (Result);
   update_node_provider : (UpdateNodeProvider) -> (Result);
 }

--- a/packages/nns/candid/governance.idl.js
+++ b/packages/nns/candid/governance.idl.js
@@ -260,10 +260,10 @@ export const idlFactory = ({ IDL }) => {
     'neuron_basket_construction_parameters' : IDL.Opt(
       NeuronBasketConstructionParameters
     ),
-    'maximum_participant_icp' : IDL.Opt(IDL.Nat64),
-    'minimum_icp' : IDL.Opt(IDL.Nat64),
-    'minimum_participant_icp' : IDL.Opt(IDL.Nat64),
-    'maximum_icp' : IDL.Opt(IDL.Nat64),
+    'maximum_participant_icp' : IDL.Opt(Tokens),
+    'minimum_icp' : IDL.Opt(Tokens),
+    'minimum_participant_icp' : IDL.Opt(Tokens),
+    'maximum_icp' : IDL.Opt(Tokens),
   });
   const SwapDistribution = IDL.Record({ 'total' : IDL.Opt(Tokens) });
   const NeuronDistribution = IDL.Record({
@@ -541,6 +541,12 @@ export const idlFactory = ({ IDL }) => {
   const ClaimOrRefreshResponse = IDL.Record({
     'refreshed_neuron_id' : IDL.Opt(NeuronId),
   });
+  const MergeResponse = IDL.Record({
+    'target_neuron' : IDL.Opt(Neuron),
+    'source_neuron' : IDL.Opt(Neuron),
+    'target_neuron_info' : IDL.Opt(NeuronInfo),
+    'source_neuron_info' : IDL.Opt(NeuronInfo),
+  });
   const MakeProposalResponse = IDL.Record({
     'proposal_id' : IDL.Opt(NeuronId),
   });
@@ -561,7 +567,7 @@ export const idlFactory = ({ IDL }) => {
     'ClaimOrRefresh' : ClaimOrRefreshResponse,
     'Configure' : IDL.Record({}),
     'RegisterVote' : IDL.Record({}),
-    'Merge' : IDL.Record({}),
+    'Merge' : MergeResponse,
     'DisburseToNeuron' : SpawnResponse,
     'MakeProposal' : MakeProposalResponse,
     'StakeMaturity' : StakeMaturityResponse,
@@ -644,6 +650,11 @@ export const idlFactory = ({ IDL }) => {
     'settle_community_fund_participation' : IDL.Func(
         [SettleCommunityFundParticipation],
         [Result],
+        [],
+      ),
+    'simulate_manage_neuron' : IDL.Func(
+        [ManageNeuron],
+        [ManageNeuronResponse],
         [],
       ),
     'transfer_gtc_neuron' : IDL.Func([NeuronId, NeuronId], [Result], []),
@@ -911,10 +922,10 @@ export const init = ({ IDL }) => {
     'neuron_basket_construction_parameters' : IDL.Opt(
       NeuronBasketConstructionParameters
     ),
-    'maximum_participant_icp' : IDL.Opt(IDL.Nat64),
-    'minimum_icp' : IDL.Opt(IDL.Nat64),
-    'minimum_participant_icp' : IDL.Opt(IDL.Nat64),
-    'maximum_icp' : IDL.Opt(IDL.Nat64),
+    'maximum_participant_icp' : IDL.Opt(Tokens),
+    'minimum_icp' : IDL.Opt(Tokens),
+    'minimum_participant_icp' : IDL.Opt(Tokens),
+    'maximum_icp' : IDL.Opt(Tokens),
   });
   const SwapDistribution = IDL.Record({ 'total' : IDL.Opt(Tokens) });
   const NeuronDistribution = IDL.Record({

--- a/packages/nns/candid/ledger.certified.idl.js
+++ b/packages/nns/candid/ledger.certified.idl.js
@@ -1,12 +1,47 @@
 /* Do not edit.  Compiled with ./scripts/compile-idl-js from packages/nns/candid/ledger.did */
 export const idlFactory = ({ IDL }) => {
+  const SubAccount = IDL.Vec(IDL.Nat8);
+  const Account = IDL.Record({
+    'owner' : IDL.Principal,
+    'subaccount' : IDL.Opt(SubAccount),
+  });
+  const UpgradeArgs = IDL.Record({
+    'maximum_number_of_accounts' : IDL.Opt(IDL.Nat64),
+    'icrc1_minting_account' : IDL.Opt(Account),
+  });
+  const Tokens = IDL.Record({ 'e8s' : IDL.Nat64 });
+  const TextAccountIdentifier = IDL.Text;
+  const Duration = IDL.Record({ 'secs' : IDL.Nat64, 'nanos' : IDL.Nat32 });
+  const ArchiveOptions = IDL.Record({
+    'num_blocks_to_archive' : IDL.Nat64,
+    'trigger_threshold' : IDL.Nat64,
+    'max_message_size_bytes' : IDL.Opt(IDL.Nat64),
+    'cycles_for_archive_creation' : IDL.Opt(IDL.Nat64),
+    'node_max_memory_size_bytes' : IDL.Opt(IDL.Nat64),
+    'controller_id' : IDL.Principal,
+  });
+  const InitArgs = IDL.Record({
+    'send_whitelist' : IDL.Vec(IDL.Principal),
+    'token_symbol' : IDL.Opt(IDL.Text),
+    'transfer_fee' : IDL.Opt(Tokens),
+    'minting_account' : TextAccountIdentifier,
+    'transaction_window' : IDL.Opt(Duration),
+    'max_message_size_bytes' : IDL.Opt(IDL.Nat64),
+    'icrc1_minting_account' : IDL.Opt(Account),
+    'archive_options' : IDL.Opt(ArchiveOptions),
+    'initial_values' : IDL.Vec(IDL.Tuple(TextAccountIdentifier, Tokens)),
+    'token_name' : IDL.Opt(IDL.Text),
+  });
+  const LedgerCanisterPayload = IDL.Variant({
+    'Upgrade' : IDL.Opt(UpgradeArgs),
+    'Init' : InitArgs,
+  });
   const BlockIndex = IDL.Nat64;
   const GetBlocksArgs = IDL.Record({
     'start' : BlockIndex,
     'length' : IDL.Nat64,
   });
   const Memo = IDL.Nat64;
-  const Tokens = IDL.Record({ 'e8s' : IDL.Nat64 });
   const AccountIdentifier = IDL.Vec(IDL.Nat8);
   const TimeStamp = IDL.Record({ 'timestamp_nanos' : IDL.Nat64 });
   const Operation = IDL.Variant({
@@ -74,9 +109,53 @@ export const idlFactory = ({ IDL }) => {
     ),
   });
   const AccountBalanceArgs = IDL.Record({ 'account' : AccountIdentifier });
+  const AccountBalanceArgsDfx = IDL.Record({
+    'account' : TextAccountIdentifier,
+  });
   const Archive = IDL.Record({ 'canister_id' : IDL.Principal });
   const Archives = IDL.Record({ 'archives' : IDL.Vec(Archive) });
-  const SubAccount = IDL.Vec(IDL.Nat8);
+  const Icrc1Tokens = IDL.Nat;
+  const Value = IDL.Variant({
+    'Int' : IDL.Int,
+    'Nat' : IDL.Nat,
+    'Blob' : IDL.Vec(IDL.Nat8),
+    'Text' : IDL.Text,
+  });
+  const Icrc1Timestamp = IDL.Nat64;
+  const TransferArg = IDL.Record({
+    'to' : Account,
+    'fee' : IDL.Opt(Icrc1Tokens),
+    'memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'from_subaccount' : IDL.Opt(SubAccount),
+    'created_at_time' : IDL.Opt(Icrc1Timestamp),
+    'amount' : Icrc1Tokens,
+  });
+  const Icrc1BlockIndex = IDL.Nat;
+  const Icrc1TransferError = IDL.Variant({
+    'GenericError' : IDL.Record({
+      'message' : IDL.Text,
+      'error_code' : IDL.Nat,
+    }),
+    'TemporarilyUnavailable' : IDL.Null,
+    'BadBurn' : IDL.Record({ 'min_burn_amount' : Icrc1Tokens }),
+    'Duplicate' : IDL.Record({ 'duplicate_of' : Icrc1BlockIndex }),
+    'BadFee' : IDL.Record({ 'expected_fee' : Icrc1Tokens }),
+    'CreatedInFuture' : IDL.Record({ 'ledger_time' : IDL.Nat64 }),
+    'TooOld' : IDL.Null,
+    'InsufficientFunds' : IDL.Record({ 'balance' : Icrc1Tokens }),
+  });
+  const Icrc1TransferResult = IDL.Variant({
+    'Ok' : Icrc1BlockIndex,
+    'Err' : Icrc1TransferError,
+  });
+  const SendArgs = IDL.Record({
+    'to' : TextAccountIdentifier,
+    'fee' : Tokens,
+    'memo' : Memo,
+    'from_subaccount' : IDL.Opt(SubAccount),
+    'created_at_time' : IDL.Opt(TimeStamp),
+    'amount' : Tokens,
+  });
   const TransferArgs = IDL.Record({
     'to' : AccountIdentifier,
     'fee' : Tokens,
@@ -101,12 +180,66 @@ export const idlFactory = ({ IDL }) => {
   return IDL.Service({
     '_blocks' : IDL.Func([GetBlocksArgs], [QueryBlocksResponse], []),
     'account_balance' : IDL.Func([AccountBalanceArgs], [Tokens], []),
+    'account_balance_dfx' : IDL.Func([AccountBalanceArgsDfx], [Tokens], []),
     'archives' : IDL.Func([], [Archives], []),
     'decimals' : IDL.Func([], [IDL.Record({ 'decimals' : IDL.Nat32 })], []),
+    'icrc1_balance_of' : IDL.Func([Account], [Icrc1Tokens], []),
+    'icrc1_decimals' : IDL.Func([], [IDL.Nat8], []),
+    'icrc1_fee' : IDL.Func([], [Icrc1Tokens], []),
+    'icrc1_metadata' : IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, Value))], []),
+    'icrc1_minting_account' : IDL.Func([], [IDL.Opt(Account)], []),
+    'icrc1_name' : IDL.Func([], [IDL.Text], []),
+    'icrc1_supported_standards' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Record({ 'url' : IDL.Text, 'name' : IDL.Text }))],
+        [],
+      ),
+    'icrc1_symbol' : IDL.Func([], [IDL.Text], []),
+    'icrc1_total_supply' : IDL.Func([], [Icrc1Tokens], []),
+    'icrc1_transfer' : IDL.Func([TransferArg], [Icrc1TransferResult], []),
     'name' : IDL.Func([], [IDL.Record({ 'name' : IDL.Text })], []),
+    'send_dfx' : IDL.Func([SendArgs], [BlockIndex], []),
     'symbol' : IDL.Func([], [IDL.Record({ 'symbol' : IDL.Text })], []),
     'transfer' : IDL.Func([TransferArgs], [TransferResult], []),
     'transfer_fee' : IDL.Func([TransferFeeArg], [TransferFee], []),
   });
 };
-export const init = ({ IDL }) => { return []; };
+export const init = ({ IDL }) => {
+  const SubAccount = IDL.Vec(IDL.Nat8);
+  const Account = IDL.Record({
+    'owner' : IDL.Principal,
+    'subaccount' : IDL.Opt(SubAccount),
+  });
+  const UpgradeArgs = IDL.Record({
+    'maximum_number_of_accounts' : IDL.Opt(IDL.Nat64),
+    'icrc1_minting_account' : IDL.Opt(Account),
+  });
+  const Tokens = IDL.Record({ 'e8s' : IDL.Nat64 });
+  const TextAccountIdentifier = IDL.Text;
+  const Duration = IDL.Record({ 'secs' : IDL.Nat64, 'nanos' : IDL.Nat32 });
+  const ArchiveOptions = IDL.Record({
+    'num_blocks_to_archive' : IDL.Nat64,
+    'trigger_threshold' : IDL.Nat64,
+    'max_message_size_bytes' : IDL.Opt(IDL.Nat64),
+    'cycles_for_archive_creation' : IDL.Opt(IDL.Nat64),
+    'node_max_memory_size_bytes' : IDL.Opt(IDL.Nat64),
+    'controller_id' : IDL.Principal,
+  });
+  const InitArgs = IDL.Record({
+    'send_whitelist' : IDL.Vec(IDL.Principal),
+    'token_symbol' : IDL.Opt(IDL.Text),
+    'transfer_fee' : IDL.Opt(Tokens),
+    'minting_account' : TextAccountIdentifier,
+    'transaction_window' : IDL.Opt(Duration),
+    'max_message_size_bytes' : IDL.Opt(IDL.Nat64),
+    'icrc1_minting_account' : IDL.Opt(Account),
+    'archive_options' : IDL.Opt(ArchiveOptions),
+    'initial_values' : IDL.Vec(IDL.Tuple(TextAccountIdentifier, Tokens)),
+    'token_name' : IDL.Opt(IDL.Text),
+  });
+  const LedgerCanisterPayload = IDL.Variant({
+    'Upgrade' : IDL.Opt(UpgradeArgs),
+    'Init' : InitArgs,
+  });
+  return [LedgerCanisterPayload];
+};

--- a/packages/nns/candid/ledger.d.ts
+++ b/packages/nns/candid/ledger.d.ts
@@ -1,12 +1,27 @@
 import type { ActorMethod } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 
+export interface Account {
+  owner: Principal;
+  subaccount: [] | [SubAccount];
+}
 export interface AccountBalanceArgs {
   account: AccountIdentifier;
+}
+export interface AccountBalanceArgsDfx {
+  account: TextAccountIdentifier;
 }
 export type AccountIdentifier = Uint8Array;
 export interface Archive {
   canister_id: Principal;
+}
+export interface ArchiveOptions {
+  num_blocks_to_archive: bigint;
+  trigger_threshold: bigint;
+  max_message_size_bytes: [] | [bigint];
+  cycles_for_archive_creation: [] | [bigint];
+  node_max_memory_size_bytes: [] | [bigint];
+  controller_id: Principal;
 }
 export interface Archives {
   archives: Array<Archive>;
@@ -20,10 +35,46 @@ export type BlockIndex = bigint;
 export interface BlockRange {
   blocks: Array<Block>;
 }
+export interface Duration {
+  secs: bigint;
+  nanos: number;
+}
 export interface GetBlocksArgs {
   start: BlockIndex;
   length: bigint;
 }
+export type Icrc1BlockIndex = bigint;
+export type Icrc1Timestamp = bigint;
+export type Icrc1Tokens = bigint;
+export type Icrc1TransferError =
+  | {
+      GenericError: { message: string; error_code: bigint };
+    }
+  | { TemporarilyUnavailable: null }
+  | { BadBurn: { min_burn_amount: Icrc1Tokens } }
+  | { Duplicate: { duplicate_of: Icrc1BlockIndex } }
+  | { BadFee: { expected_fee: Icrc1Tokens } }
+  | { CreatedInFuture: { ledger_time: bigint } }
+  | { TooOld: null }
+  | { InsufficientFunds: { balance: Icrc1Tokens } };
+export type Icrc1TransferResult =
+  | { Ok: Icrc1BlockIndex }
+  | { Err: Icrc1TransferError };
+export interface InitArgs {
+  send_whitelist: Array<Principal>;
+  token_symbol: [] | [string];
+  transfer_fee: [] | [Tokens];
+  minting_account: TextAccountIdentifier;
+  transaction_window: [] | [Duration];
+  max_message_size_bytes: [] | [bigint];
+  icrc1_minting_account: [] | [Account];
+  archive_options: [] | [ArchiveOptions];
+  initial_values: Array<[TextAccountIdentifier, Tokens]>;
+  token_name: [] | [string];
+}
+export type LedgerCanisterPayload =
+  | { Upgrade: [] | [UpgradeArgs] }
+  | { Init: InitArgs };
 export type Memo = bigint;
 export type Operation =
   | {
@@ -77,7 +128,16 @@ export interface QueryBlocksResponse {
     length: bigint;
   }>;
 }
+export interface SendArgs {
+  to: TextAccountIdentifier;
+  fee: Tokens;
+  memo: Memo;
+  from_subaccount: [] | [SubAccount];
+  created_at_time: [] | [TimeStamp];
+  amount: Tokens;
+}
 export type SubAccount = Uint8Array;
+export type TextAccountIdentifier = string;
 export interface TimeStamp {
   timestamp_nanos: bigint;
 }
@@ -89,6 +149,14 @@ export interface Transaction {
   icrc1_memo: [] | [Uint8Array];
   operation: [] | [Operation];
   created_at_time: TimeStamp;
+}
+export interface TransferArg {
+  to: Account;
+  fee: [] | [Icrc1Tokens];
+  memo: [] | [Uint8Array];
+  from_subaccount: [] | [SubAccount];
+  created_at_time: [] | [Icrc1Timestamp];
+  amount: Icrc1Tokens;
 }
 export interface TransferArgs {
   to: AccountIdentifier;
@@ -111,12 +179,36 @@ export interface TransferFee {
 }
 export type TransferFeeArg = {};
 export type TransferResult = { Ok: BlockIndex } | { Err: TransferError };
+export interface UpgradeArgs {
+  maximum_number_of_accounts: [] | [bigint];
+  icrc1_minting_account: [] | [Account];
+}
+export type Value =
+  | { Int: bigint }
+  | { Nat: bigint }
+  | { Blob: Uint8Array }
+  | { Text: string };
 export interface _SERVICE {
   account_balance: ActorMethod<[AccountBalanceArgs], Tokens>;
+  account_balance_dfx: ActorMethod<[AccountBalanceArgsDfx], Tokens>;
   archives: ActorMethod<[], Archives>;
   decimals: ActorMethod<[], { decimals: number }>;
+  icrc1_balance_of: ActorMethod<[Account], Icrc1Tokens>;
+  icrc1_decimals: ActorMethod<[], number>;
+  icrc1_fee: ActorMethod<[], Icrc1Tokens>;
+  icrc1_metadata: ActorMethod<[], Array<[string, Value]>>;
+  icrc1_minting_account: ActorMethod<[], [] | [Account]>;
+  icrc1_name: ActorMethod<[], string>;
+  icrc1_supported_standards: ActorMethod<
+    [],
+    Array<{ url: string; name: string }>
+  >;
+  icrc1_symbol: ActorMethod<[], string>;
+  icrc1_total_supply: ActorMethod<[], Icrc1Tokens>;
+  icrc1_transfer: ActorMethod<[TransferArg], Icrc1TransferResult>;
   name: ActorMethod<[], { name: string }>;
   query_blocks: ActorMethod<[GetBlocksArgs], QueryBlocksResponse>;
+  send_dfx: ActorMethod<[SendArgs], BlockIndex>;
   symbol: ActorMethod<[], { symbol: string }>;
   transfer: ActorMethod<[TransferArgs], TransferResult>;
   transfer_fee: ActorMethod<[TransferFeeArg], TransferFee>;

--- a/packages/nns/candid/ledger.did
+++ b/packages/nns/candid/ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 9aac7d457a14a4cd89efcfa07d4eb9bf8079297c 'rs/rosetta-api/icp_ledger/ledger.did' by import-candid
+// Generated from IC repo commit b9fc66eafca530e997313aa68aaac31d41e6a875 'rs/rosetta-api/icp_ledger/ledger.did' by import-candid
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.
@@ -238,30 +238,143 @@ type Archives = record {
     archives: vec Archive;
 };
 
-service : {
-  // Transfers tokens from a subaccount of the caller to the destination address.
-  // The source address is computed from the principal of the caller and the specified subaccount.
-  // When successful, returns the index of the block containing the transaction.
-  transfer : (TransferArgs) -> (TransferResult);
+type Duration = record {
+    secs: nat64;
+    nanos: nat32;
+};
 
-  // Returns the amount of Tokens on the specified account.
-  account_balance : (AccountBalanceArgs) -> (Tokens) query;
+type ArchiveOptions = record {
+    trigger_threshold : nat64;
+    num_blocks_to_archive : nat64;
+    node_max_memory_size_bytes: opt nat64;
+    max_message_size_bytes: opt nat64;
+    controller_id: principal;
+    cycles_for_archive_creation: opt nat64;
+};
 
-  // Returns the current transfer_fee.
-  transfer_fee : (TransferFeeArg) -> (TransferFee) query;
+// Account identifier encoded as a 64-byte ASCII hex string.
+type TextAccountIdentifier = text;
 
-  // Queries blocks in the specified range.
-  query_blocks : (GetBlocksArgs) -> (QueryBlocksResponse) query;
+// Arguments for the `send_dfx` call.
+type SendArgs = record {
+    memo: Memo;
+    amount: Tokens;
+    fee: Tokens;
+    from_subaccount: opt SubAccount;
+    to: TextAccountIdentifier;
+    created_at_time: opt TimeStamp;
+};
 
-  // Returns token symbol.
-  symbol : () -> (record { symbol: text }) query;
+type AccountBalanceArgsDfx = record {
+    account: TextAccountIdentifier;
+};
 
-  // Returns token name.
-  name : () -> (record { name: text }) query;
+type InitArgs = record {
+    minting_account: TextAccountIdentifier;
+    icrc1_minting_account: opt Account;
+    initial_values: vec record {TextAccountIdentifier; Tokens};
+    max_message_size_bytes: opt nat64;
+    transaction_window: opt Duration;
+    archive_options: opt ArchiveOptions;
+    send_whitelist: vec principal;
+    transfer_fee: opt Tokens;
+    token_symbol: opt text;
+    token_name: opt text;
+};
 
-  // Returns token decimals.
-  decimals : () -> (record { decimals: nat32 }) query;
+type Icrc1BlockIndex = nat;
+// Number of nanoseconds since the UNIX epoch in UTC timezone.
+type Icrc1Timestamp = nat64;
+type Icrc1Tokens = nat;
 
-  // Returns the existing archive canisters information.
-  archives : () -> (Archives) query;
+type Account = record {
+    owner : principal;
+    subaccount : opt SubAccount;
+};
+
+type TransferArg = record {
+    from_subaccount : opt SubAccount;
+    to : Account;
+    amount : Icrc1Tokens;
+    fee : opt Icrc1Tokens;
+    memo : opt blob;
+    created_at_time: opt Icrc1Timestamp;
+};
+
+type Icrc1TransferError = variant {
+    BadFee : record { expected_fee : Icrc1Tokens };
+    BadBurn : record { min_burn_amount : Icrc1Tokens };
+    InsufficientFunds : record { balance : Icrc1Tokens };
+    TooOld;
+    CreatedInFuture : record { ledger_time : nat64 };
+    TemporarilyUnavailable;
+    Duplicate : record { duplicate_of : Icrc1BlockIndex };
+    GenericError : record { error_code : nat; message : text };
+};
+
+type Icrc1TransferResult = variant {
+    Ok : Icrc1BlockIndex;
+    Err : Icrc1TransferError;
+};
+
+// The value returned from the [icrc1_metadata] endpoint.
+type Value = variant {
+    Nat : nat;
+    Int : int;
+    Text : text;
+    Blob : blob;
+};
+
+type UpgradeArgs = record {
+  maximum_number_of_accounts : opt nat64;
+  icrc1_minting_account : opt Account;
+};
+
+type LedgerCanisterPayload = variant {
+    Init: InitArgs;
+    Upgrade: opt UpgradeArgs;
+};
+
+service: (LedgerCanisterPayload) -> {
+    // Transfers tokens from a subaccount of the caller to the destination address.
+    // The source address is computed from the principal of the caller and the specified subaccount.
+    // When successful, returns the index of the block containing the transaction.
+    transfer : (TransferArgs) -> (TransferResult);
+
+    // Returns the amount of Tokens on the specified account.
+    account_balance : (AccountBalanceArgs) -> (Tokens) query;
+
+    // Returns the current transfer_fee.
+    transfer_fee : (TransferFeeArg) -> (TransferFee) query;
+
+    // Queries blocks in the specified range.
+    query_blocks : (GetBlocksArgs) -> (QueryBlocksResponse) query;
+
+    // Returns token symbol.
+    symbol : () -> (record { symbol: text }) query;
+
+    // Returns token name.
+    name : () -> (record { name: text }) query;
+
+    // Returns token decimals.
+    decimals : () -> (record { decimals: nat32 }) query;
+
+    // Returns the existing archive canisters information.
+    archives : () -> (Archives) query;
+
+    send_dfx : (SendArgs) -> (BlockIndex);
+    account_balance_dfx : (AccountBalanceArgsDfx) -> (Tokens) query;
+
+    // The following methods implement the ICRC-1 Token Standard.
+    // https://github.com/dfinity/ICRC-1/tree/main/standards/ICRC-1
+    icrc1_name : () -> (text) query;
+    icrc1_symbol : () -> (text) query;
+    icrc1_decimals : () -> (nat8) query;
+    icrc1_metadata : () -> (vec record { text; Value }) query;
+    icrc1_total_supply : () -> (Icrc1Tokens) query;
+    icrc1_fee : () -> (Icrc1Tokens) query;
+    icrc1_minting_account : () -> (opt Account) query;
+    icrc1_balance_of : (Account) -> (Icrc1Tokens) query;
+    icrc1_transfer : (TransferArg) -> (Icrc1TransferResult);
+    icrc1_supported_standards : () -> (vec record { name : text; url : text }) query;  
 }

--- a/packages/nns/candid/ledger.idl.js
+++ b/packages/nns/candid/ledger.idl.js
@@ -1,10 +1,82 @@
 /* Do not edit.  Compiled with ./scripts/compile-idl-js from packages/nns/candid/ledger.did */
 export const idlFactory = ({ IDL }) => {
+  const SubAccount = IDL.Vec(IDL.Nat8);
+  const Account = IDL.Record({
+    'owner' : IDL.Principal,
+    'subaccount' : IDL.Opt(SubAccount),
+  });
+  const UpgradeArgs = IDL.Record({
+    'maximum_number_of_accounts' : IDL.Opt(IDL.Nat64),
+    'icrc1_minting_account' : IDL.Opt(Account),
+  });
+  const Tokens = IDL.Record({ 'e8s' : IDL.Nat64 });
+  const TextAccountIdentifier = IDL.Text;
+  const Duration = IDL.Record({ 'secs' : IDL.Nat64, 'nanos' : IDL.Nat32 });
+  const ArchiveOptions = IDL.Record({
+    'num_blocks_to_archive' : IDL.Nat64,
+    'trigger_threshold' : IDL.Nat64,
+    'max_message_size_bytes' : IDL.Opt(IDL.Nat64),
+    'cycles_for_archive_creation' : IDL.Opt(IDL.Nat64),
+    'node_max_memory_size_bytes' : IDL.Opt(IDL.Nat64),
+    'controller_id' : IDL.Principal,
+  });
+  const InitArgs = IDL.Record({
+    'send_whitelist' : IDL.Vec(IDL.Principal),
+    'token_symbol' : IDL.Opt(IDL.Text),
+    'transfer_fee' : IDL.Opt(Tokens),
+    'minting_account' : TextAccountIdentifier,
+    'transaction_window' : IDL.Opt(Duration),
+    'max_message_size_bytes' : IDL.Opt(IDL.Nat64),
+    'icrc1_minting_account' : IDL.Opt(Account),
+    'archive_options' : IDL.Opt(ArchiveOptions),
+    'initial_values' : IDL.Vec(IDL.Tuple(TextAccountIdentifier, Tokens)),
+    'token_name' : IDL.Opt(IDL.Text),
+  });
+  const LedgerCanisterPayload = IDL.Variant({
+    'Upgrade' : IDL.Opt(UpgradeArgs),
+    'Init' : InitArgs,
+  });
   const AccountIdentifier = IDL.Vec(IDL.Nat8);
   const AccountBalanceArgs = IDL.Record({ 'account' : AccountIdentifier });
-  const Tokens = IDL.Record({ 'e8s' : IDL.Nat64 });
+  const AccountBalanceArgsDfx = IDL.Record({
+    'account' : TextAccountIdentifier,
+  });
   const Archive = IDL.Record({ 'canister_id' : IDL.Principal });
   const Archives = IDL.Record({ 'archives' : IDL.Vec(Archive) });
+  const Icrc1Tokens = IDL.Nat;
+  const Value = IDL.Variant({
+    'Int' : IDL.Int,
+    'Nat' : IDL.Nat,
+    'Blob' : IDL.Vec(IDL.Nat8),
+    'Text' : IDL.Text,
+  });
+  const Icrc1Timestamp = IDL.Nat64;
+  const TransferArg = IDL.Record({
+    'to' : Account,
+    'fee' : IDL.Opt(Icrc1Tokens),
+    'memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'from_subaccount' : IDL.Opt(SubAccount),
+    'created_at_time' : IDL.Opt(Icrc1Timestamp),
+    'amount' : Icrc1Tokens,
+  });
+  const Icrc1BlockIndex = IDL.Nat;
+  const Icrc1TransferError = IDL.Variant({
+    'GenericError' : IDL.Record({
+      'message' : IDL.Text,
+      'error_code' : IDL.Nat,
+    }),
+    'TemporarilyUnavailable' : IDL.Null,
+    'BadBurn' : IDL.Record({ 'min_burn_amount' : Icrc1Tokens }),
+    'Duplicate' : IDL.Record({ 'duplicate_of' : Icrc1BlockIndex }),
+    'BadFee' : IDL.Record({ 'expected_fee' : Icrc1Tokens }),
+    'CreatedInFuture' : IDL.Record({ 'ledger_time' : IDL.Nat64 }),
+    'TooOld' : IDL.Null,
+    'InsufficientFunds' : IDL.Record({ 'balance' : Icrc1Tokens }),
+  });
+  const Icrc1TransferResult = IDL.Variant({
+    'Ok' : Icrc1BlockIndex,
+    'Err' : Icrc1TransferError,
+  });
   const BlockIndex = IDL.Nat64;
   const GetBlocksArgs = IDL.Record({
     'start' : BlockIndex,
@@ -80,7 +152,14 @@ export const idlFactory = ({ IDL }) => {
       })
     ),
   });
-  const SubAccount = IDL.Vec(IDL.Nat8);
+  const SendArgs = IDL.Record({
+    'to' : TextAccountIdentifier,
+    'fee' : Tokens,
+    'memo' : Memo,
+    'from_subaccount' : IDL.Opt(SubAccount),
+    'created_at_time' : IDL.Opt(TimeStamp),
+    'amount' : Tokens,
+  });
   const TransferArgs = IDL.Record({
     'to' : AccountIdentifier,
     'fee' : Tokens,
@@ -104,21 +183,83 @@ export const idlFactory = ({ IDL }) => {
   const TransferFee = IDL.Record({ 'transfer_fee' : Tokens });
   return IDL.Service({
     'account_balance' : IDL.Func([AccountBalanceArgs], [Tokens], ['query']),
+    'account_balance_dfx' : IDL.Func(
+        [AccountBalanceArgsDfx],
+        [Tokens],
+        ['query'],
+      ),
     'archives' : IDL.Func([], [Archives], ['query']),
     'decimals' : IDL.Func(
         [],
         [IDL.Record({ 'decimals' : IDL.Nat32 })],
         ['query'],
       ),
+    'icrc1_balance_of' : IDL.Func([Account], [Icrc1Tokens], ['query']),
+    'icrc1_decimals' : IDL.Func([], [IDL.Nat8], ['query']),
+    'icrc1_fee' : IDL.Func([], [Icrc1Tokens], ['query']),
+    'icrc1_metadata' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Tuple(IDL.Text, Value))],
+        ['query'],
+      ),
+    'icrc1_minting_account' : IDL.Func([], [IDL.Opt(Account)], ['query']),
+    'icrc1_name' : IDL.Func([], [IDL.Text], ['query']),
+    'icrc1_supported_standards' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Record({ 'url' : IDL.Text, 'name' : IDL.Text }))],
+        ['query'],
+      ),
+    'icrc1_symbol' : IDL.Func([], [IDL.Text], ['query']),
+    'icrc1_total_supply' : IDL.Func([], [Icrc1Tokens], ['query']),
+    'icrc1_transfer' : IDL.Func([TransferArg], [Icrc1TransferResult], []),
     'name' : IDL.Func([], [IDL.Record({ 'name' : IDL.Text })], ['query']),
     'query_blocks' : IDL.Func(
         [GetBlocksArgs],
         [QueryBlocksResponse],
         ['query'],
       ),
+    'send_dfx' : IDL.Func([SendArgs], [BlockIndex], []),
     'symbol' : IDL.Func([], [IDL.Record({ 'symbol' : IDL.Text })], ['query']),
     'transfer' : IDL.Func([TransferArgs], [TransferResult], []),
     'transfer_fee' : IDL.Func([TransferFeeArg], [TransferFee], ['query']),
   });
 };
-export const init = ({ IDL }) => { return []; };
+export const init = ({ IDL }) => {
+  const SubAccount = IDL.Vec(IDL.Nat8);
+  const Account = IDL.Record({
+    'owner' : IDL.Principal,
+    'subaccount' : IDL.Opt(SubAccount),
+  });
+  const UpgradeArgs = IDL.Record({
+    'maximum_number_of_accounts' : IDL.Opt(IDL.Nat64),
+    'icrc1_minting_account' : IDL.Opt(Account),
+  });
+  const Tokens = IDL.Record({ 'e8s' : IDL.Nat64 });
+  const TextAccountIdentifier = IDL.Text;
+  const Duration = IDL.Record({ 'secs' : IDL.Nat64, 'nanos' : IDL.Nat32 });
+  const ArchiveOptions = IDL.Record({
+    'num_blocks_to_archive' : IDL.Nat64,
+    'trigger_threshold' : IDL.Nat64,
+    'max_message_size_bytes' : IDL.Opt(IDL.Nat64),
+    'cycles_for_archive_creation' : IDL.Opt(IDL.Nat64),
+    'node_max_memory_size_bytes' : IDL.Opt(IDL.Nat64),
+    'controller_id' : IDL.Principal,
+  });
+  const InitArgs = IDL.Record({
+    'send_whitelist' : IDL.Vec(IDL.Principal),
+    'token_symbol' : IDL.Opt(IDL.Text),
+    'transfer_fee' : IDL.Opt(Tokens),
+    'minting_account' : TextAccountIdentifier,
+    'transaction_window' : IDL.Opt(Duration),
+    'max_message_size_bytes' : IDL.Opt(IDL.Nat64),
+    'icrc1_minting_account' : IDL.Opt(Account),
+    'archive_options' : IDL.Opt(ArchiveOptions),
+    'initial_values' : IDL.Vec(IDL.Tuple(TextAccountIdentifier, Tokens)),
+    'token_name' : IDL.Opt(IDL.Text),
+  });
+  const LedgerCanisterPayload = IDL.Variant({
+    'Upgrade' : IDL.Opt(UpgradeArgs),
+    'Init' : InitArgs,
+  });
+  return [LedgerCanisterPayload];
+};

--- a/packages/nns/candid/sns_wasm.certified.idl.js
+++ b/packages/nns/candid/sns_wasm.certified.idl.js
@@ -46,6 +46,7 @@ export const idlFactory = ({ IDL }) => {
   const InitialTokenDistribution = IDL.Variant({
     'FractionalDeveloperVotingPower' : FractionalDeveloperVotingPower,
   });
+  const Countries = IDL.Record({ 'iso_codes' : IDL.Vec(IDL.Text) });
   const SnsInitPayload = IDL.Record({
     'url' : IDL.Opt(IDL.Text),
     'max_dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
@@ -54,6 +55,7 @@ export const idlFactory = ({ IDL }) => {
     'token_symbol' : IDL.Opt(IDL.Text),
     'final_reward_rate_basis_points' : IDL.Opt(IDL.Nat64),
     'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
+    'confirmation_text' : IDL.Opt(IDL.Text),
     'logo' : IDL.Opt(IDL.Text),
     'name' : IDL.Opt(IDL.Text),
     'initial_voting_period_seconds' : IDL.Opt(IDL.Nat64),
@@ -68,6 +70,7 @@ export const idlFactory = ({ IDL }) => {
     'reward_rate_transition_duration_seconds' : IDL.Opt(IDL.Nat64),
     'token_name' : IDL.Opt(IDL.Text),
     'proposal_reject_cost_e8s' : IDL.Opt(IDL.Nat64),
+    'restricted_countries' : IDL.Opt(Countries),
   });
   const DeployNewSnsRequest = IDL.Record({
     'sns_init_payload' : IDL.Opt(SnsInitPayload),

--- a/packages/nns/candid/sns_wasm.d.ts
+++ b/packages/nns/candid/sns_wasm.d.ts
@@ -11,6 +11,9 @@ export interface AddWasmResponse {
 export interface AirdropDistribution {
   airdrop_neurons: Array<NeuronDistribution>;
 }
+export interface Countries {
+  iso_codes: Array<string>;
+}
 export interface DeployNewSnsRequest {
   sns_init_payload: [] | [SnsInitPayload];
 }
@@ -110,6 +113,7 @@ export interface SnsInitPayload {
   token_symbol: [] | [string];
   final_reward_rate_basis_points: [] | [bigint];
   neuron_minimum_stake_e8s: [] | [bigint];
+  confirmation_text: [] | [string];
   logo: [] | [string];
   name: [] | [string];
   initial_voting_period_seconds: [] | [bigint];
@@ -124,6 +128,7 @@ export interface SnsInitPayload {
   reward_rate_transition_duration_seconds: [] | [bigint];
   token_name: [] | [string];
   proposal_reject_cost_e8s: [] | [bigint];
+  restricted_countries: [] | [Countries];
 }
 export interface SnsUpgrade {
   next_version: [] | [SnsVersion];

--- a/packages/nns/candid/sns_wasm.did
+++ b/packages/nns/candid/sns_wasm.did
@@ -1,7 +1,8 @@
-// Generated from IC repo commit 9aac7d457a14a4cd89efcfa07d4eb9bf8079297c 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit b9fc66eafca530e997313aa68aaac31d41e6a875 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 type AddWasmRequest = record { hash : vec nat8; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
+type Countries = record { iso_codes : vec text };
 type DeployNewSnsRequest = record { sns_init_payload : opt SnsInitPayload };
 type DeployNewSnsResponse = record {
   subnet_id : opt principal;
@@ -85,6 +86,7 @@ type SnsInitPayload = record {
   token_symbol : opt text;
   final_reward_rate_basis_points : opt nat64;
   neuron_minimum_stake_e8s : opt nat64;
+  confirmation_text : opt text;
   logo : opt text;
   name : opt text;
   initial_voting_period_seconds : opt nat64;
@@ -99,6 +101,7 @@ type SnsInitPayload = record {
   reward_rate_transition_duration_seconds : opt nat64;
   token_name : opt text;
   proposal_reject_cost_e8s : opt nat64;
+  restricted_countries : opt Countries;
 };
 type SnsUpgrade = record {
   next_version : opt SnsVersion;

--- a/packages/nns/candid/sns_wasm.idl.js
+++ b/packages/nns/candid/sns_wasm.idl.js
@@ -46,6 +46,7 @@ export const idlFactory = ({ IDL }) => {
   const InitialTokenDistribution = IDL.Variant({
     'FractionalDeveloperVotingPower' : FractionalDeveloperVotingPower,
   });
+  const Countries = IDL.Record({ 'iso_codes' : IDL.Vec(IDL.Text) });
   const SnsInitPayload = IDL.Record({
     'url' : IDL.Opt(IDL.Text),
     'max_dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
@@ -54,6 +55,7 @@ export const idlFactory = ({ IDL }) => {
     'token_symbol' : IDL.Opt(IDL.Text),
     'final_reward_rate_basis_points' : IDL.Opt(IDL.Nat64),
     'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
+    'confirmation_text' : IDL.Opt(IDL.Text),
     'logo' : IDL.Opt(IDL.Text),
     'name' : IDL.Opt(IDL.Text),
     'initial_voting_period_seconds' : IDL.Opt(IDL.Nat64),
@@ -68,6 +70,7 @@ export const idlFactory = ({ IDL }) => {
     'reward_rate_transition_duration_seconds' : IDL.Opt(IDL.Nat64),
     'token_name' : IDL.Opt(IDL.Text),
     'proposal_reject_cost_e8s' : IDL.Opt(IDL.Nat64),
+    'restricted_countries' : IDL.Opt(Countries),
   });
   const DeployNewSnsRequest = IDL.Record({
     'sns_init_payload' : IDL.Opt(SnsInitPayload),

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -997,7 +997,12 @@ describe("GovernanceCanister", () => {
       const sourceNeuronId = BigInt(10);
       const targetNeuronId = BigInt(13);
       const serviceResponse: ManageNeuronResponse = {
-        command: [{ Merge: {} }],
+        command: [{ Merge: {
+          target_neuron: [],
+          source_neuron: [],
+          target_neuron_info: [],
+          source_neuron_info: [],
+        } }],
       };
       const service = mock<ActorSubclass<GovernanceService>>();
       service.manage_neuron.mockResolvedValue(serviceResponse);


### PR DESCRIPTION
# Motivation

We want to use the API to simulate merging neurons, but also keep candid up-to date in general.
Simulating merging neurons was added in [this PR](https://gitlab.com/dfinity-lab/public/ic/-/commit/1866f8f1a94dcc6e98065e0fd554c8e0e93965df) / [this commit](https://github.com/dfinity/ic/commit/1866f8f1a94dcc6e98065e0fd554c8e0e93965df).
I used `bin/dfx-software-ic-latest --after 1866f8f1a94dcc6e98065e0fd554c8e0e93965df -x ../../ic` from snsdemo to find commit b9fc66eafca530e997313aa68aaac31d41e6a875.

# Changes

1. Checked out commit `b9fc66eafca530e997313aa68aaac31d41e6a875` in my IC repo.
2. Ran `scripts/import-candid ../../ic` to import candid from the IC repo at that commit.
3. Reverted the changes in packages other than `packages/nns`.
4. Ran `scripts/compile-idl-js`
5. Changed `packages/nns/src/governance.canister.spec.ts` to add `[]` for new fields which are optional in Candid but not in Typescript.

# Tests

`npm run test --workspaces`
Tested the changes in nns-dapp as described in https://github.com/dfinity/ic-js/blob/main/HACKING.md. I tested splitting and merging neurons.
I also ran `npm run test` in the nns-dapp repo, which somewhat surprisingly passed without additional changes. 
