### PR TITLE
Sns disburse maturity function

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     {
       "name": "@dfinity/sns",
       "path": "./packages/sns/dist/index.js",
-      "limit": "14 kB",
+      "limit": "16 kB",
       "ignore": [
         "@dfinity/agent",
         "@dfinity/candid",

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -104,6 +104,7 @@ Lookup for the canister ids of a Sns and initialize the wrapper to access its fe
 - [startDissolving](#gear-startdissolving)
 - [stopDissolving](#gear-stopdissolving)
 - [stakeMaturity](#gear-stakematurity)
+- [disburseMaturity](#gear-disbursematurity)
 - [autoStakeMaturity](#gear-autostakematurity)
 - [setDissolveTimestamp](#gear-setdissolvetimestamp)
 - [increaseDissolveDelay](#gear-increasedissolvedelay)
@@ -292,6 +293,21 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L279)
 
+##### :gear: disburseMaturity
+
+Disburse the maturity of a neuron.
+
+| Method             | Type                                                         |
+| ------------------ | ------------------------------------------------------------ |
+| `disburseMaturity` | `(params: SnsNeuronDisburseMaturityParams) => Promise<void>` |
+
+Parameters:
+
+- `toAccount. Account`: to disburse maturity.
+- `neuronId`: The id of the neuron for which to disburse the maturity
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L299)
+
 ##### :gear: autoStakeMaturity
 
 Changes auto-stake maturity for a Neuron.
@@ -305,7 +321,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to request a change of the auto stake feature
 - `autoStake`: `true` to enable the auto-stake maturity for this neuron, `false` to turn it off
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L299)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L313)
 
 ##### :gear: setDissolveTimestamp
 
@@ -315,7 +331,7 @@ Increase dissolve delay of a neuron
 | ---------------------- | ---------------------------------------------------------- |
 | `setDissolveTimestamp` | `(params: SnsSetDissolveTimestampParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L309)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L323)
 
 ##### :gear: increaseDissolveDelay
 
@@ -325,7 +341,7 @@ Increase dissolve delay of a neuron
 | ----------------------- | ----------------------------------------------------------- |
 | `increaseDissolveDelay` | `(params: SnsIncreaseDissolveDelayParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L319)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L333)
 
 ##### :gear: setTopicFollowees
 
@@ -335,7 +351,7 @@ Sets followees of a neuron for a specific Nervous System Function (topic)
 | ------------------- | ------------------------------------------------- |
 | `setTopicFollowees` | `(params: SnsSetTopicFollowees) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L329)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L343)
 
 ##### :gear: registerVote
 
@@ -345,7 +361,7 @@ Registers vote for a proposal from the neuron passed.
 | -------------- | -------------------------------------------------- |
 | `registerVote` | `(params: SnsRegisterVoteParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L337)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L351)
 
 ##### :gear: refreshNeuron
 
@@ -355,7 +371,7 @@ Refresh neuron
 | --------------- | --------------------------------------- |
 | `refreshNeuron` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L345)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L359)
 
 ##### :gear: claimNeuron
 
@@ -365,7 +381,7 @@ Claim neuron
 | ------------- | -------------------------------------------------------------------------------- |
 | `claimNeuron` | `({ memo, controller, subaccount, }: SnsClaimNeuronParams) => Promise<NeuronId>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L355)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L369)
 
 ### :factory: SnsRootCanister
 

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -305,7 +305,7 @@ Parameters:
 
 - `toAccount. Account`: to disburse maturity.
 - `neuronId`: The id of the neuron for which to disburse the maturity
-- `percentageToDisburse`: How many percents of available maturity to disburse.
+- `percentageToDisburse`: What percentage of the available maturity to disburse.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L302)
 

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -83,7 +83,7 @@ Lookup for the canister ids of a Sns and initialize the wrapper to access its fe
 
 ### :factory: SnsGovernanceCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L60)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L62)
 
 #### Methods
 
@@ -125,7 +125,7 @@ Parameters:
 
 - `options`: Miscellaneous options to initialize the canister. Its ID being the only mandatory parammeter.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L66)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L68)
 
 ##### :gear: listNeurons
 
@@ -135,7 +135,7 @@ List the neurons of the Sns
 | ------------- | ----------------------------------------------------- |
 | `listNeurons` | `(params: SnsListNeuronsParams) => Promise<Neuron[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L80)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L82)
 
 ##### :gear: listProposals
 
