### PR TITLE
build: redo global polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.18.0 (wip)
+# 0.17.1 (2023-06-21)
 
 ## Release
 
@@ -10,6 +10,19 @@
 - ic-management `v0.0.2`
 - utils `v0.0.17`
 - nns-proto `v0.0.3`
+
+## Fix
+
+- redo `global` polyfill for the browser
+- expose more types in new library `ic-management-js`
+
+## Build
+
+- fix `ic-management-js` next dependencies and version
+
+## Docs
+
+- various improvements in READMEs
 
 # 0.17.0 (2023-06-20)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "0.18.0",
+  "version": "0.17.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/ic-js",
-      "version": "0.18.0",
+      "version": "0.17.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/utils",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "0.18.0",
+  "version": "0.17.1",
   "description": "A collection of library for interfacing with the Internet Computer.",
   "license": "Apache-2.0",
   "workspaces": [

--- a/scripts/esbuild.mjs
+++ b/scripts/esbuild.mjs
@@ -58,6 +58,7 @@ const buildEsmCjs = () => {
       minify: true,
       splitting: true,
       format: "esm",
+      define: { global: "window" },
       target: ["esnext"],
       platform: "browser",
       conditions: ["worker", "browser"],


### PR DESCRIPTION
# Motivation

When the dapp - as NNS dapp - does not polyfill correctly, the library can hit a `global undefined`. Therefore this PR redo the global polyfill for the browser and bump to minor version to release to npm.

# PR

Reverts the polyfill removed in https://github.com/dfinity/ic-js/pull/350

# Screenshots

<img width="1536" alt="Capture d’écran 2023-06-21 à 10 16 23" src="https://github.com/dfinity/ic-js/assets/16886711/1aa590bd-0366-4013-b9fe-4a7088e5ffee">

