### PR TITLE
docs: release v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.18.1 (wip)
+# 0.18.1 (2023-08-07)
 
 ## Release
 
@@ -10,6 +10,20 @@
 - ic-management `v0.0.5`
 - utils `v0.0.19`
 - nns-proto `v0.0.5`
+
+## Features
+
+- update `nns/governance.did` and `sns_wasm.did` for 1-proposal
+- update `ic.did` for `@dfinity/ic-management`
+- update `icrc1_ledger.did`
+
+## Build
+
+- bump agent-js `v0.18.1`
+
+## Docs
+
+- add mention that ICRC-22 is currently a draft
 
 # 0.18.0 (2023-07-03)
 


### PR DESCRIPTION
# Motivation

I want to release agent-js. All version number are already ready, we just need the changelog.