@@ -145,7 +145,7 @@ List the proposals of the Sns
 | --------------- | ------------------------------------------------------------- |
 | `listProposals` | `(params: SnsListProposalsParams) => Promise<ProposalData[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L94)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L96)
 
 ##### :gear: getProposal
 
@@ -155,7 +155,7 @@ Get the proposal of the Sns
 | ------------- | --------------------------------------------------------- |
 | `getProposal` | `(params: SnsGetProposalParams) => Promise<ProposalData>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L108)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L110)
 
 ##### :gear: listNervousSystemFunctions
 
@@ -166,7 +166,7 @@ Neurons can follow other neurons in specific Nervous System Functions.
 | ---------------------------- | ---------------------------------------------------------------------- |
 | `listNervousSystemFunctions` | `(params: QueryParams) => Promise<ListNervousSystemFunctionsResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L127)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L129)
 
 ##### :gear: metadata
 
@@ -176,7 +176,7 @@ Get the Sns metadata (title, description, etc.)
 | ---------- | ------------------------------------------------------- |
 | `metadata` | `(params: QueryParams) => Promise<GetMetadataResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L135)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L137)
 
 ##### :gear: nervousSystemParameters
 
@@ -186,7 +186,7 @@ Get the Sns nervous system parameters (default followees, max dissolve delay, ma
 | ------------------------- | ----------------------------------------------------------- |
 | `nervousSystemParameters` | `(params: QueryParams) => Promise<NervousSystemParameters>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L141)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L143)
 
 ##### :gear: getNeuron
 
@@ -196,7 +196,7 @@ Get the neuron of the Sns
 | ----------- | ------------------------------------------------- |
 | `getNeuron` | `(params: SnsGetNeuronParams) => Promise<Neuron>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L149)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L151)
 
 ##### :gear: queryNeuron
 
@@ -206,7 +206,7 @@ Same as `getNeuron` but returns undefined instead of raising error when not foun
 | ------------- | ------------------------------------------------- |
 | `queryNeuron` | `(params: SnsGetNeuronParams) => Promise<Neuron>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L167)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L169)
 
 ##### :gear: manageNeuron
 
@@ -216,7 +216,7 @@ Manage neuron. For advanced users.
 | -------------- | ---------------------------------------------------------- |
 | `manageNeuron` | `(request: ManageNeuron) => Promise<ManageNeuronResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L187)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L189)
 
 ##### :gear: addNeuronPermissions
 
@@ -226,7 +226,7 @@ Add permissions to a neuron for a specific principal
 | ---------------------- | ------------------------------------------------------- |
 | `addNeuronPermissions` | `(params: SnsNeuronPermissionsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L200)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L202)
 
 ##### :gear: removeNeuronPermissions
 
@@ -236,7 +236,7 @@ Remove permissions to a neuron for a specific principal
 | ------------------------- | ------------------------------------------------------- |
 | `removeNeuronPermissions` | `(params: SnsNeuronPermissionsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L210)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L212)
 
 ##### :gear: splitNeuron
 
@@ -246,7 +246,7 @@ Split neuron
 | ------------- | ----------------------------------------------------- |
 | `splitNeuron` | `(params: SnsSplitNeuronParams) => Promise<NeuronId>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L220)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L222)
 
 ##### :gear: disburse
 
@@ -256,7 +256,7 @@ Disburse neuron on Account
 | ---------- | ---------------------------------------------------- |
 | `disburse` | `(params: SnsDisburseNeuronParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L251)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L253)
 
 ##### :gear: startDissolving
 
@@ -266,7 +266,7 @@ Start dissolving process of a neuron
 | ----------------- | --------------------------------------- |
 | `startDissolving` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L259)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L261)
 
 ##### :gear: stopDissolving
 
@@ -276,7 +276,7 @@ Stop dissolving process of a neuron
 | ---------------- | --------------------------------------- |
 | `stopDissolving` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L267)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L269)
 
 ##### :gear: stakeMaturity
 
@@ -291,7 +291,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to stake the maturity
 - `percentageToStake`: Optional. Percentage of the current maturity to stake. If not provided, all of the neuron's current maturity will be staked.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L279)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L281)
 
 ##### :gear: disburseMaturity
 
@@ -305,8 +305,9 @@ Parameters:
 
 - `toAccount. Account`: to disburse maturity.
 - `neuronId`: The id of the neuron for which to disburse the maturity
+- `percentageToDisburse`: How many percents of available maturity to disburse.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L299)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L302)
 
 ##### :gear: autoStakeMaturity
 
@@ -321,7 +322,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to request a change of the auto stake feature
 - `autoStake`: `true` to enable the auto-stake maturity for this neuron, `false` to turn it off
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L313)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L318)
 
 ##### :gear: setDissolveTimestamp
 
