### PR TITLE
Sns test api

### DIFF
--- a/packages/sns/candid/sns_governance.certified.idl.js
+++ b/packages/sns/candid/sns_governance.certified.idl.js
@@ -442,6 +442,7 @@ export const idlFactory = ({ IDL }) => {
   const SplitResponse = IDL.Record({ 'created_neuron_id' : IDL.Opt(NeuronId) });
   const DisburseMaturityResponse = IDL.Record({
     'amount_disbursed_e8s' : IDL.Nat64,
+    'amount_deducted_e8s' : IDL.Opt(IDL.Nat64),
   });
   const ClaimOrRefreshResponse = IDL.Record({
     'refreshed_neuron_id' : IDL.Opt(NeuronId),

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -140,6 +140,7 @@ export interface DisburseMaturityInProgress {
 }
 export interface DisburseMaturityResponse {
   amount_disbursed_e8s: bigint;
+  amount_deducted_e8s: [] | [bigint];
 }
 export interface DisburseResponse {
   transfer_block_height: bigint;

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 726b1529fd34a47fcf0627a72301d62a282c788d 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 4fbe776aeea08222b8b47f5f2902fe77b58b7150 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
@@ -116,7 +116,10 @@ type DisburseMaturityInProgress = record {
   amount_e8s : nat64;
   account_to_disburse_to : opt Account;
 };
-type DisburseMaturityResponse = record { amount_disbursed_e8s : nat64 };
+type DisburseMaturityResponse = record {
+  amount_disbursed_e8s : nat64;
+  amount_deducted_e8s : opt nat64;
+};
 type DisburseResponse = record { transfer_block_height : nat64 };
 type DissolveState = variant {
   DissolveDelaySeconds : nat64;

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -442,6 +442,7 @@ export const idlFactory = ({ IDL }) => {
   const SplitResponse = IDL.Record({ 'created_neuron_id' : IDL.Opt(NeuronId) });
   const DisburseMaturityResponse = IDL.Record({
     'amount_disbursed_e8s' : IDL.Nat64,
+    'amount_deducted_e8s' : IDL.Opt(IDL.Nat64),
   });
   const ClaimOrRefreshResponse = IDL.Record({
     'refreshed_neuron_id' : IDL.Opt(NeuronId),

--- a/packages/sns/candid/sns_governance_test.certified.idl.d.ts
+++ b/packages/sns/candid/sns_governance_test.certified.idl.d.ts
@@ -1,0 +1,2 @@
+import type { IDL } from "@dfinity/candid";
+export const idlFactory: IDL.InterfaceFactory;

--- a/packages/sns/candid/sns_governance_test.certified.idl.js
+++ b/packages/sns/candid/sns_governance_test.certified.idl.js
@@ -1,0 +1,872 @@
+/* Do not edit.  Compiled with ./scripts/compile-idl-js from packages/sns/candid/sns_governance_test.did */
+export const idlFactory = ({ IDL }) => {
+  const GenericNervousSystemFunction = IDL.Record({
+    'validator_canister_id' : IDL.Opt(IDL.Principal),
+    'target_canister_id' : IDL.Opt(IDL.Principal),
+    'validator_method_name' : IDL.Opt(IDL.Text),
+    'target_method_name' : IDL.Opt(IDL.Text),
+  });
+  const FunctionType = IDL.Variant({
+    'NativeNervousSystemFunction' : IDL.Record({}),
+    'GenericNervousSystemFunction' : GenericNervousSystemFunction,
+  });
+  const NervousSystemFunction = IDL.Record({
+    'id' : IDL.Nat64,
+    'name' : IDL.Text,
+    'description' : IDL.Opt(IDL.Text),
+    'function_type' : IDL.Opt(FunctionType),
+  });
+  const GovernanceCachedMetrics = IDL.Record({
+    'not_dissolving_neurons_e8s_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'garbage_collectable_neurons_count' : IDL.Nat64,
+    'neurons_with_invalid_stake_count' : IDL.Nat64,
+    'not_dissolving_neurons_count_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Nat64)
+    ),
+    'neurons_with_less_than_6_months_dissolve_delay_count' : IDL.Nat64,
+    'dissolved_neurons_count' : IDL.Nat64,
+    'total_staked_e8s' : IDL.Nat64,
+    'total_supply_governance_tokens' : IDL.Nat64,
+    'not_dissolving_neurons_count' : IDL.Nat64,
+    'dissolved_neurons_e8s' : IDL.Nat64,
+    'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
+    'dissolving_neurons_count_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Nat64)
+    ),
+    'dissolving_neurons_count' : IDL.Nat64,
+    'dissolving_neurons_e8s_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'timestamp_seconds' : IDL.Nat64,
+  });
+  const MaturityModulation = IDL.Record({
+    'current_basis_points' : IDL.Opt(IDL.Int32),
+    'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
+  const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
+  const DefaultFollowees = IDL.Record({
+    'followees' : IDL.Vec(IDL.Tuple(IDL.Nat64, Followees)),
+  });
+  const NeuronPermissionList = IDL.Record({
+    'permissions' : IDL.Vec(IDL.Int32),
+  });
+  const VotingRewardsParameters = IDL.Record({
+    'final_reward_rate_basis_points' : IDL.Opt(IDL.Nat64),
+    'initial_reward_rate_basis_points' : IDL.Opt(IDL.Nat64),
+    'reward_rate_transition_duration_seconds' : IDL.Opt(IDL.Nat64),
+    'round_duration_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const NervousSystemParameters = IDL.Record({
+    'default_followees' : IDL.Opt(DefaultFollowees),
+    'max_dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
+    'max_dissolve_delay_bonus_percentage' : IDL.Opt(IDL.Nat64),
+    'max_followees_per_function' : IDL.Opt(IDL.Nat64),
+    'neuron_claimer_permissions' : IDL.Opt(NeuronPermissionList),
+    'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
+    'max_neuron_age_for_age_bonus' : IDL.Opt(IDL.Nat64),
+    'initial_voting_period_seconds' : IDL.Opt(IDL.Nat64),
+    'neuron_minimum_dissolve_delay_to_vote_seconds' : IDL.Opt(IDL.Nat64),
+    'reject_cost_e8s' : IDL.Opt(IDL.Nat64),
+    'max_proposals_to_keep_per_action' : IDL.Opt(IDL.Nat32),
+    'wait_for_quiet_deadline_increase_seconds' : IDL.Opt(IDL.Nat64),
+    'max_number_of_neurons' : IDL.Opt(IDL.Nat64),
+    'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
+    'max_number_of_proposals_with_ballots' : IDL.Opt(IDL.Nat64),
+    'max_age_bonus_percentage' : IDL.Opt(IDL.Nat64),
+    'neuron_grantable_permissions' : IDL.Opt(NeuronPermissionList),
+    'voting_rewards_parameters' : IDL.Opt(VotingRewardsParameters),
+    'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
+    'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
+  });
+  const Version = IDL.Record({
+    'archive_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'root_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'swap_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'ledger_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'governance_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'index_wasm_hash' : IDL.Vec(IDL.Nat8),
+  });
+  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
+  const RewardEvent = IDL.Record({
+    'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
+    'actual_timestamp_seconds' : IDL.Nat64,
+    'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'distributed_e8s_equivalent' : IDL.Nat64,
+    'round' : IDL.Nat64,
+    'settled_proposals' : IDL.Vec(ProposalId),
+  });
+  const UpgradeInProgress = IDL.Record({
+    'mark_failed_at_seconds' : IDL.Nat64,
+    'checking_upgrade_lock' : IDL.Nat64,
+    'proposal_id' : IDL.Nat64,
+    'target_version' : IDL.Opt(Version),
+  });
+  const GovernanceError = IDL.Record({
+    'error_message' : IDL.Text,
+    'error_type' : IDL.Int32,
+  });
+  const Ballot = IDL.Record({
+    'vote' : IDL.Int32,
+    'cast_timestamp_seconds' : IDL.Nat64,
+    'voting_power' : IDL.Nat64,
+  });
+  const Tally = IDL.Record({
+    'no' : IDL.Nat64,
+    'yes' : IDL.Nat64,
+    'total' : IDL.Nat64,
+    'timestamp_seconds' : IDL.Nat64,
+  });
+  const RegisterDappCanisters = IDL.Record({
+    'canister_ids' : IDL.Vec(IDL.Principal),
+  });
+  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
+  const TransferSnsTreasuryFunds = IDL.Record({
+    'from_treasury' : IDL.Int32,
+    'to_principal' : IDL.Opt(IDL.Principal),
+    'to_subaccount' : IDL.Opt(Subaccount),
+    'memo' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Nat64,
+  });
+  const UpgradeSnsControlledCanister = IDL.Record({
+    'new_canister_wasm' : IDL.Vec(IDL.Nat8),
+    'mode' : IDL.Opt(IDL.Int32),
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
+  const DeregisterDappCanisters = IDL.Record({
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'new_controllers' : IDL.Vec(IDL.Principal),
+  });
+  const ManageSnsMetadata = IDL.Record({
+    'url' : IDL.Opt(IDL.Text),
+    'logo' : IDL.Opt(IDL.Text),
+    'name' : IDL.Opt(IDL.Text),
+    'description' : IDL.Opt(IDL.Text),
+  });
+  const ExecuteGenericNervousSystemFunction = IDL.Record({
+    'function_id' : IDL.Nat64,
+    'payload' : IDL.Vec(IDL.Nat8),
+  });
+  const Motion = IDL.Record({ 'motion_text' : IDL.Text });
+  const Action = IDL.Variant({
+    'ManageNervousSystemParameters' : NervousSystemParameters,
+    'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'RemoveGenericNervousSystemFunction' : IDL.Nat64,
+    'UpgradeSnsToNextVersion' : IDL.Record({}),
+    'RegisterDappCanisters' : RegisterDappCanisters,
+    'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
+    'UpgradeSnsControlledCanister' : UpgradeSnsControlledCanister,
+    'DeregisterDappCanisters' : DeregisterDappCanisters,
+    'Unspecified' : IDL.Record({}),
+    'ManageSnsMetadata' : ManageSnsMetadata,
+    'ExecuteGenericNervousSystemFunction' : ExecuteGenericNervousSystemFunction,
+    'Motion' : Motion,
+  });
+  const Proposal = IDL.Record({
+    'url' : IDL.Text,
+    'title' : IDL.Text,
+    'action' : IDL.Opt(Action),
+    'summary' : IDL.Text,
+  });
+  const WaitForQuietState = IDL.Record({
+    'current_deadline_timestamp_seconds' : IDL.Nat64,
+  });
+  const ProposalData = IDL.Record({
+    'id' : IDL.Opt(ProposalId),
+    'payload_text_rendering' : IDL.Opt(IDL.Text),
+    'action' : IDL.Nat64,
+    'failure_reason' : IDL.Opt(GovernanceError),
+    'ballots' : IDL.Vec(IDL.Tuple(IDL.Text, Ballot)),
+    'reward_event_round' : IDL.Nat64,
+    'failed_timestamp_seconds' : IDL.Nat64,
+    'reward_event_end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'proposal_creation_timestamp_seconds' : IDL.Nat64,
+    'initial_voting_period_seconds' : IDL.Nat64,
+    'reject_cost_e8s' : IDL.Nat64,
+    'latest_tally' : IDL.Opt(Tally),
+    'wait_for_quiet_deadline_increase_seconds' : IDL.Nat64,
+    'decided_timestamp_seconds' : IDL.Nat64,
+    'proposal' : IDL.Opt(Proposal),
+    'proposer' : IDL.Opt(NeuronId),
+    'wait_for_quiet_state' : IDL.Opt(WaitForQuietState),
+    'is_eligible_for_rewards' : IDL.Bool,
+    'executed_timestamp_seconds' : IDL.Nat64,
+  });
+  const Split = IDL.Record({ 'memo' : IDL.Nat64, 'amount_e8s' : IDL.Nat64 });
+  const Follow = IDL.Record({
+    'function_id' : IDL.Nat64,
+    'followees' : IDL.Vec(NeuronId),
+  });
+  const Account = IDL.Record({
+    'owner' : IDL.Opt(IDL.Principal),
+    'subaccount' : IDL.Opt(Subaccount),
+  });
+  const DisburseMaturity = IDL.Record({
+    'to_account' : IDL.Opt(Account),
+    'percentage_to_disburse' : IDL.Nat32,
+  });
+  const ChangeAutoStakeMaturity = IDL.Record({
+    'requested_setting_for_auto_stake_maturity' : IDL.Bool,
+  });
+  const IncreaseDissolveDelay = IDL.Record({
+    'additional_dissolve_delay_seconds' : IDL.Nat32,
+  });
+  const SetDissolveTimestamp = IDL.Record({
+    'dissolve_timestamp_seconds' : IDL.Nat64,
+  });
+  const Operation = IDL.Variant({
+    'ChangeAutoStakeMaturity' : ChangeAutoStakeMaturity,
+    'StopDissolving' : IDL.Record({}),
+    'StartDissolving' : IDL.Record({}),
+    'IncreaseDissolveDelay' : IncreaseDissolveDelay,
+    'SetDissolveTimestamp' : SetDissolveTimestamp,
+  });
+  const Configure = IDL.Record({ 'operation' : IDL.Opt(Operation) });
+  const RegisterVote = IDL.Record({
+    'vote' : IDL.Int32,
+    'proposal' : IDL.Opt(ProposalId),
+  });
+  const FinalizeDisburseMaturity = IDL.Record({
+    'amount_to_be_disbursed_e8s' : IDL.Nat64,
+    'to_account' : IDL.Opt(Account),
+  });
+  const MemoAndController = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
+    'memo' : IDL.Nat64,
+  });
+  const By = IDL.Variant({
+    'MemoAndController' : MemoAndController,
+    'NeuronId' : IDL.Record({}),
+  });
+  const ClaimOrRefresh = IDL.Record({ 'by' : IDL.Opt(By) });
+  const RemoveNeuronPermissions = IDL.Record({
+    'permissions_to_remove' : IDL.Opt(NeuronPermissionList),
+    'principal_id' : IDL.Opt(IDL.Principal),
+  });
+  const AddNeuronPermissions = IDL.Record({
+    'permissions_to_add' : IDL.Opt(NeuronPermissionList),
+    'principal_id' : IDL.Opt(IDL.Principal),
+  });
+  const MergeMaturity = IDL.Record({ 'percentage_to_merge' : IDL.Nat32 });
+  const Amount = IDL.Record({ 'e8s' : IDL.Nat64 });
+  const Disburse = IDL.Record({
+    'to_account' : IDL.Opt(Account),
+    'amount' : IDL.Opt(Amount),
+  });
+  const Command_2 = IDL.Variant({
+    'Split' : Split,
+    'Follow' : Follow,
+    'DisburseMaturity' : DisburseMaturity,
+    'Configure' : Configure,
+    'RegisterVote' : RegisterVote,
+    'SyncCommand' : IDL.Record({}),
+    'MakeProposal' : Proposal,
+    'FinalizeDisburseMaturity' : FinalizeDisburseMaturity,
+    'ClaimOrRefreshNeuron' : ClaimOrRefresh,
+    'RemoveNeuronPermissions' : RemoveNeuronPermissions,
+    'AddNeuronPermissions' : AddNeuronPermissions,
+    'MergeMaturity' : MergeMaturity,
+    'Disburse' : Disburse,
+  });
+  const NeuronInFlightCommand = IDL.Record({
+    'command' : IDL.Opt(Command_2),
+    'timestamp' : IDL.Nat64,
+  });
+  const NeuronPermission = IDL.Record({
+    'principal' : IDL.Opt(IDL.Principal),
+    'permission_type' : IDL.Vec(IDL.Int32),
+  });
+  const DissolveState = IDL.Variant({
+    'DissolveDelaySeconds' : IDL.Nat64,
+    'WhenDissolvedTimestampSeconds' : IDL.Nat64,
+  });
+  const DisburseMaturityInProgress = IDL.Record({
+    'timestamp_of_disbursement_seconds' : IDL.Nat64,
+    'amount_e8s' : IDL.Nat64,
+    'account_to_disburse_to' : IDL.Opt(Account),
+  });
+  const Neuron = IDL.Record({
+    'id' : IDL.Opt(NeuronId),
+    'staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
+    'permissions' : IDL.Vec(NeuronPermission),
+    'maturity_e8s_equivalent' : IDL.Nat64,
+    'cached_neuron_stake_e8s' : IDL.Nat64,
+    'created_timestamp_seconds' : IDL.Nat64,
+    'source_nns_neuron_id' : IDL.Opt(IDL.Nat64),
+    'auto_stake_maturity' : IDL.Opt(IDL.Bool),
+    'aging_since_timestamp_seconds' : IDL.Nat64,
+    'dissolve_state' : IDL.Opt(DissolveState),
+    'voting_power_percentage_multiplier' : IDL.Nat64,
+    'vesting_period_seconds' : IDL.Opt(IDL.Nat64),
+    'disburse_maturity_in_progress' : IDL.Vec(DisburseMaturityInProgress),
+    'followees' : IDL.Vec(IDL.Tuple(IDL.Nat64, Followees)),
+    'neuron_fees_e8s' : IDL.Nat64,
+  });
+  const Governance = IDL.Record({
+    'root_canister_id' : IDL.Opt(IDL.Principal),
+    'id_to_nervous_system_functions' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, NervousSystemFunction)
+    ),
+    'metrics' : IDL.Opt(GovernanceCachedMetrics),
+    'maturity_modulation' : IDL.Opt(MaturityModulation),
+    'mode' : IDL.Int32,
+    'parameters' : IDL.Opt(NervousSystemParameters),
+    'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),
+    'deployed_version' : IDL.Opt(Version),
+    'sns_initialization_parameters' : IDL.Text,
+    'latest_reward_event' : IDL.Opt(RewardEvent),
+    'pending_version' : IDL.Opt(UpgradeInProgress),
+    'swap_canister_id' : IDL.Opt(IDL.Principal),
+    'ledger_canister_id' : IDL.Opt(IDL.Principal),
+    'proposals' : IDL.Vec(IDL.Tuple(IDL.Nat64, ProposalData)),
+    'in_flight_commands' : IDL.Vec(IDL.Tuple(IDL.Text, NeuronInFlightCommand)),
+    'sns_metadata' : IDL.Opt(ManageSnsMetadata),
+    'neurons' : IDL.Vec(IDL.Tuple(IDL.Text, Neuron)),
+    'genesis_timestamp_seconds' : IDL.Nat64,
+  });
+  const AddMaturityRequest = IDL.Record({
+    'id' : IDL.Opt(NeuronId),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const AddMaturityResponse = IDL.Record({
+    'new_maturity_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronParameters = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
+    'dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
+    'source_nns_neuron_id' : IDL.Opt(IDL.Nat64),
+    'stake_e8s' : IDL.Opt(IDL.Nat64),
+    'followees' : IDL.Vec(NeuronId),
+    'hotkey' : IDL.Opt(IDL.Principal),
+    'neuron_id' : IDL.Opt(NeuronId),
+  });
+  const ClaimSwapNeuronsRequest = IDL.Record({
+    'neuron_parameters' : IDL.Vec(NeuronParameters),
+  });
+  const SwapNeuron = IDL.Record({
+    'id' : IDL.Opt(NeuronId),
+    'status' : IDL.Int32,
+  });
+  const ClaimedSwapNeurons = IDL.Record({
+    'swap_neurons' : IDL.Vec(SwapNeuron),
+  });
+  const ClaimSwapNeuronsResult = IDL.Variant({
+    'Ok' : ClaimedSwapNeurons,
+    'Err' : IDL.Int32,
+  });
+  const ClaimSwapNeuronsResponse = IDL.Record({
+    'claim_swap_neurons_result' : IDL.Opt(ClaimSwapNeuronsResult),
+  });
+  const GetMaturityModulationResponse = IDL.Record({
+    'maturity_modulation' : IDL.Opt(MaturityModulation),
+  });
+  const GetMetadataResponse = IDL.Record({
+    'url' : IDL.Opt(IDL.Text),
+    'logo' : IDL.Opt(IDL.Text),
+    'name' : IDL.Opt(IDL.Text),
+    'description' : IDL.Opt(IDL.Text),
+  });
+  const GetModeResponse = IDL.Record({ 'mode' : IDL.Opt(IDL.Int32) });
+  const GetNeuron = IDL.Record({ 'neuron_id' : IDL.Opt(NeuronId) });
+  const Result = IDL.Variant({ 'Error' : GovernanceError, 'Neuron' : Neuron });
+  const GetNeuronResponse = IDL.Record({ 'result' : IDL.Opt(Result) });
+  const GetProposal = IDL.Record({ 'proposal_id' : IDL.Opt(ProposalId) });
+  const Result_1 = IDL.Variant({
+    'Error' : GovernanceError,
+    'Proposal' : ProposalData,
+  });
+  const GetProposalResponse = IDL.Record({ 'result' : IDL.Opt(Result_1) });
+  const CanisterStatusType = IDL.Variant({
+    'stopped' : IDL.Null,
+    'stopping' : IDL.Null,
+    'running' : IDL.Null,
+  });
+  const DefiniteCanisterSettingsArgs = IDL.Record({
+    'freezing_threshold' : IDL.Nat,
+    'controllers' : IDL.Vec(IDL.Principal),
+    'memory_allocation' : IDL.Nat,
+    'compute_allocation' : IDL.Nat,
+  });
+  const CanisterStatusResultV2 = IDL.Record({
+    'status' : CanisterStatusType,
+    'memory_size' : IDL.Nat,
+    'cycles' : IDL.Nat,
+    'settings' : DefiniteCanisterSettingsArgs,
+    'idle_cycles_burned_per_day' : IDL.Nat,
+    'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
+  const GetRunningSnsVersionResponse = IDL.Record({
+    'deployed_version' : IDL.Opt(Version),
+    'pending_version' : IDL.Opt(UpgradeInProgress),
+  });
+  const GetSnsInitializationParametersResponse = IDL.Record({
+    'sns_initialization_parameters' : IDL.Text,
+  });
+  const ListNervousSystemFunctionsResponse = IDL.Record({
+    'reserved_ids' : IDL.Vec(IDL.Nat64),
+    'functions' : IDL.Vec(NervousSystemFunction),
+  });
+  const ListNeurons = IDL.Record({
+    'of_principal' : IDL.Opt(IDL.Principal),
+    'limit' : IDL.Nat32,
+    'start_page_at' : IDL.Opt(NeuronId),
+  });
+  const ListNeuronsResponse = IDL.Record({ 'neurons' : IDL.Vec(Neuron) });
+  const ListProposals = IDL.Record({
+    'include_reward_status' : IDL.Vec(IDL.Int32),
+    'before_proposal' : IDL.Opt(ProposalId),
+    'limit' : IDL.Nat32,
+    'exclude_type' : IDL.Vec(IDL.Nat64),
+    'include_status' : IDL.Vec(IDL.Int32),
+  });
+  const ListProposalsResponse = IDL.Record({
+    'proposals' : IDL.Vec(ProposalData),
+  });
+  const StakeMaturity = IDL.Record({
+    'percentage_to_stake' : IDL.Opt(IDL.Nat32),
+  });
+  const Command = IDL.Variant({
+    'Split' : Split,
+    'Follow' : Follow,
+    'DisburseMaturity' : DisburseMaturity,
+    'ClaimOrRefresh' : ClaimOrRefresh,
+    'Configure' : Configure,
+    'RegisterVote' : RegisterVote,
+    'MakeProposal' : Proposal,
+    'StakeMaturity' : StakeMaturity,
+    'RemoveNeuronPermissions' : RemoveNeuronPermissions,
+    'AddNeuronPermissions' : AddNeuronPermissions,
+    'MergeMaturity' : MergeMaturity,
+    'Disburse' : Disburse,
+  });
+  const ManageNeuron = IDL.Record({
+    'subaccount' : IDL.Vec(IDL.Nat8),
+    'command' : IDL.Opt(Command),
+  });
+  const SplitResponse = IDL.Record({ 'created_neuron_id' : IDL.Opt(NeuronId) });
+  const DisburseMaturityResponse = IDL.Record({
+    'amount_disbursed_e8s' : IDL.Nat64,
+    'amount_deducted_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const ClaimOrRefreshResponse = IDL.Record({
+    'refreshed_neuron_id' : IDL.Opt(NeuronId),
+  });
+  const StakeMaturityResponse = IDL.Record({
+    'maturity_e8s' : IDL.Nat64,
+    'staked_maturity_e8s' : IDL.Nat64,
+  });
+  const MergeMaturityResponse = IDL.Record({
+    'merged_maturity_e8s' : IDL.Nat64,
+    'new_stake_e8s' : IDL.Nat64,
+  });
+  const DisburseResponse = IDL.Record({ 'transfer_block_height' : IDL.Nat64 });
+  const Command_1 = IDL.Variant({
+    'Error' : GovernanceError,
+    'Split' : SplitResponse,
+    'Follow' : IDL.Record({}),
+    'DisburseMaturity' : DisburseMaturityResponse,
+    'ClaimOrRefresh' : ClaimOrRefreshResponse,
+    'Configure' : IDL.Record({}),
+    'RegisterVote' : IDL.Record({}),
+    'MakeProposal' : GetProposal,
+    'RemoveNeuronPermission' : IDL.Record({}),
+    'StakeMaturity' : StakeMaturityResponse,
+    'MergeMaturity' : MergeMaturityResponse,
+    'Disburse' : DisburseResponse,
+    'AddNeuronPermission' : IDL.Record({}),
+  });
+  const ManageNeuronResponse = IDL.Record({ 'command' : IDL.Opt(Command_1) });
+  const MintTokensRequest = IDL.Record({
+    'recipient' : IDL.Opt(Account),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const SetMode = IDL.Record({ 'mode' : IDL.Int32 });
+  return IDL.Service({
+    'add_maturity' : IDL.Func([AddMaturityRequest], [AddMaturityResponse], []),
+    'claim_swap_neurons' : IDL.Func(
+        [ClaimSwapNeuronsRequest],
+        [ClaimSwapNeuronsResponse],
+        [],
+      ),
+    'fail_stuck_upgrade_in_progress' : IDL.Func(
+        [IDL.Record({})],
+        [IDL.Record({})],
+        [],
+      ),
+    'get_build_metadata' : IDL.Func([], [IDL.Text], []),
+    'get_latest_reward_event' : IDL.Func([], [RewardEvent], []),
+    'get_maturity_modulation' : IDL.Func(
+        [IDL.Record({})],
+        [GetMaturityModulationResponse],
+        [],
+      ),
+    'get_metadata' : IDL.Func([IDL.Record({})], [GetMetadataResponse], []),
+    'get_mode' : IDL.Func([IDL.Record({})], [GetModeResponse], []),
+    'get_nervous_system_parameters' : IDL.Func(
+        [IDL.Null],
+        [NervousSystemParameters],
+        [],
+      ),
+    'get_neuron' : IDL.Func([GetNeuron], [GetNeuronResponse], []),
+    'get_proposal' : IDL.Func([GetProposal], [GetProposalResponse], []),
+    'get_root_canister_status' : IDL.Func(
+        [IDL.Null],
+        [CanisterStatusResultV2],
+        [],
+      ),
+    'get_running_sns_version' : IDL.Func(
+        [IDL.Record({})],
+        [GetRunningSnsVersionResponse],
+        [],
+      ),
+    'get_sns_initialization_parameters' : IDL.Func(
+        [IDL.Record({})],
+        [GetSnsInitializationParametersResponse],
+        [],
+      ),
+    'list_nervous_system_functions' : IDL.Func(
+        [],
+        [ListNervousSystemFunctionsResponse],
+        [],
+      ),
+    'list_neurons' : IDL.Func([ListNeurons], [ListNeuronsResponse], []),
+    'list_proposals' : IDL.Func([ListProposals], [ListProposalsResponse], []),
+    'manage_neuron' : IDL.Func([ManageNeuron], [ManageNeuronResponse], []),
+    'mint_tokens' : IDL.Func([MintTokensRequest], [IDL.Record({})], []),
+    'set_mode' : IDL.Func([SetMode], [IDL.Record({})], []),
+    'update_neuron' : IDL.Func([Neuron], [IDL.Opt(GovernanceError)], []),
+  });
+};
+export const init = ({ IDL }) => {
+  const GenericNervousSystemFunction = IDL.Record({
+    'validator_canister_id' : IDL.Opt(IDL.Principal),
+    'target_canister_id' : IDL.Opt(IDL.Principal),
+    'validator_method_name' : IDL.Opt(IDL.Text),
+    'target_method_name' : IDL.Opt(IDL.Text),
+  });
+  const FunctionType = IDL.Variant({
+    'NativeNervousSystemFunction' : IDL.Record({}),
+    'GenericNervousSystemFunction' : GenericNervousSystemFunction,
+  });
+  const NervousSystemFunction = IDL.Record({
+    'id' : IDL.Nat64,
+    'name' : IDL.Text,
+    'description' : IDL.Opt(IDL.Text),
+    'function_type' : IDL.Opt(FunctionType),
+  });
+  const GovernanceCachedMetrics = IDL.Record({
+    'not_dissolving_neurons_e8s_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'garbage_collectable_neurons_count' : IDL.Nat64,
+    'neurons_with_invalid_stake_count' : IDL.Nat64,
+    'not_dissolving_neurons_count_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Nat64)
+    ),
+    'neurons_with_less_than_6_months_dissolve_delay_count' : IDL.Nat64,
+    'dissolved_neurons_count' : IDL.Nat64,
+    'total_staked_e8s' : IDL.Nat64,
+    'total_supply_governance_tokens' : IDL.Nat64,
+    'not_dissolving_neurons_count' : IDL.Nat64,
+    'dissolved_neurons_e8s' : IDL.Nat64,
+    'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
+    'dissolving_neurons_count_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Nat64)
+    ),
+    'dissolving_neurons_count' : IDL.Nat64,
+    'dissolving_neurons_e8s_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'timestamp_seconds' : IDL.Nat64,
+  });
+  const MaturityModulation = IDL.Record({
+    'current_basis_points' : IDL.Opt(IDL.Int32),
+    'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
+  const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
+  const DefaultFollowees = IDL.Record({
+    'followees' : IDL.Vec(IDL.Tuple(IDL.Nat64, Followees)),
+  });
+  const NeuronPermissionList = IDL.Record({
+    'permissions' : IDL.Vec(IDL.Int32),
+  });
+  const VotingRewardsParameters = IDL.Record({
+    'final_reward_rate_basis_points' : IDL.Opt(IDL.Nat64),
+    'initial_reward_rate_basis_points' : IDL.Opt(IDL.Nat64),
+    'reward_rate_transition_duration_seconds' : IDL.Opt(IDL.Nat64),
+    'round_duration_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const NervousSystemParameters = IDL.Record({
+    'default_followees' : IDL.Opt(DefaultFollowees),
+    'max_dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
+    'max_dissolve_delay_bonus_percentage' : IDL.Opt(IDL.Nat64),
+    'max_followees_per_function' : IDL.Opt(IDL.Nat64),
+    'neuron_claimer_permissions' : IDL.Opt(NeuronPermissionList),
+    'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
+    'max_neuron_age_for_age_bonus' : IDL.Opt(IDL.Nat64),
+    'initial_voting_period_seconds' : IDL.Opt(IDL.Nat64),
+    'neuron_minimum_dissolve_delay_to_vote_seconds' : IDL.Opt(IDL.Nat64),
+    'reject_cost_e8s' : IDL.Opt(IDL.Nat64),
+    'max_proposals_to_keep_per_action' : IDL.Opt(IDL.Nat32),
+    'wait_for_quiet_deadline_increase_seconds' : IDL.Opt(IDL.Nat64),
+    'max_number_of_neurons' : IDL.Opt(IDL.Nat64),
+    'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
+    'max_number_of_proposals_with_ballots' : IDL.Opt(IDL.Nat64),
+    'max_age_bonus_percentage' : IDL.Opt(IDL.Nat64),
+    'neuron_grantable_permissions' : IDL.Opt(NeuronPermissionList),
+    'voting_rewards_parameters' : IDL.Opt(VotingRewardsParameters),
+    'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
+    'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
+  });
+  const Version = IDL.Record({
+    'archive_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'root_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'swap_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'ledger_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'governance_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'index_wasm_hash' : IDL.Vec(IDL.Nat8),
+  });
+  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
+  const RewardEvent = IDL.Record({
+    'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
+    'actual_timestamp_seconds' : IDL.Nat64,
+    'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'distributed_e8s_equivalent' : IDL.Nat64,
+    'round' : IDL.Nat64,
+    'settled_proposals' : IDL.Vec(ProposalId),
+  });
+  const UpgradeInProgress = IDL.Record({
+    'mark_failed_at_seconds' : IDL.Nat64,
+    'checking_upgrade_lock' : IDL.Nat64,
+    'proposal_id' : IDL.Nat64,
+    'target_version' : IDL.Opt(Version),
+  });
+  const GovernanceError = IDL.Record({
+    'error_message' : IDL.Text,
+    'error_type' : IDL.Int32,
+  });
+  const Ballot = IDL.Record({
+    'vote' : IDL.Int32,
+    'cast_timestamp_seconds' : IDL.Nat64,
+    'voting_power' : IDL.Nat64,
+  });
+  const Tally = IDL.Record({
+    'no' : IDL.Nat64,
+    'yes' : IDL.Nat64,
+    'total' : IDL.Nat64,
+    'timestamp_seconds' : IDL.Nat64,
+  });
+  const RegisterDappCanisters = IDL.Record({
+    'canister_ids' : IDL.Vec(IDL.Principal),
+  });
+  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
+  const TransferSnsTreasuryFunds = IDL.Record({
+    'from_treasury' : IDL.Int32,
+    'to_principal' : IDL.Opt(IDL.Principal),
+    'to_subaccount' : IDL.Opt(Subaccount),
+    'memo' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Nat64,
+  });
+  const UpgradeSnsControlledCanister = IDL.Record({
+    'new_canister_wasm' : IDL.Vec(IDL.Nat8),
+    'mode' : IDL.Opt(IDL.Int32),
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
+  const DeregisterDappCanisters = IDL.Record({
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'new_controllers' : IDL.Vec(IDL.Principal),
+  });
+  const ManageSnsMetadata = IDL.Record({
+    'url' : IDL.Opt(IDL.Text),
+    'logo' : IDL.Opt(IDL.Text),
+    'name' : IDL.Opt(IDL.Text),
+    'description' : IDL.Opt(IDL.Text),
+  });
+  const ExecuteGenericNervousSystemFunction = IDL.Record({
+    'function_id' : IDL.Nat64,
+    'payload' : IDL.Vec(IDL.Nat8),
+  });
+  const Motion = IDL.Record({ 'motion_text' : IDL.Text });
+  const Action = IDL.Variant({
+    'ManageNervousSystemParameters' : NervousSystemParameters,
+    'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'RemoveGenericNervousSystemFunction' : IDL.Nat64,
+    'UpgradeSnsToNextVersion' : IDL.Record({}),
+    'RegisterDappCanisters' : RegisterDappCanisters,
+    'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
+    'UpgradeSnsControlledCanister' : UpgradeSnsControlledCanister,
+    'DeregisterDappCanisters' : DeregisterDappCanisters,
+    'Unspecified' : IDL.Record({}),
+    'ManageSnsMetadata' : ManageSnsMetadata,
+    'ExecuteGenericNervousSystemFunction' : ExecuteGenericNervousSystemFunction,
+    'Motion' : Motion,
+  });
+  const Proposal = IDL.Record({
+    'url' : IDL.Text,
+    'title' : IDL.Text,
+    'action' : IDL.Opt(Action),
+    'summary' : IDL.Text,
+  });
+  const WaitForQuietState = IDL.Record({
+    'current_deadline_timestamp_seconds' : IDL.Nat64,
+  });
+  const ProposalData = IDL.Record({
+    'id' : IDL.Opt(ProposalId),
+    'payload_text_rendering' : IDL.Opt(IDL.Text),
+    'action' : IDL.Nat64,
+    'failure_reason' : IDL.Opt(GovernanceError),
+    'ballots' : IDL.Vec(IDL.Tuple(IDL.Text, Ballot)),
+    'reward_event_round' : IDL.Nat64,
+    'failed_timestamp_seconds' : IDL.Nat64,
+    'reward_event_end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'proposal_creation_timestamp_seconds' : IDL.Nat64,
+    'initial_voting_period_seconds' : IDL.Nat64,
+    'reject_cost_e8s' : IDL.Nat64,
+    'latest_tally' : IDL.Opt(Tally),
+    'wait_for_quiet_deadline_increase_seconds' : IDL.Nat64,
+    'decided_timestamp_seconds' : IDL.Nat64,
+    'proposal' : IDL.Opt(Proposal),
+    'proposer' : IDL.Opt(NeuronId),
+    'wait_for_quiet_state' : IDL.Opt(WaitForQuietState),
+    'is_eligible_for_rewards' : IDL.Bool,
+    'executed_timestamp_seconds' : IDL.Nat64,
+  });
+  const Split = IDL.Record({ 'memo' : IDL.Nat64, 'amount_e8s' : IDL.Nat64 });
+  const Follow = IDL.Record({
+    'function_id' : IDL.Nat64,
+    'followees' : IDL.Vec(NeuronId),
+  });
+  const Account = IDL.Record({
+    'owner' : IDL.Opt(IDL.Principal),
+    'subaccount' : IDL.Opt(Subaccount),
+  });
+  const DisburseMaturity = IDL.Record({
+    'to_account' : IDL.Opt(Account),
+    'percentage_to_disburse' : IDL.Nat32,
+  });
+  const ChangeAutoStakeMaturity = IDL.Record({
+    'requested_setting_for_auto_stake_maturity' : IDL.Bool,
+  });
+  const IncreaseDissolveDelay = IDL.Record({
+    'additional_dissolve_delay_seconds' : IDL.Nat32,
+  });
+  const SetDissolveTimestamp = IDL.Record({
+    'dissolve_timestamp_seconds' : IDL.Nat64,
+  });
+  const Operation = IDL.Variant({
+    'ChangeAutoStakeMaturity' : ChangeAutoStakeMaturity,
+    'StopDissolving' : IDL.Record({}),
+    'StartDissolving' : IDL.Record({}),
+    'IncreaseDissolveDelay' : IncreaseDissolveDelay,
+    'SetDissolveTimestamp' : SetDissolveTimestamp,
+  });
+  const Configure = IDL.Record({ 'operation' : IDL.Opt(Operation) });
+  const RegisterVote = IDL.Record({
+    'vote' : IDL.Int32,
+    'proposal' : IDL.Opt(ProposalId),
+  });
+  const FinalizeDisburseMaturity = IDL.Record({
+    'amount_to_be_disbursed_e8s' : IDL.Nat64,
+    'to_account' : IDL.Opt(Account),
+  });
+  const MemoAndController = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
+    'memo' : IDL.Nat64,
+  });
+  const By = IDL.Variant({
+    'MemoAndController' : MemoAndController,
+    'NeuronId' : IDL.Record({}),
+  });
+  const ClaimOrRefresh = IDL.Record({ 'by' : IDL.Opt(By) });
+  const RemoveNeuronPermissions = IDL.Record({
+    'permissions_to_remove' : IDL.Opt(NeuronPermissionList),
+    'principal_id' : IDL.Opt(IDL.Principal),
+  });
+  const AddNeuronPermissions = IDL.Record({
+    'permissions_to_add' : IDL.Opt(NeuronPermissionList),
+    'principal_id' : IDL.Opt(IDL.Principal),
+  });
+  const MergeMaturity = IDL.Record({ 'percentage_to_merge' : IDL.Nat32 });
+  const Amount = IDL.Record({ 'e8s' : IDL.Nat64 });
+  const Disburse = IDL.Record({
+    'to_account' : IDL.Opt(Account),
+    'amount' : IDL.Opt(Amount),
+  });
+  const Command_2 = IDL.Variant({
+    'Split' : Split,
+    'Follow' : Follow,
+    'DisburseMaturity' : DisburseMaturity,
+    'Configure' : Configure,
+    'RegisterVote' : RegisterVote,
+    'SyncCommand' : IDL.Record({}),
+    'MakeProposal' : Proposal,
+    'FinalizeDisburseMaturity' : FinalizeDisburseMaturity,
+    'ClaimOrRefreshNeuron' : ClaimOrRefresh,
+    'RemoveNeuronPermissions' : RemoveNeuronPermissions,
+    'AddNeuronPermissions' : AddNeuronPermissions,
+    'MergeMaturity' : MergeMaturity,
+    'Disburse' : Disburse,
+  });
+  const NeuronInFlightCommand = IDL.Record({
+    'command' : IDL.Opt(Command_2),
+    'timestamp' : IDL.Nat64,
+  });
+  const NeuronPermission = IDL.Record({
+    'principal' : IDL.Opt(IDL.Principal),
+    'permission_type' : IDL.Vec(IDL.Int32),
+  });
+  const DissolveState = IDL.Variant({
+    'DissolveDelaySeconds' : IDL.Nat64,
+    'WhenDissolvedTimestampSeconds' : IDL.Nat64,
+  });
+  const DisburseMaturityInProgress = IDL.Record({
+    'timestamp_of_disbursement_seconds' : IDL.Nat64,
+    'amount_e8s' : IDL.Nat64,
+    'account_to_disburse_to' : IDL.Opt(Account),
+  });
+  const Neuron = IDL.Record({
+    'id' : IDL.Opt(NeuronId),
+    'staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
+    'permissions' : IDL.Vec(NeuronPermission),
+    'maturity_e8s_equivalent' : IDL.Nat64,
+    'cached_neuron_stake_e8s' : IDL.Nat64,
+    'created_timestamp_seconds' : IDL.Nat64,
+    'source_nns_neuron_id' : IDL.Opt(IDL.Nat64),
+    'auto_stake_maturity' : IDL.Opt(IDL.Bool),
+    'aging_since_timestamp_seconds' : IDL.Nat64,
+    'dissolve_state' : IDL.Opt(DissolveState),
+    'voting_power_percentage_multiplier' : IDL.Nat64,
+    'vesting_period_seconds' : IDL.Opt(IDL.Nat64),
+    'disburse_maturity_in_progress' : IDL.Vec(DisburseMaturityInProgress),
+    'followees' : IDL.Vec(IDL.Tuple(IDL.Nat64, Followees)),
+    'neuron_fees_e8s' : IDL.Nat64,
+  });
+  const Governance = IDL.Record({
+    'root_canister_id' : IDL.Opt(IDL.Principal),
+    'id_to_nervous_system_functions' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, NervousSystemFunction)
+    ),
+    'metrics' : IDL.Opt(GovernanceCachedMetrics),
+    'maturity_modulation' : IDL.Opt(MaturityModulation),
+    'mode' : IDL.Int32,
+    'parameters' : IDL.Opt(NervousSystemParameters),
+    'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),
+    'deployed_version' : IDL.Opt(Version),
+    'sns_initialization_parameters' : IDL.Text,
+    'latest_reward_event' : IDL.Opt(RewardEvent),
+    'pending_version' : IDL.Opt(UpgradeInProgress),
+    'swap_canister_id' : IDL.Opt(IDL.Principal),
+    'ledger_canister_id' : IDL.Opt(IDL.Principal),
+    'proposals' : IDL.Vec(IDL.Tuple(IDL.Nat64, ProposalData)),
+    'in_flight_commands' : IDL.Vec(IDL.Tuple(IDL.Text, NeuronInFlightCommand)),
+    'sns_metadata' : IDL.Opt(ManageSnsMetadata),
+    'neurons' : IDL.Vec(IDL.Tuple(IDL.Text, Neuron)),
+    'genesis_timestamp_seconds' : IDL.Nat64,
+  });
+  return [Governance];
+};

--- a/packages/sns/candid/sns_governance_test.d.ts
+++ b/packages/sns/candid/sns_governance_test.d.ts
@@ -1,0 +1,541 @@
+import type { ActorMethod } from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+
+export interface Account {
+  owner: [] | [Principal];
+  subaccount: [] | [Subaccount];
+}
+export type Action =
+  | {
+      ManageNervousSystemParameters: NervousSystemParameters;
+    }
+  | { AddGenericNervousSystemFunction: NervousSystemFunction }
+  | { RemoveGenericNervousSystemFunction: bigint }
+  | { UpgradeSnsToNextVersion: {} }
+  | { RegisterDappCanisters: RegisterDappCanisters }
+  | { TransferSnsTreasuryFunds: TransferSnsTreasuryFunds }
+  | { UpgradeSnsControlledCanister: UpgradeSnsControlledCanister }
+  | { DeregisterDappCanisters: DeregisterDappCanisters }
+  | { Unspecified: {} }
+  | { ManageSnsMetadata: ManageSnsMetadata }
+  | {
+      ExecuteGenericNervousSystemFunction: ExecuteGenericNervousSystemFunction;
+    }
+  | { Motion: Motion };
+export interface AddMaturityRequest {
+  id: [] | [NeuronId];
+  amount_e8s: [] | [bigint];
+}
+export interface AddMaturityResponse {
+  new_maturity_e8s: [] | [bigint];
+}
+export interface AddNeuronPermissions {
+  permissions_to_add: [] | [NeuronPermissionList];
+  principal_id: [] | [Principal];
+}
+export interface Amount {
+  e8s: bigint;
+}
+export interface Ballot {
+  vote: number;
+  cast_timestamp_seconds: bigint;
+  voting_power: bigint;
+}
+export type By = { MemoAndController: MemoAndController } | { NeuronId: {} };
+export interface CanisterStatusResultV2 {
+  status: CanisterStatusType;
+  memory_size: bigint;
+  cycles: bigint;
+  settings: DefiniteCanisterSettingsArgs;
+  idle_cycles_burned_per_day: bigint;
+  module_hash: [] | [Uint8Array];
+}
+export type CanisterStatusType =
+  | { stopped: null }
+  | { stopping: null }
+  | { running: null };
+export interface ChangeAutoStakeMaturity {
+  requested_setting_for_auto_stake_maturity: boolean;
+}
+export interface ClaimOrRefresh {
+  by: [] | [By];
+}
+export interface ClaimOrRefreshResponse {
+  refreshed_neuron_id: [] | [NeuronId];
+}
+export interface ClaimSwapNeuronsRequest {
+  neuron_parameters: Array<NeuronParameters>;
+}
+export interface ClaimSwapNeuronsResponse {
+  claim_swap_neurons_result: [] | [ClaimSwapNeuronsResult];
+}
+export type ClaimSwapNeuronsResult =
+  | { Ok: ClaimedSwapNeurons }
+  | { Err: number };
+export interface ClaimedSwapNeurons {
+  swap_neurons: Array<SwapNeuron>;
+}
+export type Command =
+  | { Split: Split }
+  | { Follow: Follow }
+  | { DisburseMaturity: DisburseMaturity }
+  | { ClaimOrRefresh: ClaimOrRefresh }
+  | { Configure: Configure }
+  | { RegisterVote: RegisterVote }
+  | { MakeProposal: Proposal }
+  | { StakeMaturity: StakeMaturity }
+  | { RemoveNeuronPermissions: RemoveNeuronPermissions }
+  | { AddNeuronPermissions: AddNeuronPermissions }
+  | { MergeMaturity: MergeMaturity }
+  | { Disburse: Disburse };
+export type Command_1 =
+  | { Error: GovernanceError }
+  | { Split: SplitResponse }
+  | { Follow: {} }
+  | { DisburseMaturity: DisburseMaturityResponse }
+  | { ClaimOrRefresh: ClaimOrRefreshResponse }
+  | { Configure: {} }
+  | { RegisterVote: {} }
+  | { MakeProposal: GetProposal }
+  | { RemoveNeuronPermission: {} }
+  | { StakeMaturity: StakeMaturityResponse }
+  | { MergeMaturity: MergeMaturityResponse }
+  | { Disburse: DisburseResponse }
+  | { AddNeuronPermission: {} };
+export type Command_2 =
+  | { Split: Split }
+  | { Follow: Follow }
+  | { DisburseMaturity: DisburseMaturity }
+  | { Configure: Configure }
+  | { RegisterVote: RegisterVote }
+  | { SyncCommand: {} }
+  | { MakeProposal: Proposal }
+  | { FinalizeDisburseMaturity: FinalizeDisburseMaturity }
+  | { ClaimOrRefreshNeuron: ClaimOrRefresh }
+  | { RemoveNeuronPermissions: RemoveNeuronPermissions }
+  | { AddNeuronPermissions: AddNeuronPermissions }
+  | { MergeMaturity: MergeMaturity }
+  | { Disburse: Disburse };
+export interface Configure {
+  operation: [] | [Operation];
+}
+export interface DefaultFollowees {
+  followees: Array<[bigint, Followees]>;
+}
+export interface DefiniteCanisterSettingsArgs {
+  freezing_threshold: bigint;
+  controllers: Array<Principal>;
+  memory_allocation: bigint;
+  compute_allocation: bigint;
+}
+export interface DeregisterDappCanisters {
+  canister_ids: Array<Principal>;
+  new_controllers: Array<Principal>;
+}
+export interface Disburse {
+  to_account: [] | [Account];
+  amount: [] | [Amount];
+}
+export interface DisburseMaturity {
+  to_account: [] | [Account];
+  percentage_to_disburse: number;
+}
+export interface DisburseMaturityInProgress {
+  timestamp_of_disbursement_seconds: bigint;
+  amount_e8s: bigint;
+  account_to_disburse_to: [] | [Account];
+}
+export interface DisburseMaturityResponse {
+  amount_disbursed_e8s: bigint;
+  amount_deducted_e8s: [] | [bigint];
+}
+export interface DisburseResponse {
+  transfer_block_height: bigint;
+}
+export type DissolveState =
+  | { DissolveDelaySeconds: bigint }
+  | { WhenDissolvedTimestampSeconds: bigint };
+export interface ExecuteGenericNervousSystemFunction {
+  function_id: bigint;
+  payload: Uint8Array;
+}
+export interface FinalizeDisburseMaturity {
+  amount_to_be_disbursed_e8s: bigint;
+  to_account: [] | [Account];
+}
+export interface Follow {
+  function_id: bigint;
+  followees: Array<NeuronId>;
+}
+export interface Followees {
+  followees: Array<NeuronId>;
+}
+export type FunctionType =
+  | { NativeNervousSystemFunction: {} }
+  | { GenericNervousSystemFunction: GenericNervousSystemFunction };
+export interface GenericNervousSystemFunction {
+  validator_canister_id: [] | [Principal];
+  target_canister_id: [] | [Principal];
+  validator_method_name: [] | [string];
+  target_method_name: [] | [string];
+}
+export interface GetMaturityModulationResponse {
+  maturity_modulation: [] | [MaturityModulation];
+}
+export interface GetMetadataResponse {
+  url: [] | [string];
+  logo: [] | [string];
+  name: [] | [string];
+  description: [] | [string];
+}
+export interface GetModeResponse {
+  mode: [] | [number];
+}
+export interface GetNeuron {
+  neuron_id: [] | [NeuronId];
+}
+export interface GetNeuronResponse {
+  result: [] | [Result];
+}
+export interface GetProposal {
+  proposal_id: [] | [ProposalId];
+}
+export interface GetProposalResponse {
+  result: [] | [Result_1];
+}
+export interface GetRunningSnsVersionResponse {
+  deployed_version: [] | [Version];
+  pending_version: [] | [UpgradeInProgress];
+}
+export interface GetSnsInitializationParametersResponse {
+  sns_initialization_parameters: string;
+}
+export interface Governance {
+  root_canister_id: [] | [Principal];
+  id_to_nervous_system_functions: Array<[bigint, NervousSystemFunction]>;
+  metrics: [] | [GovernanceCachedMetrics];
+  maturity_modulation: [] | [MaturityModulation];
+  mode: number;
+  parameters: [] | [NervousSystemParameters];
+  is_finalizing_disburse_maturity: [] | [boolean];
+  deployed_version: [] | [Version];
+  sns_initialization_parameters: string;
+  latest_reward_event: [] | [RewardEvent];
+  pending_version: [] | [UpgradeInProgress];
+  swap_canister_id: [] | [Principal];
+  ledger_canister_id: [] | [Principal];
+  proposals: Array<[bigint, ProposalData]>;
+  in_flight_commands: Array<[string, NeuronInFlightCommand]>;
+  sns_metadata: [] | [ManageSnsMetadata];
+  neurons: Array<[string, Neuron]>;
+  genesis_timestamp_seconds: bigint;
+}
+export interface GovernanceCachedMetrics {
+  not_dissolving_neurons_e8s_buckets: Array<[bigint, number]>;
+  garbage_collectable_neurons_count: bigint;
+  neurons_with_invalid_stake_count: bigint;
+  not_dissolving_neurons_count_buckets: Array<[bigint, bigint]>;
+  neurons_with_less_than_6_months_dissolve_delay_count: bigint;
+  dissolved_neurons_count: bigint;
+  total_staked_e8s: bigint;
+  total_supply_governance_tokens: bigint;
+  not_dissolving_neurons_count: bigint;
+  dissolved_neurons_e8s: bigint;
+  neurons_with_less_than_6_months_dissolve_delay_e8s: bigint;
+  dissolving_neurons_count_buckets: Array<[bigint, bigint]>;
+  dissolving_neurons_count: bigint;
+  dissolving_neurons_e8s_buckets: Array<[bigint, number]>;
+  timestamp_seconds: bigint;
+}
+export interface GovernanceError {
+  error_message: string;
+  error_type: number;
+}
+export interface IncreaseDissolveDelay {
+  additional_dissolve_delay_seconds: number;
+}
+export interface ListNervousSystemFunctionsResponse {
+  reserved_ids: BigUint64Array;
+  functions: Array<NervousSystemFunction>;
+}
+export interface ListNeurons {
+  of_principal: [] | [Principal];
+  limit: number;
+  start_page_at: [] | [NeuronId];
+}
+export interface ListNeuronsResponse {
+  neurons: Array<Neuron>;
+}
+export interface ListProposals {
+  include_reward_status: Int32Array;
+  before_proposal: [] | [ProposalId];
+  limit: number;
+  exclude_type: BigUint64Array;
+  include_status: Int32Array;
+}
+export interface ListProposalsResponse {
+  proposals: Array<ProposalData>;
+}
+export interface ManageNeuron {
+  subaccount: Uint8Array;
+  command: [] | [Command];
+}
+export interface ManageNeuronResponse {
+  command: [] | [Command_1];
+}
+export interface ManageSnsMetadata {
+  url: [] | [string];
+  logo: [] | [string];
+  name: [] | [string];
+  description: [] | [string];
+}
+export interface MaturityModulation {
+  current_basis_points: [] | [number];
+  updated_at_timestamp_seconds: [] | [bigint];
+}
+export interface MemoAndController {
+  controller: [] | [Principal];
+  memo: bigint;
+}
+export interface MergeMaturity {
+  percentage_to_merge: number;
+}
+export interface MergeMaturityResponse {
+  merged_maturity_e8s: bigint;
+  new_stake_e8s: bigint;
+}
+export interface MintTokensRequest {
+  recipient: [] | [Account];
+  amount_e8s: [] | [bigint];
+}
+export interface Motion {
+  motion_text: string;
+}
+export interface NervousSystemFunction {
+  id: bigint;
+  name: string;
+  description: [] | [string];
+  function_type: [] | [FunctionType];
+}
+export interface NervousSystemParameters {
+  default_followees: [] | [DefaultFollowees];
+  max_dissolve_delay_seconds: [] | [bigint];
+  max_dissolve_delay_bonus_percentage: [] | [bigint];
+  max_followees_per_function: [] | [bigint];
+  neuron_claimer_permissions: [] | [NeuronPermissionList];
+  neuron_minimum_stake_e8s: [] | [bigint];
+  max_neuron_age_for_age_bonus: [] | [bigint];
+  initial_voting_period_seconds: [] | [bigint];
+  neuron_minimum_dissolve_delay_to_vote_seconds: [] | [bigint];
+  reject_cost_e8s: [] | [bigint];
+  max_proposals_to_keep_per_action: [] | [number];
+  wait_for_quiet_deadline_increase_seconds: [] | [bigint];
+  max_number_of_neurons: [] | [bigint];
+  transaction_fee_e8s: [] | [bigint];
+  max_number_of_proposals_with_ballots: [] | [bigint];
+  max_age_bonus_percentage: [] | [bigint];
+  neuron_grantable_permissions: [] | [NeuronPermissionList];
+  voting_rewards_parameters: [] | [VotingRewardsParameters];
+  maturity_modulation_disabled: [] | [boolean];
+  max_number_of_principals_per_neuron: [] | [bigint];
+}
+export interface Neuron {
+  id: [] | [NeuronId];
+  staked_maturity_e8s_equivalent: [] | [bigint];
+  permissions: Array<NeuronPermission>;
+  maturity_e8s_equivalent: bigint;
+  cached_neuron_stake_e8s: bigint;
+  created_timestamp_seconds: bigint;
+  source_nns_neuron_id: [] | [bigint];
+  auto_stake_maturity: [] | [boolean];
+  aging_since_timestamp_seconds: bigint;
+  dissolve_state: [] | [DissolveState];
+  voting_power_percentage_multiplier: bigint;
+  vesting_period_seconds: [] | [bigint];
+  disburse_maturity_in_progress: Array<DisburseMaturityInProgress>;
+  followees: Array<[bigint, Followees]>;
+  neuron_fees_e8s: bigint;
+}
+export interface NeuronId {
+  id: Uint8Array;
+}
+export interface NeuronInFlightCommand {
+  command: [] | [Command_2];
+  timestamp: bigint;
+}
+export interface NeuronParameters {
+  controller: [] | [Principal];
+  dissolve_delay_seconds: [] | [bigint];
+  source_nns_neuron_id: [] | [bigint];
+  stake_e8s: [] | [bigint];
+  followees: Array<NeuronId>;
+  hotkey: [] | [Principal];
+  neuron_id: [] | [NeuronId];
+}
+export interface NeuronPermission {
+  principal: [] | [Principal];
+  permission_type: Int32Array;
+}
+export interface NeuronPermissionList {
+  permissions: Int32Array;
+}
+export type Operation =
+  | {
+      ChangeAutoStakeMaturity: ChangeAutoStakeMaturity;
+    }
+  | { StopDissolving: {} }
+  | { StartDissolving: {} }
+  | { IncreaseDissolveDelay: IncreaseDissolveDelay }
+  | { SetDissolveTimestamp: SetDissolveTimestamp };
+export interface Proposal {
+  url: string;
+  title: string;
+  action: [] | [Action];
+  summary: string;
+}
+export interface ProposalData {
+  id: [] | [ProposalId];
+  payload_text_rendering: [] | [string];
+  action: bigint;
+  failure_reason: [] | [GovernanceError];
+  ballots: Array<[string, Ballot]>;
+  reward_event_round: bigint;
+  failed_timestamp_seconds: bigint;
+  reward_event_end_timestamp_seconds: [] | [bigint];
+  proposal_creation_timestamp_seconds: bigint;
+  initial_voting_period_seconds: bigint;
+  reject_cost_e8s: bigint;
+  latest_tally: [] | [Tally];
+  wait_for_quiet_deadline_increase_seconds: bigint;
+  decided_timestamp_seconds: bigint;
+  proposal: [] | [Proposal];
+  proposer: [] | [NeuronId];
+  wait_for_quiet_state: [] | [WaitForQuietState];
+  is_eligible_for_rewards: boolean;
+  executed_timestamp_seconds: bigint;
+}
+export interface ProposalId {
+  id: bigint;
+}
+export interface RegisterDappCanisters {
+  canister_ids: Array<Principal>;
+}
+export interface RegisterVote {
+  vote: number;
+  proposal: [] | [ProposalId];
+}
+export interface RemoveNeuronPermissions {
+  permissions_to_remove: [] | [NeuronPermissionList];
+  principal_id: [] | [Principal];
+}
+export type Result = { Error: GovernanceError } | { Neuron: Neuron };
+export type Result_1 = { Error: GovernanceError } | { Proposal: ProposalData };
+export interface RewardEvent {
+  rounds_since_last_distribution: [] | [bigint];
+  actual_timestamp_seconds: bigint;
+  end_timestamp_seconds: [] | [bigint];
+  distributed_e8s_equivalent: bigint;
+  round: bigint;
+  settled_proposals: Array<ProposalId>;
+}
+export interface SetDissolveTimestamp {
+  dissolve_timestamp_seconds: bigint;
+}
+export interface SetMode {
+  mode: number;
+}
+export interface Split {
+  memo: bigint;
+  amount_e8s: bigint;
+}
+export interface SplitResponse {
+  created_neuron_id: [] | [NeuronId];
+}
+export interface StakeMaturity {
+  percentage_to_stake: [] | [number];
+}
+export interface StakeMaturityResponse {
+  maturity_e8s: bigint;
+  staked_maturity_e8s: bigint;
+}
+export interface Subaccount {
+  subaccount: Uint8Array;
+}
+export interface SwapNeuron {
+  id: [] | [NeuronId];
+  status: number;
+}
+export interface Tally {
+  no: bigint;
+  yes: bigint;
+  total: bigint;
+  timestamp_seconds: bigint;
+}
+export interface TransferSnsTreasuryFunds {
+  from_treasury: number;
+  to_principal: [] | [Principal];
+  to_subaccount: [] | [Subaccount];
+  memo: [] | [bigint];
+  amount_e8s: bigint;
+}
+export interface UpgradeInProgress {
+  mark_failed_at_seconds: bigint;
+  checking_upgrade_lock: bigint;
+  proposal_id: bigint;
+  target_version: [] | [Version];
+}
+export interface UpgradeSnsControlledCanister {
+  new_canister_wasm: Uint8Array;
+  mode: [] | [number];
+  canister_id: [] | [Principal];
+  canister_upgrade_arg: [] | [Uint8Array];
+}
+export interface Version {
+  archive_wasm_hash: Uint8Array;
+  root_wasm_hash: Uint8Array;
+  swap_wasm_hash: Uint8Array;
+  ledger_wasm_hash: Uint8Array;
+  governance_wasm_hash: Uint8Array;
+  index_wasm_hash: Uint8Array;
+}
+export interface VotingRewardsParameters {
+  final_reward_rate_basis_points: [] | [bigint];
+  initial_reward_rate_basis_points: [] | [bigint];
+  reward_rate_transition_duration_seconds: [] | [bigint];
+  round_duration_seconds: [] | [bigint];
+}
+export interface WaitForQuietState {
+  current_deadline_timestamp_seconds: bigint;
+}
+export interface _SERVICE {
+  add_maturity: ActorMethod<[AddMaturityRequest], AddMaturityResponse>;
+  claim_swap_neurons: ActorMethod<
+    [ClaimSwapNeuronsRequest],
+    ClaimSwapNeuronsResponse
+  >;
+  fail_stuck_upgrade_in_progress: ActorMethod<[{}], {}>;
+  get_build_metadata: ActorMethod<[], string>;
+  get_latest_reward_event: ActorMethod<[], RewardEvent>;
+  get_maturity_modulation: ActorMethod<[{}], GetMaturityModulationResponse>;
+  get_metadata: ActorMethod<[{}], GetMetadataResponse>;
+  get_mode: ActorMethod<[{}], GetModeResponse>;
+  get_nervous_system_parameters: ActorMethod<[null], NervousSystemParameters>;
+  get_neuron: ActorMethod<[GetNeuron], GetNeuronResponse>;
+  get_proposal: ActorMethod<[GetProposal], GetProposalResponse>;
+  get_root_canister_status: ActorMethod<[null], CanisterStatusResultV2>;
+  get_running_sns_version: ActorMethod<[{}], GetRunningSnsVersionResponse>;
+  get_sns_initialization_parameters: ActorMethod<
+    [{}],
+    GetSnsInitializationParametersResponse
+  >;
+  list_nervous_system_functions: ActorMethod<
+    [],
+    ListNervousSystemFunctionsResponse
+  >;
+  list_neurons: ActorMethod<[ListNeurons], ListNeuronsResponse>;
+  list_proposals: ActorMethod<[ListProposals], ListProposalsResponse>;
+  manage_neuron: ActorMethod<[ManageNeuron], ManageNeuronResponse>;
+  mint_tokens: ActorMethod<[MintTokensRequest], {}>;
+  set_mode: ActorMethod<[SetMode], {}>;
+  update_neuron: ActorMethod<[Neuron], [] | [GovernanceError]>;
+}

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,0 +1,445 @@
+// Generated from IC repo commit 4fbe776aeea08222b8b47f5f2902fe77b58b7150 'rs/sns/governance/canister/governance_test.did' by import-candid
+type Account = record { owner : opt principal; subaccount : opt Subaccount };
+type Action = variant {
+  ManageNervousSystemParameters : NervousSystemParameters;
+  AddGenericNervousSystemFunction : NervousSystemFunction;
+  RemoveGenericNervousSystemFunction : nat64;
+  UpgradeSnsToNextVersion : record {};
+  RegisterDappCanisters : RegisterDappCanisters;
+  TransferSnsTreasuryFunds : TransferSnsTreasuryFunds;
+  UpgradeSnsControlledCanister : UpgradeSnsControlledCanister;
+  DeregisterDappCanisters : DeregisterDappCanisters;
+  Unspecified : record {};
+  ManageSnsMetadata : ManageSnsMetadata;
+  ExecuteGenericNervousSystemFunction : ExecuteGenericNervousSystemFunction;
+  Motion : Motion;
+};
+type AddMaturityRequest = record { id : opt NeuronId; amount_e8s : opt nat64 };
+type AddMaturityResponse = record { new_maturity_e8s : opt nat64 };
+type AddNeuronPermissions = record {
+  permissions_to_add : opt NeuronPermissionList;
+  principal_id : opt principal;
+};
+type Amount = record { e8s : nat64 };
+type Ballot = record {
+  vote : int32;
+  cast_timestamp_seconds : nat64;
+  voting_power : nat64;
+};
+type By = variant {
+  MemoAndController : MemoAndController;
+  NeuronId : record {};
+};
+type CanisterStatusResultV2 = record {
+  status : CanisterStatusType;
+  memory_size : nat;
+  cycles : nat;
+  settings : DefiniteCanisterSettingsArgs;
+  idle_cycles_burned_per_day : nat;
+  module_hash : opt vec nat8;
+};
+type CanisterStatusType = variant { stopped; stopping; running };
+type ChangeAutoStakeMaturity = record {
+  requested_setting_for_auto_stake_maturity : bool;
+};
+type ClaimOrRefresh = record { by : opt By };
+type ClaimOrRefreshResponse = record { refreshed_neuron_id : opt NeuronId };
+type ClaimSwapNeuronsRequest = record {
+  neuron_parameters : vec NeuronParameters;
+};
+type ClaimSwapNeuronsResponse = record {
+  claim_swap_neurons_result : opt ClaimSwapNeuronsResult;
+};
+type ClaimSwapNeuronsResult = variant { Ok : ClaimedSwapNeurons; Err : int32 };
+type ClaimedSwapNeurons = record { swap_neurons : vec SwapNeuron };
+type Command = variant {
+  Split : Split;
+  Follow : Follow;
+  DisburseMaturity : DisburseMaturity;
+  ClaimOrRefresh : ClaimOrRefresh;
+  Configure : Configure;
+  RegisterVote : RegisterVote;
+  MakeProposal : Proposal;
+  StakeMaturity : StakeMaturity;
+  RemoveNeuronPermissions : RemoveNeuronPermissions;
+  AddNeuronPermissions : AddNeuronPermissions;
+  MergeMaturity : MergeMaturity;
+  Disburse : Disburse;
+};
+type Command_1 = variant {
+  Error : GovernanceError;
+  Split : SplitResponse;
+  Follow : record {};
+  DisburseMaturity : DisburseMaturityResponse;
+  ClaimOrRefresh : ClaimOrRefreshResponse;
+  Configure : record {};
+  RegisterVote : record {};
+  MakeProposal : GetProposal;
+  RemoveNeuronPermission : record {};
+  StakeMaturity : StakeMaturityResponse;
+  MergeMaturity : MergeMaturityResponse;
+  Disburse : DisburseResponse;
+  AddNeuronPermission : record {};
+};
+type Command_2 = variant {
+  Split : Split;
+  Follow : Follow;
+  DisburseMaturity : DisburseMaturity;
+  Configure : Configure;
+  RegisterVote : RegisterVote;
+  SyncCommand : record {};
+  MakeProposal : Proposal;
+  FinalizeDisburseMaturity : FinalizeDisburseMaturity;
+  ClaimOrRefreshNeuron : ClaimOrRefresh;
+  RemoveNeuronPermissions : RemoveNeuronPermissions;
+  AddNeuronPermissions : AddNeuronPermissions;
+  MergeMaturity : MergeMaturity;
+  Disburse : Disburse;
+};
+type Configure = record { operation : opt Operation };
+type DefaultFollowees = record { followees : vec record { nat64; Followees } };
+type DefiniteCanisterSettingsArgs = record {
+  freezing_threshold : nat;
+  controllers : vec principal;
+  memory_allocation : nat;
+  compute_allocation : nat;
+};
+type DeregisterDappCanisters = record {
+  canister_ids : vec principal;
+  new_controllers : vec principal;
+};
+type Disburse = record { to_account : opt Account; amount : opt Amount };
+type DisburseMaturity = record {
+  to_account : opt Account;
+  percentage_to_disburse : nat32;
+};
+type DisburseMaturityInProgress = record {
+  timestamp_of_disbursement_seconds : nat64;
+  amount_e8s : nat64;
+  account_to_disburse_to : opt Account;
+};
+type DisburseMaturityResponse = record {
+  amount_disbursed_e8s : nat64;
+  amount_deducted_e8s : opt nat64;
+};
+type DisburseResponse = record { transfer_block_height : nat64 };
+type DissolveState = variant {
+  DissolveDelaySeconds : nat64;
+  WhenDissolvedTimestampSeconds : nat64;
+};
+type ExecuteGenericNervousSystemFunction = record {
+  function_id : nat64;
+  payload : vec nat8;
+};
+type FinalizeDisburseMaturity = record {
+  amount_to_be_disbursed_e8s : nat64;
+  to_account : opt Account;
+};
+type Follow = record { function_id : nat64; followees : vec NeuronId };
+type Followees = record { followees : vec NeuronId };
+type FunctionType = variant {
+  NativeNervousSystemFunction : record {};
+  GenericNervousSystemFunction : GenericNervousSystemFunction;
+};
+type GenericNervousSystemFunction = record {
+  validator_canister_id : opt principal;
+  target_canister_id : opt principal;
+  validator_method_name : opt text;
+  target_method_name : opt text;
+};
+type GetMaturityModulationResponse = record {
+  maturity_modulation : opt MaturityModulation;
+};
+type GetMetadataResponse = record {
+  url : opt text;
+  logo : opt text;
+  name : opt text;
+  description : opt text;
+};
+type GetModeResponse = record { mode : opt int32 };
+type GetNeuron = record { neuron_id : opt NeuronId };
+type GetNeuronResponse = record { result : opt Result };
+type GetProposal = record { proposal_id : opt ProposalId };
+type GetProposalResponse = record { result : opt Result_1 };
+type GetRunningSnsVersionResponse = record {
+  deployed_version : opt Version;
+  pending_version : opt UpgradeInProgress;
+};
+type GetSnsInitializationParametersResponse = record {
+  sns_initialization_parameters : text;
+};
+type Governance = record {
+  root_canister_id : opt principal;
+  id_to_nervous_system_functions : vec record { nat64; NervousSystemFunction };
+  metrics : opt GovernanceCachedMetrics;
+  maturity_modulation : opt MaturityModulation;
+  mode : int32;
+  parameters : opt NervousSystemParameters;
+  is_finalizing_disburse_maturity : opt bool;
+  deployed_version : opt Version;
+  sns_initialization_parameters : text;
+  latest_reward_event : opt RewardEvent;
+  pending_version : opt UpgradeInProgress;
+  swap_canister_id : opt principal;
+  ledger_canister_id : opt principal;
+  proposals : vec record { nat64; ProposalData };
+  in_flight_commands : vec record { text; NeuronInFlightCommand };
+  sns_metadata : opt ManageSnsMetadata;
+  neurons : vec record { text; Neuron };
+  genesis_timestamp_seconds : nat64;
+};
+type GovernanceCachedMetrics = record {
+  not_dissolving_neurons_e8s_buckets : vec record { nat64; float64 };
+  garbage_collectable_neurons_count : nat64;
+  neurons_with_invalid_stake_count : nat64;
+  not_dissolving_neurons_count_buckets : vec record { nat64; nat64 };
+  neurons_with_less_than_6_months_dissolve_delay_count : nat64;
+  dissolved_neurons_count : nat64;
+  total_staked_e8s : nat64;
+  total_supply_governance_tokens : nat64;
+  not_dissolving_neurons_count : nat64;
+  dissolved_neurons_e8s : nat64;
+  neurons_with_less_than_6_months_dissolve_delay_e8s : nat64;
+  dissolving_neurons_count_buckets : vec record { nat64; nat64 };
+  dissolving_neurons_count : nat64;
+  dissolving_neurons_e8s_buckets : vec record { nat64; float64 };
+  timestamp_seconds : nat64;
+};
+type GovernanceError = record { error_message : text; error_type : int32 };
+type IncreaseDissolveDelay = record {
+  additional_dissolve_delay_seconds : nat32;
+};
+type ListNervousSystemFunctionsResponse = record {
+  reserved_ids : vec nat64;
+  functions : vec NervousSystemFunction;
+};
+type ListNeurons = record {
+  of_principal : opt principal;
+  limit : nat32;
+  start_page_at : opt NeuronId;
+};
+type ListNeuronsResponse = record { neurons : vec Neuron };
+type ListProposals = record {
+  include_reward_status : vec int32;
+  before_proposal : opt ProposalId;
+  limit : nat32;
+  exclude_type : vec nat64;
+  include_status : vec int32;
+};
+type ListProposalsResponse = record { proposals : vec ProposalData };
+type ManageNeuron = record { subaccount : vec nat8; command : opt Command };
+type ManageNeuronResponse = record { command : opt Command_1 };
+type ManageSnsMetadata = record {
+  url : opt text;
+  logo : opt text;
+  name : opt text;
+  description : opt text;
+};
+type MaturityModulation = record {
+  current_basis_points : opt int32;
+  updated_at_timestamp_seconds : opt nat64;
+};
+type MemoAndController = record { controller : opt principal; memo : nat64 };
+type MergeMaturity = record { percentage_to_merge : nat32 };
+type MergeMaturityResponse = record {
+  merged_maturity_e8s : nat64;
+  new_stake_e8s : nat64;
+};
+type MintTokensRequest = record {
+  recipient : opt Account;
+  amount_e8s : opt nat64;
+};
+type Motion = record { motion_text : text };
+type NervousSystemFunction = record {
+  id : nat64;
+  name : text;
+  description : opt text;
+  function_type : opt FunctionType;
+};
+type NervousSystemParameters = record {
+  default_followees : opt DefaultFollowees;
+  max_dissolve_delay_seconds : opt nat64;
+  max_dissolve_delay_bonus_percentage : opt nat64;
+  max_followees_per_function : opt nat64;
+  neuron_claimer_permissions : opt NeuronPermissionList;
+  neuron_minimum_stake_e8s : opt nat64;
+  max_neuron_age_for_age_bonus : opt nat64;
+  initial_voting_period_seconds : opt nat64;
+  neuron_minimum_dissolve_delay_to_vote_seconds : opt nat64;
+  reject_cost_e8s : opt nat64;
+  max_proposals_to_keep_per_action : opt nat32;
+  wait_for_quiet_deadline_increase_seconds : opt nat64;
+  max_number_of_neurons : opt nat64;
+  transaction_fee_e8s : opt nat64;
+  max_number_of_proposals_with_ballots : opt nat64;
+  max_age_bonus_percentage : opt nat64;
+  neuron_grantable_permissions : opt NeuronPermissionList;
+  voting_rewards_parameters : opt VotingRewardsParameters;
+  maturity_modulation_disabled : opt bool;
+  max_number_of_principals_per_neuron : opt nat64;
+};
+type Neuron = record {
+  id : opt NeuronId;
+  staked_maturity_e8s_equivalent : opt nat64;
+  permissions : vec NeuronPermission;
+  maturity_e8s_equivalent : nat64;
+  cached_neuron_stake_e8s : nat64;
+  created_timestamp_seconds : nat64;
+  source_nns_neuron_id : opt nat64;
+  auto_stake_maturity : opt bool;
+  aging_since_timestamp_seconds : nat64;
+  dissolve_state : opt DissolveState;
+  voting_power_percentage_multiplier : nat64;
+  vesting_period_seconds : opt nat64;
+  disburse_maturity_in_progress : vec DisburseMaturityInProgress;
+  followees : vec record { nat64; Followees };
+  neuron_fees_e8s : nat64;
+};
+type NeuronId = record { id : vec nat8 };
+type NeuronInFlightCommand = record {
+  command : opt Command_2;
+  timestamp : nat64;
+};
+type NeuronParameters = record {
+  controller : opt principal;
+  dissolve_delay_seconds : opt nat64;
+  source_nns_neuron_id : opt nat64;
+  stake_e8s : opt nat64;
+  followees : vec NeuronId;
+  hotkey : opt principal;
+  neuron_id : opt NeuronId;
+};
+type NeuronPermission = record {
+  "principal" : opt principal;
+  permission_type : vec int32;
+};
+type NeuronPermissionList = record { permissions : vec int32 };
+type Operation = variant {
+  ChangeAutoStakeMaturity : ChangeAutoStakeMaturity;
+  StopDissolving : record {};
+  StartDissolving : record {};
+  IncreaseDissolveDelay : IncreaseDissolveDelay;
+  SetDissolveTimestamp : SetDissolveTimestamp;
+};
+type Proposal = record {
+  url : text;
+  title : text;
+  action : opt Action;
+  summary : text;
+};
+type ProposalData = record {
+  id : opt ProposalId;
+  payload_text_rendering : opt text;
+  action : nat64;
+  failure_reason : opt GovernanceError;
+  ballots : vec record { text; Ballot };
+  reward_event_round : nat64;
+  failed_timestamp_seconds : nat64;
+  reward_event_end_timestamp_seconds : opt nat64;
+  proposal_creation_timestamp_seconds : nat64;
+  initial_voting_period_seconds : nat64;
+  reject_cost_e8s : nat64;
+  latest_tally : opt Tally;
+  wait_for_quiet_deadline_increase_seconds : nat64;
+  decided_timestamp_seconds : nat64;
+  proposal : opt Proposal;
+  proposer : opt NeuronId;
+  wait_for_quiet_state : opt WaitForQuietState;
+  is_eligible_for_rewards : bool;
+  executed_timestamp_seconds : nat64;
+};
+type ProposalId = record { id : nat64 };
+type RegisterDappCanisters = record { canister_ids : vec principal };
+type RegisterVote = record { vote : int32; proposal : opt ProposalId };
+type RemoveNeuronPermissions = record {
+  permissions_to_remove : opt NeuronPermissionList;
+  principal_id : opt principal;
+};
+type Result = variant { Error : GovernanceError; Neuron : Neuron };
+type Result_1 = variant { Error : GovernanceError; Proposal : ProposalData };
+type RewardEvent = record {
+  rounds_since_last_distribution : opt nat64;
+  actual_timestamp_seconds : nat64;
+  end_timestamp_seconds : opt nat64;
+  distributed_e8s_equivalent : nat64;
+  round : nat64;
+  settled_proposals : vec ProposalId;
+};
+type SetDissolveTimestamp = record { dissolve_timestamp_seconds : nat64 };
+type SetMode = record { mode : int32 };
+type Split = record { memo : nat64; amount_e8s : nat64 };
+type SplitResponse = record { created_neuron_id : opt NeuronId };
+type StakeMaturity = record { percentage_to_stake : opt nat32 };
+type StakeMaturityResponse = record {
+  maturity_e8s : nat64;
+  staked_maturity_e8s : nat64;
+};
+type Subaccount = record { subaccount : vec nat8 };
+type SwapNeuron = record { id : opt NeuronId; status : int32 };
+type Tally = record {
+  no : nat64;
+  yes : nat64;
+  total : nat64;
+  timestamp_seconds : nat64;
+};
+type TransferSnsTreasuryFunds = record {
+  from_treasury : int32;
+  to_principal : opt principal;
+  to_subaccount : opt Subaccount;
+  memo : opt nat64;
+  amount_e8s : nat64;
+};
+type UpgradeInProgress = record {
+  mark_failed_at_seconds : nat64;
+  checking_upgrade_lock : nat64;
+  proposal_id : nat64;
+  target_version : opt Version;
+};
+type UpgradeSnsControlledCanister = record {
+  new_canister_wasm : vec nat8;
+  mode : opt int32;
+  canister_id : opt principal;
+  canister_upgrade_arg : opt vec nat8;
+};
+type Version = record {
+  archive_wasm_hash : vec nat8;
+  root_wasm_hash : vec nat8;
+  swap_wasm_hash : vec nat8;
+  ledger_wasm_hash : vec nat8;
+  governance_wasm_hash : vec nat8;
+  index_wasm_hash : vec nat8;
+};
+type VotingRewardsParameters = record {
+  final_reward_rate_basis_points : opt nat64;
+  initial_reward_rate_basis_points : opt nat64;
+  reward_rate_transition_duration_seconds : opt nat64;
+  round_duration_seconds : opt nat64;
+};
+type WaitForQuietState = record { current_deadline_timestamp_seconds : nat64 };
+service : (Governance) -> {
+  add_maturity : (AddMaturityRequest) -> (AddMaturityResponse);
+  claim_swap_neurons : (ClaimSwapNeuronsRequest) -> (ClaimSwapNeuronsResponse);
+  fail_stuck_upgrade_in_progress : (record {}) -> (record {});
+  get_build_metadata : () -> (text) query;
+  get_latest_reward_event : () -> (RewardEvent) query;
+  get_maturity_modulation : (record {}) -> (GetMaturityModulationResponse);
+  get_metadata : (record {}) -> (GetMetadataResponse) query;
+  get_mode : (record {}) -> (GetModeResponse) query;
+  get_nervous_system_parameters : (null) -> (NervousSystemParameters) query;
+  get_neuron : (GetNeuron) -> (GetNeuronResponse) query;
+  get_proposal : (GetProposal) -> (GetProposalResponse) query;
+  get_root_canister_status : (null) -> (CanisterStatusResultV2);
+  get_running_sns_version : (record {}) -> (GetRunningSnsVersionResponse) query;
+  get_sns_initialization_parameters : (record {}) -> (
+      GetSnsInitializationParametersResponse,
+    ) query;
+  list_nervous_system_functions : () -> (
+      ListNervousSystemFunctionsResponse,
+    ) query;
+  list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
+  list_proposals : (ListProposals) -> (ListProposalsResponse) query;
+  manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
+  mint_tokens : (MintTokensRequest) -> (record {});
+  set_mode : (SetMode) -> (record {});
+  update_neuron : (Neuron) -> (opt GovernanceError);
+}

--- a/packages/sns/candid/sns_governance_test.idl.d.ts
+++ b/packages/sns/candid/sns_governance_test.idl.d.ts
@@ -1,0 +1,2 @@
+import type { IDL } from "@dfinity/candid";
+export const idlFactory: IDL.InterfaceFactory;

--- a/packages/sns/candid/sns_governance_test.idl.js
+++ b/packages/sns/candid/sns_governance_test.idl.js
@@ -1,0 +1,880 @@
+/* Do not edit.  Compiled with ./scripts/compile-idl-js from packages/sns/candid/sns_governance_test.did */
+export const idlFactory = ({ IDL }) => {
+  const GenericNervousSystemFunction = IDL.Record({
+    'validator_canister_id' : IDL.Opt(IDL.Principal),
+    'target_canister_id' : IDL.Opt(IDL.Principal),
+    'validator_method_name' : IDL.Opt(IDL.Text),
+    'target_method_name' : IDL.Opt(IDL.Text),
+  });
+  const FunctionType = IDL.Variant({
+    'NativeNervousSystemFunction' : IDL.Record({}),
+    'GenericNervousSystemFunction' : GenericNervousSystemFunction,
+  });
+  const NervousSystemFunction = IDL.Record({
+    'id' : IDL.Nat64,
+    'name' : IDL.Text,
+    'description' : IDL.Opt(IDL.Text),
+    'function_type' : IDL.Opt(FunctionType),
+  });
+  const GovernanceCachedMetrics = IDL.Record({
+    'not_dissolving_neurons_e8s_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'garbage_collectable_neurons_count' : IDL.Nat64,
+    'neurons_with_invalid_stake_count' : IDL.Nat64,
+    'not_dissolving_neurons_count_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Nat64)
+    ),
+    'neurons_with_less_than_6_months_dissolve_delay_count' : IDL.Nat64,
+    'dissolved_neurons_count' : IDL.Nat64,
+    'total_staked_e8s' : IDL.Nat64,
+    'total_supply_governance_tokens' : IDL.Nat64,
+    'not_dissolving_neurons_count' : IDL.Nat64,
+    'dissolved_neurons_e8s' : IDL.Nat64,
+    'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
+    'dissolving_neurons_count_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Nat64)
+    ),
+    'dissolving_neurons_count' : IDL.Nat64,
+    'dissolving_neurons_e8s_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'timestamp_seconds' : IDL.Nat64,
+  });
+  const MaturityModulation = IDL.Record({
+    'current_basis_points' : IDL.Opt(IDL.Int32),
+    'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
+  const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
+  const DefaultFollowees = IDL.Record({
+    'followees' : IDL.Vec(IDL.Tuple(IDL.Nat64, Followees)),
+  });
+  const NeuronPermissionList = IDL.Record({
+    'permissions' : IDL.Vec(IDL.Int32),
+  });
+  const VotingRewardsParameters = IDL.Record({
+    'final_reward_rate_basis_points' : IDL.Opt(IDL.Nat64),
+    'initial_reward_rate_basis_points' : IDL.Opt(IDL.Nat64),
+    'reward_rate_transition_duration_seconds' : IDL.Opt(IDL.Nat64),
+    'round_duration_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const NervousSystemParameters = IDL.Record({
+    'default_followees' : IDL.Opt(DefaultFollowees),
+    'max_dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
+    'max_dissolve_delay_bonus_percentage' : IDL.Opt(IDL.Nat64),
+    'max_followees_per_function' : IDL.Opt(IDL.Nat64),
+    'neuron_claimer_permissions' : IDL.Opt(NeuronPermissionList),
+    'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
+    'max_neuron_age_for_age_bonus' : IDL.Opt(IDL.Nat64),
+    'initial_voting_period_seconds' : IDL.Opt(IDL.Nat64),
+    'neuron_minimum_dissolve_delay_to_vote_seconds' : IDL.Opt(IDL.Nat64),
+    'reject_cost_e8s' : IDL.Opt(IDL.Nat64),
+    'max_proposals_to_keep_per_action' : IDL.Opt(IDL.Nat32),
+    'wait_for_quiet_deadline_increase_seconds' : IDL.Opt(IDL.Nat64),
+    'max_number_of_neurons' : IDL.Opt(IDL.Nat64),
+    'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
+    'max_number_of_proposals_with_ballots' : IDL.Opt(IDL.Nat64),
+    'max_age_bonus_percentage' : IDL.Opt(IDL.Nat64),
+    'neuron_grantable_permissions' : IDL.Opt(NeuronPermissionList),
+    'voting_rewards_parameters' : IDL.Opt(VotingRewardsParameters),
+    'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
+    'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
+  });
+  const Version = IDL.Record({
+    'archive_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'root_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'swap_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'ledger_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'governance_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'index_wasm_hash' : IDL.Vec(IDL.Nat8),
+  });
+  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
+  const RewardEvent = IDL.Record({
+    'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
+    'actual_timestamp_seconds' : IDL.Nat64,
+    'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'distributed_e8s_equivalent' : IDL.Nat64,
+    'round' : IDL.Nat64,
+    'settled_proposals' : IDL.Vec(ProposalId),
+  });
+  const UpgradeInProgress = IDL.Record({
+    'mark_failed_at_seconds' : IDL.Nat64,
+    'checking_upgrade_lock' : IDL.Nat64,
+    'proposal_id' : IDL.Nat64,
+    'target_version' : IDL.Opt(Version),
+  });
+  const GovernanceError = IDL.Record({
+    'error_message' : IDL.Text,
+    'error_type' : IDL.Int32,
+  });
+  const Ballot = IDL.Record({
+    'vote' : IDL.Int32,
+    'cast_timestamp_seconds' : IDL.Nat64,
+    'voting_power' : IDL.Nat64,
+  });
+  const Tally = IDL.Record({
+    'no' : IDL.Nat64,
+    'yes' : IDL.Nat64,
+    'total' : IDL.Nat64,
+    'timestamp_seconds' : IDL.Nat64,
+  });
+  const RegisterDappCanisters = IDL.Record({
+    'canister_ids' : IDL.Vec(IDL.Principal),
+  });
+  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
+  const TransferSnsTreasuryFunds = IDL.Record({
+    'from_treasury' : IDL.Int32,
+    'to_principal' : IDL.Opt(IDL.Principal),
+    'to_subaccount' : IDL.Opt(Subaccount),
+    'memo' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Nat64,
+  });
+  const UpgradeSnsControlledCanister = IDL.Record({
+    'new_canister_wasm' : IDL.Vec(IDL.Nat8),
+    'mode' : IDL.Opt(IDL.Int32),
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
+  const DeregisterDappCanisters = IDL.Record({
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'new_controllers' : IDL.Vec(IDL.Principal),
+  });
+  const ManageSnsMetadata = IDL.Record({
+    'url' : IDL.Opt(IDL.Text),
+    'logo' : IDL.Opt(IDL.Text),
+    'name' : IDL.Opt(IDL.Text),
+    'description' : IDL.Opt(IDL.Text),
+  });
+  const ExecuteGenericNervousSystemFunction = IDL.Record({
+    'function_id' : IDL.Nat64,
+    'payload' : IDL.Vec(IDL.Nat8),
+  });
+  const Motion = IDL.Record({ 'motion_text' : IDL.Text });
+  const Action = IDL.Variant({
+    'ManageNervousSystemParameters' : NervousSystemParameters,
+    'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'RemoveGenericNervousSystemFunction' : IDL.Nat64,
+    'UpgradeSnsToNextVersion' : IDL.Record({}),
+    'RegisterDappCanisters' : RegisterDappCanisters,
+    'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
+    'UpgradeSnsControlledCanister' : UpgradeSnsControlledCanister,
+    'DeregisterDappCanisters' : DeregisterDappCanisters,
+    'Unspecified' : IDL.Record({}),
+    'ManageSnsMetadata' : ManageSnsMetadata,
+    'ExecuteGenericNervousSystemFunction' : ExecuteGenericNervousSystemFunction,
+    'Motion' : Motion,
+  });
+  const Proposal = IDL.Record({
+    'url' : IDL.Text,
+    'title' : IDL.Text,
+    'action' : IDL.Opt(Action),
+    'summary' : IDL.Text,
+  });
+  const WaitForQuietState = IDL.Record({
+    'current_deadline_timestamp_seconds' : IDL.Nat64,
+  });
+  const ProposalData = IDL.Record({
+    'id' : IDL.Opt(ProposalId),
+    'payload_text_rendering' : IDL.Opt(IDL.Text),
+    'action' : IDL.Nat64,
+    'failure_reason' : IDL.Opt(GovernanceError),
+    'ballots' : IDL.Vec(IDL.Tuple(IDL.Text, Ballot)),
+    'reward_event_round' : IDL.Nat64,
+    'failed_timestamp_seconds' : IDL.Nat64,
+    'reward_event_end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'proposal_creation_timestamp_seconds' : IDL.Nat64,
+    'initial_voting_period_seconds' : IDL.Nat64,
+    'reject_cost_e8s' : IDL.Nat64,
+    'latest_tally' : IDL.Opt(Tally),
+    'wait_for_quiet_deadline_increase_seconds' : IDL.Nat64,
+    'decided_timestamp_seconds' : IDL.Nat64,
+    'proposal' : IDL.Opt(Proposal),
+    'proposer' : IDL.Opt(NeuronId),
+    'wait_for_quiet_state' : IDL.Opt(WaitForQuietState),
+    'is_eligible_for_rewards' : IDL.Bool,
+    'executed_timestamp_seconds' : IDL.Nat64,
+  });
+  const Split = IDL.Record({ 'memo' : IDL.Nat64, 'amount_e8s' : IDL.Nat64 });
+  const Follow = IDL.Record({
+    'function_id' : IDL.Nat64,
+    'followees' : IDL.Vec(NeuronId),
+  });
+  const Account = IDL.Record({
+    'owner' : IDL.Opt(IDL.Principal),
+    'subaccount' : IDL.Opt(Subaccount),
+  });
+  const DisburseMaturity = IDL.Record({
+    'to_account' : IDL.Opt(Account),
+    'percentage_to_disburse' : IDL.Nat32,
+  });
+  const ChangeAutoStakeMaturity = IDL.Record({
+    'requested_setting_for_auto_stake_maturity' : IDL.Bool,
+  });
+  const IncreaseDissolveDelay = IDL.Record({
+    'additional_dissolve_delay_seconds' : IDL.Nat32,
+  });
+  const SetDissolveTimestamp = IDL.Record({
+    'dissolve_timestamp_seconds' : IDL.Nat64,
+  });
+  const Operation = IDL.Variant({
+    'ChangeAutoStakeMaturity' : ChangeAutoStakeMaturity,
+    'StopDissolving' : IDL.Record({}),
+    'StartDissolving' : IDL.Record({}),
+    'IncreaseDissolveDelay' : IncreaseDissolveDelay,
+    'SetDissolveTimestamp' : SetDissolveTimestamp,
+  });
+  const Configure = IDL.Record({ 'operation' : IDL.Opt(Operation) });
+  const RegisterVote = IDL.Record({
+    'vote' : IDL.Int32,
+    'proposal' : IDL.Opt(ProposalId),
+  });
+  const FinalizeDisburseMaturity = IDL.Record({
+    'amount_to_be_disbursed_e8s' : IDL.Nat64,
+    'to_account' : IDL.Opt(Account),
+  });
+  const MemoAndController = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
+    'memo' : IDL.Nat64,
+  });
+  const By = IDL.Variant({
+    'MemoAndController' : MemoAndController,
+    'NeuronId' : IDL.Record({}),
+  });
+  const ClaimOrRefresh = IDL.Record({ 'by' : IDL.Opt(By) });
+  const RemoveNeuronPermissions = IDL.Record({
+    'permissions_to_remove' : IDL.Opt(NeuronPermissionList),
+    'principal_id' : IDL.Opt(IDL.Principal),
+  });
+  const AddNeuronPermissions = IDL.Record({
+    'permissions_to_add' : IDL.Opt(NeuronPermissionList),
+    'principal_id' : IDL.Opt(IDL.Principal),
+  });
+  const MergeMaturity = IDL.Record({ 'percentage_to_merge' : IDL.Nat32 });
+  const Amount = IDL.Record({ 'e8s' : IDL.Nat64 });
+  const Disburse = IDL.Record({
+    'to_account' : IDL.Opt(Account),
+    'amount' : IDL.Opt(Amount),
+  });
+  const Command_2 = IDL.Variant({
+    'Split' : Split,
+    'Follow' : Follow,
+    'DisburseMaturity' : DisburseMaturity,
+    'Configure' : Configure,
+    'RegisterVote' : RegisterVote,
+    'SyncCommand' : IDL.Record({}),
+    'MakeProposal' : Proposal,
+    'FinalizeDisburseMaturity' : FinalizeDisburseMaturity,
+    'ClaimOrRefreshNeuron' : ClaimOrRefresh,
+    'RemoveNeuronPermissions' : RemoveNeuronPermissions,
+    'AddNeuronPermissions' : AddNeuronPermissions,
+    'MergeMaturity' : MergeMaturity,
+    'Disburse' : Disburse,
+  });
+  const NeuronInFlightCommand = IDL.Record({
+    'command' : IDL.Opt(Command_2),
+    'timestamp' : IDL.Nat64,
+  });
+  const NeuronPermission = IDL.Record({
+    'principal' : IDL.Opt(IDL.Principal),
+    'permission_type' : IDL.Vec(IDL.Int32),
+  });
+  const DissolveState = IDL.Variant({
+    'DissolveDelaySeconds' : IDL.Nat64,
+    'WhenDissolvedTimestampSeconds' : IDL.Nat64,
+  });
+  const DisburseMaturityInProgress = IDL.Record({
+    'timestamp_of_disbursement_seconds' : IDL.Nat64,
+    'amount_e8s' : IDL.Nat64,
+    'account_to_disburse_to' : IDL.Opt(Account),
+  });
+  const Neuron = IDL.Record({
+    'id' : IDL.Opt(NeuronId),
+    'staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
+    'permissions' : IDL.Vec(NeuronPermission),
+    'maturity_e8s_equivalent' : IDL.Nat64,
+    'cached_neuron_stake_e8s' : IDL.Nat64,
+    'created_timestamp_seconds' : IDL.Nat64,
+    'source_nns_neuron_id' : IDL.Opt(IDL.Nat64),
+    'auto_stake_maturity' : IDL.Opt(IDL.Bool),
+    'aging_since_timestamp_seconds' : IDL.Nat64,
+    'dissolve_state' : IDL.Opt(DissolveState),
+    'voting_power_percentage_multiplier' : IDL.Nat64,
+    'vesting_period_seconds' : IDL.Opt(IDL.Nat64),
+    'disburse_maturity_in_progress' : IDL.Vec(DisburseMaturityInProgress),
+    'followees' : IDL.Vec(IDL.Tuple(IDL.Nat64, Followees)),
+    'neuron_fees_e8s' : IDL.Nat64,
+  });
+  const Governance = IDL.Record({
+    'root_canister_id' : IDL.Opt(IDL.Principal),
+    'id_to_nervous_system_functions' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, NervousSystemFunction)
+    ),
+    'metrics' : IDL.Opt(GovernanceCachedMetrics),
+    'maturity_modulation' : IDL.Opt(MaturityModulation),
+    'mode' : IDL.Int32,
+    'parameters' : IDL.Opt(NervousSystemParameters),
+    'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),
+    'deployed_version' : IDL.Opt(Version),
+    'sns_initialization_parameters' : IDL.Text,
+    'latest_reward_event' : IDL.Opt(RewardEvent),
+    'pending_version' : IDL.Opt(UpgradeInProgress),
+    'swap_canister_id' : IDL.Opt(IDL.Principal),
+    'ledger_canister_id' : IDL.Opt(IDL.Principal),
+    'proposals' : IDL.Vec(IDL.Tuple(IDL.Nat64, ProposalData)),
+    'in_flight_commands' : IDL.Vec(IDL.Tuple(IDL.Text, NeuronInFlightCommand)),
+    'sns_metadata' : IDL.Opt(ManageSnsMetadata),
+    'neurons' : IDL.Vec(IDL.Tuple(IDL.Text, Neuron)),
+    'genesis_timestamp_seconds' : IDL.Nat64,
+  });
+  const AddMaturityRequest = IDL.Record({
+    'id' : IDL.Opt(NeuronId),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const AddMaturityResponse = IDL.Record({
+    'new_maturity_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronParameters = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
+    'dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
+    'source_nns_neuron_id' : IDL.Opt(IDL.Nat64),
+    'stake_e8s' : IDL.Opt(IDL.Nat64),
+    'followees' : IDL.Vec(NeuronId),
+    'hotkey' : IDL.Opt(IDL.Principal),
+    'neuron_id' : IDL.Opt(NeuronId),
+  });
+  const ClaimSwapNeuronsRequest = IDL.Record({
+    'neuron_parameters' : IDL.Vec(NeuronParameters),
+  });
+  const SwapNeuron = IDL.Record({
+    'id' : IDL.Opt(NeuronId),
+    'status' : IDL.Int32,
+  });
+  const ClaimedSwapNeurons = IDL.Record({
+    'swap_neurons' : IDL.Vec(SwapNeuron),
+  });
+  const ClaimSwapNeuronsResult = IDL.Variant({
+    'Ok' : ClaimedSwapNeurons,
+    'Err' : IDL.Int32,
+  });
+  const ClaimSwapNeuronsResponse = IDL.Record({
+    'claim_swap_neurons_result' : IDL.Opt(ClaimSwapNeuronsResult),
+  });
+  const GetMaturityModulationResponse = IDL.Record({
+    'maturity_modulation' : IDL.Opt(MaturityModulation),
+  });
+  const GetMetadataResponse = IDL.Record({
+    'url' : IDL.Opt(IDL.Text),
+    'logo' : IDL.Opt(IDL.Text),
+    'name' : IDL.Opt(IDL.Text),
+    'description' : IDL.Opt(IDL.Text),
+  });
+  const GetModeResponse = IDL.Record({ 'mode' : IDL.Opt(IDL.Int32) });
+  const GetNeuron = IDL.Record({ 'neuron_id' : IDL.Opt(NeuronId) });
+  const Result = IDL.Variant({ 'Error' : GovernanceError, 'Neuron' : Neuron });
+  const GetNeuronResponse = IDL.Record({ 'result' : IDL.Opt(Result) });
+  const GetProposal = IDL.Record({ 'proposal_id' : IDL.Opt(ProposalId) });
+  const Result_1 = IDL.Variant({
+    'Error' : GovernanceError,
+    'Proposal' : ProposalData,
+  });
+  const GetProposalResponse = IDL.Record({ 'result' : IDL.Opt(Result_1) });
+  const CanisterStatusType = IDL.Variant({
+    'stopped' : IDL.Null,
+    'stopping' : IDL.Null,
+    'running' : IDL.Null,
+  });
+  const DefiniteCanisterSettingsArgs = IDL.Record({
+    'freezing_threshold' : IDL.Nat,
+    'controllers' : IDL.Vec(IDL.Principal),
+    'memory_allocation' : IDL.Nat,
+    'compute_allocation' : IDL.Nat,
+  });
+  const CanisterStatusResultV2 = IDL.Record({
+    'status' : CanisterStatusType,
+    'memory_size' : IDL.Nat,
+    'cycles' : IDL.Nat,
+    'settings' : DefiniteCanisterSettingsArgs,
+    'idle_cycles_burned_per_day' : IDL.Nat,
+    'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
+  const GetRunningSnsVersionResponse = IDL.Record({
+    'deployed_version' : IDL.Opt(Version),
+    'pending_version' : IDL.Opt(UpgradeInProgress),
+  });
+  const GetSnsInitializationParametersResponse = IDL.Record({
+    'sns_initialization_parameters' : IDL.Text,
+  });
+  const ListNervousSystemFunctionsResponse = IDL.Record({
+    'reserved_ids' : IDL.Vec(IDL.Nat64),
+    'functions' : IDL.Vec(NervousSystemFunction),
+  });
+  const ListNeurons = IDL.Record({
+    'of_principal' : IDL.Opt(IDL.Principal),
+    'limit' : IDL.Nat32,
+    'start_page_at' : IDL.Opt(NeuronId),
+  });
+  const ListNeuronsResponse = IDL.Record({ 'neurons' : IDL.Vec(Neuron) });
+  const ListProposals = IDL.Record({
+    'include_reward_status' : IDL.Vec(IDL.Int32),
+    'before_proposal' : IDL.Opt(ProposalId),
+    'limit' : IDL.Nat32,
+    'exclude_type' : IDL.Vec(IDL.Nat64),
+    'include_status' : IDL.Vec(IDL.Int32),
+  });
+  const ListProposalsResponse = IDL.Record({
+    'proposals' : IDL.Vec(ProposalData),
+  });
+  const StakeMaturity = IDL.Record({
+    'percentage_to_stake' : IDL.Opt(IDL.Nat32),
+  });
+  const Command = IDL.Variant({
+    'Split' : Split,
+    'Follow' : Follow,
+    'DisburseMaturity' : DisburseMaturity,
+    'ClaimOrRefresh' : ClaimOrRefresh,
+    'Configure' : Configure,
+    'RegisterVote' : RegisterVote,
+    'MakeProposal' : Proposal,
+    'StakeMaturity' : StakeMaturity,
+    'RemoveNeuronPermissions' : RemoveNeuronPermissions,
+    'AddNeuronPermissions' : AddNeuronPermissions,
+    'MergeMaturity' : MergeMaturity,
+    'Disburse' : Disburse,
+  });
+  const ManageNeuron = IDL.Record({
+    'subaccount' : IDL.Vec(IDL.Nat8),
+    'command' : IDL.Opt(Command),
+  });
+  const SplitResponse = IDL.Record({ 'created_neuron_id' : IDL.Opt(NeuronId) });
+  const DisburseMaturityResponse = IDL.Record({
+    'amount_disbursed_e8s' : IDL.Nat64,
+    'amount_deducted_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const ClaimOrRefreshResponse = IDL.Record({
+    'refreshed_neuron_id' : IDL.Opt(NeuronId),
+  });
+  const StakeMaturityResponse = IDL.Record({
+    'maturity_e8s' : IDL.Nat64,
+    'staked_maturity_e8s' : IDL.Nat64,
+  });
+  const MergeMaturityResponse = IDL.Record({
+    'merged_maturity_e8s' : IDL.Nat64,
+    'new_stake_e8s' : IDL.Nat64,
+  });
+  const DisburseResponse = IDL.Record({ 'transfer_block_height' : IDL.Nat64 });
+  const Command_1 = IDL.Variant({
+    'Error' : GovernanceError,
+    'Split' : SplitResponse,
+    'Follow' : IDL.Record({}),
+    'DisburseMaturity' : DisburseMaturityResponse,
+    'ClaimOrRefresh' : ClaimOrRefreshResponse,
+    'Configure' : IDL.Record({}),
+    'RegisterVote' : IDL.Record({}),
+    'MakeProposal' : GetProposal,
+    'RemoveNeuronPermission' : IDL.Record({}),
+    'StakeMaturity' : StakeMaturityResponse,
+    'MergeMaturity' : MergeMaturityResponse,
+    'Disburse' : DisburseResponse,
+    'AddNeuronPermission' : IDL.Record({}),
+  });
+  const ManageNeuronResponse = IDL.Record({ 'command' : IDL.Opt(Command_1) });
+  const MintTokensRequest = IDL.Record({
+    'recipient' : IDL.Opt(Account),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const SetMode = IDL.Record({ 'mode' : IDL.Int32 });
+  return IDL.Service({
+    'add_maturity' : IDL.Func([AddMaturityRequest], [AddMaturityResponse], []),
+    'claim_swap_neurons' : IDL.Func(
+        [ClaimSwapNeuronsRequest],
+        [ClaimSwapNeuronsResponse],
+        [],
+      ),
+    'fail_stuck_upgrade_in_progress' : IDL.Func(
+        [IDL.Record({})],
+        [IDL.Record({})],
+        [],
+      ),
+    'get_build_metadata' : IDL.Func([], [IDL.Text], ['query']),
+    'get_latest_reward_event' : IDL.Func([], [RewardEvent], ['query']),
+    'get_maturity_modulation' : IDL.Func(
+        [IDL.Record({})],
+        [GetMaturityModulationResponse],
+        [],
+      ),
+    'get_metadata' : IDL.Func(
+        [IDL.Record({})],
+        [GetMetadataResponse],
+        ['query'],
+      ),
+    'get_mode' : IDL.Func([IDL.Record({})], [GetModeResponse], ['query']),
+    'get_nervous_system_parameters' : IDL.Func(
+        [IDL.Null],
+        [NervousSystemParameters],
+        ['query'],
+      ),
+    'get_neuron' : IDL.Func([GetNeuron], [GetNeuronResponse], ['query']),
+    'get_proposal' : IDL.Func([GetProposal], [GetProposalResponse], ['query']),
+    'get_root_canister_status' : IDL.Func(
+        [IDL.Null],
+        [CanisterStatusResultV2],
+        [],
+      ),
+    'get_running_sns_version' : IDL.Func(
+        [IDL.Record({})],
+        [GetRunningSnsVersionResponse],
+        ['query'],
+      ),
+    'get_sns_initialization_parameters' : IDL.Func(
+        [IDL.Record({})],
+        [GetSnsInitializationParametersResponse],
+        ['query'],
+      ),
+    'list_nervous_system_functions' : IDL.Func(
+        [],
+        [ListNervousSystemFunctionsResponse],
+        ['query'],
+      ),
+    'list_neurons' : IDL.Func([ListNeurons], [ListNeuronsResponse], ['query']),
+    'list_proposals' : IDL.Func(
+        [ListProposals],
+        [ListProposalsResponse],
+        ['query'],
+      ),
+    'manage_neuron' : IDL.Func([ManageNeuron], [ManageNeuronResponse], []),
+    'mint_tokens' : IDL.Func([MintTokensRequest], [IDL.Record({})], []),
+    'set_mode' : IDL.Func([SetMode], [IDL.Record({})], []),
+    'update_neuron' : IDL.Func([Neuron], [IDL.Opt(GovernanceError)], []),
+  });
+};
+export const init = ({ IDL }) => {
+  const GenericNervousSystemFunction = IDL.Record({
+    'validator_canister_id' : IDL.Opt(IDL.Principal),
+    'target_canister_id' : IDL.Opt(IDL.Principal),
+    'validator_method_name' : IDL.Opt(IDL.Text),
+    'target_method_name' : IDL.Opt(IDL.Text),
+  });
+  const FunctionType = IDL.Variant({
+    'NativeNervousSystemFunction' : IDL.Record({}),
+    'GenericNervousSystemFunction' : GenericNervousSystemFunction,
+  });
+  const NervousSystemFunction = IDL.Record({
+    'id' : IDL.Nat64,
+    'name' : IDL.Text,
+    'description' : IDL.Opt(IDL.Text),
+    'function_type' : IDL.Opt(FunctionType),
+  });
+  const GovernanceCachedMetrics = IDL.Record({
+    'not_dissolving_neurons_e8s_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'garbage_collectable_neurons_count' : IDL.Nat64,
+    'neurons_with_invalid_stake_count' : IDL.Nat64,
+    'not_dissolving_neurons_count_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Nat64)
+    ),
+    'neurons_with_less_than_6_months_dissolve_delay_count' : IDL.Nat64,
+    'dissolved_neurons_count' : IDL.Nat64,
+    'total_staked_e8s' : IDL.Nat64,
+    'total_supply_governance_tokens' : IDL.Nat64,
+    'not_dissolving_neurons_count' : IDL.Nat64,
+    'dissolved_neurons_e8s' : IDL.Nat64,
+    'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
+    'dissolving_neurons_count_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Nat64)
+    ),
+    'dissolving_neurons_count' : IDL.Nat64,
+    'dissolving_neurons_e8s_buckets' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'timestamp_seconds' : IDL.Nat64,
+  });
+  const MaturityModulation = IDL.Record({
+    'current_basis_points' : IDL.Opt(IDL.Int32),
+    'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
+  const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
+  const DefaultFollowees = IDL.Record({
+    'followees' : IDL.Vec(IDL.Tuple(IDL.Nat64, Followees)),
+  });
+  const NeuronPermissionList = IDL.Record({
+    'permissions' : IDL.Vec(IDL.Int32),
+  });
+  const VotingRewardsParameters = IDL.Record({
+    'final_reward_rate_basis_points' : IDL.Opt(IDL.Nat64),
+    'initial_reward_rate_basis_points' : IDL.Opt(IDL.Nat64),
+    'reward_rate_transition_duration_seconds' : IDL.Opt(IDL.Nat64),
+    'round_duration_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const NervousSystemParameters = IDL.Record({
+    'default_followees' : IDL.Opt(DefaultFollowees),
+    'max_dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
+    'max_dissolve_delay_bonus_percentage' : IDL.Opt(IDL.Nat64),
+    'max_followees_per_function' : IDL.Opt(IDL.Nat64),
+    'neuron_claimer_permissions' : IDL.Opt(NeuronPermissionList),
+    'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
+    'max_neuron_age_for_age_bonus' : IDL.Opt(IDL.Nat64),
+    'initial_voting_period_seconds' : IDL.Opt(IDL.Nat64),
+    'neuron_minimum_dissolve_delay_to_vote_seconds' : IDL.Opt(IDL.Nat64),
+    'reject_cost_e8s' : IDL.Opt(IDL.Nat64),
+    'max_proposals_to_keep_per_action' : IDL.Opt(IDL.Nat32),
+    'wait_for_quiet_deadline_increase_seconds' : IDL.Opt(IDL.Nat64),
+    'max_number_of_neurons' : IDL.Opt(IDL.Nat64),
+    'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
+    'max_number_of_proposals_with_ballots' : IDL.Opt(IDL.Nat64),
+    'max_age_bonus_percentage' : IDL.Opt(IDL.Nat64),
+    'neuron_grantable_permissions' : IDL.Opt(NeuronPermissionList),
+    'voting_rewards_parameters' : IDL.Opt(VotingRewardsParameters),
+    'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
+    'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
+  });
+  const Version = IDL.Record({
+    'archive_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'root_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'swap_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'ledger_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'governance_wasm_hash' : IDL.Vec(IDL.Nat8),
+    'index_wasm_hash' : IDL.Vec(IDL.Nat8),
+  });
+  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
+  const RewardEvent = IDL.Record({
+    'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
+    'actual_timestamp_seconds' : IDL.Nat64,
+    'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'distributed_e8s_equivalent' : IDL.Nat64,
+    'round' : IDL.Nat64,
+    'settled_proposals' : IDL.Vec(ProposalId),
+  });
+  const UpgradeInProgress = IDL.Record({
+    'mark_failed_at_seconds' : IDL.Nat64,
+    'checking_upgrade_lock' : IDL.Nat64,
+    'proposal_id' : IDL.Nat64,
+    'target_version' : IDL.Opt(Version),
+  });
+  const GovernanceError = IDL.Record({
+    'error_message' : IDL.Text,
+    'error_type' : IDL.Int32,
+  });
+  const Ballot = IDL.Record({
+    'vote' : IDL.Int32,
+    'cast_timestamp_seconds' : IDL.Nat64,
+    'voting_power' : IDL.Nat64,
+  });
+  const Tally = IDL.Record({
+    'no' : IDL.Nat64,
+    'yes' : IDL.Nat64,
+    'total' : IDL.Nat64,
+    'timestamp_seconds' : IDL.Nat64,
+  });
+  const RegisterDappCanisters = IDL.Record({
+    'canister_ids' : IDL.Vec(IDL.Principal),
+  });
+  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
+  const TransferSnsTreasuryFunds = IDL.Record({
+    'from_treasury' : IDL.Int32,
+    'to_principal' : IDL.Opt(IDL.Principal),
+    'to_subaccount' : IDL.Opt(Subaccount),
+    'memo' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Nat64,
+  });
+  const UpgradeSnsControlledCanister = IDL.Record({
+    'new_canister_wasm' : IDL.Vec(IDL.Nat8),
+    'mode' : IDL.Opt(IDL.Int32),
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
+  const DeregisterDappCanisters = IDL.Record({
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'new_controllers' : IDL.Vec(IDL.Principal),
+  });
+  const ManageSnsMetadata = IDL.Record({
+    'url' : IDL.Opt(IDL.Text),
+    'logo' : IDL.Opt(IDL.Text),
+    'name' : IDL.Opt(IDL.Text),
+    'description' : IDL.Opt(IDL.Text),
+  });
+  const ExecuteGenericNervousSystemFunction = IDL.Record({
+    'function_id' : IDL.Nat64,
+    'payload' : IDL.Vec(IDL.Nat8),
+  });
+  const Motion = IDL.Record({ 'motion_text' : IDL.Text });
+  const Action = IDL.Variant({
+    'ManageNervousSystemParameters' : NervousSystemParameters,
+    'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'RemoveGenericNervousSystemFunction' : IDL.Nat64,
+    'UpgradeSnsToNextVersion' : IDL.Record({}),
+    'RegisterDappCanisters' : RegisterDappCanisters,
+    'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
+    'UpgradeSnsControlledCanister' : UpgradeSnsControlledCanister,
+    'DeregisterDappCanisters' : DeregisterDappCanisters,
+    'Unspecified' : IDL.Record({}),
+    'ManageSnsMetadata' : ManageSnsMetadata,
+    'ExecuteGenericNervousSystemFunction' : ExecuteGenericNervousSystemFunction,
+    'Motion' : Motion,
+  });
+  const Proposal = IDL.Record({
+    'url' : IDL.Text,
+    'title' : IDL.Text,
+    'action' : IDL.Opt(Action),
+    'summary' : IDL.Text,
+  });
+  const WaitForQuietState = IDL.Record({
+    'current_deadline_timestamp_seconds' : IDL.Nat64,
+  });
+  const ProposalData = IDL.Record({
+    'id' : IDL.Opt(ProposalId),
+    'payload_text_rendering' : IDL.Opt(IDL.Text),
+    'action' : IDL.Nat64,
+    'failure_reason' : IDL.Opt(GovernanceError),
+    'ballots' : IDL.Vec(IDL.Tuple(IDL.Text, Ballot)),
+    'reward_event_round' : IDL.Nat64,
+    'failed_timestamp_seconds' : IDL.Nat64,
+    'reward_event_end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'proposal_creation_timestamp_seconds' : IDL.Nat64,
+    'initial_voting_period_seconds' : IDL.Nat64,
+    'reject_cost_e8s' : IDL.Nat64,
+    'latest_tally' : IDL.Opt(Tally),
+    'wait_for_quiet_deadline_increase_seconds' : IDL.Nat64,
+    'decided_timestamp_seconds' : IDL.Nat64,
+    'proposal' : IDL.Opt(Proposal),
+    'proposer' : IDL.Opt(NeuronId),
+    'wait_for_quiet_state' : IDL.Opt(WaitForQuietState),
+    'is_eligible_for_rewards' : IDL.Bool,
+    'executed_timestamp_seconds' : IDL.Nat64,
+  });
+  const Split = IDL.Record({ 'memo' : IDL.Nat64, 'amount_e8s' : IDL.Nat64 });
+  const Follow = IDL.Record({
+    'function_id' : IDL.Nat64,
+    'followees' : IDL.Vec(NeuronId),
+  });
+  const Account = IDL.Record({
+    'owner' : IDL.Opt(IDL.Principal),
+    'subaccount' : IDL.Opt(Subaccount),
+  });
+  const DisburseMaturity = IDL.Record({
+    'to_account' : IDL.Opt(Account),
+    'percentage_to_disburse' : IDL.Nat32,
+  });
+  const ChangeAutoStakeMaturity = IDL.Record({
+    'requested_setting_for_auto_stake_maturity' : IDL.Bool,
+  });
+  const IncreaseDissolveDelay = IDL.Record({
+    'additional_dissolve_delay_seconds' : IDL.Nat32,
+  });
+  const SetDissolveTimestamp = IDL.Record({
+    'dissolve_timestamp_seconds' : IDL.Nat64,
+  });
+  const Operation = IDL.Variant({
+    'ChangeAutoStakeMaturity' : ChangeAutoStakeMaturity,
+    'StopDissolving' : IDL.Record({}),
+    'StartDissolving' : IDL.Record({}),
+    'IncreaseDissolveDelay' : IncreaseDissolveDelay,
+    'SetDissolveTimestamp' : SetDissolveTimestamp,
+  });
+  const Configure = IDL.Record({ 'operation' : IDL.Opt(Operation) });
+  const RegisterVote = IDL.Record({
+    'vote' : IDL.Int32,
+    'proposal' : IDL.Opt(ProposalId),
+  });
+  const FinalizeDisburseMaturity = IDL.Record({
+    'amount_to_be_disbursed_e8s' : IDL.Nat64,
+    'to_account' : IDL.Opt(Account),
+  });
+  const MemoAndController = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
+    'memo' : IDL.Nat64,
+  });
+  const By = IDL.Variant({
+    'MemoAndController' : MemoAndController,
+    'NeuronId' : IDL.Record({}),
+  });
+  const ClaimOrRefresh = IDL.Record({ 'by' : IDL.Opt(By) });
+  const RemoveNeuronPermissions = IDL.Record({
+    'permissions_to_remove' : IDL.Opt(NeuronPermissionList),
+    'principal_id' : IDL.Opt(IDL.Principal),
+  });
+  const AddNeuronPermissions = IDL.Record({
+    'permissions_to_add' : IDL.Opt(NeuronPermissionList),
+    'principal_id' : IDL.Opt(IDL.Principal),
+  });
+  const MergeMaturity = IDL.Record({ 'percentage_to_merge' : IDL.Nat32 });
+  const Amount = IDL.Record({ 'e8s' : IDL.Nat64 });
+  const Disburse = IDL.Record({
+    'to_account' : IDL.Opt(Account),
+    'amount' : IDL.Opt(Amount),
+  });
+  const Command_2 = IDL.Variant({
+    'Split' : Split,
+    'Follow' : Follow,
+    'DisburseMaturity' : DisburseMaturity,
+    'Configure' : Configure,
+    'RegisterVote' : RegisterVote,
+    'SyncCommand' : IDL.Record({}),
+    'MakeProposal' : Proposal,
+    'FinalizeDisburseMaturity' : FinalizeDisburseMaturity,
+    'ClaimOrRefreshNeuron' : ClaimOrRefresh,
+    'RemoveNeuronPermissions' : RemoveNeuronPermissions,
+    'AddNeuronPermissions' : AddNeuronPermissions,
+    'MergeMaturity' : MergeMaturity,
+    'Disburse' : Disburse,
+  });
+  const NeuronInFlightCommand = IDL.Record({
+    'command' : IDL.Opt(Command_2),
+    'timestamp' : IDL.Nat64,
+  });
+  const NeuronPermission = IDL.Record({
+    'principal' : IDL.Opt(IDL.Principal),
+    'permission_type' : IDL.Vec(IDL.Int32),
+  });
+  const DissolveState = IDL.Variant({
+    'DissolveDelaySeconds' : IDL.Nat64,
+    'WhenDissolvedTimestampSeconds' : IDL.Nat64,
+  });
+  const DisburseMaturityInProgress = IDL.Record({
+    'timestamp_of_disbursement_seconds' : IDL.Nat64,
+    'amount_e8s' : IDL.Nat64,
+    'account_to_disburse_to' : IDL.Opt(Account),
+  });
+  const Neuron = IDL.Record({
+    'id' : IDL.Opt(NeuronId),
+    'staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
+    'permissions' : IDL.Vec(NeuronPermission),
+    'maturity_e8s_equivalent' : IDL.Nat64,
+    'cached_neuron_stake_e8s' : IDL.Nat64,
+    'created_timestamp_seconds' : IDL.Nat64,
+    'source_nns_neuron_id' : IDL.Opt(IDL.Nat64),
+    'auto_stake_maturity' : IDL.Opt(IDL.Bool),
+    'aging_since_timestamp_seconds' : IDL.Nat64,
+    'dissolve_state' : IDL.Opt(DissolveState),
+    'voting_power_percentage_multiplier' : IDL.Nat64,
+    'vesting_period_seconds' : IDL.Opt(IDL.Nat64),
+    'disburse_maturity_in_progress' : IDL.Vec(DisburseMaturityInProgress),
+    'followees' : IDL.Vec(IDL.Tuple(IDL.Nat64, Followees)),
+    'neuron_fees_e8s' : IDL.Nat64,
+  });
+  const Governance = IDL.Record({
+    'root_canister_id' : IDL.Opt(IDL.Principal),
+    'id_to_nervous_system_functions' : IDL.Vec(
+      IDL.Tuple(IDL.Nat64, NervousSystemFunction)
+    ),
+    'metrics' : IDL.Opt(GovernanceCachedMetrics),
+    'maturity_modulation' : IDL.Opt(MaturityModulation),
+    'mode' : IDL.Int32,
+    'parameters' : IDL.Opt(NervousSystemParameters),
+    'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),
+    'deployed_version' : IDL.Opt(Version),
+    'sns_initialization_parameters' : IDL.Text,
+    'latest_reward_event' : IDL.Opt(RewardEvent),
+    'pending_version' : IDL.Opt(UpgradeInProgress),
+    'swap_canister_id' : IDL.Opt(IDL.Principal),
+    'ledger_canister_id' : IDL.Opt(IDL.Principal),
+    'proposals' : IDL.Vec(IDL.Tuple(IDL.Nat64, ProposalData)),
+    'in_flight_commands' : IDL.Vec(IDL.Tuple(IDL.Text, NeuronInFlightCommand)),
+    'sns_metadata' : IDL.Opt(ManageSnsMetadata),
+    'neurons' : IDL.Vec(IDL.Tuple(IDL.Text, Neuron)),
+    'genesis_timestamp_seconds' : IDL.Nat64,
+  });
+  return [Governance];
+};

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -1165,7 +1165,14 @@ describe("Governance canister", () => {
 
       const service = mock<ActorSubclass<SnsGovernanceService>>();
       service.manage_neuron.mockResolvedValue({
-        command: [{ DisburseMaturity: { amount_disbursed_e8s: BigInt(0) } }],
+        command: [
+          {
+            DisburseMaturity: {
+              amount_disbursed_e8s: BigInt(0),
+              amount_deducted_e8s: [BigInt(0)],
+            },
+          },
+        ],
       });
 
       const canister = SnsGovernanceCanister.create({

--- a/packages/sns/src/governance_test.canister.ts
+++ b/packages/sns/src/governance_test.canister.ts
@@ -13,7 +13,7 @@ import { idlFactory as certifiedIdlFactory } from "../candid/sns_governance_test
 import { idlFactory } from "../candid/sns_governance_test.idl";
 import { SnsGovernanceError } from "./errors/governance.errors";
 import type { SnsCanisterOptions } from "./types/canister.options";
-import { SnsAddMaturityParams } from "./types/governance_test.params";
+import type { SnsAddMaturityParams } from "./types/governance_test.params";
 
 export class SnsGovernanceTestCanister extends Canister<SnsGovernanceTestService> {
   /**

--- a/packages/sns/src/governance_test.canister.ts
+++ b/packages/sns/src/governance_test.canister.ts
@@ -33,7 +33,7 @@ export class SnsGovernanceTestCanister extends Canister<SnsGovernanceTestService
   }
 
   /**
-   * List the neurons of the Sns
+   * Add maturity to a neuron (only for testing purposes. Testnet only.)
    */
   addMaturity = async (params: SnsAddMaturityParams): Promise<void> => {
     const { id, amountE8s } = params;

--- a/packages/sns/src/governance_test.canister.ts
+++ b/packages/sns/src/governance_test.canister.ts
@@ -1,0 +1,51 @@
+import {
+  Canister,
+  createServices,
+  fromNullable,
+  isNullish,
+  toNullable,
+} from "@dfinity/utils";
+import type {
+  NeuronId,
+  _SERVICE as SnsGovernanceTestService,
+} from "../candid/sns_governance_test";
+import { idlFactory as certifiedIdlFactory } from "../candid/sns_governance_test.certified.idl";
+import { idlFactory } from "../candid/sns_governance_test.idl";
+import { SnsGovernanceError } from "./errors/governance.errors";
+import type { SnsCanisterOptions } from "./types/canister.options";
+import { SnsAddMaturityParams } from "./types/governance_test.params";
+
+export class SnsGovernanceTestCanister extends Canister<SnsGovernanceTestService> {
+  /**
+   * Instantiate a canister to interact with the governance of a Sns project.
+   *
+   * @param {SnsCanisterOptions} options Miscellaneous options to initialize the canister. Its ID being the only mandatory parammeter.
+   */
+  static create(options: SnsCanisterOptions<SnsGovernanceTestService>) {
+    const { service, certifiedService, canisterId } =
+      createServices<SnsGovernanceTestService>({
+        options,
+        idlFactory,
+        certifiedIdlFactory,
+      });
+
+    return new SnsGovernanceTestCanister(canisterId, service, certifiedService);
+  }
+
+  /**
+   * List the neurons of the Sns
+   */
+  addMaturity = async (params: SnsAddMaturityParams): Promise<void> => {
+    const { id, amountE8s } = params;
+
+    const { new_maturity_e8s } = await this.caller(params).add_maturity({
+      id: toNullable<NeuronId>(id),
+      amount_e8s: toNullable(amountE8s),
+    });
+    const newMaturity = fromNullable(new_maturity_e8s);
+
+    if (isNullish(newMaturity) || newMaturity < amountE8s) {
+      throw new SnsGovernanceError("No maturity added");
+    }
+  };
+}

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -46,6 +46,7 @@ export * from "./errors/common.errors";
 export * from "./errors/governance.errors";
 export * from "./errors/swap.errors";
 export { SnsGovernanceCanister } from "./governance.canister";
+export { SnsGovernanceTestCanister } from "./governance_test.canister";
 export { SnsRootCanister } from "./root.canister";
 export * from "./sns";
 export * from "./sns.wrapper";

--- a/packages/sns/src/types/governance_test.params.ts
+++ b/packages/sns/src/types/governance_test.params.ts
@@ -1,0 +1,8 @@
+import type { QueryParams } from "@dfinity/utils";
+import type { NeuronId } from "../../candid/sns_governance";
+import type { E8s } from "./common";
+
+export interface SnsAddMaturityParams extends QueryParams {
+  id: NeuronId;
+  amountE8s: E8s;
+}

--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -64,6 +64,7 @@ mkdir -p packages/sns/candid
 import_did "rs/sns/swap/canister/swap.did" "sns_swap.did" "sns"
 import_did "rs/sns/root/canister/root.did" "sns_root.did" "sns"
 import_did "rs/sns/governance/canister/governance.did" "sns_governance.did" "sns"
+import_did "rs/sns/governance/canister/governance_test.did" "sns_governance_test.did" "sns"
 
 mkdir -p packages/cmc/candid
 import_did "rs/nns/cmc/cmc.did" "cmc.did" "cmc"


### PR DESCRIPTION
# Motivation

Add `addMaturity` test function.
Replacement of https://github.com/dfinity/ic-js/pull/406
The only disadvantage is the package size changes +23% vs +0.98%

# Changes

- add sns/governance_test candid file (4fbe776aeea08222b8b47f5f2902fe77b58b7150)
- update sns/governance candid file to keep both (standard and _test) in sync (4fbe776aeea08222b8b47f5f2902fe77b58b7150)
- related ids
- SnsGovernanceTestCanister
- addMaturity function

# Tests

Manually tested. No unit tests because of the dev usage only.
