### PR TITLE
Sns add maturity api

### DIFF
--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -83,7 +83,7 @@ Lookup for the canister ids of a Sns and initialize the wrapper to access its fe
 
 ### :factory: SnsGovernanceCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L62)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L64)
 
 #### Methods
 
@@ -106,6 +106,7 @@ Lookup for the canister ids of a Sns and initialize the wrapper to access its fe
 - [stakeMaturity](#gear-stakematurity)
 - [disburseMaturity](#gear-disbursematurity)
 - [autoStakeMaturity](#gear-autostakematurity)
+- [addMaturity](#gear-addmaturity)
 - [setDissolveTimestamp](#gear-setdissolvetimestamp)
 - [increaseDissolveDelay](#gear-increasedissolvedelay)
 - [setTopicFollowees](#gear-settopicfollowees)
@@ -125,7 +126,7 @@ Parameters:
 
 - `options`: Miscellaneous options to initialize the canister. Its ID being the only mandatory parammeter.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L68)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L70)
 
 ##### :gear: listNeurons
 
@@ -135,7 +136,7 @@ List the neurons of the Sns
 | ------------- | ----------------------------------------------------- |
 | `listNeurons` | `(params: SnsListNeuronsParams) => Promise<Neuron[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L82)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L84)
 
 ##### :gear: listProposals
 
@@ -145,7 +146,7 @@ List the proposals of the Sns
 | --------------- | ------------------------------------------------------------- |
 | `listProposals` | `(params: SnsListProposalsParams) => Promise<ProposalData[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L96)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L98)
 
 ##### :gear: getProposal
 
@@ -155,7 +156,7 @@ Get the proposal of the Sns
 | ------------- | --------------------------------------------------------- |
 | `getProposal` | `(params: SnsGetProposalParams) => Promise<ProposalData>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L110)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L112)
 
 ##### :gear: listNervousSystemFunctions
 
@@ -166,7 +167,7 @@ Neurons can follow other neurons in specific Nervous System Functions.
 | ---------------------------- | ---------------------------------------------------------------------- |
 | `listNervousSystemFunctions` | `(params: QueryParams) => Promise<ListNervousSystemFunctionsResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L129)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L131)
 
 ##### :gear: metadata
 
@@ -176,7 +177,7 @@ Get the Sns metadata (title, description, etc.)
 | ---------- | ------------------------------------------------------- |
 | `metadata` | `(params: QueryParams) => Promise<GetMetadataResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L137)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L139)
 
 ##### :gear: nervousSystemParameters
 
@@ -186,7 +187,7 @@ Get the Sns nervous system parameters (default followees, max dissolve delay, ma
 | ------------------------- | ----------------------------------------------------------- |
 | `nervousSystemParameters` | `(params: QueryParams) => Promise<NervousSystemParameters>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L143)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L145)
 
 ##### :gear: getNeuron
 
@@ -196,7 +197,7 @@ Get the neuron of the Sns
 | ----------- | ------------------------------------------------- |
 | `getNeuron` | `(params: SnsGetNeuronParams) => Promise<Neuron>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L151)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L153)
 
 ##### :gear: queryNeuron
 
@@ -206,7 +207,7 @@ Same as `getNeuron` but returns undefined instead of raising error when not foun
 | ------------- | ------------------------------------------------- |
 | `queryNeuron` | `(params: SnsGetNeuronParams) => Promise<Neuron>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L169)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L171)
 
 ##### :gear: manageNeuron
 
@@ -216,7 +217,7 @@ Manage neuron. For advanced users.
 | -------------- | ---------------------------------------------------------- |
 | `manageNeuron` | `(request: ManageNeuron) => Promise<ManageNeuronResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L189)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L191)
 
 ##### :gear: addNeuronPermissions
 
@@ -226,7 +227,7 @@ Add permissions to a neuron for a specific principal
 | ---------------------- | ------------------------------------------------------- |
 | `addNeuronPermissions` | `(params: SnsNeuronPermissionsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L202)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L204)
 
 ##### :gear: removeNeuronPermissions
 
