### PR TITLE
build: bump agent-js v0.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -638,6 +638,8 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -650,6 +652,8 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -657,31 +661,26 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.15.4.tgz",
-      "integrity": "sha512-JuWaLUUtdGJx2DwHgnGrtTNwF5bC6a+izMbcHeN2M0RSaukeVNkRdYz4Bfxg7yTwdFxQRfQWcXcwvKF8/R2IEg==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.18.1.tgz",
+      "integrity": "sha512-nMFK/y0ZkPfQYECdojmltXsBIdGvXa1Sxa4rDV2cibEq9lsjWMEIUqPsiBaNHuwuz+gzsGVq4N2b9umKQIQaRQ==",
       "peer": true,
       "dependencies": {
         "base64-arraybuffer": "^0.2.0",
-        "bignumber.js": "^9.0.0",
         "borc": "^2.1.1",
         "js-sha256": "0.9.0",
-        "simple-cbor": "^0.4.1",
-        "ts-node": "^10.8.2"
+        "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.15.4",
-        "@dfinity/principal": "^0.15.4"
+        "@dfinity/candid": "^0.18.1",
+        "@dfinity/principal": "^0.18.1"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.15.4.tgz",
-      "integrity": "sha512-ImoZ18i95DDstn+EXm/Y1ms7RqF1KVS7+KqZLNvpHFTlcOgfAQc5Bq8W6l1nfkOqeh7wcehDYdjFJwLxBoeTlw==",
-      "peer": true,
-      "dependencies": {
-        "ts-node": "^10.8.2"
-      }
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.18.1.tgz",
+      "integrity": "sha512-/PC3wDnrGcWhaF/veYKevcAAn5A5jK0mRkVKcz0YxK/a78Ai9wMJg0fUk7aoyZryCOz8JPVgR4nK1/zTmvEBHg==",
+      "peer": true
     },
     "node_modules/@dfinity/ckbtc": {
       "resolved": "packages/ckbtc",
@@ -708,13 +707,12 @@
       "link": true
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.15.4.tgz",
-      "integrity": "sha512-ZH0InIXaIQqXfUDgkSa0S+9VlkAduhu2JJ984KtRs3BSHUyxG32OGnRcvxfJDdm6GHXWndTWoQUraHPoA3RplQ==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.18.1.tgz",
+      "integrity": "sha512-xeV+5zV7VQRT2xJTbXW4IDra1urEcchuwuKFTU/ERcJWBWEk8chsZcd6DBc8SPq83xRgXW2ZTVVSOZR8NKaVoQ==",
       "peer": true,
       "dependencies": {
-        "js-sha256": "^0.9.0",
-        "ts-node": "^10.8.2"
+        "js-sha256": "^0.9.0"
       }
     },
     "node_modules/@dfinity/rosetta-client": {
@@ -1527,6 +1525,7 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.8.tgz",
       "integrity": "sha512-YK5G9LaddzGbcucK4c8h5tWFmMPBvRZ/uyWmN1/SbBdIvqGUdWGkJ5BAaccgs6XbzVLsqbPJrBSFwKv3kT9i7w==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1543,7 +1542,8 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.15",
@@ -1662,24 +1662,32 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
       "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/@types/babel__core": {
@@ -1787,7 +1795,8 @@
     "node_modules/@types/node": {
       "version": "18.15.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "dev": true
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -2212,6 +2221,7 @@
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
       "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2232,6 +2242,8 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.4.0"
@@ -2321,6 +2333,8 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/argparse": {
@@ -2896,6 +2910,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/cross-spawn": {
@@ -2994,6 +3010,8 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.3.1"
@@ -5507,7 +5525,8 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -6087,9 +6106,9 @@
       "dev": true
     },
     "node_modules/readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -6676,6 +6695,8 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -6844,6 +6865,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6912,6 +6934,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/v8-to-istanbul": {
@@ -7094,6 +7118,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -7121,9 +7147,9 @@
         "js-sha256": "^0.9.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.15.4",
-        "@dfinity/candid": "^0.15.4",
-        "@dfinity/principal": "^0.15.4",
+        "@dfinity/agent": "^0.18.1",
+        "@dfinity/candid": "^0.18.1",
+        "@dfinity/principal": "^0.18.1",
         "@dfinity/utils": "^0.0.19"
       }
     },
@@ -7132,9 +7158,9 @@
       "version": "0.0.15",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^0.15.4",
-        "@dfinity/candid": "^0.15.4",
-        "@dfinity/principal": "^0.15.4",
+        "@dfinity/agent": "^0.18.1",
+        "@dfinity/candid": "^0.18.1",
+        "@dfinity/principal": "^0.18.1",
         "@dfinity/utils": "^0.0.19"
       }
     },