@@ -331,7 +332,7 @@ Increase dissolve delay of a neuron
 | ---------------------- | ---------------------------------------------------------- |
 | `setDissolveTimestamp` | `(params: SnsSetDissolveTimestampParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L323)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L328)
 
 ##### :gear: increaseDissolveDelay
 
@@ -341,7 +342,7 @@ Increase dissolve delay of a neuron
 | ----------------------- | ----------------------------------------------------------- |
 | `increaseDissolveDelay` | `(params: SnsIncreaseDissolveDelayParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L333)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L338)
 
 ##### :gear: setTopicFollowees
 
@@ -351,7 +352,7 @@ Sets followees of a neuron for a specific Nervous System Function (topic)
 | ------------------- | ------------------------------------------------- |
 | `setTopicFollowees` | `(params: SnsSetTopicFollowees) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L343)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L348)
 
 ##### :gear: registerVote
 
@@ -361,7 +362,7 @@ Registers vote for a proposal from the neuron passed.
 | -------------- | -------------------------------------------------- |
 | `registerVote` | `(params: SnsRegisterVoteParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L351)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L356)
 
 ##### :gear: refreshNeuron
 
@@ -371,7 +372,7 @@ Refresh neuron
 | --------------- | --------------------------------------- |
 | `refreshNeuron` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L359)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L364)
 
 ##### :gear: claimNeuron
 
@@ -381,7 +382,7 @@ Claim neuron
 | ------------- | -------------------------------------------------------------------------------- |
 | `claimNeuron` | `({ memo, controller, subaccount, }: SnsClaimNeuronParams) => Promise<NeuronId>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L369)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L374)
 
 ### :factory: SnsRootCanister
 

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -586,6 +586,7 @@ Parameters:
 - [getDerivedState](#gear-getderivedstate)
 - [getTransactions](#gear-gettransactions)
 - [stakeMaturity](#gear-stakematurity)
+- [disburseMaturity](#gear-disbursematurity)
 - [autoStakeMaturity](#gear-autostakematurity)
 
 ##### :gear: listNeurons
@@ -938,12 +939,20 @@ Always certified
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L437)
 
+##### :gear: disburseMaturity
+
+| Method             | Type                                                         |
+| ------------------ | ------------------------------------------------------------ |
+| `disburseMaturity` | `(params: SnsNeuronDisburseMaturityParams) => Promise<void>` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L441)
+
 ##### :gear: autoStakeMaturity
 
 | Method              | Type                                                          |
 | ------------------- | ------------------------------------------------------------- |
 | `autoStakeMaturity` | `(params: SnsNeuronAutoStakeMaturityParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L441)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L445)
 
 <!-- TSDOC_END -->

