### PR TITLE
feat: ckBTC get minter info

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     {
       "name": "@dfinity/ckbtc",
       "path": "./packages/ckbtc/dist/index.js",
-      "limit": "8 kB",
+      "limit": "9 kB",
       "ignore": [
         "@dfinity/agent",
         "@dfinity/candid",

--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -95,6 +95,7 @@ Parameters:
 - [retrieveBtc](#gear-retrievebtc)
 - [estimateWithdrawalFee](#gear-estimatewithdrawalfee)
 - [getDepositFee](#gear-getdepositfee)
+- [getMinterInfo](#gear-getminterinfo)
 
 ##### :gear: create
 
@@ -185,6 +186,19 @@ Returns the fee that the minter will charge for a bitcoin deposit.
 | Method          | Type                                              |
 | --------------- | ------------------------------------------------- |
 | `getDepositFee` | `({ certified }: QueryParams) => Promise<bigint>` |
+
+Parameters:
+
+- `params`: The parameters to get the deposit fee.
+- `params.certified`: query or update call
+
+##### :gear: getMinterInfo
+
+Returns internal minter parameters such as the minimal amount to retrieve BTC, minimal number of confirmations or KYT fee.
+
+| Method          | Type                                                  |
+| --------------- | ----------------------------------------------------- |
+| `getMinterInfo` | `({ certified }: QueryParams) => Promise<MinterInfo>` |
 
 Parameters:
 

--- a/packages/ckbtc/candid/minter.certified.idl.js
+++ b/packages/ckbtc/candid/minter.certified.idl.js
@@ -54,6 +54,7 @@ export const idlFactory = ({ IDL }) => {
       'utxos' : IDL.Vec(Utxo),
     }),
     'sent_transaction' : IDL.Record({
+      'fee' : IDL.Opt(IDL.Nat64),
       'change_output' : IDL.Opt(
         IDL.Record({ 'value' : IDL.Nat64, 'vout' : IDL.Nat32 })
       ),
@@ -62,22 +63,48 @@ export const idlFactory = ({ IDL }) => {
       'requests' : IDL.Vec(IDL.Nat64),
       'submitted_at' : IDL.Nat64,
     }),
+    'distributed_kyt_fee' : IDL.Record({
+      'block_index' : IDL.Nat64,
+      'amount' : IDL.Nat64,
+      'kyt_provider' : IDL.Principal,
+    }),
     'init' : InitArgs,
     'upgrade' : UpgradeArgs,
+    'retrieve_btc_kyt_failed' : IDL.Record({
+      'block_index' : IDL.Nat64,
+      'uuid' : IDL.Text,
+      'address' : IDL.Text,
+      'amount' : IDL.Nat64,
+      'kyt_provider' : IDL.Principal,
+    }),
     'accepted_retrieve_btc_request' : IDL.Record({
       'received_at' : IDL.Nat64,
       'block_index' : IDL.Nat64,
       'address' : BitcoinAddress,
       'amount' : IDL.Nat64,
+      'kyt_provider' : IDL.Opt(IDL.Principal),
     }),
     'checked_utxo' : IDL.Record({
       'clean' : IDL.Bool,
       'utxo' : Utxo,
       'uuid' : IDL.Text,
+      'kyt_provider' : IDL.Opt(IDL.Principal),
     }),
     'removed_retrieve_btc_request' : IDL.Record({ 'block_index' : IDL.Nat64 }),
     'confirmed_transaction' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8) }),
+    'replaced_transaction' : IDL.Record({
+      'fee' : IDL.Nat64,
+      'change_output' : IDL.Record({ 'value' : IDL.Nat64, 'vout' : IDL.Nat32 }),
+      'old_txid' : IDL.Vec(IDL.Nat8),
+      'new_txid' : IDL.Vec(IDL.Nat8),
+      'submitted_at' : IDL.Nat64,
+    }),
     'ignored_utxo' : IDL.Record({ 'utxo' : Utxo }),
+  });
+  const MinterInfo = IDL.Record({
+    'retrieve_btc_min_amount' : IDL.Nat64,
+    'min_confirmations' : IDL.Nat32,
+    'kyt_fee' : IDL.Nat64,
   });
   const RetrieveBtcArgs = IDL.Record({
     'address' : IDL.Text,
@@ -148,6 +175,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(Event)],
         [],
       ),
+    'get_minter_info' : IDL.Func([], [MinterInfo], []),
     'get_withdrawal_account' : IDL.Func([], [Account], []),
     'retrieve_btc' : IDL.Func(
         [RetrieveBtcArgs],

--- a/packages/ckbtc/candid/minter.did
+++ b/packages/ckbtc/candid/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 078de6d2b8d15cccb09fcfe2483fddabe6c39457 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
+// Generated from IC repo commit 010a489c530137d893222ccac356b704b32f007a 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
 // Represents an account on the ckBTC ledger.
 type Account = record { owner : principal; subaccount : opt blob };
 
@@ -194,6 +194,12 @@ type BitcoinAddress = variant {
     p2sh : blob;
 };
 
+type MinterInfo = record {
+    min_confirmations : nat32;
+    retrieve_btc_min_amount : nat64;
+    kyt_fee : nat64;
+};
+
 type Event = variant {
     init : InitArgs;
     upgrade : UpgradeArgs;
@@ -203,6 +209,12 @@ type Event = variant {
         address : BitcoinAddress;
         block_index : nat64;
         received_at : nat64;
+        kyt_provider : opt principal;
+    };
+    distributed_kyt_fee : record {
+        kyt_provider : principal;
+        amount : nat64;
+        block_index: nat64;
     };
     removed_retrieve_btc_request : record { block_index : nat64 };
     sent_transaction : record {
@@ -211,20 +223,36 @@ type Event = variant {
         utxos : vec Utxo;
         change_output : opt record { vout : nat32; value : nat64 };
         submitted_at : nat64;
+        fee: opt nat64;
+    };
+    replaced_transaction : record {
+        new_txid : blob;
+        old_txid : blob;
+        change_output : record { vout : nat32; value : nat64 };
+        submitted_at : nat64;
+        fee: nat64;
     };
     confirmed_transaction : record { txid : blob };
     checked_utxo : record {
         utxo : Utxo;
         uuid : text;
         clean : bool;
+        kyt_provider : opt principal;
     };
     ignored_utxo : record { utxo: Utxo; };
+    retrieve_btc_kyt_failed : record {
+        address : text;
+        amount : nat64;
+        kyt_provider : principal;
+        uuid : text;
+        block_index : nat64;
+    };
 };
 
 type MinterArg = variant {
     Init : InitArgs;
     Upgrade : opt UpgradeArgs;
-}
+};
 
 service : (minter_arg : MinterArg) -> {
     // Section "Convert BTC to ckBTC" {{{
@@ -252,7 +280,7 @@ service : (minter_arg : MinterArg) -> {
 
     /// Returns an estimate of the user's fee (in Satoshi) for a
     /// retrieve_btc request based on the current status of the Bitcoin network.
-    estimate_withdrawal_fee : (record { amount : opt nat64 }) -> (record { bitcoin_fee: nat64; minter_fee: nat64;}) query;
+    estimate_withdrawal_fee : (record { amount : opt nat64 }) -> (record { bitcoin_fee : nat64; minter_fee : nat64 }) query;
 
     /// Returns the fee that the minter will charge for a bitcoin deposit.
     get_deposit_fee: () -> (nat64) query;
@@ -260,6 +288,7 @@ service : (minter_arg : MinterArg) -> {
     // Returns the account to which the caller should deposit ckBTC
     // before withdrawing BTC using the [retrieve_btc] endpoint.
     get_withdrawal_account : () -> (Account);
+
 
     // Submits a request to convert ckBTC to BTC.
     //
@@ -280,6 +309,11 @@ service : (minter_arg : MinterArg) -> {
     retrieve_btc_status : (record { block_index : nat64 }) -> (RetrieveBtcStatus) query;
 
     // }}} Section "Convert ckBTC to BTC"
+
+    // Section "Minter Information" {{{
+    // Returns internal minter parameters.
+    get_minter_info : () -> (MinterInfo) query;
+    // }}}
 
     // Section "Event log" {{{
 

--- a/packages/ckbtc/candid/minter.idl.js
+++ b/packages/ckbtc/candid/minter.idl.js
@@ -54,6 +54,7 @@ export const idlFactory = ({ IDL }) => {
       'utxos' : IDL.Vec(Utxo),
     }),
     'sent_transaction' : IDL.Record({
+      'fee' : IDL.Opt(IDL.Nat64),
       'change_output' : IDL.Opt(
         IDL.Record({ 'value' : IDL.Nat64, 'vout' : IDL.Nat32 })
       ),
@@ -62,22 +63,48 @@ export const idlFactory = ({ IDL }) => {
       'requests' : IDL.Vec(IDL.Nat64),
       'submitted_at' : IDL.Nat64,
     }),
+    'distributed_kyt_fee' : IDL.Record({
+      'block_index' : IDL.Nat64,
+      'amount' : IDL.Nat64,
+      'kyt_provider' : IDL.Principal,
+    }),
     'init' : InitArgs,
     'upgrade' : UpgradeArgs,
+    'retrieve_btc_kyt_failed' : IDL.Record({
+      'block_index' : IDL.Nat64,
+      'uuid' : IDL.Text,
+      'address' : IDL.Text,
+      'amount' : IDL.Nat64,
+      'kyt_provider' : IDL.Principal,
+    }),
     'accepted_retrieve_btc_request' : IDL.Record({
       'received_at' : IDL.Nat64,
       'block_index' : IDL.Nat64,
       'address' : BitcoinAddress,
       'amount' : IDL.Nat64,
+      'kyt_provider' : IDL.Opt(IDL.Principal),
     }),
     'checked_utxo' : IDL.Record({
       'clean' : IDL.Bool,
       'utxo' : Utxo,
       'uuid' : IDL.Text,
+      'kyt_provider' : IDL.Opt(IDL.Principal),
     }),
     'removed_retrieve_btc_request' : IDL.Record({ 'block_index' : IDL.Nat64 }),
     'confirmed_transaction' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8) }),
+    'replaced_transaction' : IDL.Record({
+      'fee' : IDL.Nat64,
+      'change_output' : IDL.Record({ 'value' : IDL.Nat64, 'vout' : IDL.Nat32 }),
+      'old_txid' : IDL.Vec(IDL.Nat8),
+      'new_txid' : IDL.Vec(IDL.Nat8),
+      'submitted_at' : IDL.Nat64,
+    }),
     'ignored_utxo' : IDL.Record({ 'utxo' : Utxo }),
+  });
+  const MinterInfo = IDL.Record({
+    'retrieve_btc_min_amount' : IDL.Nat64,
+    'min_confirmations' : IDL.Nat32,
+    'kyt_fee' : IDL.Nat64,
   });
   const RetrieveBtcArgs = IDL.Record({
     'address' : IDL.Text,
@@ -148,6 +175,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(Event)],
         ['query'],
       ),
+    'get_minter_info' : IDL.Func([], [MinterInfo], ['query']),
     'get_withdrawal_account' : IDL.Func([], [Account], []),
     'retrieve_btc' : IDL.Func(
         [RetrieveBtcArgs],

--- a/packages/ckbtc/src/index.ts
+++ b/packages/ckbtc/src/index.ts
@@ -1,5 +1,6 @@
 export type {
   Account as WithdrawalAccount,
+  MinterInfo,
   RetrieveBtcOk,
 } from "../candid/minter";
 export * from "./enums/btc.enums";

--- a/packages/ckbtc/src/minter.canister.spec.ts
+++ b/packages/ckbtc/src/minter.canister.spec.ts
@@ -469,4 +469,39 @@ describe("ckBTC minter canister", () => {
       ).rejects.toThrowError();
     });
   });
