### PR TITLE
feat: replaces the js-sha256 library with @noble/hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - utils `v0.0.22`
 - nns-proto `v0.0.8`
 
+## Features
+
+- replaces the `js-sha256` library with `@noble/hashes`
+
 # 0.18.3 (2023-09-04)
 
 ## Release

--- a/package-lock.json
+++ b/package-lock.json
@@ -5365,11 +5365,6 @@
       "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
     },
-    "node_modules/js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11076,11 +11071,6 @@
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
       "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
-    },
-    "js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7245,7 +7245,7 @@
       "version": "0.0.21",
       "license": "Apache-2.0",
       "dependencies": {
-        "js-sha256": "^0.9.0"
+        "@noble/hashes": "^1.3.2"
       },
       "peerDependencies": {
         "@dfinity/agent": "^0.19.1",
@@ -7807,7 +7807,7 @@
     "@dfinity/sns": {
       "version": "file:packages/sns",
       "requires": {
-        "js-sha256": "^0.9.0"
+        "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7210,7 +7210,7 @@
       "version": "0.16.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "js-sha256": "^0.9.0",
+        "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       },
       "devDependencies": {
@@ -7780,8 +7780,8 @@
     "@dfinity/nns": {
       "version": "file:packages/nns",
       "requires": {
+        "@noble/hashes": "^1.3.2",
         "@types/randombytes": "^2.0.0",
-        "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1562,7 +1562,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -7157,9 +7156,9 @@
       "version": "0.0.10",
       "license": "Apache-2.0",
       "dependencies": {
+        "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
-        "bech32": "^2.0.0",
-        "js-sha256": "^0.9.0"
+        "bech32": "^2.0.0"
       },
       "peerDependencies": {
         "@dfinity/agent": "^0.19.1",
@@ -7757,9 +7756,9 @@
     "@dfinity/ckbtc": {
       "version": "file:packages/ckbtc",
       "requires": {
+        "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
-        "bech32": "^2.0.0",
-        "js-sha256": "^0.9.0"
+        "bech32": "^2.0.0"
       }
     },
     "@dfinity/cmc": {
@@ -8345,8 +8344,7 @@
     "@noble/hashes": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "peer": true
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -44,8 +44,8 @@
     "@dfinity/utils": "^0.0.21"
   },
   "dependencies": {
+    "@noble/hashes": "^1.3.2",
     "base58-js": "^1.0.5",
-    "bech32": "^2.0.0",
-    "js-sha256": "^0.9.0"
+    "bech32": "^2.0.0"
   }
 }

--- a/packages/ckbtc/src/utils/btc.utils.ts
+++ b/packages/ckbtc/src/utils/btc.utils.ts
@@ -1,7 +1,7 @@
 import { isNullish } from "@dfinity/utils";
+import { sha256 } from "@noble/hashes/sha256";
 import { base58_to_binary } from "base58-js";
 import { bech32, bech32m, type Decoded } from "bech32";
-import { sha256 } from "js-sha256";
 import { BtcAddressType, BtcNetwork } from "../enums/btc.enums";
 import {
   ParseBtcAddressBadWitnessLengthError,
@@ -78,7 +78,7 @@ const parseBase58Address = ({
     const checksumHash = sha256.create();
     checksumHash.update(bodyHash.digest());
 
-    const checksum = checksumHash.array().slice(0, 4);
+    const checksum = checksumHash.digest().slice(0, 4);
 
     if (
       expectedChecksum.some(

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -121,7 +121,7 @@ Parameters:
 
 ### :factory: AccountIdentifier
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L12)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L13)
 
 #### Methods
 
@@ -139,7 +139,7 @@ Parameters:
 | --------- | ------------------------------------ |
 | `fromHex` | `(hex: string) => AccountIdentifier` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L15)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L16)
 
 ##### :gear: fromPrincipal
 
@@ -147,7 +147,7 @@ Parameters:
 | --------------- | ------------------------------------------------------------------------------------------------------- |
 | `fromPrincipal` | `({ principal, subAccount, }: { principal: Principal; subAccount?: SubAccount; }) => AccountIdentifier` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L19)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L20)
 
 ##### :gear: toProto
 
@@ -155,7 +155,7 @@ Parameters:
 | --------- | ---------------------------------- |
 | `toProto` | `() => Promise<AccountIdentifier>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L46)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L49)
 
 ##### :gear: toHex
 
@@ -163,7 +163,7 @@ Parameters:
 | ------- | -------------- |
 | `toHex` | `() => string` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L54)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L57)
 
 ##### :gear: toUint8Array
 
@@ -171,7 +171,7 @@ Parameters:
 | -------------- | ------------------ |
 | `toUint8Array` | `() => Uint8Array` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L58)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L61)
 
 ##### :gear: toNumbers
 
@@ -179,7 +179,7 @@ Parameters:
 | ----------- | ---------------- |
 | `toNumbers` | `() => number[]` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L62)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L65)
 
 ##### :gear: toAccountIdentifierHash
 
@@ -187,11 +187,11 @@ Parameters:
 | ------------------------- | ------------------------- |
 | `toAccountIdentifierHash` | `() => AccountIdentifier` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L66)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L69)
 
 ### :factory: SubAccount
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L73)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L76)
 
 #### Methods
 
@@ -206,7 +206,7 @@ Parameters:
 | ----------- | -------------------------------------------- |
 | `fromBytes` | `(bytes: Uint8Array) => SubAccount or Error` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L76)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L79)
 
 ##### :gear: fromPrincipal
 
@@ -214,7 +214,7 @@ Parameters:
 | --------------- | -------------------------------------- |
 | `fromPrincipal` | `(principal: Principal) => SubAccount` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L84)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L87)
 
 ##### :gear: fromID
 
@@ -222,7 +222,7 @@ Parameters:
 | -------- | ---------------------------- |
 | `fromID` | `(id: number) => SubAccount` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L97)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L100)
 
 ##### :gear: toUint8Array
 
@@ -230,7 +230,7 @@ Parameters:
 | -------------- | ------------------ |
 | `toUint8Array` | `() => Uint8Array` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L109)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/account_identifier.ts#L112)
 
 ### :factory: GenesisTokenCanister
 
@@ -312,7 +312,7 @@ Returns the index of the block containing the tx if it was successful.
 
 ### :factory: GovernanceCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L106)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L107)
 
 #### Methods
 
@@ -353,7 +353,7 @@ Returns the index of the block containing the tx if it was successful.
 | -------- | ------------------------------------------------------------- |
 | `create` | `(options?: GovernanceCanisterOptions) => GovernanceCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L121)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L122)
 
 ##### :gear: listNeurons
 
@@ -368,7 +368,7 @@ it is fetched using a query call.
 | ------------- | ----------------------------------------------------------------------------------------------------- |
 | `listNeurons` | `({ certified, neuronIds, }: { certified: boolean; neuronIds?: bigint[]; }) => Promise<NeuronInfo[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L153)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L154)
 
 ##### :gear: listKnownNeurons
 
@@ -382,7 +382,7 @@ it is fetched using a query call.
 | ------------------ | ------------------------------------------------- |
 | `listKnownNeurons` | `(certified?: boolean) => Promise<KnownNeuron[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L185)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L186)
 
 ##### :gear: getLastestRewardEvent
 
@@ -395,7 +395,7 @@ it's fetched using a query call.
 | ----------------------- | ----------------------------------------------- |
 | `getLastestRewardEvent` | `(certified?: boolean) => Promise<RewardEvent>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L208)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L209)
 
 ##### :gear: listProposals
 
@@ -414,7 +414,7 @@ Parameters:
 - `request`: the options to list the proposals (limit number of results, topics to search for, etc.)
 - `certified`: query or update calls
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L224)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L225)
 
 ##### :gear: stakeNeuron
 
@@ -422,7 +422,7 @@ Parameters:
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `stakeNeuron` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, fee, }: { stake: bigint; principal: Principal; fromSubAccount?: number[]; ledgerCanister: LedgerCanister; createdAt?: bigint; fee?: bigint; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L244)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L245)
 
 ##### :gear: increaseDissolveDelay
 
@@ -432,7 +432,7 @@ Increases dissolve delay of a neuron
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `increaseDissolveDelay` | `({ neuronId, additionalDissolveDelaySeconds, }: { neuronId: bigint; additionalDissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L305)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L306)
 
 ##### :gear: setDissolveDelay
 
@@ -443,7 +443,7 @@ The new date is now + dissolveDelaySeconds.
 | ------------------ | ------------------------------------------------------------------------------------------------------------- |
 | `setDissolveDelay` | `({ neuronId, dissolveDelaySeconds, }: { neuronId: bigint; dissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L337)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L338)
 
 ##### :gear: startDissolving
 
@@ -453,7 +453,7 @@ Start dissolving process of a neuron
 | ----------------- | ------------------------------------- |
 | `startDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L360)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L361)
 
 ##### :gear: stopDissolving
 