@@ -236,7 +237,7 @@ Remove permissions to a neuron for a specific principal
 | ------------------------- | ------------------------------------------------------- |
 | `removeNeuronPermissions` | `(params: SnsNeuronPermissionsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L212)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L214)
 
 ##### :gear: splitNeuron
 
@@ -246,7 +247,7 @@ Split neuron
 | ------------- | ----------------------------------------------------- |
 | `splitNeuron` | `(params: SnsSplitNeuronParams) => Promise<NeuronId>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L222)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L224)
 
 ##### :gear: disburse
 
@@ -256,7 +257,7 @@ Disburse neuron on Account
 | ---------- | ---------------------------------------------------- |
 | `disburse` | `(params: SnsDisburseNeuronParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L253)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L255)
 
 ##### :gear: startDissolving
 
@@ -266,7 +267,7 @@ Start dissolving process of a neuron
 | ----------------- | --------------------------------------- |
 | `startDissolving` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L261)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L263)
 
 ##### :gear: stopDissolving
 
@@ -276,7 +277,7 @@ Stop dissolving process of a neuron
 | ---------------- | --------------------------------------- |
 | `stopDissolving` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L269)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L271)
 
 ##### :gear: stakeMaturity
 
@@ -291,7 +292,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to stake the maturity
 - `percentageToStake`: Optional. Percentage of the current maturity to stake. If not provided, all of the neuron's current maturity will be staked.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L281)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L283)
 
 ##### :gear: disburseMaturity
 
@@ -307,7 +308,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to disburse the maturity
 - `percentageToDisburse`: What percentage of the available maturity to disburse.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L302)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L304)
 
 ##### :gear: autoStakeMaturity
 
@@ -322,7 +323,22 @@ Parameters:
 - `neuronId`: The id of the neuron for which to request a change of the auto stake feature
 - `autoStake`: `true` to enable the auto-stake maturity for this neuron, `false` to turn it off
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L318)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L320)
+
+##### :gear: addMaturity
+
+sns-governance-test function to simulate maturity related function.
+
+| Method        | Type                                                      |
+| ------------- | --------------------------------------------------------- |
+| `addMaturity` | `(params: SnsNeuronAddMaturityParams) => Promise<bigint>` |
+
+Parameters:
+
+- `neuronId`: The id of the neuron for which to increase the maturity
+- `amountE8s`: How much maturity to add.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L334)
 
 ##### :gear: setDissolveTimestamp
 
@@ -332,7 +348,7 @@ Increase dissolve delay of a neuron
 | ---------------------- | ---------------------------------------------------------- |
 | `setDissolveTimestamp` | `(params: SnsSetDissolveTimestampParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L328)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L354)
 
 ##### :gear: increaseDissolveDelay
 
@@ -342,7 +358,7 @@ Increase dissolve delay of a neuron
 | ----------------------- | ----------------------------------------------------------- |
 | `increaseDissolveDelay` | `(params: SnsIncreaseDissolveDelayParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L338)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L364)
 
 ##### :gear: setTopicFollowees
 
@@ -352,7 +368,7 @@ Sets followees of a neuron for a specific Nervous System Function (topic)
 | ------------------- | ------------------------------------------------- |
 | `setTopicFollowees` | `(params: SnsSetTopicFollowees) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L348)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L374)
 
 ##### :gear: registerVote
 
@@ -362,7 +378,7 @@ Registers vote for a proposal from the neuron passed.
 | -------------- | -------------------------------------------------- |
 | `registerVote` | `(params: SnsRegisterVoteParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L356)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L382)
 
 ##### :gear: refreshNeuron
 
@@ -372,7 +388,7 @@ Refresh neuron
 | --------------- | --------------------------------------- |
 | `refreshNeuron` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L364)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L390)
 
 ##### :gear: claimNeuron
 
@@ -382,7 +398,7 @@ Claim neuron
 | ------------- | -------------------------------------------------------------------------------- |
 | `claimNeuron` | `({ memo, controller, subaccount, }: SnsClaimNeuronParams) => Promise<NeuronId>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L374)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L400)
 
 ### :factory: SnsRootCanister
 
