### PR TITLE
simulateMergeNeurons on GovernanceCanister

### DIFF
--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -375,6 +375,7 @@ Returns the index of the block containing the tx if it was successful.
 - [leaveCommunityFund](#gear-leavecommunityfund)
 - [setNodeProviderAccount](#gear-setnodeprovideraccount)
 - [mergeNeurons](#gear-mergeneurons)
+- [simulateMergeNeurons](#gear-simulatemergeneurons)
 - [splitNeuron](#gear-splitneuron)
 - [getProposal](#gear-getproposal)
 - [makeProposal](#gear-makeproposal)
@@ -533,6 +534,14 @@ Merge two neurons
 | Method         | Type                                                                              |
 | -------------- | --------------------------------------------------------------------------------- |
 | `mergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<void>` |
+
+##### :gear: simulateMergeNeurons
+
+Simulate merging two neurons
+
+| Method                 | Type                                                                                    |
+| ---------------------- | --------------------------------------------------------------------------------------- |
+| `simulateMergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<NeuronInfo>` |
 
 ##### :gear: splitNeuron
 

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -68,7 +68,7 @@ import {
   principalToAccountIdentifier,
 } from "../../utils/account_identifier.utils";
 
-const toNeuronInfo = ({
+export const toNeuronInfo = ({
   neuronId,
   neuronInfo,
   rawNeuron,

--- a/packages/nns/src/canisters/governance/services.ts
+++ b/packages/nns/src/canisters/governance/services.ts
@@ -43,3 +43,17 @@ export const manageNeuron = async ({
   // We use it only to assert that there are no errors
   getSuccessfulCommandFromResponse(response);
 };
+
+/**
+ * @throws {@link GovernanceError}
+ */
+export const simulateManageNeuron = async ({
+  request,
+  service,
+}: {
+  request: ManageNeuron;
+  service: GovernanceService;
+}): Promise<Command_1> => {
+  const response = await service.simulate_manage_neuron(request);
+  return getSuccessfulCommandFromResponse(response);
+};

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -57,12 +57,14 @@ import {
   convertPbNeuronToNeuronInfo,
   toArrayOfNeuronInfo,
   toListProposalsResponse,
+  toNeuronInfo,
   toProposalInfo,
 } from "./canisters/governance/response.converters";
 import { checkPbManageNeuronResponse } from "./canisters/governance/response.proto.converters";
 import {
   getSuccessfulCommandFromResponse,
   manageNeuron,
+  simulateManageNeuron,
 } from "./canisters/governance/services";
 import { MAINNET_GOVERNANCE_CANISTER_ID } from "./constants/canister_ids";
 import { E8S_PER_TOKEN } from "./constants/constants";
@@ -460,6 +462,41 @@ export class GovernanceCanister {
       request: rawRequest,
       service: this.certifiedService,
     });
+  };
+
+  /**
+   * Simulate merging two neurons
+   *
+   * @throws {@link GovernanceError}
+   */
+  public simulateMergeNeurons = async (request: {
+    sourceNeuronId: NeuronId;
+    targetNeuronId: NeuronId;
+  }): Promise<NeuronInfo> => {
+    const rawRequest = toMergeRequest(request);
+
+    const command = await simulateManageNeuron({
+      request: rawRequest,
+      service: this.certifiedService,
+    });
+
+    if (
+      "Merge" in command &&
+      command.Merge.target_neuron_info[0] !== undefined &&
+      command.Merge.target_neuron[0]?.id[0]?.id !== undefined
+    ) {
+      return toNeuronInfo({
+        neuronId: command.Merge.target_neuron[0].id[0].id,
+        neuronInfo: command.Merge.target_neuron_info[0],
+        rawNeuron: command.Merge.target_neuron[0],
+        canisterId: this.canisterId,
+      });
+    }
+
+    // Edge case
+    throw new UnrecognizedTypeError(
+      `Unrecognized Merge error in ${JSON.stringify(command)}`
+    );
   };
 
   /**

--- a/packages/nns/src/mocks/governance.mock.ts
+++ b/packages/nns/src/mocks/governance.mock.ts
@@ -1,4 +1,9 @@
-import type { ListNeuronsResponse, NeuronInfo } from "../../candid/governance";
+import { Principal } from "@dfinity/principal";
+import type {
+  ListNeuronsResponse,
+  Neuron,
+  NeuronInfo,
+} from "../../candid/governance";
 
 const one = BigInt(1);
 export const mockNeuronId = BigInt(14567);
@@ -14,7 +19,29 @@ export const mockNeuronInfo: NeuronInfo = {
   voting_power: one,
   age_seconds: one,
 };
+export const mockNeuron: Neuron = {
+  id: [{ id: mockNeuronId }],
+  staked_maturity_e8s_equivalent: [one],
+  controller: [Principal.fromHex("1f")],
+  recent_ballots: [],
+  kyc_verified: false,
+  not_for_profit: false,
+  maturity_e8s_equivalent: one,
+  cached_neuron_stake_e8s: one,
+  created_timestamp_seconds: one,
+  auto_stake_maturity: [false],
+  aging_since_timestamp_seconds: one,
+  hot_keys: [],
+  account: new Uint8Array([1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 5, 6]),
+  joined_community_fund_timestamp_seconds: [],
+  dissolve_state: [],
+  followees: [],
+  neuron_fees_e8s: one,
+  transfer: [],
+  known_neuron_data: [],
+  spawn_at_timestamp_seconds: [],
+};
 export const mockListNeuronsResponse: ListNeuronsResponse = {
   neuron_infos: [[mockNeuronId, mockNeuronInfo]],
-  full_neurons: [],
+  full_neurons: [mockNeuron],
 };


### PR DESCRIPTION
# Motivation

In nns-dapp we want to show the properties of the resulting neuron before committing to merging neurons.
For this purpose, the governance canister exposes `simulate_manage_neuron`.

# Changes

Add `simulateMergeNeurons` which calls `simulate_manage_neuron`, analogous to `mergeNeurons` which calls `manage_neuron`.

# Tests

1. Added unit test following the same pattern as existing unit tests.
2. Installed the changes in nns-dapp repo locally and made some local changes to verify that I can make the `simulateMergeNeurons` call as expected.
