### PR TITLE
build: bump agent js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 ## Features
 
 - Reviver and replacer to interpret `BigInt`, `Principal`, and `Uint8Array` in `JSON.stringify|parse`
+- Add Sns disburse maturity function
+
+## Build
+
+- bump agent-js `v0.19.0`
 
 # 0.18.1 (2023-08-07)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -661,26 +661,29 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.18.1.tgz",
-      "integrity": "sha512-nMFK/y0ZkPfQYECdojmltXsBIdGvXa1Sxa4rDV2cibEq9lsjWMEIUqPsiBaNHuwuz+gzsGVq4N2b9umKQIQaRQ==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.0.tgz",
+      "integrity": "sha512-BniHTvNh6qQ4FNHZEf6Y4GtOkXPBhjDPcereO1KMNpCKLRSXS4LNqfK7ExPdgUhBlYaXtto551ISEbKvo+TLMQ==",
       "peer": true,
       "dependencies": {
+        "@noble/hashes": "^1.3.1",
         "base64-arraybuffer": "^0.2.0",
         "borc": "^2.1.1",
-        "js-sha256": "0.9.0",
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.18.1",
-        "@dfinity/principal": "^0.18.1"
+        "@dfinity/candid": "^0.19.0",
+        "@dfinity/principal": "^0.19.0"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.18.1.tgz",
-      "integrity": "sha512-/PC3wDnrGcWhaF/veYKevcAAn5A5jK0mRkVKcz0YxK/a78Ai9wMJg0fUk7aoyZryCOz8JPVgR4nK1/zTmvEBHg==",
-      "peer": true
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.0.tgz",
+      "integrity": "sha512-cuK1PcLROTWhlOV6ew9K0HgVil6Og2pFdQz37jnpOmoYg+SrRzCQLcadjUrxy+RS4ryvkX8lCzH8liUiFYgPWg==",
+      "peer": true,
+      "peerDependencies": {
+        "@dfinity/principal": "^0.19.0"
+      }
     },
     "node_modules/@dfinity/ckbtc": {
       "resolved": "packages/ckbtc",
@@ -707,12 +710,12 @@
       "link": true
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.18.1.tgz",
-      "integrity": "sha512-xeV+5zV7VQRT2xJTbXW4IDra1urEcchuwuKFTU/ERcJWBWEk8chsZcd6DBc8SPq83xRgXW2ZTVVSOZR8NKaVoQ==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.0.tgz",
+      "integrity": "sha512-s7N+MNEnvEz4sbSv7mKvJiz9JnREu6LFtgNTJq4L9aBXgbWUe+bjdbVjqXz8Uk0kRgPAfnFfezM6ddVd/80tew==",
       "peer": true,
       "dependencies": {
-        "js-sha256": "^0.9.0"
+        "@noble/hashes": "^1.3.1"
       }
     },
     "node_modules/@dfinity/rosetta-client": {
@@ -1553,6 +1556,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "peer": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7147,9 +7162,9 @@
         "js-sha256": "^0.9.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.18.1",
-        "@dfinity/candid": "^0.18.1",
-        "@dfinity/principal": "^0.18.1",
+        "@dfinity/agent": "^0.19.0",
+        "@dfinity/candid": "^0.19.0",
+        "@dfinity/principal": "^0.19.0",
         "@dfinity/utils": "^0.0.20"
       }
     },
@@ -7158,9 +7173,9 @@
       "version": "0.0.16",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^0.18.1",
-        "@dfinity/candid": "^0.18.1",
-        "@dfinity/principal": "^0.18.1",
+        "@dfinity/agent": "^0.19.0",
+        "@dfinity/candid": "^0.19.0",
+        "@dfinity/principal": "^0.19.0",
         "@dfinity/utils": "^0.0.20"
       }
     },
@@ -7174,9 +7189,9 @@
         "js-sha256": "^0.9.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.18.1",