@@ -463,7 +463,7 @@ Stop dissolving process of a neuron
 | ---------------- | ------------------------------------- |
 | `stopDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L377)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L378)
 
 ##### :gear: joinCommunityFund
 
@@ -473,7 +473,7 @@ Neuron joins the community fund
 | ------------------- | ------------------------------------- |
 | `joinCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L394)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L395)
 
 ##### :gear: autoStakeMaturity
 
@@ -488,7 +488,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to request a change of the auto stake feature
 - `autoStake`: `true` to enable the auto-stake maturity for this neuron, `false` to turn it off
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L416)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L417)
 
 ##### :gear: leaveCommunityFund
 
@@ -498,7 +498,7 @@ Neuron leaves the community fund
 | -------------------- | ------------------------------------- |
 | `leaveCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L430)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L431)
 
 ##### :gear: setNodeProviderAccount
 
@@ -509,7 +509,7 @@ Where the reward is paid to.
 | ------------------------ | ---------------------------------------------- |
 | `setNodeProviderAccount` | `(accountIdentifier: string) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L447)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L448)
 
 ##### :gear: mergeNeurons
 
@@ -519,7 +519,7 @@ Merge two neurons
 | -------------- | --------------------------------------------------------------------------------- |
 | `mergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L467)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L468)
 
 ##### :gear: simulateMergeNeurons
 
@@ -529,7 +529,7 @@ Simulate merging two neurons
 | ---------------------- | --------------------------------------------------------------------------------------- |
 | `simulateMergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<NeuronInfo>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L484)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L485)
 
 ##### :gear: splitNeuron
 