@@ -7148,9 +7174,9 @@
         "js-sha256": "^0.9.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.15.4",
-        "@dfinity/candid": "^0.15.4",
-        "@dfinity/principal": "^0.15.4",
+        "@dfinity/agent": "^0.18.1",
+        "@dfinity/candid": "^0.18.1",
+        "@dfinity/principal": "^0.18.1",
         "@dfinity/utils": "^0.0.19"
       }
     },
@@ -7159,9 +7185,9 @@
       "version": "0.0.12",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^0.15.4",
-        "@dfinity/candid": "^0.15.4",
-        "@dfinity/principal": "^0.15.4",
+        "@dfinity/agent": "^0.18.1",
+        "@dfinity/candid": "^0.18.1",
+        "@dfinity/principal": "^0.18.1",
         "@dfinity/utils": "^0.0.19"
       }
     },
@@ -7177,10 +7203,10 @@
         "@types/randombytes": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.15.4",
-        "@dfinity/candid": "^0.15.4",
+        "@dfinity/agent": "^0.18.1",
+        "@dfinity/candid": "^0.18.1",
         "@dfinity/nns-proto": "^0.0.5",
-        "@dfinity/principal": "^0.15.4",
+        "@dfinity/principal": "^0.18.1",
         "@dfinity/utils": "^0.0.19"
       }
     },
@@ -7208,10 +7234,10 @@
         "js-sha256": "^0.9.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.15.4",
-        "@dfinity/candid": "^0.15.4",
+        "@dfinity/agent": "^0.18.1",
+        "@dfinity/candid": "^0.18.1",
         "@dfinity/ledger": "^0.0.12",
-        "@dfinity/principal": "^0.15.4",
+        "@dfinity/principal": "^0.18.1",
         "@dfinity/utils": "^0.0.19"
       }
     },
@@ -7220,9 +7246,9 @@
       "version": "0.0.19",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^0.15.4",
-        "@dfinity/candid": "^0.15.4",
-        "@dfinity/principal": "^0.15.4"
+        "@dfinity/agent": "^0.18.1",
+        "@dfinity/candid": "^0.18.1",
+        "@dfinity/principal": "^0.18.1"
       }
     }
   },
@@ -7673,6 +7699,8 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "optional": true,
       "peer": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -7682,6 +7710,8 @@
           "version": "0.3.9",
           "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
           "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
+          "optional": true,
           "peer": true,
           "requires": {
             "@jridgewell/resolve-uri": "^3.0.3",
@@ -7691,27 +7721,22 @@
       }
     },
     "@dfinity/agent": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.15.4.tgz",
-      "integrity": "sha512-JuWaLUUtdGJx2DwHgnGrtTNwF5bC6a+izMbcHeN2M0RSaukeVNkRdYz4Bfxg7yTwdFxQRfQWcXcwvKF8/R2IEg==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.18.1.tgz",
+      "integrity": "sha512-nMFK/y0ZkPfQYECdojmltXsBIdGvXa1Sxa4rDV2cibEq9lsjWMEIUqPsiBaNHuwuz+gzsGVq4N2b9umKQIQaRQ==",
       "peer": true,
       "requires": {
         "base64-arraybuffer": "^0.2.0",
-        "bignumber.js": "^9.0.0",
         "borc": "^2.1.1",
         "js-sha256": "0.9.0",
-        "simple-cbor": "^0.4.1",
-        "ts-node": "^10.8.2"
+        "simple-cbor": "^0.4.1"
       }
     },
     "@dfinity/candid": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.15.4.tgz",
-      "integrity": "sha512-ImoZ18i95DDstn+EXm/Y1ms7RqF1KVS7+KqZLNvpHFTlcOgfAQc5Bq8W6l1nfkOqeh7wcehDYdjFJwLxBoeTlw==",
-      "peer": true,
-      "requires": {
-        "ts-node": "^10.8.2"
-      }
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.18.1.tgz",
+      "integrity": "sha512-/PC3wDnrGcWhaF/veYKevcAAn5A5jK0mRkVKcz0YxK/a78Ai9wMJg0fUk7aoyZryCOz8JPVgR4nK1/zTmvEBHg==",
+      "peer": true
     },
     "@dfinity/ckbtc": {
       "version": "file:packages/ckbtc",
@@ -7753,13 +7778,12 @@
       }
     },
     "@dfinity/principal": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.15.4.tgz",
