### PR TITLE
feat: deprecate ckBTC deposit fee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
 - utils `v0.0.16`
 - nns-proto `v0.0.2`
 
+## Breaking Changes
+
+- ckBTC `getDepositFee` has been deprecated. Instead, use the new feature `getMinterInfo`
+
+## Features
+
+- introduces `getMinterInfo` for ckBTC which returns internal minter parameters such as the minimal amount to retrieve BTC, minimal number of confirmations or KYT fee
+
 # 0.16.0 (2023-05-24)
 
 ## Release

--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -94,7 +94,6 @@ Parameters:
 - [getWithdrawalAccount](#gear-getwithdrawalaccount)
 - [retrieveBtc](#gear-retrievebtc)
 - [estimateWithdrawalFee](#gear-estimatewithdrawalfee)
-- [getDepositFee](#gear-getdepositfee)
 - [getMinterInfo](#gear-getminterinfo)
 
 ##### :gear: create
@@ -178,19 +177,6 @@ Parameters:
 - `params`: The parameters to estimate the fee.
 - `params.certified`: query or update call
 - `params.amount`: The optional amount for which the fee should be estimated.
-
-##### :gear: getDepositFee
-
-Returns the fee that the minter will charge for a bitcoin deposit.
-
-| Method          | Type                                              |
-| --------------- | ------------------------------------------------- |
-| `getDepositFee` | `({ certified }: QueryParams) => Promise<bigint>` |
-
-Parameters:
-
-- `params`: The parameters to get the deposit fee.
-- `params.certified`: query or update call
 
 ##### :gear: getMinterInfo
 

--- a/packages/ckbtc/src/minter.canister.spec.ts
+++ b/packages/ckbtc/src/minter.canister.spec.ts
@@ -439,37 +439,6 @@ describe("ckBTC minter canister", () => {
     });
   });
 
-  describe("Deposit Fee", () => {
-    it("should return deposit fee", async () => {
-      const result = 123789n;
-
-      const service = mock<ActorSubclass<CkBTCMinterService>>();
-      service.get_deposit_fee.mockResolvedValue(result);
-
-      const canister = minter(service);
-
-      const res = await canister.getDepositFee({
-        certified: true,
-      });
-
-      expect(service.get_deposit_fee).toBeCalled();
-      expect(res).toEqual(result);
-    });
-
-    it("should bubble errors", () => {
-      const service = mock<ActorSubclass<CkBTCMinterService>>();
-      service.get_deposit_fee.mockImplementation(() => {
-        throw new Error();
-      });
-
-      const canister = minter(service);
-
-      expect(() =>
-        canister.getDepositFee({ certified: true })
-      ).rejects.toThrowError();
-    });
-  });
-
   describe("Minter Info", () => {
     it("should return minter info", async () => {
       const result = {

--- a/packages/ckbtc/src/minter.canister.ts
+++ b/packages/ckbtc/src/minter.canister.ts
@@ -141,17 +141,6 @@ export class CkBTCMinterCanister extends Canister<CkBTCMinterService> {
     }).estimate_withdrawal_fee({ amount: toNullable(amount) });
 
   /**
-   * Returns the fee that the minter will charge for a bitcoin deposit.
-   *
-   * @param {QueryParams} params The parameters to get the deposit fee.
-   * @param {boolean} params.certified query or update call
-   */
-  getDepositFee = async ({ certified }: QueryParams): Promise<bigint> =>
-    this.caller({
-      certified,
-    }).get_deposit_fee();
-
-  /**
    * Returns internal minter parameters such as the minimal amount to retrieve BTC, minimal number of confirmations or KYT fee.
    *
    * @param {QueryParams} params The parameters to get the deposit fee.


### PR DESCRIPTION
# Motivation

The ckBTC `get_deposit_fee` can (or should) be deprecated. Instead, the new `get_minter_info` should be used.

Confirmed by Léo:

> get_deposit_fee = get_minter_info.kyt_fee