-        "@dfinity/candid": "^0.18.1",
-        "@dfinity/principal": "^0.18.1",
+        "@dfinity/agent": "^0.19.0",
+        "@dfinity/candid": "^0.19.0",
+        "@dfinity/principal": "^0.19.0",
         "@dfinity/utils": "^0.0.20"
       }
     },
@@ -7185,9 +7200,9 @@
       "version": "0.0.13",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^0.18.1",
-        "@dfinity/candid": "^0.18.1",
-        "@dfinity/principal": "^0.18.1",
+        "@dfinity/agent": "^0.19.0",
+        "@dfinity/candid": "^0.19.0",
+        "@dfinity/principal": "^0.19.0",
         "@dfinity/utils": "^0.0.20"
       }
     },
@@ -7203,10 +7218,10 @@
         "@types/randombytes": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.18.1",
-        "@dfinity/candid": "^0.18.1",
+        "@dfinity/agent": "^0.19.0",
+        "@dfinity/candid": "^0.19.0",
         "@dfinity/nns-proto": "^0.0.6",
-        "@dfinity/principal": "^0.18.1",
+        "@dfinity/principal": "^0.19.0",
         "@dfinity/utils": "^0.0.20"
       }
     },
@@ -7234,10 +7249,10 @@
         "js-sha256": "^0.9.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.18.1",
-        "@dfinity/candid": "^0.18.1",
+        "@dfinity/agent": "^0.19.0",
+        "@dfinity/candid": "^0.19.0",
         "@dfinity/ledger": "^0.0.13",
-        "@dfinity/principal": "^0.18.1",
+        "@dfinity/principal": "^0.19.0",
         "@dfinity/utils": "^0.0.20"
       }
     },
@@ -7246,9 +7261,9 @@
       "version": "0.0.20",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^0.18.1",
-        "@dfinity/candid": "^0.18.1",
-        "@dfinity/principal": "^0.18.1"
+        "@dfinity/agent": "^0.19.0",
+        "@dfinity/candid": "^0.19.0",
+        "@dfinity/principal": "^0.19.0"
       }
     }
   },
@@ -7721,22 +7736,23 @@
       }
     },
     "@dfinity/agent": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.18.1.tgz",
-      "integrity": "sha512-nMFK/y0ZkPfQYECdojmltXsBIdGvXa1Sxa4rDV2cibEq9lsjWMEIUqPsiBaNHuwuz+gzsGVq4N2b9umKQIQaRQ==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.0.tgz",
+      "integrity": "sha512-BniHTvNh6qQ4FNHZEf6Y4GtOkXPBhjDPcereO1KMNpCKLRSXS4LNqfK7ExPdgUhBlYaXtto551ISEbKvo+TLMQ==",
       "peer": true,
       "requires": {
+        "@noble/hashes": "^1.3.1",
         "base64-arraybuffer": "^0.2.0",
         "borc": "^2.1.1",
-        "js-sha256": "0.9.0",
         "simple-cbor": "^0.4.1"
       }
     },
     "@dfinity/candid": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.18.1.tgz",
-      "integrity": "sha512-/PC3wDnrGcWhaF/veYKevcAAn5A5jK0mRkVKcz0YxK/a78Ai9wMJg0fUk7aoyZryCOz8JPVgR4nK1/zTmvEBHg==",
-      "peer": true
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.0.tgz",
+      "integrity": "sha512-cuK1PcLROTWhlOV6ew9K0HgVil6Og2pFdQz37jnpOmoYg+SrRzCQLcadjUrxy+RS4ryvkX8lCzH8liUiFYgPWg==",
+      "peer": true,
+      "requires": {}
     },
     "@dfinity/ckbtc": {
       "version": "file:packages/ckbtc",
@@ -7778,12 +7794,12 @@
       }
     },
     "@dfinity/principal": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.18.1.tgz",