-      "integrity": "sha512-ZH0InIXaIQqXfUDgkSa0S+9VlkAduhu2JJ984KtRs3BSHUyxG32OGnRcvxfJDdm6GHXWndTWoQUraHPoA3RplQ==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.18.1.tgz",
+      "integrity": "sha512-xeV+5zV7VQRT2xJTbXW4IDra1urEcchuwuKFTU/ERcJWBWEk8chsZcd6DBc8SPq83xRgXW2ZTVVSOZR8NKaVoQ==",
       "peer": true,
       "requires": {
-        "js-sha256": "^0.9.0",
-        "ts-node": "^10.8.2"
+        "js-sha256": "^0.9.0"
       }
     },
     "@dfinity/rosetta-client": {
@@ -8277,7 +8301,8 @@
     "@jridgewell/resolve-uri": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.8.tgz",
-      "integrity": "sha512-YK5G9LaddzGbcucK4c8h5tWFmMPBvRZ/uyWmN1/SbBdIvqGUdWGkJ5BAaccgs6XbzVLsqbPJrBSFwKv3kT9i7w=="
+      "integrity": "sha512-YK5G9LaddzGbcucK4c8h5tWFmMPBvRZ/uyWmN1/SbBdIvqGUdWGkJ5BAaccgs6XbzVLsqbPJrBSFwKv3kT9i7w==",
+      "dev": true
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
@@ -8288,7 +8313,8 @@
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.15",
@@ -8383,24 +8409,32 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
       "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "@types/babel__core": {
@@ -8508,7 +8542,8 @@
     "@types/node": {
       "version": "18.15.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "dev": true
     },
     "@types/prettier": {
       "version": "2.7.2",
@@ -8769,7 +8804,8 @@
     "acorn": {
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -8782,6 +8818,8 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "ajv": {
@@ -8842,6 +8880,8 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "argparse": {
@@ -9251,6 +9291,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "cross-spawn": {
@@ -9323,6 +9365,8 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "diff-sequences": {
@@ -11157,7 +11201,8 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.12",
@@ -11549,9 +11594,9 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "peer": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -11956,6 +12001,8 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "optional": true,
       "peer": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -12068,7 +12115,8 @@
     "typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -12111,6 +12159,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "v8-to-istanbul": {
@@ -12251,6 +12301,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "optional": true,
       "peer": true
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test-all": "npm ci && npm run build --workspace=packages/utils && npm run build --workspace=packages/ledger && npm run test --workspaces",
     "docs": "node scripts/docs.js && prettier --write packages/nns/README.md packages/sns/README.md packages/cmc/README.md packages/utils/README.md packages/ledger/README.md packages/ckbtc/README.md packages/rosetta-client/README.md packages/ic-management/README.md",
     "build": "npm run build --workspaces",
-    "size": "size-limit --json"
+    "size": "size-limit --json",
+    "update:agent": "./scripts/update-agent"
   },
   "repository": {
     "type": "git",

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.15.4",
-    "@dfinity/candid": "^0.15.4",
-    "@dfinity/principal": "^0.15.4",
+    "@dfinity/agent": "^0.18.1",
+    "@dfinity/candid": "^0.18.1",
+    "@dfinity/principal": "^0.18.1",
     "@dfinity/utils": "^0.0.19"
   },
   "dependencies": {

--- a/packages/cmc/package.json
+++ b/packages/cmc/package.json
@@ -36,9 +36,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.15.4",
-    "@dfinity/candid": "^0.15.4",
-    "@dfinity/principal": "^0.15.4",
+    "@dfinity/agent": "^0.18.1",
+    "@dfinity/candid": "^0.18.1",
+    "@dfinity/principal": "^0.18.1",
     "@dfinity/utils": "^0.0.19"
   }
 }

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -34,9 +34,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.15.4",
-    "@dfinity/candid": "^0.15.4",
-    "@dfinity/principal": "^0.15.4",
+    "@dfinity/agent": "^0.18.1",
+    "@dfinity/candid": "^0.18.1",
+    "@dfinity/principal": "^0.18.1",
     "@dfinity/utils": "^0.0.19"
   },
   "dependencies": {

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -37,9 +37,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.15.4",
-    "@dfinity/candid": "^0.15.4",
-    "@dfinity/principal": "^0.15.4",
+    "@dfinity/agent": "^0.18.1",
+    "@dfinity/candid": "^0.18.1",
+    "@dfinity/principal": "^0.18.1",
     "@dfinity/utils": "^0.0.19"
   }
 }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -51,10 +51,10 @@
     "network-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^0.15.4",
-    "@dfinity/candid": "^0.15.4",
+    "@dfinity/agent": "^0.18.1",
+    "@dfinity/candid": "^0.18.1",
     "@dfinity/nns-proto": "^0.0.5",
-    "@dfinity/principal": "^0.15.4",
+    "@dfinity/principal": "^0.18.1",
     "@dfinity/utils": "^0.0.19"
   }
 }

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -2,6 +2,7 @@ import {
   ActorSubclass,
   AnonymousIdentity,
   polling,
+  SubmitResponse,
   type Agent,
   type RequestId,
 } from "@dfinity/agent";
@@ -54,7 +55,7 @@ describe("GovernanceCanister", () => {
       status: 13,
       statusText: "good",
     },
-  };
+  } as SubmitResponse;
   const newSpawnNeuronId = new PbNeuronId();
   newSpawnNeuronId.setId("1234");
   const spawnResponse = new PbManageNeuronResponse.SpawnResponse();
