### PR TITLE
Chore: Add readonly to property

### DIFF
--- a/packages/sns/src/errors/common.errors.ts
+++ b/packages/sns/src/errors/common.errors.ts
@@ -1,7 +1,7 @@
 // This is possible specially in SNS projects/
 // Because they share the same canisters but in different versions.
 export class UnsupportedMethodError extends Error {
-  constructor(public methodName: string) {
+  constructor(public readonly methodName: string) {
     super();
   }
 }


### PR DESCRIPTION
# Motivation

I forgot to add the `readonly` to `UnsupportedMethodError` property in the previous PR.

# Changes

* Set `methodName` of `UnsupportedMethodError` as readonly

# Tests

Not necessary
