### PR TITLE
Chore: Expose init response type

### DIFF
--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -25,6 +25,7 @@ export type {
   GetBuyerStateRequest as SnsGetBuyerStateRequest,
   GetBuyerStateResponse as SnsGetBuyerStateResponse,
   GetDerivedStateResponse as SnsGetDerivedStateResponse,
+  GetInitResponse as SnsGetInitResponse,
   GetLifecycleResponse as SnsGetLifecycleResponse,
   GetSaleParametersResponse as SnsGetSaleParametersResponse,
   Init as SnsSwapInit,


### PR DESCRIPTION
# Motivation

Add new fields from the SNS aggregator.

In this PR: Expose the GetInitResponse. Which is a new (non used yet) field of the SNS aggregator.

# Changes

* Expose GetInitResponse type as SnsGetInitResponse

# Tests

Not applicable
