### PR TITLE
Chore: Add fee to nns stake neuron method

### DIFF
--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -452,9 +452,9 @@ Parameters:
 
 ##### :gear: stakeNeuron
 
-| Method        | Type                                                                                                                                                                                                             |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `stakeNeuron` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, }: { stake: bigint; principal: Principal; fromSubAccount?: number[]; ledgerCanister: LedgerCanister; createdAt?: bigint; }) => Promise<bigint>` |
+| Method        | Type                                                                                                                                                                                                                                |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stakeNeuron` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, fee, }: { stake: bigint; principal: Principal; fromSubAccount?: number[]; ledgerCanister: LedgerCanister; createdAt?: bigint; fee?: bigint; }) => Promise<bigint>` |
 
 ##### :gear: increaseDissolveDelay
 

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -247,6 +247,7 @@ export class GovernanceCanister {
     fromSubAccount,
     ledgerCanister,
     createdAt,
+    fee,
   }: {
     stake: bigint;
     principal: Principal;
@@ -255,6 +256,7 @@ export class GovernanceCanister {
     // Used for the TransferRequest parameters.
     // Check the TransferRequest type for more information.
     createdAt?: bigint;
+    fee?: E8s;
   }): Promise<NeuronId> => {
     if (stake < E8S_PER_TOKEN) {
       throw new InsufficientAmountError(stake);
@@ -275,6 +277,7 @@ export class GovernanceCanister {
       fromSubAccount,
       to: accountIdentifier,
       createdAt,
+      fee,
     });
 
     // Notify the governance of the transaction so that the neuron is created.


### PR DESCRIPTION
# Motivation

Prepare for migration of HW to Candid.

If the fee is not passed, the transfer fetches it. Yet, the Ledger App doesn't support fetching the transfer fee.

One solution is to pass a fee when staking a neuron, which is then passed when making the transfer.

Another solution (not here) is to use an anonymous identity when fetching the fee. This is not straightforward because we use classes. The identity is in the agent, which is passed in the initialization of the class.

# Changes

* Add a `fee` parameter when staking an NNS neuron.

# Tests

* Add a test to check that the `fee` parameter is passed then to the `transfer` method.
