### PR TITLE
GIX-1841: Add unsupported method error for getFinalizationStatus

### DIFF
--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -415,7 +415,7 @@ Source code: https://github.com/dfinity/ic/blob/master/rs/sns/root/src/lib.rs
 
 ### :factory: SnsSwapCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L31)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L33)
 
 #### Methods
 
@@ -437,7 +437,7 @@ Source code: https://github.com/dfinity/ic/blob/master/rs/sns/root/src/lib.rs
 | -------- | ------------------------------------------------------------ |
 | `create` | `(options: SnsCanisterOptions<_SERVICE>) => SnsSwapCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L32)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L34)
 
 ##### :gear: state
 
@@ -447,7 +447,7 @@ Get the state of the swap
 | ------- | ---------------------------------------------------- |
 | `state` | `(params: QueryParams) => Promise<GetStateResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L46)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L48)
 
 ##### :gear: notifyPaymentFailure
 
@@ -457,7 +457,7 @@ Notify of the payment failure to remove the ticket
 | ---------------------- | ----------------------- |
 | `notifyPaymentFailure` | `() => Promise<Ticket>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L52)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L54)
 
 ##### :gear: notifyParticipation
 
@@ -467,7 +467,7 @@ Notify of the user participating in the swap
 | --------------------- | ---------------------------------------------------------------------------- |
 | `notifyParticipation` | `(params: RefreshBuyerTokensRequest) => Promise<RefreshBuyerTokensResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L62)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L64)
 
 ##### :gear: getUserCommitment
 
@@ -477,7 +477,7 @@ Get user commitment
 | ------------------- | ----------------------------------------------------------------------- |
 | `getUserCommitment` | `(params: GetBuyerStateRequest and QueryParams) => Promise<BuyerState>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L70)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L72)
 
 ##### :gear: getDerivedState
 
@@ -487,7 +487,7 @@ Get sale buyers state
 | ----------------- | ------------------------------------------------------------------- |
 | `getDerivedState` | `({ certified, }: QueryParams) => Promise<GetDerivedStateResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L82)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L84)
 
 ##### :gear: getSaleParameters
 
@@ -497,7 +497,7 @@ Get sale parameters
 | ------------------- | --------------------------------------------------------------------- |
 | `getSaleParameters` | `({ certified, }: QueryParams) => Promise<GetSaleParametersResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L91)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L93)
 
 ##### :gear: getOpenTicket
 
@@ -507,7 +507,7 @@ Return a sale ticket if created and not yet removed (payment flow)
 | --------------- | ------------------------------------------ |
 | `getOpenTicket` | `(params: QueryParams) => Promise<Ticket>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L100)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L102)
 
 ##### :gear: newSaleTicket
 
@@ -517,7 +517,7 @@ Create a sale ticket (payment flow)
 | --------------- | -------------------------------------------------- |
 | `newSaleTicket` | `(params: NewSaleTicketParams) => Promise<Ticket>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L117)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L119)
 
 ##### :gear: getLifecycle
 
@@ -527,7 +527,7 @@ Get sale lifecycle state
 | -------------- | -------------------------------------------------------- |
 | `getLifecycle` | `(params: QueryParams) => Promise<GetLifecycleResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L142)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L144)
 
 ##### :gear: getFinalizationStatus
 
@@ -537,7 +537,7 @@ Get sale lifecycle state
 | ----------------------- | --------------------------------------------------------------------- |
 | `getFinalizationStatus` | `(params: QueryParams) => Promise<GetAutoFinalizationStatusResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L149)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L151)
 
 ### :factory: SnsWrapper
 

--- a/packages/sns/src/errors/common.errors.ts
+++ b/packages/sns/src/errors/common.errors.ts
@@ -1,0 +1,7 @@
+// This is possible specially in SNS projects/
+// Because they share the same canisters but in different versions.
+export class UnsupportedMethodError extends Error {
+  constructor(public methodName: string) {
+    super();
+  }
+}

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -42,6 +42,7 @@ export type {
 export { fromCandidAction } from "./converters/governance.converters";
 export * from "./enums/governance.enums";
 export * from "./enums/swap.enums";
+export * from "./errors/common.errors";
 export * from "./errors/governance.errors";
 export * from "./errors/swap.errors";
 export { SnsGovernanceCanister } from "./governance.canister";

--- a/packages/sns/src/utils/error.utils.spec.ts
+++ b/packages/sns/src/utils/error.utils.spec.ts
@@ -1,0 +1,31 @@
+import { isMethodNotSupportedError } from "./error.utils";
+
+describe("error utils", () => {
+  describe("isMethodNotSupportedError", () => {
+    it("returns true for method is not supported for update", () => {
+      const errorMessage = `"Call was rejected:
+       Request ID: 3a6ef904b35fd19721c95c3df2b0b00b8abefba7f0ad188f5c472809b772c914
+       Reject code: 3
+       Reject text: Canister 75ffu-oaaaa-aaaaa-aabbq-cai has no update method 'get_auto_finalization_status'"`;
+      const err = new Error(errorMessage);
+      expect(isMethodNotSupportedError(err)).toBe(true);
+    });
+
+    it("returns true for method is not supported for update", () => {
+      const errorMessage = `Call failed:
+      Canister: s55qq-oqaaa-aaaaa-aaakq-cai
+      Method: get_auto_finalization_status (query)
+      "Status": "rejected"
+      "Code": "DestinationInvalid"
+      "Message": "IC0302: Canister s55qq-oqaaa-aaaaa-aaakq-cai has no query method 'get_auto_finalization_status'"`;
+      const err = new Error(errorMessage);
+      expect(isMethodNotSupportedError(err)).toBe(true);
+    });
+
+    it("returns false for other errors and non errors", () => {
+      expect(isMethodNotSupportedError(new Error("another error"))).toBe(false);
+      expect(isMethodNotSupportedError(undefined)).toBe(false);
+      expect(isMethodNotSupportedError({})).toBe(false);
+    });
+  });
+});

--- a/packages/sns/src/utils/error.utils.ts
+++ b/packages/sns/src/utils/error.utils.ts
@@ -1,0 +1,23 @@
+import { nonNullish } from "@dfinity/utils";
+
+/**
+ * Identifies errors of method not being present in the canister.
+ *
+ * This is useful because SNS projects have different versions of SNS canisters.
+ * Therefore, what works in the latest version might not work in the previous one.
+ *
+ * Error message example: "Call was rejected:
+ * Request ID: 3a6ef904b35fd19721c95c3df2b0b00b8abefba7f0ad188f5c472809b772c914
+ * Reject code: 3
+ * Reject text: Canister 75ffu-oaaaa-aaaaa-aabbq-cai has no update method 'get_auto_finalization_status'"
+ */
+export const isMethodNotSupportedError = (err: unknown): boolean => {
+  if (typeof err === "object" && nonNullish(err) && "message" in err) {
+    const message = err.message as string;
+    return (
+      message.includes("has no update method") ||
+      message.includes("has no query method")
+    );
+  }
+  return false;
+};


### PR DESCRIPTION
# Motivation

Check the error raised in getFinalizationStatus to return a new error UnsupportedMethodError

This way, the clients using the endpoints can easily identify whether a method is supported by the canister or not.

# Changes

* New error `UnsupportedMethodError`.
* New error util `isMethodNotSupportedError`.
* Use new error util and error in `getFinalizationStatus`.

# Tests

* Test new error util.
* Test new functionality in getFinalizationStatus