-      "integrity": "sha512-xeV+5zV7VQRT2xJTbXW4IDra1urEcchuwuKFTU/ERcJWBWEk8chsZcd6DBc8SPq83xRgXW2ZTVVSOZR8NKaVoQ==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.0.tgz",
+      "integrity": "sha512-s7N+MNEnvEz4sbSv7mKvJiz9JnREu6LFtgNTJq4L9aBXgbWUe+bjdbVjqXz8Uk0kRgPAfnFfezM6ddVd/80tew==",
       "peer": true,
       "requires": {
-        "js-sha256": "^0.9.0"
+        "@noble/hashes": "^1.3.1"
       }
     },
     "@dfinity/rosetta-client": {
@@ -8325,6 +8341,12 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "peer": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.18.1",
-    "@dfinity/candid": "^0.18.1",
-    "@dfinity/principal": "^0.18.1",
+    "@dfinity/agent": "^0.19.0",
+    "@dfinity/candid": "^0.19.0",
+    "@dfinity/principal": "^0.19.0",
     "@dfinity/utils": "^0.0.20"
   },
   "dependencies": {

--- a/packages/cmc/package.json
+++ b/packages/cmc/package.json
@@ -36,9 +36,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.18.1",
-    "@dfinity/candid": "^0.18.1",
-    "@dfinity/principal": "^0.18.1",
+    "@dfinity/agent": "^0.19.0",
+    "@dfinity/candid": "^0.19.0",
+    "@dfinity/principal": "^0.19.0",
     "@dfinity/utils": "^0.0.20"
   }
 }

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -34,9 +34,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.18.1",
-    "@dfinity/candid": "^0.18.1",
-    "@dfinity/principal": "^0.18.1",
+    "@dfinity/agent": "^0.19.0",
+    "@dfinity/candid": "^0.19.0",
+    "@dfinity/principal": "^0.19.0",
     "@dfinity/utils": "^0.0.20"
   },
   "dependencies": {

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -37,9 +37,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.18.1",
-    "@dfinity/candid": "^0.18.1",
-    "@dfinity/principal": "^0.18.1",
+    "@dfinity/agent": "^0.19.0",
+    "@dfinity/candid": "^0.19.0",
+    "@dfinity/principal": "^0.19.0",
     "@dfinity/utils": "^0.0.20"
   }
 }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -51,10 +51,10 @@
     "network-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^0.18.1",
-    "@dfinity/candid": "^0.18.1",
+    "@dfinity/agent": "^0.19.0",
+    "@dfinity/candid": "^0.19.0",
     "@dfinity/nns-proto": "^0.0.6",
-    "@dfinity/principal": "^0.18.1",
+    "@dfinity/principal": "^0.19.0",
     "@dfinity/utils": "^0.0.20"
   }
 }

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -36,10 +36,10 @@
     "sns"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^0.18.1",
-    "@dfinity/candid": "^0.18.1",
+    "@dfinity/agent": "^0.19.0",
+    "@dfinity/candid": "^0.19.0",
     "@dfinity/ledger": "^0.0.13",
-    "@dfinity/principal": "^0.18.1",
+    "@dfinity/principal": "^0.19.0",
     "@dfinity/utils": "^0.0.20"
   },
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -47,8 +47,8 @@
     "service-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^0.18.1",
-    "@dfinity/candid": "^0.18.1",
-    "@dfinity/principal": "^0.18.1"
+    "@dfinity/agent": "^0.19.0",
+    "@dfinity/candid": "^0.19.0",
+    "@dfinity/principal": "^0.19.0"
   }
 }


### PR DESCRIPTION
# Motivation

Bump agent-js and prepare changelog for release.

Updating agent-js https://github.com/dfinity/agent-js/releases/tag/v0.19.0 solve an issue with last version of Chrome 116.0.5845.110 which sometimes fails (not on all devices) a verifying responses using the sha256 library. That's why in agent-js they replaced the library.

Library which we will also replace on our side in the future (in other PRs).