@@ -539,7 +539,7 @@ Splits a neuron creating a new one
 | ------------- | ----------------------------------------------------------------------------------- |
 | `splitNeuron` | `({ neuronId, amount, }: { neuronId: bigint; amount: bigint; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L529)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L530)
 
 ##### :gear: getProposal
 
@@ -552,7 +552,7 @@ it is fetched using a query call.
 | ------------- | ----------------------------------------------------------------------------------------------------- |
 | `getProposal` | `({ proposalId, certified, }: { proposalId: bigint; certified?: boolean; }) => Promise<ProposalInfo>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L569)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L570)
 
 ##### :gear: makeProposal
 
@@ -562,7 +562,7 @@ Create new proposal
 | -------------- | ------------------------------------------------- |
 | `makeProposal` | `(request: MakeProposalRequest) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L586)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L587)
 
 ##### :gear: registerVote
 
@@ -572,7 +572,7 @@ Registers vote for a proposal from the neuron passed.
 | -------------- | ----------------------------------------------------------------------------------------------------------- |
 | `registerVote` | `({ neuronId, vote, proposalId, }: { neuronId: bigint; vote: Vote; proposalId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L601)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L602)
 
 ##### :gear: setFollowees
 
@@ -582,7 +582,7 @@ Edit neuron followees per topic
 | -------------- | ------------------------------------------------- |
 | `setFollowees` | `(followRequest: FollowRequest) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L623)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L624)
 
 ##### :gear: disburse
 
@@ -592,7 +592,7 @@ Disburse neuron on Account
 | ---------- | --------------------------------------------------------------------------------------------------------------------- |
 | `disburse` | `({ neuronId, toAccountId, amount, }: { neuronId: bigint; toAccountId?: string; amount?: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L638)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L639)
 
 ##### :gear: mergeMaturity
 
