### PR TITLE
feat: implement IC mgmt - copy getCanisterDetails and updateSettings from NNS dapp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 
 ## Features
 
-- introduces `getMinterInfo` for ckBTC which returns internal minter parameters such as the minimal amount to retrieve BTC, minimal number of confirmations or KYT fee
+- introducing `@dfinity/ic-management` — a new library for interfacing with IC management canister
+- add `getMinterInfo` for ckBTC which returns internal minter parameters such as the minimal amount to retrieve BTC, minimal number of confirmations or KYT fee
 
 # 0.16.0 (2023-05-24)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The libraries are still in active development, and new features will incremental
 - [cmc](/packages/cmc): interfacing with the **cmc** canister of the IC
 - [ledger](/packages/ledger): interacting with ICRC compatible **ledgers**
 - [ckBTC](/packages/ckbtc): interfacing with **ckBTC**
+- [ic-management](/packages/ic-management): interfacing with the **IC management canister**
 - [utils](/packages/utils): a collection of utilities and constants
 - [nns-proto](/packages/nns-proto): the protobuf source used by `nns-js` to support hardware wallets
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "packages/cmc",
         "packages/ckbtc",
         "packages/rosetta-client",
-        "package/ic-management"
+        "packages/ic-management"
       ],
       "devDependencies": {
         "@size-limit/esbuild": "^8.2.4",
@@ -4321,7 +4321,7 @@
       }
     },
     "node_modules/ic-management": {
-      "resolved": "package/ic-management",
+      "resolved": "packages/ic-management",
       "link": true
     },
     "node_modules/ieee754": {
@@ -7164,7 +7164,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "package/ic-management": {
+    "packages/ic-management": {
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {}
@@ -10326,7 +10326,7 @@
       "dev": true
     },
     "ic-management": {
-      "version": "file:package/ic-management"
+      "version": "file:packages/ic-management"
     },
     "ieee754": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7166,7 +7166,7 @@
     },
     "packages/ic-management": {
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "Apache-2.0",
       "devDependencies": {}
     },
     "packages/ckbtc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -708,6 +708,10 @@
       "resolved": "packages/cmc",
       "link": true
     },
