### PR TITLE
feat: update IC management did file and source

### DIFF
--- a/packages/ic-management/candid/ic-management.certified.idl.js
+++ b/packages/ic-management/candid/ic-management.certified.idl.js
@@ -233,6 +233,7 @@ export const idlFactory = ({ IDL }) => {
             'settings' : IDL.Opt(canister_settings),
             'specified_id' : IDL.Opt(canister_id),
             'amount' : IDL.Opt(IDL.Nat),
+            'sender_canister_version' : IDL.Opt(IDL.Nat64),
           }),
         ],
         [IDL.Record({ 'canister_id' : canister_id })],

--- a/packages/ic-management/candid/ic-management.d.ts
+++ b/packages/ic-management/candid/ic-management.d.ts
@@ -170,6 +170,7 @@ export interface _SERVICE {
         settings: [] | [canister_settings];
         specified_id: [] | [canister_id];
         amount: [] | [bigint];
+        sender_canister_version: [] | [bigint];
       }
     ],
     { canister_id: canister_id }

--- a/packages/ic-management/candid/ic-management.did
+++ b/packages/ic-management/candid/ic-management.did
@@ -189,6 +189,7 @@ service ic : {
     amount: opt nat;
     settings : opt canister_settings;
     specified_id: opt canister_id;
+    sender_canister_version : opt nat64;
   }) -> (record {canister_id : canister_id});
   provisional_top_up_canister :
     (record { canister_id: canister_id; amount: nat }) -> ();

--- a/packages/ic-management/candid/ic-management.idl.js
+++ b/packages/ic-management/candid/ic-management.idl.js
@@ -233,6 +233,7 @@ export const idlFactory = ({ IDL }) => {
             'settings' : IDL.Opt(canister_settings),
             'specified_id' : IDL.Opt(canister_id),
             'amount' : IDL.Opt(IDL.Nat),
+            'sender_canister_version' : IDL.Opt(IDL.Nat64),
           }),
         ],
         [IDL.Record({ 'canister_id' : canister_id })],

--- a/packages/ic-management/src/ic-management.canister.spec.ts
+++ b/packages/ic-management/src/ic-management.canister.spec.ts
@@ -389,6 +389,7 @@ describe("ICManagementCanister", () => {
         amount: [BigInt(100_000)],
         settings: [mappedMockCanisterSettings],
         specified_id: [mockCanisterId],
+        sender_canister_version: [],
       });
     });
 

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -216,6 +216,7 @@ export class ICManagementCanister {
         settings: toNullable(toCanisterSettings(settings)),
         amount: toNullable(amount),
         specified_id: toNullable(canisterId),
+        sender_canister_version: [],
       });
 
     return canister_id;

--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -76,5 +76,5 @@ mkdir -p packages/ckbtc/candid
 import_did "rs/bitcoin/ckbtc/minter/ckbtc_minter.did" "minter.did" "ckbtc"
 
 mkdir -p packages/ic-management/candid
-curl https://raw.githubusercontent.com/dfinity/interface-spec/master/spec/ic.did -o packages/ic-management/candid/ic-management.did
+curl https://raw.githubusercontent.com/dfinity/interface-spec/master/spec/_attachments/ic.did -o packages/ic-management/candid/ic-management.did
 : Fin


### PR DESCRIPTION
# Motivation

They have moved the `ic.did` file in the https://github.com/dfinity/interface-spec repo, therefore we have to adapt the source we use to populate the did file with a script.

At the same time, this PR upgrades the related did file.
