### PR TITLE
Add icrc1Transfer method to ICP ledger canister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - add support for `icrc2_transfer_from`, `icrc2_approve` and `icrc2_allowance` in `@dfinity/ledger`
 - update index did definitions in ledger which provides more information in the transactions
+- add support for icrc1_transfer on the ICP ledger canister in `@dfinity/nss`
 
 ## Build
 

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -259,7 +259,7 @@ Parameters:
 
 ### :factory: LedgerCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/ledger.canister.ts#L27)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/ledger.canister.ts#L32)
 
 #### Methods
 
@@ -267,6 +267,7 @@ Parameters:
 - [accountBalance](#gear-accountbalance)
 - [transactionFee](#gear-transactionfee)
 - [transfer](#gear-transfer)
+- [icrc1Transfer](#gear-icrc1transfer)
 
 ##### :gear: create
 
@@ -274,7 +275,7 @@ Parameters:
 | -------- | ----------------------------------------------------- |
 | `create` | `(options?: LedgerCanisterOptions) => LedgerCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/ledger.canister.ts#L38)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/ledger.canister.ts#L43)
 
 ##### :gear: accountBalance
 
@@ -287,7 +288,7 @@ it is fetched using a query call.
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `accountBalance` | `({ accountIdentifier, certified, }: { accountIdentifier: AccountIdentifier; certified?: boolean; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/ledger.canister.ts#L70)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/ledger.canister.ts#L75)
 
 ##### :gear: transactionFee
 
@@ -297,7 +298,7 @@ Returns the transaction fee of the ledger canister
 | ---------------- | ----------------------- |
 | `transactionFee` | `() => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/ledger.canister.ts#L94)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/ledger.canister.ts#L99)
 
 ##### :gear: transfer
 
@@ -308,7 +309,18 @@ Returns the index of the block containing the tx if it was successful.
 | ---------- | ----------------------------------------------- |
 | `transfer` | `(request: TransferRequest) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/ledger.canister.ts#L107)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/ledger.canister.ts#L112)
+
+##### :gear: icrc1Transfer
+
+Transfer ICP from the caller to the destination `Account`.
+Returns the index of the block containing the tx if it was successful.
+
+| Method          | Type                                                 |
+| --------------- | ---------------------------------------------------- |
+| `icrc1Transfer` | `(request: Icrc1TransferRequest) => Promise<bigint>` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/ledger.canister.ts#L137)
 
 ### :factory: GovernanceCanister
 

--- a/packages/nns/src/canisters/ledger/ledger.request.converts.ts
+++ b/packages/nns/src/canisters/ledger/ledger.request.converts.ts
@@ -1,11 +1,15 @@
 import type { ICPTs, Subaccount } from "@dfinity/nns-proto";
-import { arrayOfNumberToUint8Array } from "@dfinity/utils";
+import { arrayOfNumberToUint8Array, toNullable } from "@dfinity/utils";
 import type {
   Tokens,
+  TransferArg as Icrc1TransferRawRequest,
   TransferArgs as TransferRawRequest,
 } from "../../../candid/ledger";
 import { TRANSACTION_FEE } from "../../constants/constants";
-import type { TransferRequest } from "../../types/ledger_converters";
+import type {
+  Icrc1TransferRequest,
+  TransferRequest,
+} from "../../types/ledger_converters";
 import { importNnsProto } from "../../utils/proto.utils";
 
 export const subAccountNumbersToSubaccount = async (
@@ -48,23 +52,19 @@ export const toTransferRawRequest = ({
       : [arrayOfNumberToUint8Array(fromSubAccount)],
 });
 
-export const toTransferRawRequest = ({
+export const toIcrc1TransferRawRequest = ({
+  fromSubAccount,
   to,
   amount,
-  memo,
   fee,
-  fromSubAccount,
+  memo,
   createdAt,
-}: TransferRequest): TransferRawRequest => ({
-  to: to.toUint8Array(),
-  fee: e8sToTokens(fee ?? TRANSACTION_FEE),
-  amount: e8sToTokens(amount),
+}: Icrc1TransferRequest): Icrc1TransferRawRequest => ({
+  to,
+  fee: toNullable(fee ?? TRANSACTION_FEE),
+  amount,
   // Always explicitly set the memo for compatibility with ledger wallet - hardware wallet
-  memo: memo ?? BigInt(0),
-  created_at_time:
-    createdAt !== undefined ? [{ timestamp_nanos: createdAt }] : [],
-  from_subaccount:
-    fromSubAccount === undefined
-      ? []
-      : [arrayOfNumberToUint8Array(fromSubAccount)],
+  memo: toNullable(memo ?? new Uint8Array()),
+  created_at_time: toNullable(createdAt),
+  from_subaccount: toNullable(fromSubAccount),
 });

--- a/packages/nns/src/canisters/ledger/ledger.request.converts.ts
+++ b/packages/nns/src/canisters/ledger/ledger.request.converts.ts
@@ -47,3 +47,24 @@ export const toTransferRawRequest = ({
       ? []
       : [arrayOfNumberToUint8Array(fromSubAccount)],
 });
+
+export const toTransferRawRequest = ({
+  to,
+  amount,
+  memo,
+  fee,
+  fromSubAccount,
+  createdAt,
+}: TransferRequest): TransferRawRequest => ({
+  to: to.toUint8Array(),
+  fee: e8sToTokens(fee ?? TRANSACTION_FEE),
+  amount: e8sToTokens(amount),
+  // Always explicitly set the memo for compatibility with ledger wallet - hardware wallet
+  memo: memo ?? BigInt(0),
+  created_at_time:
+    createdAt !== undefined ? [{ timestamp_nanos: createdAt }] : [],
+  from_subaccount:
+    fromSubAccount === undefined
+      ? []
+      : [arrayOfNumberToUint8Array(fromSubAccount)],
+});

--- a/packages/nns/src/errors/ledger.errors.ts
+++ b/packages/nns/src/errors/ledger.errors.ts
@@ -1,5 +1,8 @@
 import { convertStringToE8s } from "@dfinity/utils";
-import type { TransferError as RawTransferError } from "../../candid/ledger";
+import type {
+  Icrc1TransferError as RawIcrc1TransferError,
+  TransferError as RawTransferError,
+} from "../../candid/ledger";
 import type { BlockHeight } from "../types/common";
 
 export class TransferError extends Error {}
@@ -13,7 +16,7 @@ export class InsufficientFundsError extends TransferError {
 }
 
 export class TxTooOldError extends TransferError {
-  constructor(public readonly allowed_window_secs: number) {
+  constructor(public readonly allowed_window_secs?: number | undefined) {
     super();
   }
 }
@@ -60,27 +63,25 @@ export const mapTransferError = (
   );
 };
 
-export const mapTransferError = (
-  rawTransferError: RawTransferError,
+export const mapIcrc1TransferError = (
+  rawTransferError: RawIcrc1TransferError,
 ): TransferError => {
-  if ("TxDuplicate" in rawTransferError) {
-    return new TxDuplicateError(rawTransferError.TxDuplicate.duplicate_of);
+  if ("Duplicate" in rawTransferError) {
+    return new TxDuplicateError(rawTransferError.Duplicate.duplicate_of);
   }
   if ("InsufficientFunds" in rawTransferError) {
     return new InsufficientFundsError(
-      rawTransferError.InsufficientFunds.balance.e8s,
+      rawTransferError.InsufficientFunds.balance,
     );
   }
-  if ("TxCreatedInFuture" in rawTransferError) {
+  if ("CreatedInFuture" in rawTransferError) {
     return new TxCreatedInFutureError();
   }
-  if ("TxTooOld" in rawTransferError) {
-    return new TxTooOldError(
-      Number(rawTransferError.TxTooOld.allowed_window_nanos),
-    );
+  if ("TooOld" in rawTransferError) {
+    return new TxTooOldError();
   }
   if ("BadFee" in rawTransferError) {
-    return new BadFeeError(rawTransferError.BadFee.expected_fee.e8s);
+    return new BadFeeError(rawTransferError.BadFee.expected_fee);
   }
   // Edge case
   return new TransferError(

--- a/packages/nns/src/errors/ledger.errors.ts
+++ b/packages/nns/src/errors/ledger.errors.ts
@@ -60,6 +60,34 @@ export const mapTransferError = (
   );
 };
 
+export const mapTransferError = (
+  rawTransferError: RawTransferError,
+): TransferError => {
+  if ("TxDuplicate" in rawTransferError) {
+    return new TxDuplicateError(rawTransferError.TxDuplicate.duplicate_of);
+  }
+  if ("InsufficientFunds" in rawTransferError) {
+    return new InsufficientFundsError(
+      rawTransferError.InsufficientFunds.balance.e8s,
+    );
+  }
+  if ("TxCreatedInFuture" in rawTransferError) {
+    return new TxCreatedInFutureError();
+  }
+  if ("TxTooOld" in rawTransferError) {
+    return new TxTooOldError(
+      Number(rawTransferError.TxTooOld.allowed_window_nanos),
+    );
+  }
+  if ("BadFee" in rawTransferError) {
+    return new BadFeeError(rawTransferError.BadFee.expected_fee.e8s);
+  }
+  // Edge case
+  return new TransferError(
+    `Unknown error type ${JSON.stringify(rawTransferError)}`,
+  );
+};
+
 export const mapTransferProtoError = (responseBytes: Error): TransferError => {
   const { message } = responseBytes;
 

--- a/packages/nns/src/ledger.canister.spec.ts
+++ b/packages/nns/src/ledger.canister.spec.ts
@@ -615,4 +615,509 @@ describe("LedgerCanister", () => {
       });
     });
   });
+
+  describe("transfer", () => {
+    describe("no hardware wallet", () => {
+      const to = accountIdentifier;
+      const amount = BigInt(100000);
+
+      it("fetches transaction fee if not present", async () => {
+        const service = mock<ActorSubclass<LedgerService>>();
+        service.transfer_fee.mockResolvedValue({
+          transfer_fee: { e8s: BigInt(10_000) },
+        });
+        service.transfer.mockResolvedValue({
+          Ok: BigInt(1234),
+        });
+        const ledger = LedgerCanister.create({
+          certifiedServiceOverride: service,
+          serviceOverride: service,
+        });
+        await ledger.transfer({
+          to,
+          amount,
+        });
+
+        expect(service.transfer_fee).toBeCalled();
+      });
+
+      it("calls transfer certified service with data", async () => {
+        const service = mock<ActorSubclass<LedgerService>>();
+        service.transfer.mockResolvedValue({
+          Ok: BigInt(1234),
+        });
+        const fee = BigInt(10_000);
+        const memo = BigInt(3456);
+        const ledger = LedgerCanister.create({
+          certifiedServiceOverride: service,
+        });
+        await ledger.transfer({
+          to,
+          amount,
+          fee,
+          memo,
+        });
+
+        expect(service.transfer).toBeCalledWith({
+          to: to.toUint8Array(),
+          fee: {
+            e8s: fee,
+          },
+          amount: {
+            e8s: amount,
+          },
+          memo,
+          created_at_time: [],
+          from_subaccount: [],
+        });
+      });
+
+      it("sets a default memo if not passed", async () => {
+        const service = mock<ActorSubclass<LedgerService>>();
+        service.transfer.mockResolvedValue({
+          Ok: BigInt(1234),
+        });
+        const fee = BigInt(10_000);
+        const defaultMemo = BigInt(0);
+        const ledger = LedgerCanister.create({
+          certifiedServiceOverride: service,
+        });
+        await ledger.transfer({
+          to,
+          amount,
+          fee,
+        });
+
+        expect(service.transfer).toBeCalledWith({
+          to: to.toUint8Array(),
+          fee: {
+            e8s: fee,
+          },
+          amount: {
+            e8s: amount,
+          },
+          memo: defaultMemo,
+          created_at_time: [],
+          from_subaccount: [],
+        });
+      });
+
+      it("handles createdAt parameter", async () => {
+        const service = mock<ActorSubclass<LedgerService>>();
+        service.transfer.mockResolvedValue({
+          Ok: BigInt(1234),
+        });
+        const fee = BigInt(10_000);
+        const memo = BigInt(3456);
+        const ledger = LedgerCanister.create({
+          certifiedServiceOverride: service,
+        });
+        const createdAt = BigInt(123132223);
+        await ledger.transfer({
+          to,
+          amount,
+          fee,
+          memo,
+          createdAt,
+        });
+
+        expect(service.transfer).toBeCalledWith({
+          to: to.toUint8Array(),
+          fee: {
+            e8s: fee,
+          },
+          amount: {
+            e8s: amount,
+          },
+          memo,
+          created_at_time: [{ timestamp_nanos: createdAt }],
+          from_subaccount: [],
+        });
+      });
+
+      it("handles subaccount", async () => {
+        const service = mock<ActorSubclass<LedgerService>>();
+        service.transfer.mockResolvedValue({
+          Ok: BigInt(1234),
+        });
+        const fee = BigInt(10_000);
+        const memo = BigInt(0);
+        const fromSubAccount = [
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ];
+        const ledger = LedgerCanister.create({
+          certifiedServiceOverride: service,
+        });
+        await ledger.transfer({
+          to,
+          amount,
+          fee,
+          memo,
+          fromSubAccount,
+        });
+
+        expect(service.transfer).toBeCalledWith({
+          to: to.toUint8Array(),
+          fee: {
+            e8s: fee,
+          },
+          amount: {
+            e8s: amount,
+          },
+          memo,
+          created_at_time: [],
+          from_subaccount: [arrayOfNumberToUint8Array(fromSubAccount)],
+        });
+      });
+
+      it("handles duplicate transaction", async () => {
+        const service = mock<ActorSubclass<LedgerService>>();
+        service.transfer.mockResolvedValue({
+          Err: {
+            TxDuplicate: {
+              duplicate_of: BigInt(10),
+            },
+          },
+        });
+        const ledger = LedgerCanister.create({
+          certifiedServiceOverride: service,
+          serviceOverride: service,
+        });
+        const call = async () =>
+          await ledger.transfer({
+            to,
+            amount,
+            fee: BigInt(10_000),
+          });
+
+        expect(call).rejects.toThrowError(TxDuplicateError);
+      });
+
+      it("handles insufficient balance", async () => {
+        const service = mock<ActorSubclass<LedgerService>>();
+        service.transfer.mockResolvedValue({
+          Err: {
+            InsufficientFunds: {
+              balance: {
+                e8s: BigInt(12312414),
+              },
+            },
+          },
+        });
+        const ledger = LedgerCanister.create({
+          certifiedServiceOverride: service,
+          serviceOverride: service,
+        });
+        const call = async () =>
+          await ledger.transfer({
+            to,
+            amount,
+            fee: BigInt(10_000),
+          });
+
+        expect(call).rejects.toThrowError(InsufficientFundsError);
+      });
+
+      it("handles old tx", async () => {
+        const service = mock<ActorSubclass<LedgerService>>();
+        service.transfer.mockResolvedValue({
+          Err: {
+            TxTooOld: {
+              allowed_window_nanos: BigInt(1234),
+            },
+          },
+        });
+        const ledger = LedgerCanister.create({
+          certifiedServiceOverride: service,
+          serviceOverride: service,
+        });
+        const call = async () =>
+          await ledger.transfer({
+            to,
+            amount,
+            fee: BigInt(10_000),
+          });
+
+        expect(call).rejects.toThrowError(TxTooOldError);
+      });
+
+      it("handles bad fee", async () => {
+        const service = mock<ActorSubclass<LedgerService>>();
+        service.transfer.mockResolvedValue({
+          Err: {
+            BadFee: {
+              expected_fee: {
+                e8s: BigInt(1234),
+              },
+            },
+          },
+        });
+        const ledger = LedgerCanister.create({
+          certifiedServiceOverride: service,
+          serviceOverride: service,
+        });
+        const call = async () =>
+          await ledger.transfer({
+            to,
+            amount,
+            fee: BigInt(10_000),
+          });
+
+        expect(call).rejects.toThrowError(BadFeeError);
+      });
+
+      it("handles transaction created in the future", async () => {
+        const service = mock<ActorSubclass<LedgerService>>();
+        service.transfer.mockResolvedValue({
+          Err: {
+            TxCreatedInFuture: null,
+          },
+        });
+        const ledger = LedgerCanister.create({
+          certifiedServiceOverride: service,
+          serviceOverride: service,
+        });
+        const call = async () =>
+          await ledger.transfer({
+            to,
+            amount,
+            fee: BigInt(10_000),
+          });
+
+        expect(call).rejects.toThrowError(TxCreatedInFutureError);
+      });
+    });
+
+    describe("for hardware wallet", () => {
+      const to = accountIdentifier;
+      const amount = BigInt(100000);
+
+      it("handles invalid sender", async () => {
+        const ledger = LedgerCanister.create({
+          updateCallOverride: () => {
+            throw new Error(`Reject code: 5
+                Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'Sending from 2vxsx-fae is not allowed', rosetta-api/ledger_canister/src/main.rs:135:9`);
+          },
+          hardwareWallet: true,
+        });
+
+        const call = async () =>
+          await ledger.transfer({
+            to,
+            amount,
+          });
+
+        await expect(call).rejects.toThrow(new InvalidSenderError());
+      });
+
+      it("handles duplicate transaction", async () => {
+        const ledger = LedgerCanister.create({
+          updateCallOverride: () => {
+            throw new Error(`Reject code: 5
+                Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'transaction is a duplicate of another transaction in block 1235123', rosetta-api/ledger_canister/src/main.rs:135:9`);
+          },
+          hardwareWallet: true,
+        });
+
+        const call = async () =>
+          await ledger.transfer({
+            to,
+            amount,
+          });
+
+        await expect(call).rejects.toThrow(
+          new TxDuplicateError(BigInt(1235123)),
+        );
+      });
+
+      it("handles insufficient balance", async () => {
+        const ledger = LedgerCanister.create({
+          updateCallOverride: () => {
+            throw new Error(`Reject code: 5
+                Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'the debit account doesn't have enough funds to complete the transaction, current balance: 123.46789123', rosetta-api/ledger_canister/src/main.rs:135:9`);
+          },
+          hardwareWallet: true,
+        });
+
+        const call = async () =>
+          await ledger.transfer({
+            to,
+            amount,
+          });
+
+        await expect(call).rejects.toThrow(
+          new InsufficientFundsError(BigInt(12346789123)),
+        );
+      });
+
+      it("handles future tx", async () => {
+        const ledger = LedgerCanister.create({
+          updateCallOverride: () => {
+            throw new Error(`Reject code: 5
+                Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'transaction's created_at_time is in future', rosetta-api/ledger_canister/src/main.rs:135:9`);
+          },
+          hardwareWallet: true,
+        });
+
+        const call = async () =>
+          await ledger.transfer({
+            to,
+            amount,
+          });
+
+        await expect(call).rejects.toThrow(new TxCreatedInFutureError());
+      });
+
+      it("handles old tx", async () => {
+        const ledger = LedgerCanister.create({
+          updateCallOverride: () => {
+            throw new Error(`Reject code: 5
+                Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'transaction is older than 123 seconds', rosetta-api/ledger_canister/src/main.rs:135:9`);
+          },
+          hardwareWallet: true,
+        });
+
+        const call = async () =>
+          await ledger.transfer({
+            to,
+            amount,
+          });
+
+        await expect(call).rejects.toThrow(new TxTooOldError(123));
+      });
+
+      it("handles subaccount for hw", async () => {
+        const ledger = LedgerCanister.create({
+          updateCallOverride: jest
+            .fn()
+            .mockResolvedValue(new Uint8Array(32).fill(0)),
+          hardwareWallet: true,
+        });
+        const fromSubAccount = [
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ];
+
+        const res = await ledger.transfer({
+          to,
+          amount,
+          fromSubAccount,
+        });
+
+        expect(typeof res).toEqual("bigint");
+      });
+
+      const initExpectedRequest = async ({
+        to,
+        amount,
+        memo,
+        fee,
+      }: {
+        to: AccountIdentifier;
+        amount: bigint;
+        memo?: bigint;
+        fee?: E8s;
+      }): Promise<SendRequest> => {
+        const expectedRequest = new SendRequest();
+        expectedRequest.setTo(await to.toProto());
+
+        const payment = new Payment();
+        payment.setReceiverGets(await toICPTs(amount));
+        expectedRequest.setPayment(payment);
+
+        const requestMemo = new Memo();
+        requestMemo.setMemo((memo ?? BigInt(0)).toString());
+        expectedRequest.setMemo(requestMemo);
+
+        expectedRequest.setMaxFee(await toICPTs(fee ?? TRANSACTION_FEE));
+
+        return expectedRequest;
+      };
+
+      it("should set a default fee for a transfer", async () => {
+        const ledger = LedgerCanister.create({
+          updateCallOverride: () => Promise.resolve(new Uint8Array()),
+          hardwareWallet: true,
+        });
+
+        // @ts-ignore - private function
+        const spy = jest.spyOn(ledger, "updateFetcher");
+
+        const expectedRequest = await initExpectedRequest({ to, amount });
+
+        await ledger.transfer({
+          to,
+          amount,
+        });
+
+        expect(spy).toHaveBeenCalledWith({
+          // @ts-ignore - private variable
+          agent: ledger.agent,
+          // @ts-ignore - private variable
+          canisterId: ledger.canisterId,
+          methodName: "send_pb",
+          arg: expectedRequest.serializeBinary(),
+        });
+      });
+
+      it("should use custom fee for a transfer", async () => {
+        const ledger = LedgerCanister.create({
+          updateCallOverride: () => Promise.resolve(new Uint8Array()),
+          hardwareWallet: true,
+        });
+
+        // @ts-ignore - private function
+        const spy = jest.spyOn(ledger, "updateFetcher");
+
+        const fee = BigInt(990_000);
+
+        const expectedRequest = await initExpectedRequest({ to, amount, fee });
+
+        await ledger.transfer({
+          to,
+          amount,
+          fee,
+        });
+
+        expect(spy).toHaveBeenCalledWith({
+          // @ts-ignore - private variable
+          agent: ledger.agent,
+          // @ts-ignore - private variable
+          canisterId: ledger.canisterId,
+          methodName: "send_pb",
+          arg: expectedRequest.serializeBinary(),
+        });
+      });
+
+      it("should use custom memo for a transfer", async () => {
+        const ledger = LedgerCanister.create({
+          updateCallOverride: () => Promise.resolve(new Uint8Array()),
+          hardwareWallet: true,
+        });
+
+        // @ts-ignore - private function
+        const spy = jest.spyOn(ledger, "updateFetcher");
+
+        const memo = BigInt(990_000);
+
+        const expectedRequest = await initExpectedRequest({ to, amount, memo });
+
+        await ledger.transfer({
+          to,
+          amount,
+          memo,
+        });
+
+        expect(spy).toHaveBeenCalledWith({
+          // @ts-ignore - private variable
+          agent: ledger.agent,
+          // @ts-ignore - private variable
+          canisterId: ledger.canisterId,
+          methodName: "send_pb",
+          arg: expectedRequest.serializeBinary(),
+        });
+      });
+    });
+  });
 });

--- a/packages/nns/src/ledger.canister.ts
+++ b/packages/nns/src/ledger.canister.ts
@@ -123,6 +123,31 @@ export class LedgerCanister {
     return response.Ok;
   };
 
+  /**
+   * Transfer ICP from the caller to the destination `accountIdentifier`.
+   * Returns the index of the block containing the tx if it was successful.
+   *
+   * @throws {@link TransferError}
+   */
+  public transfer = async (request: TransferRequest): Promise<BlockHeight> => {
+    if (this.hardwareWallet) {
+      return this.transferHardwareWallet(request);
+    }
+    // When candid is implemented, the previous lines will go away.
+    // But the transaction fee method is not supported by Ledger App yet.
+    if (request.fee === undefined) {
+      request.fee = this.hardwareWallet
+        ? TRANSACTION_FEE
+        : await this.transactionFee();
+    }
+    const rawRequest = toTransferRawRequest(request);
+    const response = await this.certifiedService.transfer(rawRequest);
+    if ("Err" in response) {
+      throw mapTransferError(response.Err);
+    }
+    return response.Ok;
+  };
+
   private accountBalanceHardwareWallet = async ({
     accountIdentifier,
     certified = true,

--- a/packages/nns/src/types/ledger_converters.ts
+++ b/packages/nns/src/types/ledger_converters.ts
@@ -1,3 +1,9 @@
+import type {
+  Account,
+  Icrc1Timestamp,
+  Icrc1Tokens,
+  SubAccount,
+} from "../../candid/ledger";
 import type { AccountIdentifier } from "../account_identifier";
 import type { E8s } from "./common";
 
@@ -14,15 +20,14 @@ export type TransferRequest = {
   createdAt?: bigint;
 };
 
-export type TransferRequest = {
-  to: AccountIdentifier;
-  amount: bigint;
-  memo?: bigint;
-  fee?: E8s;
-  // TODO: If didc is updated in nns-dapp as well, this array of number will become a Uint8Array
-  fromSubAccount?: number[];
+export type Icrc1TransferRequest = {
+  to: Account;
+  amount: Icrc1Tokens;
+  memo?: Uint8Array;
+  fee?: Icrc1Tokens;
+  fromSubAccount?: SubAccount;
   // Nanoseconds since unix epoc to trigger deduplication and avoid other issues
   // See the link for more details on deduplication
   // https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#transaction_deduplication
-  createdAt?: bigint;
+  createdAt?: Icrc1Timestamp;
 };

--- a/packages/nns/src/types/ledger_converters.ts
+++ b/packages/nns/src/types/ledger_converters.ts
@@ -13,3 +13,16 @@ export type TransferRequest = {
   // https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#transaction_deduplication
   createdAt?: bigint;
 };
+
+export type TransferRequest = {
+  to: AccountIdentifier;
+  amount: bigint;
+  memo?: bigint;
+  fee?: E8s;
+  // TODO: If didc is updated in nns-dapp as well, this array of number will become a Uint8Array
+  fromSubAccount?: number[];
+  // Nanoseconds since unix epoc to trigger deduplication and avoid other issues
+  // See the link for more details on deduplication
+  // https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#transaction_deduplication
+  createdAt?: bigint;
+};


### PR DESCRIPTION
# Motivation

We want to transfer ICP using the ICRC-1 API because then we don't have to compute account identifiers in the client.
Passing the ICP ledger canister ID to the ICRC-1 API works but the ICP ledger canister has its own ICRC-1 interface so calling it directly on the ICP ledger API is cleaner.

*Note*: I started with a commit that duplicates the non-ICRC-1 code. That way you can see how the ICRC-1 code differs from the existing code by reviewing the second commit.

# Changes

1. Added `icrc1Transfer` canister method.
2. Added `toIcrc1TransferRawRequest` request converter.
3. Added `mapIcrc1TransferError` error converter.
4. Added `Icrc1TransferRequest` request type.

# Tests

Copied the existing tests for `transfer` and applied them to `icrc1Transfer` as far as they made sense. The new method has less custom code for hardware wallets so some of those test have not been duplicated.

Tested manually in NNS dapp by using the new method when making ICRC-1 transfers and then testing an ICRC-1 transfer.