### PR TITLE
build: improve docs generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build
+        run: npm run build
+
       - name: Generate docs
         run: npm run docs
 

--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -80,6 +80,12 @@ Parameters:
 
 `public`
 
+Parameters:
+
+- `id`
+- `service`
+- `certifiedService`
+
 #### Methods
 
 - [create](#gear-create)
@@ -162,9 +168,9 @@ Parameters:
 
 Returns an estimation of the user's fee (in Satoshi) for a retrieve_btc request based on the current status of the Bitcoin network and the fee related to the minter.
 
-| Method                  | Type                                                              |
-| ----------------------- | ----------------------------------------------------------------- |
-| `estimateWithdrawalFee` | `({ certified, amount, }: any) => Promise<EstimateWithdrawalFee>` |
+| Method                  | Type                                                                                      |
+| ----------------------- | ----------------------------------------------------------------------------------------- |
+| `estimateWithdrawalFee` | `({ certified, amount, }: EstimateWithdrawalFeeParams) => Promise<EstimateWithdrawalFee>` |
 
 Parameters:
 

--- a/packages/ledger/README.md
+++ b/packages/ledger/README.md
@@ -91,6 +91,12 @@ Parameters:
 
 `public`
 
+Parameters:
+
+- `id`
+- `service`
+- `certifiedService`
+
 #### Methods
 
 - [create](#gear-create)
@@ -126,9 +132,9 @@ The ledger transaction fees.
 
 Returns the balance of the given account.
 
-| Method    | Type                               |
-| --------- | ---------------------------------- |
-| `balance` | `(params: any) => Promise<bigint>` |
+| Method    | Type                                         |
+| --------- | -------------------------------------------- |
+| `balance` | `(params: BalanceParams) => Promise<bigint>` |
 
 Parameters:
 
@@ -159,6 +165,12 @@ Returns the total supply of tokens.
 #### Constructors
 
 `public`
+
+Parameters:
+
+- `id`
+- `service`
+- `certifiedService`
 
 #### Methods
 

--- a/packages/ledger/README.md
+++ b/packages/ledger/README.md
@@ -1,6 +1,6 @@
 # ledger-js
 
-A library for interfacing with [ICRC ledgers](https://github.com/dfinity/ic/tree/master/rs/rosetta-api/icrc1) on the Internet Computer.
+A library for interfacing with [ICRC ledger](https://github.com/dfinity/ic/tree/master/rs/rosetta-api/icrc1) on the Internet Computer.
 
 [![npm version](https://img.shields.io/npm/v/@dfinity/ledger.svg?logo=npm)](https://www.npmjs.com/package/@dfinity/ledger) [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/packages/ledger/src/ledger.canister.ts
+++ b/packages/ledger/src/ledger.canister.ts
@@ -40,7 +40,7 @@ export class IcrcLedgerCanister extends Canister<IcrcLedgerService> {
     this.caller(params).icrc1_fee();
 
   /**
-   * Returns the balance of the given account.
+   * Returns the balance for a given account provided as owner and with optional subaccount.
    *
    * @param {BalanceParams} params The parameters to get the balance of an account.
    * @returns {Promise<Tokens>} The balance of the given account.

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -162,9 +162,9 @@ Parameters:
 
 ##### :gear: toProto
 
-| Method    | Type                                 |
-| --------- | ------------------------------------ |
-| `toProto` | `() => Promise<AccountIdentifierPb>` |
+| Method    | Type                               |
+| --------- | ---------------------------------- |
+| `toProto` | `() => Promise<AccountIdentifier>` |
 
 ##### :gear: toHex
 

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -85,6 +85,12 @@ Lookup for the canister ids of a Sns and initialize the wrapper to access its fe
 
 `public`
 
+Parameters:
+
+- `id`
+- `service`
+- `certifiedService`
+
 #### Methods
 
 - [create](#gear-create)
@@ -325,6 +331,12 @@ Claim neuron
 
 `public`
 
+Parameters:
+
+- `id`
+- `service`
+- `certifiedService`
+
 #### Methods
 
 - [create](#gear-create)
@@ -351,6 +363,12 @@ Source code: https://github.com/dfinity/ic/blob/master/rs/sns/root/src/lib.rs
 #### Constructors
 
 `public`
+
+Parameters:
+
+- `id`
+- `service`
+- `certifiedService`
 
 #### Methods
 
@@ -399,9 +417,9 @@ Notify of the user participating in the swap
 
 Get user commitment
 
-| Method              | Type                                   |
-| ------------------- | -------------------------------------- |
-| `getUserCommitment` | `(params: any) => Promise<BuyerState>` |
+| Method              | Type                                                                    |
+| ------------------- | ----------------------------------------------------------------------- |
+| `getUserCommitment` | `(params: GetBuyerStateRequest and QueryParams) => Promise<BuyerState>` |
 
 ##### :gear: getDerivedState
 
@@ -545,27 +563,27 @@ Parameters:
 
 ##### :gear: transactionFee
 
-| Method           | Type                                                              |
-| ---------------- | ----------------------------------------------------------------- |
-| `transactionFee` | `(params: Omit<QueryParams, "certified">) => Promise<IcrcTokens>` |
+| Method           | Type                                                          |
+| ---------------- | ------------------------------------------------------------- |
+| `transactionFee` | `(params: Omit<QueryParams, "certified">) => Promise<bigint>` |
 
 ##### :gear: totalTokensSupply
 
-| Method              | Type                                                              |
-| ------------------- | ----------------------------------------------------------------- |
-| `totalTokensSupply` | `(params: Omit<QueryParams, "certified">) => Promise<IcrcTokens>` |
+| Method              | Type                                                          |
+| ------------------- | ------------------------------------------------------------- |
+| `totalTokensSupply` | `(params: Omit<QueryParams, "certified">) => Promise<bigint>` |
 
 ##### :gear: balance
 
-| Method    | Type                                                                |
-| --------- | ------------------------------------------------------------------- |
-| `balance` | `(params: Omit<BalanceParams, "certified">) => Promise<IcrcTokens>` |
+| Method    | Type                                                            |
+| --------- | --------------------------------------------------------------- |
+| `balance` | `(params: Omit<BalanceParams, "certified">) => Promise<bigint>` |
 
 ##### :gear: transfer
 
-| Method     | Type                                                  |
-| ---------- | ----------------------------------------------------- |
-| `transfer` | `(params: TransferParams) => Promise<IcrcBlockIndex>` |
+| Method     | Type                                          |
+| ---------- | --------------------------------------------- |
+| `transfer` | `(params: TransferParams) => Promise<bigint>` |
 
 ##### :gear: getNeuron
 
@@ -623,9 +641,9 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 
 ##### :gear: getNeuronBalance
 
-| Method             | Type                                          |
-| ------------------ | --------------------------------------------- |
-| `getNeuronBalance` | `(neuronId: NeuronId) => Promise<IcrcTokens>` |
+| Method             | Type                                      |
+| ------------------ | ----------------------------------------- |
+| `getNeuronBalance` | `(neuronId: NeuronId) => Promise<bigint>` |
 
 ##### :gear: addNeuronPermissions
 
@@ -761,9 +779,9 @@ Always certified
 
 ##### :gear: getTransactions
 
-| Method            | Type                                                                     |
-| ----------------- | ------------------------------------------------------------------------ |
-| `getTransactions` | `(params: GetAccountTransactionsParams) => Promise<IcrcGetTransactions>` |
+| Method            | Type                                                                 |
+| ----------------- | -------------------------------------------------------------------- |
+| `getTransactions` | `(params: GetAccountTransactionsParams) => Promise<GetTransactions>` |
 
 ##### :gear: stakeMaturity
 


### PR DESCRIPTION
# Motivation

- add `npm run build` before generating the docs. this allow the doc library to resolve few parameters that were documented as `any`
- While not necessary, it's probably a best practice to set node version before running the script
- Bump `actions/checkout` to v3 for no particular other reason than using a more up-to-date version