@@ -602,7 +602,7 @@ Merge Maturity of a neuron
 | --------------- | ------------------------------------------------------------------------------------------------------- |
 | `mergeMaturity` | `({ neuronId, percentageToMerge, }: { neuronId: bigint; percentageToMerge: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L677)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L678)
 
 ##### :gear: stakeMaturity
 
@@ -617,7 +617,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to stake the maturity
 - `percentageToStake`: Optional. Percentage of the current maturity to stake. If not provided, all of the neuron's current maturity will be staked.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L710)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L711)
 
 ##### :gear: spawnNeuron
 
@@ -627,7 +627,7 @@ Merge Maturity of a neuron
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `spawnNeuron` | `({ neuronId, percentageToSpawn, newController, nonce, }: { neuronId: bigint; percentageToSpawn?: number; newController?: Principal; nonce?: bigint; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L732)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L733)
 
 ##### :gear: addHotkey
 
@@ -637,7 +637,7 @@ Add hotkey to neuron
 | ----------- | ------------------------------------------------------------------------------------------ |
 | `addHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L786)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L787)
 
 ##### :gear: removeHotkey
 
@@ -647,7 +647,7 @@ Remove hotkey to neuron
 | -------------- | ------------------------------------------------------------------------------------------ |
 | `removeHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L810)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L811)
 
 ##### :gear: claimOrRefreshNeuronFromAccount
 
@@ -657,7 +657,7 @@ Gets the NeuronID of a newly created neuron.
 | --------------------------------- | --------------------------------------------------------------------------------------- |
 | `claimOrRefreshNeuronFromAccount` | `({ memo, controller, }: { memo: bigint; controller?: Principal; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L831)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L832)
 
 ##### :gear: claimOrRefreshNeuron
 
@@ -668,7 +668,7 @@ Uses query call only.
 | ---------------------- | ----------------------------------------------------------- |
 | `claimOrRefreshNeuron` | `(request: ClaimOrRefreshNeuronRequest) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L862)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L863)
 
 ##### :gear: getNeuron
 