@@ -545,7 +561,7 @@ Sns wrapper - notably used by NNS-dapp - ease the access to a particular Sns.
 It knows all the Sns' canisters, wrap and enhance their available features.
 A wrapper either performs query or update calls.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L84)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L85)
 
 #### Constructors
 
@@ -600,6 +616,7 @@ Parameters:
 - [stakeMaturity](#gear-stakematurity)
 - [disburseMaturity](#gear-disbursematurity)
 - [autoStakeMaturity](#gear-autostakematurity)
+- [addMaturity](#gear-addmaturity)
 
 ##### :gear: listNeurons
 
@@ -607,7 +624,7 @@ Parameters:
 | ------------- | ------------------------------------------------------------------------ |
 | `listNeurons` | `(params: Omit<SnsListNeuronsParams, "certified">) => Promise<Neuron[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L130)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L131)
 
 ##### :gear: listProposals
 
@@ -615,7 +632,7 @@ Parameters:
 | --------------- | -------------------------------------------------------------------------------- |
 | `listProposals` | `(params: Omit<SnsListProposalsParams, "certified">) => Promise<ProposalData[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L134)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L135)
 
 ##### :gear: getProposal
 
@@ -623,7 +640,7 @@ Parameters:
 | ------------- | ---------------------------------------------------------------------------- |
 | `getProposal` | `(params: Omit<SnsGetProposalParams, "certified">) => Promise<ProposalData>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L139)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L140)
 
 ##### :gear: listNervousSystemFunctions
 
@@ -631,7 +648,7 @@ Parameters:
 | ---------------------------- | ----------------------------------------------------------------------------------------- |
 | `listNervousSystemFunctions` | `(params: Omit<QueryParams, "certified">) => Promise<ListNervousSystemFunctionsResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L144)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L145)
 
 ##### :gear: metadata
 
@@ -639,7 +656,7 @@ Parameters:
 | ---------- | ------------------------------------------------------------------------------------------------------- |
 | `metadata` | `(params: Omit<QueryParams, "certified">) => Promise<[GetMetadataResponse, IcrcTokenMetadataResponse]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L149)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L150)
 
 ##### :gear: nervousSystemParameters
 
@@ -647,7 +664,7 @@ Parameters:
 | ------------------------- | ------------------------------------------------------------------------------ |
 | `nervousSystemParameters` | `(params: Omit<QueryParams, "certified">) => Promise<NervousSystemParameters>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L157)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L158)
 
 ##### :gear: ledgerMetadata
 
@@ -655,7 +672,7 @@ Parameters:
 | ---------------- | -------------------------------------------------------------------------------- |
 | `ledgerMetadata` | `(params: Omit<QueryParams, "certified">) => Promise<IcrcTokenMetadataResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L162)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L163)
 
 ##### :gear: transactionFee
 
@@ -663,7 +680,7 @@ Parameters:
 | ---------------- | ------------------------------------------------------------- |
 | `transactionFee` | `(params: Omit<QueryParams, "certified">) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L167)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L168)
 
 ##### :gear: totalTokensSupply
 
@@ -671,7 +688,7 @@ Parameters:
 | ------------------- | ------------------------------------------------------------- |
 | `totalTokensSupply` | `(params: Omit<QueryParams, "certified">) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L172)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L173)
 
 ##### :gear: balance
 
@@ -679,7 +696,7 @@ Parameters:
 | --------- | --------------------------------------------------------------- |
 | `balance` | `(params: Omit<BalanceParams, "certified">) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L177)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L178)
 
 ##### :gear: transfer
 
@@ -687,7 +704,7 @@ Parameters:
 | ---------- | --------------------------------------------- |
 | `transfer` | `(params: TransferParams) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L181)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L182)
 
 ##### :gear: getNeuron
 
@@ -695,7 +712,7 @@ Parameters:
 | ----------- | -------------------------------------------------------------------- |
 | `getNeuron` | `(params: Omit<SnsGetNeuronParams, "certified">) => Promise<Neuron>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L184)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L185)
 
 ##### :gear: queryNeuron
 