+    "node_modules/@dfinity/ic-management": {
+      "resolved": "packages/ic-management",
+      "link": true
+    },
     "node_modules/@dfinity/ledger": {
       "resolved": "packages/ledger",
       "link": true
@@ -4320,10 +4324,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/ic-management": {
-      "resolved": "packages/ic-management",
-      "link": true
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -7164,11 +7164,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/ic-management": {
-      "version": "1.0.0",
-      "license": "Apache-2.0",
-      "devDependencies": {}
-    },
     "packages/ckbtc": {
       "name": "@dfinity/ckbtc",
       "version": "0.0.5",
@@ -7189,6 +7184,22 @@
       "name": "@dfinity/cmc",
       "version": "0.0.12",
       "license": "Apache-2.0",
+      "peerDependencies": {
+        "@dfinity/agent": "^0.15.4",
+        "@dfinity/candid": "^0.15.4",
+        "@dfinity/principal": "^0.15.4",
+        "@dfinity/utils": "^0.0.16"
+      }
+    },
+    "packages/ic-management": {
+      "name": "@dfinity/ic-management",
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base58-js": "^1.0.5",
+        "bech32": "^2.0.0",
+        "js-sha256": "^0.9.0"
+      },
       "peerDependencies": {
         "@dfinity/agent": "^0.15.4",
         "@dfinity/candid": "^0.15.4",
@@ -7782,6 +7793,14 @@
     "@dfinity/cmc": {
       "version": "file:packages/cmc",
       "requires": {}
+    },
+    "@dfinity/ic-management": {
+      "version": "file:packages/ic-management",
+      "requires": {
+        "base58-js": "^1.0.5",
+        "bech32": "^2.0.0",
+        "js-sha256": "^0.9.0"
+      }
     },
     "@dfinity/ledger": {
       "version": "file:packages/ledger",
@@ -10324,9 +10343,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
-    },
-    "ic-management": {
-      "version": "file:packages/ic-management"
     },
     "ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,16 @@
       "path": "./packages/rosetta-client/dist/index.js",
       "limit": "1 kB",
       "ignore": []
+    },
+    {
+      "name": "@dfinity/ic-management",
+      "path": "./packages/ic-management/dist/index.js",
+      "limit": "10 kB",
+      "ignore": [
+        "@dfinity/agent",
+        "@dfinity/candid",
+        "@dfinity/principal"
+      ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     {
       "name": "@dfinity/ic-management",
       "path": "./packages/ic-management/dist/index.js",
-      "limit": "10 kB",
+      "limit": "3 kB",
       "ignore": [
         "@dfinity/agent",
         "@dfinity/candid",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "packages/cmc",
     "packages/ckbtc",
     "packages/rosetta-client",
-    "package/ic-management"
+    "packages/ic-management"
   ],
   "scripts": {
     "did": "scripts/compile-idl-js",

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -43,7 +43,7 @@ const { getCanisterDetails } = ICMgmtCanister.create({
   agent,
 });
 
-const details = await getCanisterDetails({ canisterId: YOUR_CANISTER_ID });
+const details = await getCanisterDetails(YOUR_CANISTER_ID);
 ```
 
 ## Features

--- a/packages/ic-management/src/errors/ic-management.errors.spec.ts
+++ b/packages/ic-management/src/errors/ic-management.errors.spec.ts
@@ -1,0 +1,26 @@
+import { mapError, UserNotTheControllerError } from "./ic-management.errors";
+
+describe("IC Management Error utils", () => {
+  describe("mapError", () => {
+    it("returns error based on code", () => {
+      expect(mapError(new Error("code: 403"))).toBeInstanceOf(
+        UserNotTheControllerError
+      );
+      expect(
+        mapError(new Error("This is an error message with\ncode: 514"))
+      ).toBeInstanceOf(Error);
+      expect(
+        mapError(new Error("And this is yet another one with\ncode: 509"))
+      ).toBeInstanceOf(Error);
+    });
+
+    it("returns Error if no code is found", () => {
+      expect(mapError(new Error("no code is found here"))).toBeInstanceOf(
+        Error
+      );
+      expect(
+        mapError(new Error("erro message with code: 509 in the same line"))
+      ).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/packages/ic-management/src/errors/ic-management.errors.ts
+++ b/packages/ic-management/src/errors/ic-management.errors.ts
@@ -1,0 +1,23 @@
+/**
+ * Parses and throws convenient error class.
+ *
+ * @throws UserNotTheControllerError and Error.
+ */
+export function mapError(error: Error | unknown): Error | unknown {
+  const statusLine =
+    error instanceof Error
+      ? error.message
+      : ""
+          .split("\n")
+          .map((l) => l.trim().toLowerCase())
+          .find(
+            (l) => l.startsWith("code:") || l.startsWith("http status code:")
+          );
+
+  if (statusLine?.includes("403")) {
+    return new UserNotTheControllerError();
+  }
+  return error;
+}
+
+export class UserNotTheControllerError extends Error {}

--- a/packages/ic-management/src/ic-management.canister.spec.ts
+++ b/packages/ic-management/src/ic-management.canister.spec.ts
@@ -1,0 +1,145 @@
+import type { ManagementCanisterRecord } from "@dfinity/agent";
+import { ActorSubclass, HttpAgent } from "@dfinity/agent";
+import { Principal } from "@dfinity/principal";
+import { mock } from "jest-mock-extended";
+import { UserNotTheControllerError } from "./errors/ic-management.errors";
+import { ICManagementCanister } from "./ic-management.canister";
+import {
+  mockCanisterDetails,
+  mockCanisterId,
+  mockCanisterSettings,
+} from "./ic-management.mock";
+import { CanisterStatusDidResponse } from "./types/ic-management.did";
+import { toCanisterDetails } from "./utils/ic-management.converters";
+
+describe("ICManagementCanister", () => {
+  const mockAgent: HttpAgent = mock<HttpAgent>();
+
+  const createICManagement = async (service: ManagementCanisterRecord) => {
+    return ICManagementCanister.create({
+      agent: mockAgent,
+      serviceOverride: service as ActorSubclass<ManagementCanisterRecord>,
+    });
+  };
+
+  describe("ICManagementCanister.getCanisterDetails", () => {
+    it("returns account identifier when success", async () => {
+      const settings = {
+        freezing_threshold: BigInt(2),
+        controllers: [
+          Principal.fromText(
+            "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
+          ),
+        ],
+        memory_allocation: BigInt(4),
+        compute_allocation: BigInt(10),
+      };
+      const response: CanisterStatusDidResponse = {
+        status: { running: null },
+        memory_size: BigInt(1000),
+        cycles: BigInt(10_000),
+        settings,
+        module_hash: [],
+      };
+      const service = mock<ManagementCanisterRecord>();
+      service.canister_status.mockResolvedValue(response);
+
+      const icManagement = await createICManagement(service);
+
+      const res = await icManagement.getCanisterDetails(mockCanisterDetails.id);
+
+      expect(res).toEqual(
+        toCanisterDetails({ response, canisterId: mockCanisterDetails.id })
+      );
+    });
+
+    it("throws UserNotTheControllerError", async () => {
+      const error = new Error("code: 403");
+      const service = mock<ManagementCanisterRecord>();
+      service.canister_status.mockRejectedValue(error);
+
+      const icManagement = await createICManagement(service);
+
+      const call = () =>
+        icManagement.getCanisterDetails(Principal.fromText("aaaaa-aa"));
+
+      expect(call).rejects.toThrowError(UserNotTheControllerError);
+    });
+
+    it("throws Error", async () => {
+      const error = new Error("Test");
+      const service = mock<ManagementCanisterRecord>();
+      service.canister_status.mockRejectedValue(error);
+
+      const icManagement = await createICManagement(service);
+
+      const call = () =>
+        icManagement.getCanisterDetails(Principal.fromText("aaaaa-aa"));
+
+      expect(call).rejects.toThrowError(Error);
+    });
+  });
+
+  describe("updateSettings", () => {
+    it("calls update_settings with new settings", async () => {
+      const service = mock<ManagementCanisterRecord>();
+      service.update_settings.mockResolvedValue(undefined);
+
+      const icManagement = await createICManagement(service);
+
+      await icManagement.updateSettings({
+        canisterId: mockCanisterId,
+        settings: mockCanisterSettings,
+      });
+      expect(service.update_settings).toBeCalled();
+    });
+
+    it("works when passed partial settings", async () => {
+      const partialSettings = {
+        controllers: [
+          "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe",
+        ],
+      };
+      const service = mock<ManagementCanisterRecord>();
+      service.update_settings.mockResolvedValue(undefined);
+
+      const icManagement = await createICManagement(service);
+
+      await icManagement.updateSettings({
+        canisterId: mockCanisterId,
+        settings: partialSettings,
+      });
+      expect(service.update_settings).toBeCalled();
+    });
+
+    it("throws UserNotTheControllerError", async () => {
+      const error = new Error("code: 403");
+      const service = mock<ManagementCanisterRecord>();
+      service.update_settings.mockRejectedValue(error);
+
+      const icManagement = await createICManagement(service);
+
+      const call = () =>
+        icManagement.updateSettings({
+          canisterId: mockCanisterId,
+          settings: mockCanisterSettings,
+        });
+      expect(call).rejects.toThrowError(UserNotTheControllerError);
+    });
+
+    it("throws Error", async () => {
+      const error = new Error("Test");
+      const service = mock<ManagementCanisterRecord>();
+      service.update_settings.mockRejectedValue(error);
+
+      const icManagement = await createICManagement(service);
+
+      const call = () =>
+        icManagement.updateSettings({
+          canisterId: mockCanisterId,
+          settings: mockCanisterSettings,
+        });
+      expect(call).rejects.toThrowError(Error);
+    });
+  });
+});

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -3,7 +3,7 @@ import {
   type ManagementCanisterRecord,
 } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
-import { toNullable } from "@dfinity/utils/src";
+import { toNullable } from "@dfinity/utils";
 import { mapError } from "./errors/ic-management.errors";
 import type { ICManagementCanisterOptions } from "./types/canister.options";
 import type { CanisterStatusDidResponse } from "./types/ic-management.did";

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -5,12 +5,12 @@ import {
 import { Principal } from "@dfinity/principal";
 import { toNullable } from "@dfinity/utils/src";
 import { mapError } from "./errors/ic-management.errors";
+import type { ICManagementCanisterOptions } from "./types/canister.options";
+import type { CanisterStatusDidResponse } from "./types/ic-management.did";
 import type {
   CanisterDetails,
   CanisterSettings,
 } from "./types/ic-management.response";
-import type { ICManagementCanisterOptions } from "./types/canister.options";
-import type { CanisterStatusDidResponse } from "./types/ic-management.did";
 import { toCanisterDetails } from "./utils/ic-management.converters";
 
 export class ICManagementCanister {

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -1,0 +1,91 @@
+import {
+  getManagementCanister,
+  type ManagementCanisterRecord,
+} from "@dfinity/agent";
+import { Principal } from "@dfinity/principal";
+import { toNullable } from "@dfinity/utils/src";
+import { mapError } from "./errors/ic-management.errors";
+import type {
+  CanisterDetails,
+  CanisterSettings,
+} from "./types/ic-management.response";
+import type { ICManagementCanisterOptions } from "./types/canister.options";
+import type { CanisterStatusDidResponse } from "./types/ic-management.did";
+import { toCanisterDetails } from "./utils/ic-management.converters";
+
+export class ICManagementCanister {
+  private constructor(private readonly service: ManagementCanisterRecord) {
+    this.service = service;
+  }
+
+  public static create(options: ICManagementCanisterOptions) {
+    const agent = options.agent;
+
+    const service = options.serviceOverride ?? getManagementCanister({ agent });
+
+    return new ICManagementCanister(service);
+  }
+
+  /**
+   * Returns canister details (memory size, status, etc.)
+   *
+   * @param {Principal} canisterId
+   * @returns Promise<CanisterDetails>
+   * @throws UserNotTheController, Error
+   */
+  public getCanisterDetails = async (
+    canisterId: Principal
+  ): Promise<CanisterDetails> => {
+    try {
+      const rawResponse: CanisterStatusDidResponse =
+        await this.service.canister_status({
+          canister_id: canisterId,
+        });
+      return toCanisterDetails({
+        response: rawResponse,
+        canisterId,
+      });
+    } catch (error: unknown) {
+      throw mapError(error);
+    }
+  };
+
+  /**
+   * Update canister settings
+   *
+   * @param {Object} params
+   * @param {Principal} params.canisterId
+   * @param {CanisterSettings} params.settings
+   * @returns Promise<void>
+   * @throws UserNotTheController, Error
+   */
+  public updateSettings = async ({
+    canisterId,
+    settings: {
+      controllers,
+      freezingThreshold,
+      memoryAllocation,
+      computeAllocation,
+    },
+  }: {
+    canisterId: Principal;
+    settings: Partial<CanisterSettings>;
+  }): Promise<void> => {
+    try {
+      // Empty array does not change the value in the settings.
+      await this.service.update_settings({
+        canister_id: canisterId,
+        settings: {
+          controllers: toNullable(
+            controllers?.map((c) => Principal.fromText(c))
+          ),
+          freezing_threshold: toNullable(freezingThreshold),
+          memory_allocation: toNullable(memoryAllocation),
+          compute_allocation: toNullable(computeAllocation),
+        },
+      });
+    } catch (error: unknown) {
+      throw mapError(error);
+    }
+  };
+}

--- a/packages/ic-management/src/ic-management.mock.ts
+++ b/packages/ic-management/src/ic-management.mock.ts
@@ -1,0 +1,39 @@
+import { Identity } from "@dfinity/agent";
+import { Principal } from "@dfinity/principal";
+import {
+  CanisterDetails,
+  CanisterStatus,
+} from "./types/ic-management.response";
+
+export const mockPrincipalText =
+  "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe";
+
+export const mockPrincipal = Principal.fromText(mockPrincipalText);
+
+export const mockIdentity = {
+  getPrincipal: () => mockPrincipal,
+} as unknown as Identity;
+
+export const mockCanisterId = Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai");
+
+export const mockCanisterDetails: CanisterDetails = {
+  id: mockCanisterId,
+  status: CanisterStatus.Running,
+  memorySize: BigInt(10),
+  cycles: BigInt(30),
+  settings: {
+    controllers: [mockIdentity.getPrincipal().toText()],
+    freezingThreshold: BigInt(30),
+    memoryAllocation: BigInt(1000),
+    computeAllocation: BigInt(2000),
+  },
+};
+
+export const mockCanisterSettings = {
+  freezing_threshold: BigInt(2),
+  controllers: [
+    "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe",
+  ],
+  memory_allocation: BigInt(4),
+  compute_allocation: BigInt(10),
+};

--- a/packages/ic-management/src/index.spec.ts
+++ b/packages/ic-management/src/index.spec.ts
@@ -1,7 +1,0 @@
-import * as lib from "./index";
-
-describe("ic-mgmt", () => {
-  it("is implemented", () => {
-    expect(lib).toEqual({});
-  });
-});

--- a/packages/ic-management/src/index.ts
+++ b/packages/ic-management/src/index.ts
@@ -1,1 +1,2 @@
-export {};
+export { ICManagementCanister } from "./ic-management.canister";
+export * from "./types/ic-management.response";

--- a/packages/ic-management/src/types/canister.options.ts
+++ b/packages/ic-management/src/types/canister.options.ts
@@ -1,5 +1,5 @@
 import type { ManagementCanisterRecord as ManagementCanisterService } from "@dfinity/agent";
-import type { CanisterOptions } from "@dfinity/utils/src";
+import type { CanisterOptions } from "@dfinity/utils";
 
 export type ICManagementCanisterOptions = Pick<
   CanisterOptions<ManagementCanisterService>,

--- a/packages/ic-management/src/types/canister.options.ts
+++ b/packages/ic-management/src/types/canister.options.ts
@@ -1,7 +1,7 @@
-import type {CanisterOptions} from "@dfinity/utils/src";
-import type {ManagementCanisterRecord as ManagementCanisterService} from "@dfinity/agent";
+import type { ManagementCanisterRecord as ManagementCanisterService } from "@dfinity/agent";
+import type { CanisterOptions } from "@dfinity/utils/src";
 
 export type ICManagementCanisterOptions = Pick<
-    CanisterOptions<ManagementCanisterService>,
-    "agent" | "serviceOverride"
+  CanisterOptions<ManagementCanisterService>,
+  "agent" | "serviceOverride"
 >;

--- a/packages/ic-management/src/types/canister.options.ts
+++ b/packages/ic-management/src/types/canister.options.ts
@@ -1,0 +1,7 @@
+import type {CanisterOptions} from "@dfinity/utils/src";
+import type {ManagementCanisterRecord as ManagementCanisterService} from "@dfinity/agent";
+
+export type ICManagementCanisterOptions = Pick<
+    CanisterOptions<ManagementCanisterService>,
+    "agent" | "serviceOverride"
+>;

--- a/packages/ic-management/src/types/ic-management.did.ts
+++ b/packages/ic-management/src/types/ic-management.did.ts
@@ -1,0 +1,14 @@
+import type { definite_canister_settings } from "../../candid/ic-management";
+
+export type CanisterStatusDid =
+  | { stopped: null }
+  | { stopping: null }
+  | { running: null };
+
+export type CanisterStatusDidResponse = {
+  status: CanisterStatusDid;
+  memory_size: bigint;
+  cycles: bigint;
+  settings: definite_canister_settings;
+  module_hash: [] | [Array<number>];
+};

--- a/packages/ic-management/src/types/ic-management.response.ts
+++ b/packages/ic-management/src/types/ic-management.response.ts
@@ -1,4 +1,4 @@
-import type {Principal} from "@dfinity/principal";
+import type { Principal } from "@dfinity/principal";
 
 export interface CanisterSettings {
   controllers: string[];

--- a/packages/ic-management/src/types/ic-management.response.ts
+++ b/packages/ic-management/src/types/ic-management.response.ts
@@ -1,0 +1,23 @@
+import type {Principal} from "@dfinity/principal";
+
+export interface CanisterSettings {
+  controllers: string[];
+  freezingThreshold: bigint;
+  memoryAllocation: bigint;
+  computeAllocation: bigint;
+}
+
+export enum CanisterStatus {
+  Stopped,
+  Stopping,
+  Running,
+}
+
+export interface CanisterDetails {
+  id: Principal;
+  status: CanisterStatus;
+  memorySize: bigint;
+  cycles: bigint;
+  settings: CanisterSettings;
+  moduleHash?: ArrayBuffer;
+}

--- a/packages/ic-management/src/utils/ic-management.converters.ts
+++ b/packages/ic-management/src/utils/ic-management.converters.ts
@@ -1,11 +1,11 @@
 import type { Principal } from "@dfinity/principal";
+import { nonNullish } from "@dfinity/utils/src";
+import type {
+  CanisterStatusDid as RawCanisterStatus,
+  CanisterStatusDidResponse,
+} from "../types/ic-management.did";
 import type { CanisterDetails } from "../types/ic-management.response";
 import { CanisterStatus } from "../types/ic-management.response";
-import type {
-  CanisterStatusDidResponse,
-  CanisterStatusDid as RawCanisterStatus,
-} from "../types/ic-management.did";
-import {nonNullish} from "@dfinity/utils/src";
 
 const getCanisterStatus = (status: RawCanisterStatus): CanisterStatus => {
   if ("stopped" in status) {

--- a/packages/ic-management/src/utils/ic-management.converters.ts
+++ b/packages/ic-management/src/utils/ic-management.converters.ts
@@ -1,5 +1,5 @@
 import type { Principal } from "@dfinity/principal";
-import { nonNullish } from "@dfinity/utils/src";
+import { nonNullish } from "@dfinity/utils";
 import type {
   CanisterStatusDid as RawCanisterStatus,
   CanisterStatusDidResponse,

--- a/packages/ic-management/src/utils/ic-management.converters.ts
+++ b/packages/ic-management/src/utils/ic-management.converters.ts
@@ -1,0 +1,42 @@
+import type { Principal } from "@dfinity/principal";
+import type { CanisterDetails } from "../types/ic-management.response";
+import { CanisterStatus } from "../types/ic-management.response";
+import type {
+  CanisterStatusDidResponse,
+  CanisterStatusDid as RawCanisterStatus,
+} from "../types/ic-management.did";
+import {nonNullish} from "@dfinity/utils/src";
+
+const getCanisterStatus = (status: RawCanisterStatus): CanisterStatus => {
+  if ("stopped" in status) {
+    return CanisterStatus.Stopped;
+  } else if ("stopping" in status) {
+    return CanisterStatus.Stopping;
+  } else if ("running" in status) {
+    return CanisterStatus.Running;
+  }
+  throw new Error(status);
+};
+
+export const toCanisterDetails = ({
+  response: { memory_size, status, cycles, settings, module_hash },
+  canisterId,
+}: {
+  response: CanisterStatusDidResponse;
+  canisterId: Principal;
+}): CanisterDetails => ({
+  id: canisterId,
+  status: getCanisterStatus(status),
+  memorySize: memory_size,
+  cycles: cycles,
+  settings: {
+    controllers: settings.controllers.map((principal) => principal.toText()),
+    freezingThreshold: settings.freezing_threshold,
+    memoryAllocation: settings.memory_allocation,
+    computeAllocation: settings.compute_allocation,
+  },
+  moduleHash:
+    module_hash.length > 0 && nonNullish(module_hash[0])
+      ? new Uint8Array(module_hash[0]).buffer
+      : undefined,
+});

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -39,7 +39,7 @@ const ckBTCInputFiles = [
 
 const rosettaInputFiles = ["./packages/rosetta-client/src/index.ts"];
 
-const icMgmtInputFiles = ["./packages/ic-management/src/index.ts"];
+const icMgmtInputFiles = ["./packages/ckbtc/src/ic-management.canister.ts"];
 
 generateDocumentation({
   inputFiles: nnsInputFiles,


### PR DESCRIPTION
# Changes

- copy `getCanisterDetails` and `updateSettings` from NNS dapp to implement `@dfinity/ic-management`.
- adapt structure and file naming (no functional changes)
- fix `packages` instead of `package` in root `package.json`
- set size limit checker
- adapt docs to generate docs for canister

