### PR TITLE
feat: expose Sns index canister id in wrapper

### DIFF
--- a/packages/sns/src/sns.spec.ts
+++ b/packages/sns/src/sns.spec.ts
@@ -3,9 +3,11 @@ import { mock } from "jest-mock-extended";
 import type { _SERVICE as SnsRootService } from "../candid/sns_root";
 import {
   governanceCanisterIdMock,
+  indexCanisterIdMock,
   ledgerCanisterIdMock,
   rootCanisterIdMock,
   snsMock,
+  swapCanisterIdMock,
 } from "./mocks/sns.mock";
 import { initSnsWrapper } from "./sns";
 
@@ -23,12 +25,12 @@ describe("Sns", () => {
 
     expect(canisterIds).not.toBeNull();
 
-    const { rootCanisterId, ledgerCanisterId, governanceCanisterId } =
-      canisterIds;
-    expect(rootCanisterId.toText()).toEqual(rootCanisterIdMock.toText());
-    expect(ledgerCanisterId.toText()).toEqual(ledgerCanisterIdMock.toText());
-    expect(governanceCanisterId.toText()).toEqual(
-      governanceCanisterIdMock.toText()
-    );
+    expect(canisterIds).toEqual({
+      rootCanisterId: rootCanisterIdMock,
+      ledgerCanisterId: ledgerCanisterIdMock,
+      governanceCanisterId: governanceCanisterIdMock,
+      swapCanisterId: swapCanisterIdMock,
+      indexCanisterId: indexCanisterIdMock,
+    });
   });
 });

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -114,12 +114,14 @@ export class SnsWrapper {
     ledgerCanisterId: Principal;
     governanceCanisterId: Principal;
     swapCanisterId: Principal;
+    indexCanisterId: Principal;
   } {
     return {
       rootCanisterId: this.root.canisterId,
       ledgerCanisterId: this.ledger.canisterId,
       governanceCanisterId: this.governance.canisterId,
       swapCanisterId: this.swap.canisterId,
+      indexCanisterId: this.index.canisterId,
     };
   }
 


### PR DESCRIPTION
# Motivation

We need the Sns index cansiter id to be exposed in the wrapper for NNS-dapp feature [#2639](https://github.com/dfinity/nns-dapp/pull/2639) but also (most probably) because in the future it will be possible to get the balance of an account not only from the ledger but also from the index canister.