@@ -703,7 +720,7 @@ Parameters:
 | ------------- | -------------------------------------------------------------------- |
 | `queryNeuron` | `(params: Omit<SnsGetNeuronParams, "certified">) => Promise<Neuron>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L188)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L189)
 
 ##### :gear: nextNeuronAccount
 
@@ -723,7 +740,7 @@ This is how the backend can identify which neuron is being claimed.
 | ------------------- | ------------------------------------------------------------------------------ |
 | `nextNeuronAccount` | `(controller: Principal) => Promise<{ account: IcrcAccount; index: bigint; }>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L209)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L210)
 
 ##### :gear: stakeNeuron
 
@@ -737,7 +754,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ------------- | ------------------------------------------------------------------------------------------------ |
 | `stakeNeuron` | `({ stakeE8s, source, controller, createdAt, fee, }: SnsStakeNeuronParams) => Promise<NeuronId>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L256)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L257)
 
 ##### :gear: increaseStakeNeuron
 
@@ -751,7 +768,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | --------------------- | ---------------------------------------------------------------------------------- |
 | `increaseStakeNeuron` | `({ stakeE8s, source, neuronId, }: SnsIncreaseStakeNeuronParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L304)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L305)
 
 ##### :gear: getNeuronBalance
 
@@ -759,7 +776,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ------------------ | ----------------------------------------- |
 | `getNeuronBalance` | `(neuronId: NeuronId) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L323)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L324)
 
 ##### :gear: addNeuronPermissions
 
@@ -767,7 +784,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ---------------------- | ------------------------------------------------------- |
 | `addNeuronPermissions` | `(params: SnsNeuronPermissionsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L332)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L333)
 
 ##### :gear: refreshNeuron
 
@@ -775,7 +792,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | --------------- | --------------------------------------- |
 | `refreshNeuron` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L336)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L337)
 
 ##### :gear: claimNeuron
 
@@ -783,7 +800,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ------------- | ----------------------------------------------------- |
 | `claimNeuron` | `(params: SnsClaimNeuronParams) => Promise<NeuronId>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L340)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L341)
 
 ##### :gear: removeNeuronPermissions
 
@@ -791,7 +808,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ------------------------- | ------------------------------------------------------- |
 | `removeNeuronPermissions` | `(params: SnsNeuronPermissionsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L344)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L345)
 
 ##### :gear: splitNeuron
 
@@ -799,7 +816,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ------------- | ----------------------------------------------------- |
 | `splitNeuron` | `(params: SnsSplitNeuronParams) => Promise<NeuronId>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L349)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L350)
 
 ##### :gear: disburse
 
@@ -807,7 +824,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ---------- | ---------------------------------------------------- |
 | `disburse` | `(params: SnsDisburseNeuronParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L353)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L354)
 
 ##### :gear: startDissolving
 
@@ -815,7 +832,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ----------------- | --------------------------------------- |
 | `startDissolving` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L357)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L358)
 
 ##### :gear: stopDissolving
 
@@ -823,7 +840,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ---------------- | --------------------------------------- |
 | `stopDissolving` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L361)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L362)
 
 ##### :gear: setDissolveTimestamp
 
@@ -831,7 +848,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ---------------------- | ---------------------------------------------------------- |
 | `setDissolveTimestamp` | `(params: SnsSetDissolveTimestampParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L365)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L366)
 
 ##### :gear: increaseDissolveDelay
 
@@ -839,7 +856,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ----------------------- | ----------------------------------------------------------- |
 | `increaseDissolveDelay` | `(params: SnsIncreaseDissolveDelayParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L370)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L371)
 
 ##### :gear: setTopicFollowees
 
@@ -847,7 +864,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ------------------- | ------------------------------------------------- |
 | `setTopicFollowees` | `(params: SnsSetTopicFollowees) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L375)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L376)
 
 ##### :gear: registerVote
 
@@ -855,7 +872,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | -------------- | -------------------------------------------------- |
 | `registerVote` | `(params: SnsRegisterVoteParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L379)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L380)
 
 ##### :gear: swapState
 
