### PR TITLE
docs: fix library name

### DIFF
--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -26,7 +26,7 @@ npm i @dfinity/agent @dfinity/candid @dfinity/principal @dfinity/utils
 
 ## Usage
 
-The features are available through the class `LedgerCanister`. It has to be instantiated with a canister ID.
+The features are available through the class `CkBTCCanister`. It has to be instantiated with a canister ID.
 
 e.g. fetching a token metadata.
 

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -1,4 +1,4 @@
-# ckbtc-js
+# ic-management-js
 
 A library for interfacing with [Internet Computer (IC) management canister](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-to-use/#ic-management-canister).
 

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -26,7 +26,7 @@ npm i @dfinity/agent @dfinity/candid @dfinity/principal @dfinity/utils
 
 ## Usage
 
-The features are available through the class `LedgerCanister`. It has to be instantiated with a canister ID.
+The features are available through the class `ICMgmtCanister`. It has to be instantiated with a canister ID.
 
 e.g. fetching a token metadata.
 


### PR DESCRIPTION
# Motivation

Of course I had to notice after release there was a typo in the title of the readme 😆.