@@ -678,7 +678,7 @@ Return the data of the neuron provided as id.
 | ----------- | ---------------------------------------------------------------------------------------------- |
 | `getNeuron` | `({ certified, neuronId, }: { certified: boolean; neuronId: bigint; }) => Promise<NeuronInfo>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L897)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L905)
 
 ### :factory: ICP
 

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "js-sha256": "^0.9.0",
+    "@noble/hashes": "^1.3.2",
     "randombytes": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/nns/src/account_identifier.ts
+++ b/packages/nns/src/account_identifier.ts
@@ -1,11 +1,12 @@
 import type { AccountIdentifier as AccountIdentifierPb } from "@dfinity/nns-proto";
 import type { Principal } from "@dfinity/principal";
 import {
+  arrayOfNumberToUint8Array,
   asciiStringToByteArray,
   bigEndianCrc32,
   uint8ArrayToHexString,
 } from "@dfinity/utils";
-import { sha224 } from "js-sha256";
+import { sha224 } from "@noble/hashes/sha256";
 import type { AccountIdentifier as AccountIdentifierCandid } from "../candid/governance";
 import { importNnsProto } from "./utils/proto.utils";
 
@@ -27,12 +28,14 @@ export class AccountIdentifier {
     const padding = asciiStringToByteArray("\x0Aaccount-id");
 
     const shaObj = sha224.create();
-    shaObj.update([
-      ...padding,
-      ...principal.toUint8Array(),
-      ...subAccount.toUint8Array(),
-    ]);
-    const hash = new Uint8Array(shaObj.array());
+    shaObj.update(
+      arrayOfNumberToUint8Array([
+        ...padding,
+        ...principal.toUint8Array(),
+        ...subAccount.toUint8Array(),
+      ]),
+    );
+    const hash = shaObj.digest();
 
     // Prepend the checksum of the hash and convert to a hex string
     const checksum = bigEndianCrc32(hash);

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -2,6 +2,7 @@ import type { ActorSubclass, Agent } from "@dfinity/agent";
 import type { ManageNeuron as PbManageNeuron } from "@dfinity/nns-proto";
 import type { Principal } from "@dfinity/principal";
 import {
+  arrayOfNumberToUint8Array,
   asciiStringToByteArray,
   assertPercentageNumber,
   createServices,
@@ -10,7 +11,7 @@ import {
   nonNullish,
   uint8ArrayToBigInt,
 } from "@dfinity/utils";
-import { sha256 } from "js-sha256";
+import { sha256 } from "@noble/hashes/sha256";
 import randomBytes from "randombytes";
 import type {
   Command_1,
@@ -883,8 +884,15 @@ export class GovernanceCanister {
   ): SubAccount => {
     const padding = asciiStringToByteArray("neuron-stake");
     const shaObj = sha256.create();
-    shaObj.update([0x0c, ...padding, ...principal.toUint8Array(), ...nonce]);
-    return SubAccount.fromBytes(new Uint8Array(shaObj.array())) as SubAccount;
+    shaObj.update(
+      arrayOfNumberToUint8Array([
+        0x0c,
+        ...padding,
+        ...principal.toUint8Array(),
+        ...nonce,
+      ]),
+    );
+    return SubAccount.fromBytes(shaObj.digest()) as SubAccount;
   };
 
   private getGovernanceService(certified: boolean): GovernanceService {

--- a/packages/nns/src/utils/account_identifier.utils.ts
+++ b/packages/nns/src/utils/account_identifier.utils.ts
@@ -1,11 +1,12 @@
 import type { Principal } from "@dfinity/principal";
 import {
+  arrayOfNumberToUint8Array,
   asciiStringToByteArray,
   bigEndianCrc32,
   uint8ArrayToHexString,
 } from "@dfinity/utils";
+import { sha224 } from "@noble/hashes/sha256";
 import { Buffer } from "buffer";
-import { sha224 } from "js-sha256";
 import type { AccountIdentifier } from "../types/common";
 
 export const accountIdentifierToBytes = (
@@ -25,12 +26,14 @@ export const principalToAccountIdentifier = (
   const padding = asciiStringToByteArray("\x0Aaccount-id");
 
   const shaObj = sha224.create();
-  shaObj.update([
-    ...padding,
-    ...principal.toUint8Array(),
-    ...(subAccount ?? Array(32).fill(0)),
-  ]);
-  const hash = new Uint8Array(shaObj.array());
+  shaObj.update(
+    arrayOfNumberToUint8Array([
+      ...padding,
+      ...principal.toUint8Array(),
+      ...(subAccount ?? Array(32).fill(0)),
+    ]),
+  );
+  const hash = shaObj.digest();
 
   // Prepend the checksum of the hash and convert to a hex string
   const checksum = bigEndianCrc32(hash);

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -43,6 +43,6 @@
     "@dfinity/utils": "^0.0.21"
   },
   "dependencies": {
-    "js-sha256": "^0.9.0"
+    "@noble/hashes": "^1.3.2"
   }
 }

--- a/packages/sns/src/utils/governance.utils.ts
+++ b/packages/sns/src/utils/governance.utils.ts
@@ -1,7 +1,7 @@
 import type { IcrcSubaccount } from "@dfinity/ledger";
 import type { Principal } from "@dfinity/principal";
-import { asciiStringToByteArray, numberToUint8Array } from "@dfinity/utils";
-import { sha256 } from "js-sha256";
+import { arrayOfNumberToUint8Array,asciiStringToByteArray,numberToUint8Array } from "@dfinity/utils";
+import { sha256 } from "@noble/hashes/sha256";
 
 /**
  * Neuron subaccount is calculated as "sha256(0x0c . “neuron-stake” . controller . i)"
@@ -27,6 +27,6 @@ export const neuronSubaccount = ({
   ];
   // TODO(#238): Implement without library and make it compatible with NodeJS and browser
   const shaObj = sha256.create();
-  shaObj.update(data);
-  return new Uint8Array(shaObj.array());
+  shaObj.update(arrayOfNumberToUint8Array(data));
+  return shaObj.digest();
 };

--- a/packages/sns/src/utils/governance.utils.ts
+++ b/packages/sns/src/utils/governance.utils.ts
@@ -1,6 +1,10 @@
 import type { IcrcSubaccount } from "@dfinity/ledger";
 import type { Principal } from "@dfinity/principal";
-import { arrayOfNumberToUint8Array,asciiStringToByteArray,numberToUint8Array } from "@dfinity/utils";
+import {
+  arrayOfNumberToUint8Array,
+  asciiStringToByteArray,
+  numberToUint8Array,
+} from "@dfinity/utils";
 import { sha256 } from "@noble/hashes/sha256";
 
 /**


### PR DESCRIPTION
# Motivation

Similar to what was done in `agent-js` to solve the issue regarding last version of Chrome and validation of the certificate, replace `js-sha256` with `@noble/hashes`.

Related agent-js PR is https://github.com/dfinity/agent-js/pull/753