@@ -863,7 +880,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ----------- | ----------------------------------------------------------------------- |
 | `swapState` | `(params: Omit<QueryParams, "certified">) => Promise<GetStateResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L382)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L383)
 
 ##### :gear: notifyPaymentFailure
 
@@ -877,7 +894,7 @@ Always certified
 | ---------------------- | ----------------------- |
 | `notifyPaymentFailure` | `() => Promise<Ticket>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L395)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L396)
 
 ##### :gear: notifyParticipation
 
@@ -885,7 +902,7 @@ Always certified
 | --------------------- | ---------------------------------------------------------------------------- |
 | `notifyParticipation` | `(params: RefreshBuyerTokensRequest) => Promise<RefreshBuyerTokensResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L399)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L400)
 
 ##### :gear: getUserCommitment
 
@@ -893,7 +910,7 @@ Always certified
 | ------------------- | ------------------------------------------------------- |
 | `getUserCommitment` | `(params: GetBuyerStateRequest) => Promise<BuyerState>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L404)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L405)
 
 ##### :gear: getOpenTicket
 
@@ -901,7 +918,7 @@ Always certified
 | --------------- | ------------------------------------------------------------- |
 | `getOpenTicket` | `(params: Omit<QueryParams, "certified">) => Promise<Ticket>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L409)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L410)
 
 ##### :gear: newSaleTicket
 
@@ -909,7 +926,7 @@ Always certified
 | --------------- | -------------------------------------------------- |
 | `newSaleTicket` | `(params: NewSaleTicketParams) => Promise<Ticket>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L415)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L416)
 
 ##### :gear: getLifecycle
 
@@ -917,7 +934,7 @@ Always certified
 | -------------- | --------------------------------------------------------------------------- |
 | `getLifecycle` | `(params: Omit<QueryParams, "certified">) => Promise<GetLifecycleResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L418)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L419)
 
 ##### :gear: getFinalizationStatus
 
@@ -925,7 +942,7 @@ Always certified
 | ----------------------- | ---------------------------------------------------------------------------------------- |
 | `getFinalizationStatus` | `(params: Omit<QueryParams, "certified">) => Promise<GetAutoFinalizationStatusResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L423)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L424)
 
 ##### :gear: getSaleParameters
 
@@ -933,7 +950,7 @@ Always certified
 | ------------------- | -------------------------------------------------------------------------------- |
 | `getSaleParameters` | `(params: Omit<QueryParams, "certified">) => Promise<GetSaleParametersResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L428)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L429)
 
 ##### :gear: getDerivedState
 
@@ -941,7 +958,7 @@ Always certified
 | ----------------- | ------------------------------------------------------------------------------ |
 | `getDerivedState` | `(params: Omit<QueryParams, "certified">) => Promise<GetDerivedStateResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L433)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L434)
 
 ##### :gear: getTransactions
 
@@ -949,7 +966,7 @@ Always certified
 | ----------------- | -------------------------------------------------------------------- |
 | `getTransactions` | `(params: GetAccountTransactionsParams) => Promise<GetTransactions>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L439)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L440)
 
 ##### :gear: stakeMaturity
 
@@ -957,7 +974,7 @@ Always certified
 | --------------- | --------------------------------------------------------- |
 | `stakeMaturity` | `(params: SnsNeuronStakeMaturityParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L444)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L445)
 
 ##### :gear: disburseMaturity
 
@@ -965,7 +982,7 @@ Always certified
 | ------------------ | ------------------------------------------------------------ |
 | `disburseMaturity` | `(params: SnsNeuronDisburseMaturityParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L448)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L449)
 
 ##### :gear: autoStakeMaturity
 
@@ -973,6 +990,14 @@ Always certified
 | ------------------- | ------------------------------------------------------------- |
 | `autoStakeMaturity` | `(params: SnsNeuronAutoStakeMaturityParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L452)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L453)
+
+##### :gear: addMaturity
+
+| Method        | Type                                                      |
+| ------------- | --------------------------------------------------------- |
+| `addMaturity` | `(params: SnsNeuronAddMaturityParams) => Promise<bigint>` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L458)
 
 <!-- TSDOC_END -->