--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -35,6 +35,7 @@ import type {
   SnsIncreaseDissolveDelayParams,
   SnsListProposalsParams,
   SnsNeuronAutoStakeMaturityParams,
+  SnsNeuronDisburseMaturityParams,
   SnsNeuronPermissionsParams,
   SnsNeuronStakeMaturityParams,
   SnsRegisterVoteParams,
@@ -174,6 +175,23 @@ export const toStakeMaturityRequest = ({
     command: {
       StakeMaturity: {
         percentage_to_stake: toNullable(percentageToStake),
+      },
+    },
+  });
+
+export const toDisburseMaturityRequest = ({
+  neuronId,
+  percentageToDisburse,
+  toAccount,
+}: SnsNeuronDisburseMaturityParams): ManageNeuron =>
+  toManageNeuronCommand({
+    neuronId,
+    command: {
+      DisburseMaturity: {
+        // currently there is a main account only support
+        to_account:
+          toAccount === undefined ? [] : toNullable(toCandidAccount(toAccount)),
+        percentage_to_disburse: percentageToDisburse,
       },
     },
   });

--- a/packages/sns/src/governance.canister.ts
+++ b/packages/sns/src/governance.canister.ts
@@ -297,6 +297,7 @@ export class SnsGovernanceCanister extends Canister<SnsGovernanceService> {
    * @param {neuronId: NeuronId; toAccount?: IcrcAccount; percentageToDisburse: number; } params
    * @param {IcrcAccount} toAccount. Account to disburse maturity.
    * @param {NeuronId} neuronId The id of the neuron for which to disburse the maturity
+   * @param {number} percentageToDisburse How many percents of available maturity to disburse.
    */
   disburseMaturity = async (
     params: SnsNeuronDisburseMaturityParams,

--- a/packages/sns/src/governance.canister.ts
+++ b/packages/sns/src/governance.canister.ts
@@ -26,6 +26,7 @@ import {
   toAddPermissionsRequest,
   toAutoStakeMaturityNeuronRequest,
   toClaimOrRefreshRequest,
+  toDisburseMaturityRequest,
   toDisburseNeuronRequest,
   toFollowRequest,
   toIncreaseDissolveDelayRequest,
@@ -49,6 +50,7 @@ import type {
   SnsListNeuronsParams,
   SnsListProposalsParams,
   SnsNeuronAutoStakeMaturityParams,
+  SnsNeuronDisburseMaturityParams,
   SnsNeuronPermissionsParams,
   SnsNeuronStakeMaturityParams,
   SnsRegisterVoteParams,
@@ -286,6 +288,22 @@ export class SnsGovernanceCanister extends Canister<SnsGovernanceService> {
       neuronId,
       percentageToStake,
     });
+    await this.manageNeuron(request);
+  };
+
+  /**
+   * Disburse the maturity of a neuron.
+   *
+   * @param {neuronId: NeuronId; toAccount?: IcrcAccount; percentageToDisburse: number; } params
+   * @param {IcrcAccount} toAccount. Account to disburse maturity.
+   * @param {NeuronId} neuronId The id of the neuron for which to disburse the maturity
+   */
+  disburseMaturity = async (
+    params: SnsNeuronDisburseMaturityParams,
+  ): Promise<void> => {
+    assertPercentageNumber(params.percentageToDisburse);
+
+    const request: ManageNeuron = toDisburseMaturityRequest(params);
     await this.manageNeuron(request);
   };
 

--- a/packages/sns/src/governance.canister.ts
+++ b/packages/sns/src/governance.canister.ts
@@ -297,7 +297,7 @@ export class SnsGovernanceCanister extends Canister<SnsGovernanceService> {
    * @param {neuronId: NeuronId; toAccount?: IcrcAccount; percentageToDisburse: number; } params
    * @param {IcrcAccount} toAccount. Account to disburse maturity.
    * @param {NeuronId} neuronId The id of the neuron for which to disburse the maturity
-   * @param {number} percentageToDisburse How many percents of available maturity to disburse.
+   * @param {number} percentageToDisburse What percentage of the available maturity to disburse.
    */
   disburseMaturity = async (
     params: SnsNeuronDisburseMaturityParams,

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -609,6 +609,27 @@ describe("SnsWrapper", () => {
     });
   });
 
+  it("should call disburseMaturity", async () => {
+    const neuronId = {
+      id: arrayOfNumberToUint8Array([1, 2, 3]),
+    };
+    const toAccount = {
+      owner: Principal.fromText("aaaaa-aa"),
+      subaccount: arrayOfNumberToUint8Array([0, 0, 1]),
+    };
+    const percentageToDisburse = 50;
+    await snsWrapper.disburseMaturity({
+      neuronId,
+      percentageToDisburse,
+      toAccount,
+    });
+    expect(mockGovernanceCanister.disburseMaturity).toHaveBeenCalledWith({
+      neuronId,
+      percentageToDisburse,
+      toAccount,
+    });
+  });
+
   it("should call autoStakeMaturity", async () => {
     const neuronId = {
       id: arrayOfNumberToUint8Array([1, 2, 3]),

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -47,6 +47,7 @@ import type {
   SnsListNeuronsParams,
   SnsListProposalsParams,
   SnsNeuronAutoStakeMaturityParams,
+  SnsNeuronDisburseMaturityParams,
   SnsNeuronPermissionsParams,
   SnsNeuronStakeMaturityParams,
   SnsRegisterVoteParams,
@@ -436,6 +437,10 @@ export class SnsWrapper {
   // Always certified
   stakeMaturity = (params: SnsNeuronStakeMaturityParams): Promise<void> =>
     this.governance.stakeMaturity(params);
+
+  // Always certified
+  disburseMaturity = (params: SnsNeuronDisburseMaturityParams): Promise<void> =>
+    this.governance.disburseMaturity(params);
 
   // Always certified
   autoStakeMaturity = (

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -166,6 +166,15 @@ export interface SnsNeuronStakeMaturityParams
 }
 
 /**
+ * The parameters to disburse maturity of a neuron
+ */
+export interface SnsNeuronDisburseMaturityParams
+  extends SnsNeuronManagementParams {
+  toAccount?: IcrcAccount;
+  percentageToDisburse: number;
+}
+
+/**
  * The parameters to toggle auto stake maturity of a neuron
  */
 export interface SnsNeuronAutoStakeMaturityParams


### PR DESCRIPTION
# Motivation

Add `disburseMaturity` to sns functions

# Changes

- `disburseMaturity` function
- related types
- increased size limit for sns: 14Kb -> 16Kb

# Tests

- disburseMaturity params spec

