### PR TITLE
Don't replace absent memo with empty memo on ICRC-1

### DIFF
--- a/packages/nns/src/canisters/ledger/ledger.request.converts.ts
+++ b/packages/nns/src/canisters/ledger/ledger.request.converts.ts
@@ -63,8 +63,7 @@ export const toIcrc1TransferRawRequest = ({
   to,
   fee: toNullable(fee ?? TRANSACTION_FEE),
   amount,
-  // Always explicitly set the memo for compatibility with ledger wallet - hardware wallet
-  memo: toNullable(memo ?? new Uint8Array()),
+  memo: toNullable(memo),
   created_at_time: toNullable(createdAt),
   from_subaccount: toNullable(fromSubAccount),
 });

--- a/packages/nns/src/ledger.canister.spec.ts
+++ b/packages/nns/src/ledger.canister.spec.ts
@@ -678,7 +678,6 @@ describe("LedgerCanister", () => {
           Ok: BigInt(1234),
         });
         const fee = BigInt(10_000);
-        const defaultMemo = new Uint8Array();
         const ledger = LedgerCanister.create({
           certifiedServiceOverride: service,
         });
@@ -692,7 +691,7 @@ describe("LedgerCanister", () => {
           to,
           fee: [fee],
           amount,
-          memo: [defaultMemo],
+          memo: [],
           created_at_time: [],
           from_subaccount: [],
         });


### PR DESCRIPTION
# Motivation

Ledger hardware wallet displays the memo as a number, even though for ICRC-1 transfer the memo is a byte array.
When the memo is not set at all, it renders the number 0, but when the empty byte array is set, it renders the number 422710814078008.
Rendering no memo as 0 seems better than rendering it as 422710814078008 and setting an empty array was done for HW compatibility in the first place so let's stop doing it.

# Changes

When the memo is absent, keep it like that instead of replacing it with the empty byte array.

# Tests

Unit test is updated.
Also tested manually with NNS dapp to verify that it renders memo 0 now.
