### PR TITLE
build: publish ic-management

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,34 +20,37 @@ jobs:
         run: npm run build --workspaces
       - name: Set up npm
         run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
-      - name: Publish utils
-        run: npm publish --workspace=packages/utils --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - name: Publish Ledger
-        run: npm publish --workspace=packages/ledger --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - name: Publish NNS-proto
-        run: npm publish --workspace=packages/nns-proto --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - name: Publish NNS
-        run: npm publish --workspace=packages/nns --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - name: Publish SNS
-        run: npm publish --workspace=packages/sns --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - name: Publish CMC
-        run: npm publish --workspace=packages/cmc --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - name: Publish ckBTC
-        run: npm publish --workspace=packages/ckbtc --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+#
+# Temporary commented to publish only ic-management.
+#
+#      - name: Publish utils
+#        run: npm publish --workspace=packages/utils --provenance --access public
+#        env:
+#          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+#      - name: Publish Ledger
+#        run: npm publish --workspace=packages/ledger --provenance --access public
+#        env:
+#          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+#      - name: Publish NNS-proto
+#        run: npm publish --workspace=packages/nns-proto --provenance --access public
+#        env:
+#          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+#      - name: Publish NNS
+#        run: npm publish --workspace=packages/nns --provenance --access public
+#        env:
+#          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+#      - name: Publish SNS
+#        run: npm publish --workspace=packages/sns --provenance --access public
+#        env:
+#          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+#      - name: Publish CMC
+#        run: npm publish --workspace=packages/cmc --provenance --access public
+#        env:
+#          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+#      - name: Publish ckBTC
+#        run: npm publish --workspace=packages/ckbtc --provenance --access public
+#        env:
+#          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish ic-management
         run: npm publish --workspace=packages/ic-management --provenance --access public
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.17.2 (2023-06-21)
+
+## Release
+
+- ic-management `v0.0.3`
+
+## Build
+
+No particular changes. Resolve a version conflicts in npmjs.
+
 # 0.17.1 (2023-06-21)
 
 ## Release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/ic-js",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/utils",
@@ -7193,7 +7193,7 @@
     },
     "packages/ic-management": {
       "name": "@dfinity/ic-management",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "base58-js": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "A collection of library for interfacing with the Internet Computer.",
   "license": "Apache-2.0",
   "workspaces": [

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-management",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A library for interfacing with the IC management canister.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",


### PR DESCRIPTION
# Motivation

Last publish failed for `@dfinity/ic-management`: https://github.com/dfinity/ic-js/actions/runs/5332655039

Root cause is npmjs that displays v0.0.1 but has already received v0.0.2.

This PR temporary comment the publication of other libs (will be reactivated in #362) and bump `ic-management` for a release.