+
+  describe("Minter Info", () => {
+    it("should return minter info", async () => {
+      const result = {
+        retrieve_btc_min_amount: 1n,
+        min_confirmations: 12,
+        kyt_fee: 3n,
+      };
+
+      const service = mock<ActorSubclass<CkBTCMinterService>>();
+      service.get_minter_info.mockResolvedValue(result);
+
+      const canister = minter(service);
+
+      const res = await canister.getMinterInfo({
+        certified: true,
+      });
+
+      expect(service.get_minter_info).toBeCalled();
+      expect(res).toEqual(result);
+    });
+
+    it("should bubble errors", () => {
+      const service = mock<ActorSubclass<CkBTCMinterService>>();
+      service.get_minter_info.mockImplementation(() => {
+        throw new Error();
+      });
+
+      const canister = minter(service);
+
+      expect(() =>
+        canister.getMinterInfo({ certified: true })
+      ).rejects.toThrowError();
+    });
+  });
 });

--- a/packages/ckbtc/src/minter.canister.ts
+++ b/packages/ckbtc/src/minter.canister.ts
@@ -6,6 +6,7 @@ import {
 } from "@dfinity/utils";
 import type {
   Account as WithdrawalAccount,
+  MinterInfo,
   RetrieveBtcOk,
   _SERVICE as CkBTCMinterService,
 } from "../candid/minter";
@@ -149,4 +150,15 @@ export class CkBTCMinterCanister extends Canister<CkBTCMinterService> {
     this.caller({
       certified,
     }).get_deposit_fee();
+
+  /**
+   * Returns internal minter parameters such as the minimal amount to retrieve BTC, minimal number of confirmations or KYT fee.
+   *
+   * @param {QueryParams} params The parameters to get the deposit fee.
+   * @param {boolean} params.certified query or update call
+   */
+  getMinterInfo = async ({ certified }: QueryParams): Promise<MinterInfo> =>
+    this.caller({
+      certified,
+    }).get_minter_info();
 }


### PR DESCRIPTION
# Motivation

Expose new ckBTC `get_minter_info` (already available on mainnet) which returns internal minter parameters such as the minimal amount to retrieve BTC, minimal number of confirmations or KYT fee.

# Changes

- update did files
- imeplement `get_minter_info`
