### PR TITLE
Group tests properly in governance.canister.spec.ts

### DIFF
--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -82,7 +82,6 @@ describe("GovernanceCanister", () => {
     jest.clearAllMocks();
   });
 
-  // TODO: Take out tests from "listKnownNeurons" describe
   describe("GovernanceCanister.listKnownNeurons", () => {
     it("populates all KnownNeuron fields correctly", async () => {
       const response: ListKnownNeuronsResponse = {
@@ -163,7 +162,9 @@ describe("GovernanceCanister", () => {
 
       expect(res.map((n) => Number(n.id))).toEqual([100, 200, 300, 400]);
     });
+  });
 
+  describe("GovernanceCanister.stakeNeuron", () => {
     it("creates new neuron successfully", async () => {
       const neuronId = BigInt(10);
       const serviceResponse: ManageNeuronResponse = {
@@ -288,52 +289,54 @@ describe("GovernanceCanister", () => {
         new InsufficientAmountError(BigInt(10_000_000)),
       );
     });
+  });
 
-    describe("listNeurons", () => {
-      it("list user neurons", async () => {
-        const service = mock<ActorSubclass<GovernanceService>>();
-        service.list_neurons.mockResolvedValue(mockListNeuronsResponse);
+  describe("GovernanceCanister.listNeurons", () => {
+    it("list user neurons", async () => {
+      const service = mock<ActorSubclass<GovernanceService>>();
+      service.list_neurons.mockResolvedValue(mockListNeuronsResponse);
 
-        const governance = GovernanceCanister.create({
-          certifiedServiceOverride: service,
-          serviceOverride: service,
-        });
-        const neurons = await governance.listNeurons({
-          certified: true,
-        });
-        expect(service.list_neurons).toBeCalled();
-        expect(neurons.length).toBe(1);
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
       });
-
-      it("list Hardware Wallet neurons", async () => {
-        const agent = mock<Agent>();
-        agent.call.mockResolvedValue(agentCallSuccessfulResponse);
-
-        const governance = GovernanceCanister.create({
-          agent,
-          hardwareWallet: true,
-        });
-        await governance.listNeurons({ certified: true });
-        expect(agent.call).toBeCalled();
-        expect(spyPollForResponse).toBeCalled();
+      const neurons = await governance.listNeurons({
+        certified: true,
       });
-
-      it("should not support query neurons with hardware wallet (only update calls)", async () => {
-        const agent = mock<Agent>();
-        agent.call.mockResolvedValue(agentCallSuccessfulResponse);
-
-        const governance = GovernanceCanister.create({
-          agent,
-          hardwareWallet: true,
-        });
-
-        const call = async () =>
-          await governance.listNeurons({ certified: false });
-
-        await expect(call).rejects.toThrow(new FeatureNotSupportedError());
-      });
+      expect(service.list_neurons).toBeCalled();
+      expect(neurons.length).toBe(1);
     });
 
+    it("list Hardware Wallet neurons", async () => {
+      const agent = mock<Agent>();
+      agent.call.mockResolvedValue(agentCallSuccessfulResponse);
+
+      const governance = GovernanceCanister.create({
+        agent,
+        hardwareWallet: true,
+      });
+      await governance.listNeurons({ certified: true });
+      expect(agent.call).toBeCalled();
+      expect(spyPollForResponse).toBeCalled();
+    });
+
+    it("should not support query neurons with hardware wallet (only update calls)", async () => {
+      const agent = mock<Agent>();
+      agent.call.mockResolvedValue(agentCallSuccessfulResponse);
+
+      const governance = GovernanceCanister.create({
+        agent,
+        hardwareWallet: true,
+      });
+
+      const call = async () =>
+        await governance.listNeurons({ certified: false });
+
+      await expect(call).rejects.toThrow(new FeatureNotSupportedError());
+    });
+  });
+
+  describe("GovernanceCanister.registerVote", () => {
     it("registers vote successfully", async () => {
       const serviceResponse: ManageNeuronResponse = {
         command: [{ RegisterVote: {} }],
@@ -392,7 +395,9 @@ describe("GovernanceCanister", () => {
         new GovernanceError(unexpectedGovernanceError),
       );
     });
+  });
 
+  describe("GovernanceCanister.getNeuron", () => {
     it("should fetch and convert a neuron", async () => {
       const service = mock<ActorSubclass<GovernanceService>>();
       const governance = GovernanceCanister.create({


### PR DESCRIPTION
# Motivation

In `governance.canister.spec.ts`, the `describe` block of `listKnownNeurons` has lots of tests that are not about `listKnownNeurons`.
There is also a TODO to fix this from May 2022.

# Changes

Group tests by tested method.

# Tests

Pass and the grouping looks like this in the output of `npm run test`:
``` PASS  src/governance.canister.spec.ts
  GovernanceCanister
    GovernanceCanister.listKnownNeurons
      ✓ populates all KnownNeuron fields correctly (10 ms)
      ✓ handles description being undefined (6 ms)
      ✓ returns all KnownNeurons returned by the Governance canister (4 ms)
    GovernanceCanister.stakeNeuron
      ✓ creates new neuron successfully (6 ms)
      ✓ stakeNeuron passes fee to the ledger transfer (5 ms)
      ✓ creates new neuron from subaccount successfully (5 ms)
      ✓ returns insufficient amount errors (31 ms)
    GovernanceCanister.listNeurons
      ✓ list user neurons
      ✓ list Hardware Wallet neurons (9 ms)
      ✓ should not support query neurons with hardware wallet (only update calls) (10 ms)
    GovernanceCanister.registerVote
      ✓ registers vote successfully (4 ms)
      ✓ throw error when registers vote fails with error (10 ms)
      ✓ throw error when registers vote fails unexpectedly (5 ms)
    GovernanceCanister.getNeuron
      ✓ should fetch and convert a neuron (1 ms)
    GovernanceCanister.getProposal
      ✓ should fetch and convert single ProposalInfo (1 ms)
    GovernanceCanister.claimOrRefreshNeuronFromAccount
      ✓ returns successfully neuron id (5 ms)
      ✓ throws in unexpected response (5 ms)
    GovernanceCanister.increaseDissolveDelay
      ✓ increases dissolve delay of the neuron successfully (4 ms)
      ✓ increases dissolve delay of the neuron from a Hardware Wallet successfully (9 ms)
      ✓ throw error when increaseDissolveDelay fails with error (5 ms)
      ✓ throw error when increaseDissolveDelay fails unexpectedly (4 ms)
    GovernanceCanister.setDissolveDelay
      ✓ sets dissolve delay of the neuron successfully (4 ms)
      ✓ throw error when setDissolveDelay fails with error (4 ms)
      ✓ throw error when setDissolveDelay fails unexpectedly (4 ms)
    GovernanceCanister.setNodeProviderAccount
      ✓ sets node provider reward account successfully (5 ms)
      ✓ throw error when update_node_provider returns error (4 ms)
      ✓ throw error when account is not valid (5 ms)
    GovernanceCanister.setFollowees
      ✓ sets followees successfully (4 ms)
      ✓ throw error when setFollowees fails with error (4 ms)
      ✓ throw error when setFollowees fails unexpectedly (5 ms)
    GovernanceCanister.claimOrRefreshNeuron
      ✓ successfully claims or refreshes (4 ms)
      ✓ throws error if response does not match (4 ms)
    GovernanceCanister.joinCommunityFund
      ✓ successfully joins community fund (4 ms)
      ✓ successfully joins CF from Hardware Wallet (8 ms)
      ✓ throws error if response is error (4 ms)
    GovernanceCanister.leaveCommunityFund
      ✓ successfully leaves community fund (4 ms)
      ✓ throws error if response is error (4 ms)
    GovernanceCanister.autoStakeMaturity
      ✓ successfully auto stake maturity (4 ms)
      ✓ should convert auto stake parameter (5 ms)
      ✓ throws error if response is error (5 ms)
    GovernanceCanister.addHotkey
      ✓ successfully adds hotkey to neuron (4 ms)
      ✓ successfully adds hotkey to neuron from Hardware Wallet (9 ms)
      ✓ throws error if response is error (4 ms)
    GovernanceCanister.removeHotkey
      ✓ successfully removes hotkey to neuron (5 ms)
      ✓ successfully removes hotkey to neuron from Hardware Wallet (9 ms)
      ✓ throws error if response is error (4 ms)
    GovernanceCanister.mergeNeurons
      ✓ successfully merges two neurons (4 ms)
      ✓ throws error if response is error (5 ms)
    GovernanceCanister.simulateMergeNeurons
      ✓ successfully simulate merging two neurons (5 ms)
      ✓ throws error if response is error (4 ms)
    GovernanceCanister.mergeMaturity
      ✓ successfully merges maturity neurons (4 ms)
      ✓ successfully merges maturity neurons from Hardware Wallet (10 ms)
      ✓ throws error if percentage not valid (6 ms)
      ✓ throws error if response is error (4 ms)
    GovernanceCanister.stakeMaturity
      ✓ successfully stake maturity for neuron (4 ms)
      ✓ should stake maturity for neuron with no percentage (5 ms)
      ✓ throws error if percentage not valid (6 ms)
      ✓ throws error if response is error (4 ms)
    GovernanceCanister.spawnNeuron
      ✓ successfully spawns new neuron (4 ms)
      ✓ successfully spawns new neuron from Hardware Wallet (8 ms)
      ✓ throws error if percentage not valid (5 ms)
      ✓ throws error if response is error (4 ms)
    GovernanceCanister.disburse
      ✓ successfully disburses neuron (4 ms)
      ✓ successfully disburses neuron from Hardware Wallet (8 ms)
      ✓ throws error if response is error (5 ms)
      ✓ throws error if invalid account id (4 ms)
    GovernanceCanister.splitNeuron
      ✓ successfully splits neuron (4 ms)
      ✓ throws error if response is error (4 ms)
    GovernanceCanister.startDissolving
      ✓ successfully starts dissolving process (4 ms)
      ✓ successfully starts dissolving process from Hardware Wallet (9 ms)
      ✓ throws error if response is error (4 ms)
    GovernanceCanister.stopDissolving
      ✓ successfully stops dissolving process (4 ms)
      ✓ successfully stops dissolving process from Hardware Wallet (9 ms)
      ✓ throws error if response is error (4 ms)
    GovernanceCanister.makeProposal
      ✓ successfully creates a proposal (5 ms)
      ✓ throws error if response is error (4 ms)
    getLastestRewardEvent
      ✓ gets the latest reward event
```