--- a/packages/sns/candid/sns_governance.certified.idl.js
+++ b/packages/sns/candid/sns_governance.certified.idl.js
@@ -327,6 +327,13 @@ export const idlFactory = ({ IDL }) => {
     'neurons' : IDL.Vec(IDL.Tuple(IDL.Text, Neuron)),
     'genesis_timestamp_seconds' : IDL.Nat64,
   });
+  const AddMaturityRequest = IDL.Record({
+    'id' : IDL.Opt(NeuronId),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const AddMaturityResponse = IDL.Record({
+    'new_maturity_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const NeuronParameters = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
     'dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
@@ -473,6 +480,7 @@ export const idlFactory = ({ IDL }) => {
   const ManageNeuronResponse = IDL.Record({ 'command' : IDL.Opt(Command_1) });
   const SetMode = IDL.Record({ 'mode' : IDL.Int32 });
   return IDL.Service({
+    'add_maturity' : IDL.Func([AddMaturityRequest], [AddMaturityResponse], []),
     'claim_swap_neurons' : IDL.Func(
         [ClaimSwapNeuronsRequest],
         [ClaimSwapNeuronsResponse],
@@ -523,6 +531,7 @@ export const idlFactory = ({ IDL }) => {
     'list_proposals' : IDL.Func([ListProposals], [ListProposalsResponse], []),
     'manage_neuron' : IDL.Func([ManageNeuron], [ManageNeuronResponse], []),
     'set_mode' : IDL.Func([SetMode], [IDL.Record({})], []),
+    'update_neuron' : IDL.Func([Neuron], [IDL.Opt(GovernanceError)], []),
   });
 };
 export const init = ({ IDL }) => {

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -22,6 +22,13 @@ export type Action =
       ExecuteGenericNervousSystemFunction: ExecuteGenericNervousSystemFunction;
     }
   | { Motion: Motion };
+export interface AddMaturityRequest {
+  id: [] | [NeuronId];
+  amount_e8s: [] | [bigint];
+}
+export interface AddMaturityResponse {
+  new_maturity_e8s: [] | [bigint];
+}
 export interface AddNeuronPermissions {
   permissions_to_add: [] | [NeuronPermissionList];
   principal_id: [] | [Principal];
@@ -496,6 +503,7 @@ export interface WaitForQuietState {
   current_deadline_timestamp_seconds: bigint;
 }
 export interface _SERVICE {
+  add_maturity: ActorMethod<[AddMaturityRequest], AddMaturityResponse>;
   claim_swap_neurons: ActorMethod<
     [ClaimSwapNeuronsRequest],
     ClaimSwapNeuronsResponse
@@ -523,4 +531,5 @@ export interface _SERVICE {
   list_proposals: ActorMethod<[ListProposals], ListProposalsResponse>;
   manage_neuron: ActorMethod<[ManageNeuron], ManageNeuronResponse>;
   set_mode: ActorMethod<[SetMode], {}>;
+  update_neuron: ActorMethod<[Neuron], [] | [GovernanceError]>;
 }

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 726b1529fd34a47fcf0627a72301d62a282c788d 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit e2e4d177416cbf835c3a3f2ef0ef628b9c232892 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
@@ -14,6 +14,8 @@ type Action = variant {
   ExecuteGenericNervousSystemFunction : ExecuteGenericNervousSystemFunction;
   Motion : Motion;
 };
+type AddMaturityRequest = record { id : opt NeuronId; amount_e8s : opt nat64 };
+type AddMaturityResponse = record { new_maturity_e8s : opt nat64 };
 type AddNeuronPermissions = record {
   permissions_to_add : opt NeuronPermissionList;
   principal_id : opt principal;
@@ -408,6 +410,7 @@ type VotingRewardsParameters = record {
 };
 type WaitForQuietState = record { current_deadline_timestamp_seconds : nat64 };
 service : (Governance) -> {
+  add_maturity : (AddMaturityRequest) -> (AddMaturityResponse);
   claim_swap_neurons : (ClaimSwapNeuronsRequest) -> (ClaimSwapNeuronsResponse);
   fail_stuck_upgrade_in_progress : (record {}) -> (record {});
   get_build_metadata : () -> (text) query;
@@ -430,4 +433,5 @@ service : (Governance) -> {
   list_proposals : (ListProposals) -> (ListProposalsResponse) query;
   manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
   set_mode : (SetMode) -> (record {});
+  update_neuron : (Neuron) -> (opt GovernanceError);
 }

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -327,6 +327,13 @@ export const idlFactory = ({ IDL }) => {
     'neurons' : IDL.Vec(IDL.Tuple(IDL.Text, Neuron)),
     'genesis_timestamp_seconds' : IDL.Nat64,
   });
+  const AddMaturityRequest = IDL.Record({
+    'id' : IDL.Opt(NeuronId),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const AddMaturityResponse = IDL.Record({
+    'new_maturity_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const NeuronParameters = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
     'dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
@@ -473,6 +480,7 @@ export const idlFactory = ({ IDL }) => {
   const ManageNeuronResponse = IDL.Record({ 'command' : IDL.Opt(Command_1) });
   const SetMode = IDL.Record({ 'mode' : IDL.Int32 });
   return IDL.Service({
+    'add_maturity' : IDL.Func([AddMaturityRequest], [AddMaturityResponse], []),
     'claim_swap_neurons' : IDL.Func(
         [ClaimSwapNeuronsRequest],
         [ClaimSwapNeuronsResponse],
@@ -531,6 +539,7 @@ export const idlFactory = ({ IDL }) => {
       ),
     'manage_neuron' : IDL.Func([ManageNeuron], [ManageNeuronResponse], []),
     'set_mode' : IDL.Func([SetMode], [IDL.Record({})], []),
+    'update_neuron' : IDL.Func([Neuron], [IDL.Opt(GovernanceError)], []),
   });
 };
 export const init = ({ IDL }) => {

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -47,6 +47,7 @@ import type {
   SnsIncreaseStakeNeuronParams,
   SnsListNeuronsParams,
   SnsListProposalsParams,
+  SnsNeuronAddMaturityParams,
   SnsNeuronAutoStakeMaturityParams,
   SnsNeuronDisburseMaturityParams,
   SnsNeuronPermissionsParams,
@@ -452,6 +453,10 @@ export class SnsWrapper {
   autoStakeMaturity = (
     params: SnsNeuronAutoStakeMaturityParams,
   ): Promise<void> => this.governance.autoStakeMaturity(params);
+
+  // Always certified
+  addMaturity = (params: SnsNeuronAddMaturityParams): Promise<bigint> =>
+    this.governance.addMaturity(params);
 
   private mergeParams<T>(params: T): QueryParams & T {
     return {

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -181,3 +181,9 @@ export interface SnsNeuronAutoStakeMaturityParams
   extends SnsNeuronManagementParams {
   autoStake: boolean;
 }
+/**
+ * The parameters to add maturity of a neuron
+ */
+export interface SnsNeuronAddMaturityParams extends SnsNeuronManagementParams {
+  amountE8s: bigint;
+}

--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -63,7 +63,7 @@ import_did "rs/nns/sns-wasm/canister/sns-wasm.did" "sns_wasm.did" "nns"
 mkdir -p packages/sns/candid
 import_did "rs/sns/swap/canister/swap.did" "sns_swap.did" "sns"
 import_did "rs/sns/root/canister/root.did" "sns_root.did" "sns"
-import_did "rs/sns/governance/canister/governance.did" "sns_governance.did" "sns"
+import_did "rs/sns/governance/canister/governance_test.did" "sns_governance.did" "sns"
 
 mkdir -p packages/cmc/candid
 import_did "rs/nns/cmc/cmc.did" "cmc.did" "cmc"


### PR DESCRIPTION
# Motivation

Add `add_maturity` testnet api support.

# Changes

- switch to `governance_test` candid (same types + extra APIs that available only on testnet)
- add `addMaturity` sns wrapper function

# Tests

No tests since it's a dev feature
