### PR TITLE
fix: usage of ic-management locally

### DIFF
--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -86,7 +86,7 @@ Create a new canister
 | ---------------- | ------------------------------------------------------------------------------------ |
 | `createCanister` | `({ settings, senderCanisterVerion, }?: CreateCanisterParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L69)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L70)
 
 ##### :gear: updateSettings
 
@@ -96,7 +96,7 @@ Update canister settings
 | ---------------- | ------------------------------------------------------------------------------------------ |
 | `updateSettings` | `({ canisterId, senderCanisterVerion, settings, }: UpdateSettingsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L90)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L91)
 
 ##### :gear: installCode
 
@@ -106,7 +106,7 @@ Install code to a canister
 | ------------- | ---------------------------------------------------------------------------------------------------- |
 | `installCode` | `({ mode, canisterId, wasmModule, arg, senderCanisterVerion, }: InstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L112)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L113)
 
 ##### :gear: uninstallCode
 
@@ -116,7 +116,7 @@ Uninstall code from a canister
 | --------------- | ------------------------------------------------------------------------------- |
 | `uninstallCode` | `({ canisterId, senderCanisterVerion, }: UninstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L135)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L136)
 
 ##### :gear: startCanister
 
@@ -126,7 +126,7 @@ Start a canister
 | --------------- | ------------------------------------------ |
 | `startCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L150)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L151)
 
 ##### :gear: stopCanister
 
@@ -136,7 +136,7 @@ Stop a canister
 | -------------- | ------------------------------------------ |
 | `stopCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L159)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L160)
 
 ##### :gear: canisterStatus
 
@@ -146,7 +146,7 @@ Get canister details (memory size, status, etc.)
 | ---------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
 | `canisterStatus` | `(canisterId: Principal) => Promise<{ status: { stopped: null; } or { stopping: null; } | { running: null; }; memory_size: bigint; cycles: bigint; settings: definite_canister_settings; idle_cycles_burned_per_day: bigint; module_hash: [] | [...]; }>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L168)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L169)
 
 ##### :gear: canisterInfo
 
@@ -156,7 +156,7 @@ Get canister info (controllers, module hash, changes, etc.)
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `canisterInfo` | `({ canisterId, numRequestChanges, }: CanisterInfoParams) => Promise<{ controllers: Principal[]; module_hash: [] or [Uint8Array]; recent_changes: change[]; total_num_changes: bigint; }>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L181)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L182)
 
 ##### :gear: deleteCanister
 
@@ -166,7 +166,7 @@ Deletes a canister
 | ---------------- | ------------------------------------------ |
 | `deleteCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L196)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L197)
 
 ##### :gear: provisionalCreateCanisterWithCycles
 
@@ -176,7 +176,7 @@ Creates a canister. Only available on development instances.
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `provisionalCreateCanisterWithCycles` | `({ settings, amount, canisterId, }?: ProvisionalCreateCanisterWithCyclesParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L208)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L209)
 
 <!-- TSDOC_END -->
 

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -1,4 +1,4 @@
-import { CallConfig } from "@dfinity/agent";
+import type { CallConfig } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { createServices, toNullable } from "@dfinity/utils";
 import type { _SERVICE as IcManagementService } from "../candid/ic-management";
