### PR TITLE
docs: correct ICRC text encoding reference

### DIFF
--- a/packages/ledger/README.md
+++ b/packages/ledger/README.md
@@ -63,7 +63,7 @@ const data = await metadata();
 #### :gear: encodeIcrcAccount
 
 Encodes an Icrc-1 account compatible into a string.
-Formatting Reference: https://github.com/dfinity/ICRC-1/pull/55/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R238
+Formatting Reference: https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/TextualEncoding.md
 
 | Function            | Type                                              |
 | ------------------- | ------------------------------------------------- |

--- a/packages/ledger/README.md
+++ b/packages/ledger/README.md
@@ -78,7 +78,7 @@ Parameters:
 #### :gear: decodeIcrcAccount
 
 Decodes a string into an Icrc-1 compatible account.
-Formatting Reference: https://github.com/dfinity/ICRC-1/pull/98
+Formatting Reference: https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/TextualEncoding.md
 
 | Function            | Type                                     |
 | ------------------- | ---------------------------------------- |

--- a/packages/ledger/src/utils/ledger.utils.ts
+++ b/packages/ledger/src/utils/ledger.utils.ts
@@ -50,7 +50,7 @@ const encodeCrc = ({ owner, subaccount }: Required<IcrcAccount>): string => {
 
 /**
  * Decodes a string into an Icrc-1 compatible account.
- * Formatting Reference: https://github.com/dfinity/ICRC-1/pull/98
+ * Formatting Reference: https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/TextualEncoding.md
  *
  * @param accountString string
  * @throws Error if the string is not a valid Icrc-1 account

--- a/packages/ledger/src/utils/ledger.utils.ts
+++ b/packages/ledger/src/utils/ledger.utils.ts
@@ -13,7 +13,7 @@ const MAX_SUBACCOUNT_HEX_LENGTH = 64;
 
 /**
  * Encodes an Icrc-1 account compatible into a string.
- * Formatting Reference: https://github.com/dfinity/ICRC-1/pull/55/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R238
+ * Formatting Reference: https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/TextualEncoding.md
  *
  * @param account { owner: Principal, subaccount?: Uint8Array }
  * @returns string


### PR DESCRIPTION
# Motivation

There is now a dedicated markdown file that describes the ICRC text encoding in the related repo.

Resolves #381