@@ -1335,7 +1336,7 @@ describe("GovernanceCanister", () => {
           status: 13,
           statusText: "good",
         },
-      };
+      } as SubmitResponse;
       agent.call.mockResolvedValue(response);
 
       const governance = GovernanceCanister.create({

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -36,10 +36,10 @@
     "sns"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^0.15.4",
-    "@dfinity/candid": "^0.15.4",
+    "@dfinity/agent": "^0.18.1",
+    "@dfinity/candid": "^0.18.1",
     "@dfinity/ledger": "^0.0.12",
-    "@dfinity/principal": "^0.15.4",
+    "@dfinity/principal": "^0.18.1",
     "@dfinity/utils": "^0.0.19"
   },
   "dependencies": {

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -52,7 +52,6 @@ describe("SnsWrapper", () => {
 
   const mockIndexCanister = mock<IcrcIndexCanister>();
   mockIndexCanister.getTransactions.mockResolvedValue({
-    balance: 2n,
     transactions: [],
     oldest_tx_id: [BigInt(2)],
   });

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -52,6 +52,7 @@ describe("SnsWrapper", () => {
 
   const mockIndexCanister = mock<IcrcIndexCanister>();
   mockIndexCanister.getTransactions.mockResolvedValue({
+    balance: 2n,
     transactions: [],
     oldest_tx_id: [BigInt(2)],
   });

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -47,8 +47,8 @@
     "service-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^0.15.4",
-    "@dfinity/candid": "^0.15.4",
-    "@dfinity/principal": "^0.15.4"
+    "@dfinity/agent": "^0.18.1",
+    "@dfinity/candid": "^0.18.1",
+    "@dfinity/principal": "^0.18.1"
   }
 }

--- a/scripts/update-agent
+++ b/scripts/update-agent
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+function rm_agent() {
+  local package=$1
+
+  npm rm @dfinity/agent @dfinity/candid @dfinity/principal --workspace=packages/"$package"
+}
+
+function install_agent() {
+  local package=$1
+
+  npm i @dfinity/agent@latest @dfinity/candid@latest @dfinity/principal@latest --workspace=packages/"$package" --save-peer
+}
+
+PACKAGES=utils,ckbtc,cmc,ic-management,ledger,nns,sns
+
+# Remove all agents first to avoid resolve conflicts
+for package in $(echo $PACKAGES | sed "s/,/ /g")
+do
+    rm_agent "$package"
+done
+
+for package in $(echo $PACKAGES | sed "s/,/ /g")
+do
+    install_agent "$package"
+done

--- a/scripts/update-agent
+++ b/scripts/update-agent
@@ -15,12 +15,10 @@ function install_agent() {
 PACKAGES=utils,ckbtc,cmc,ic-management,ledger,nns,sns
 
 # Remove all agents first to avoid resolve conflicts
-for package in $(echo $PACKAGES | sed "s/,/ /g")
-do
-    rm_agent "$package"
+for package in $(echo $PACKAGES | sed "s/,/ /g"); do
+  rm_agent "$package"
 done
 
-for package in $(echo $PACKAGES | sed "s/,/ /g")
-do
-    install_agent "$package"
+for package in $(echo $PACKAGES | sed "s/,/ /g"); do
+  install_agent "$package"
 done

--- a/scripts/update-agent
+++ b/scripts/update-agent
@@ -14,7 +14,7 @@ function install_agent() {
 
 PACKAGES=utils,ckbtc,cmc,ic-management,ledger,nns,sns
 
-# Remove all agents first to avoid resolve conflicts
+# Remove agent-js libraries from all packages first to avoid resolve conflicts between those
 for package in $(echo $PACKAGES | sed "s/,/ /g"); do
   rm_agent "$package"
 done


### PR DESCRIPTION
# Motivation

Bump `agent-js` version to `v0.18.1`. This is required to resolve an "endless loop issue" when the ic-mgmt library is used to request the statuses of canister for which the caller is not a controler.

"endless loop" because from obversation it seems to ends after 5min.

# Note

Will be integrated in NNS dapp (https://github.com/dfinity/nns-dapp/pull/2950) to solve similar issue.

# Changes

- bump agent-js last version
- add a script `npm run update:agent` to update all peer dependencies of the libs that use agent-js