@@ -33,6 +33,7 @@ export class ICManagementCanister {
     const transform = (
       _methodName: string,
       args: unknown[],
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       _callConfig: CallConfig
     ) => {
       const first = args[0] as { canister_id: string };

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -1,3 +1,4 @@
+import { CallConfig } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { createServices, toNullable } from "@dfinity/utils";
 import type { _SERVICE as IcManagementService } from "../candid/ic-management";
@@ -27,10 +28,28 @@ export class ICManagementCanister {
   }
 
   public static create(options: ICManagementCanisterOptions) {
+    // Source getManagementCanister in agent-js.
+    // Allow usage of the ICManagementCanister wrapper locally.
+    const transform = (
+      _methodName: string,
+      args: unknown[],
+      _callConfig: CallConfig
+    ) => {
+      const first = args[0] as { canister_id: string };
+      let effectiveCanisterId = Principal.fromHex("");
+      if (first && typeof first === "object" && first.canister_id) {
+        effectiveCanisterId = Principal.from(first.canister_id as unknown);
+      }
+      return { effectiveCanisterId };
+    };
+
     const { service } = createServices<IcManagementService>({
       options: {
         ...options,
-        canisterId: Principal.fromText("aaaaa-aa"),
+        // Resolve to "aaaaa-aa" on mainnet
+        canisterId: Principal.fromHex(""),
+        callTransform: transform,
+        queryTransform: transform,
       },
       idlFactory,
       certifiedIdlFactory,

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -101,11 +101,11 @@ Parameters:
 
 #### :gear: createServices
 
-| Function         | Type                                                                                                                                                                                                                                                                                           |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `createServices` | `<T>({ options: { canisterId, serviceOverride, certifiedServiceOverride, agent: agentOption, callTransform, queryTransform, }, idlFactory, certifiedIdlFactory, }: { options: RequiredCanisterOptions<T>; idlFactory: InterfaceFactory; certifiedIdlFactory: InterfaceFactory; }) => { ...; }` |
+| Function         | Type                                                                                                                                                                                                                                                                                                                                 |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `createServices` | `<T>({ options: { canisterId, serviceOverride, certifiedServiceOverride, agent: agentOption, callTransform, queryTransform, }, idlFactory, certifiedIdlFactory, }: { options: Required<Pick<CanisterOptions<T>, "canisterId">> and Omit<CanisterOptions<T>, "canisterId"> & Pick<...>; idlFactory: InterfaceFactory; certifiedId...` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/actor.utils.ts#L14)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/actor.utils.ts#L13)
 
 #### :gear: assertNonNullish
 

--- a/packages/utils/src/utils/actor.utils.ts
+++ b/packages/utils/src/utils/actor.utils.ts
@@ -8,8 +8,7 @@ import { defaultAgent } from "./agent.utils";
 type RequiredCanisterOptions<T> = Required<
   Pick<CanisterOptions<T>, "canisterId">
 > &
-  Omit<CanisterOptions<T>, "canisterId"> &
-  Pick<ActorConfig, "queryTransform" | "callTransform">;
+  Omit<CanisterOptions<T>, "canisterId">;
 
 export const createServices = <T>({
   options: {
@@ -23,7 +22,8 @@ export const createServices = <T>({
   idlFactory,
   certifiedIdlFactory,
 }: {
-  options: RequiredCanisterOptions<T>;
+  options: RequiredCanisterOptions<T> &
+    Pick<ActorConfig, "queryTransform" | "callTransform">;
   idlFactory: IDL.InterfaceFactory;
   certifiedIdlFactory: IDL.InterfaceFactory;
 }): {

--- a/packages/utils/src/utils/actor.utils.ts
+++ b/packages/utils/src/utils/actor.utils.ts
@@ -48,6 +48,8 @@ export const createServices = <T>({
     Actor.createActor<T>(certifiedIdlFactory, {
       agent,
       canisterId,
+      callTransform,
+      queryTransform,
     });
 
   return { service, certifiedService, agent, canisterId };

--- a/packages/utils/src/utils/actor.utils.ts
+++ b/packages/utils/src/utils/actor.utils.ts
@@ -1,4 +1,4 @@
-import type { ActorSubclass, Agent } from "@dfinity/agent";
+import type { ActorConfig, ActorSubclass, Agent } from "@dfinity/agent";
 import { Actor } from "@dfinity/agent";
 import type { IDL } from "@dfinity/candid";
 import type { Principal } from "@dfinity/principal";
@@ -8,7 +8,8 @@ import { defaultAgent } from "./agent.utils";
 type RequiredCanisterOptions<T> = Required<
   Pick<CanisterOptions<T>, "canisterId">
 > &
-  Omit<CanisterOptions<T>, "canisterId">;
+  Omit<CanisterOptions<T>, "canisterId"> &
+  Pick<ActorConfig, "queryTransform" | "callTransform">;
 
 export const createServices = <T>({
   options: {
@@ -16,6 +17,8 @@ export const createServices = <T>({
     serviceOverride,
     certifiedServiceOverride,
     agent: agentOption,
+    callTransform,
+    queryTransform,
   },
   idlFactory,
   certifiedIdlFactory,
@@ -36,6 +39,8 @@ export const createServices = <T>({
     Actor.createActor<T>(idlFactory, {
       agent,
       canisterId,
+      callTransform,
+      queryTransform,
     });
 
   const certifiedService: ActorSubclass<T> =


### PR DESCRIPTION
# Motivation

agent-js applies a transformation to interpret the canister id when instantiating the IC management canister: https://github.com/dfinity/agent-js/blob/e292412e51a48d2fc34310c149984822a64418d5/packages/agent/src/actor.ts#L399

This is useful to interact with it from the local environment. It was also part of the Dart iteration of NNS-dapp.

# Changes

- copy `transform` method from agent-js
- extend `createService`
