### PR TITLE
GIX-1909: Update candid files sns-js

### DIFF
--- a/packages/nns/candid/sns_wasm.certified.idl.js
+++ b/packages/nns/candid/sns_wasm.certified.idl.js
@@ -25,6 +25,18 @@ export const idlFactory = ({ IDL }) => {
   });
   const Canister = IDL.Record({ 'id' : IDL.Opt(IDL.Principal) });
   const DappCanisters = IDL.Record({ 'canisters' : IDL.Vec(Canister) });
+  const LinearScalingCoefficient = IDL.Record({
+    'slope_numerator' : IDL.Opt(IDL.Nat64),
+    'intercept_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'from_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'slope_denominator' : IDL.Opt(IDL.Nat64),
+    'to_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundParticipationConstraints = IDL.Record({
+    'coefficient_intervals' : IDL.Vec(LinearScalingCoefficient),
+    'max_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'min_direct_participation_threshold_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const CfNeuron = IDL.Record({
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
@@ -92,6 +104,9 @@ export const idlFactory = ({ IDL }) => {
     'wait_for_quiet_deadline_increase_seconds' : IDL.Opt(IDL.Nat64),
     'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
     'dapp_canisters' : IDL.Opt(DappCanisters),
+    'neurons_fund_participation_constraints' : IDL.Opt(
+      NeuronsFundParticipationConstraints
+    ),
     'neurons_fund_participants' : IDL.Opt(NeuronsFundParticipants),
     'max_age_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'initial_token_distribution' : IDL.Opt(InitialTokenDistribution),

--- a/packages/nns/candid/sns_wasm.d.ts
+++ b/packages/nns/candid/sns_wasm.d.ts
@@ -87,6 +87,13 @@ export interface InsertUpgradePathEntriesRequest {
 export interface InsertUpgradePathEntriesResponse {
   error: [] | [SnsWasmError];
 }
+export interface LinearScalingCoefficient {
+  slope_numerator: [] | [bigint];
+  intercept_icp_e8s: [] | [bigint];
+  from_direct_participation_icp_e8s: [] | [bigint];
+  slope_denominator: [] | [bigint];
+  to_direct_participation_icp_e8s: [] | [bigint];
+}
 export interface ListDeployedSnsesResponse {
   instances: Array<DeployedSns>;
 }
@@ -115,6 +122,11 @@ export interface NeuronDistribution {
 }
 export interface NeuronsFundParticipants {
   participants: Array<CfParticipant>;
+}
+export interface NeuronsFundParticipationConstraints {
+  coefficient_intervals: Array<LinearScalingCoefficient>;
+  max_neurons_fund_participation_icp_e8s: [] | [bigint];
+  min_direct_participation_threshold_icp_e8s: [] | [bigint];
 }
 export interface PrettySnsVersion {
   archive_wasm_hash: string;
@@ -160,6 +172,9 @@ export interface SnsInitPayload {
   wait_for_quiet_deadline_increase_seconds: [] | [bigint];
   transaction_fee_e8s: [] | [bigint];
   dapp_canisters: [] | [DappCanisters];
+  neurons_fund_participation_constraints:
+    | []
+    | [NeuronsFundParticipationConstraints];
   neurons_fund_participants: [] | [NeuronsFundParticipants];
   max_age_bonus_percentage: [] | [bigint];
   initial_token_distribution: [] | [InitialTokenDistribution];

--- a/packages/nns/candid/sns_wasm.did
+++ b/packages/nns/candid/sns_wasm.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 72b42535224bc01c89266be2e9ec067cadf10515 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit 557b532805beb8d63c5ab65146d4e338849a50e1 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 type AddWasmRequest = record { hash : vec nat8; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
@@ -57,6 +57,13 @@ type InsertUpgradePathEntriesRequest = record {
   sns_governance_canister_id : opt principal;
 };
 type InsertUpgradePathEntriesResponse = record { error : opt SnsWasmError };
+type LinearScalingCoefficient = record {
+  slope_numerator : opt nat64;
+  intercept_icp_e8s : opt nat64;
+  from_direct_participation_icp_e8s : opt nat64;
+  slope_denominator : opt nat64;
+  to_direct_participation_icp_e8s : opt nat64;
+};
 type ListDeployedSnsesResponse = record { instances : vec DeployedSns };
 type ListUpgradeStep = record {
   pretty_version : opt PrettySnsVersion;
@@ -80,6 +87,11 @@ type NeuronDistribution = record {
   vesting_period_seconds : opt nat64;
 };
 type NeuronsFundParticipants = record { participants : vec CfParticipant };
+type NeuronsFundParticipationConstraints = record {
+  coefficient_intervals : vec LinearScalingCoefficient;
+  max_neurons_fund_participation_icp_e8s : opt nat64;
+  min_direct_participation_threshold_icp_e8s : opt nat64;
+};
 type PrettySnsVersion = record {
   archive_wasm_hash : text;
   root_wasm_hash : text;
@@ -122,6 +134,7 @@ type SnsInitPayload = record {
   wait_for_quiet_deadline_increase_seconds : opt nat64;
   transaction_fee_e8s : opt nat64;
   dapp_canisters : opt DappCanisters;
+  neurons_fund_participation_constraints : opt NeuronsFundParticipationConstraints;
   neurons_fund_participants : opt NeuronsFundParticipants;
   max_age_bonus_percentage : opt nat64;
   initial_token_distribution : opt InitialTokenDistribution;

--- a/packages/nns/candid/sns_wasm.idl.js
+++ b/packages/nns/candid/sns_wasm.idl.js
@@ -25,6 +25,18 @@ export const idlFactory = ({ IDL }) => {
   });
   const Canister = IDL.Record({ 'id' : IDL.Opt(IDL.Principal) });
   const DappCanisters = IDL.Record({ 'canisters' : IDL.Vec(Canister) });
+  const LinearScalingCoefficient = IDL.Record({
+    'slope_numerator' : IDL.Opt(IDL.Nat64),
+    'intercept_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'from_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'slope_denominator' : IDL.Opt(IDL.Nat64),
+    'to_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundParticipationConstraints = IDL.Record({
+    'coefficient_intervals' : IDL.Vec(LinearScalingCoefficient),
+    'max_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'min_direct_participation_threshold_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const CfNeuron = IDL.Record({
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
@@ -92,6 +104,9 @@ export const idlFactory = ({ IDL }) => {
     'wait_for_quiet_deadline_increase_seconds' : IDL.Opt(IDL.Nat64),
     'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
     'dapp_canisters' : IDL.Opt(DappCanisters),
+    'neurons_fund_participation_constraints' : IDL.Opt(
+      NeuronsFundParticipationConstraints
+    ),
     'neurons_fund_participants' : IDL.Opt(NeuronsFundParticipants),
     'max_age_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'initial_token_distribution' : IDL.Opt(InitialTokenDistribution),

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 4fbe776aeea08222b8b47f5f2902fe77b58b7150 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 557b532805beb8d63c5ab65146d4e338849a50e1 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 4fbe776aeea08222b8b47f5f2902fe77b58b7150 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 557b532805beb8d63c5ab65146d4e338849a50e1 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 726b1529fd34a47fcf0627a72301d62a282c788d 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit 557b532805beb8d63c5ab65146d4e338849a50e1 'rs/sns/root/canister/root.did' by import-candid
 type AuthzChangeOp = variant {
   Authorize : record { add_self : bool };
   Deauthorize;

--- a/packages/sns/candid/sns_swap.certified.idl.js
+++ b/packages/sns/candid/sns_swap.certified.idl.js
@@ -4,6 +4,18 @@ export const idlFactory = ({ IDL }) => {
     'dissolve_delay_interval_seconds' : IDL.Nat64,
     'count' : IDL.Nat64,
   });
+  const LinearScalingCoefficient = IDL.Record({
+    'slope_numerator' : IDL.Opt(IDL.Nat64),
+    'intercept_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'from_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'slope_denominator' : IDL.Opt(IDL.Nat64),
+    'to_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundParticipationConstraints = IDL.Record({
+    'coefficient_intervals' : IDL.Vec(LinearScalingCoefficient),
+    'max_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'min_direct_participation_threshold_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const CfNeuron = IDL.Record({
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
@@ -35,6 +47,9 @@ export const idlFactory = ({ IDL }) => {
     'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
     'icp_ledger_canister_id' : IDL.Text,
     'sns_ledger_canister_id' : IDL.Text,
+    'neurons_fund_participation_constraints' : IDL.Opt(
+      NeuronsFundParticipationConstraints
+    ),
     'neurons_fund_participants' : IDL.Opt(NeuronsFundParticipants),
     'should_auto_finalize' : IDL.Opt(IDL.Bool),
     'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
@@ -152,6 +167,8 @@ export const idlFactory = ({ IDL }) => {
     'sns_tokens_per_icp' : IDL.Opt(IDL.Float64),
     'buyer_total_icp_e8s' : IDL.Opt(IDL.Nat64),
     'cf_participant_count' : IDL.Opt(IDL.Nat64),
+    'neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'direct_participant_count' : IDL.Opt(IDL.Nat64),
     'cf_neuron_count' : IDL.Opt(IDL.Nat64),
   });
@@ -218,9 +235,11 @@ export const idlFactory = ({ IDL }) => {
     'cf_participants' : IDL.Vec(CfParticipant),
     'init' : IDL.Opt(Init),
     'already_tried_to_auto_finalize' : IDL.Opt(IDL.Bool),
+    'neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'purge_old_tickets_last_completion_timestamp_nanoseconds' : IDL.Opt(
       IDL.Nat64
     ),
+    'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'lifecycle' : IDL.Int32,
     'purge_old_tickets_next_principal' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'buyers' : IDL.Vec(IDL.Tuple(IDL.Text, BuyerState)),
@@ -231,6 +250,8 @@ export const idlFactory = ({ IDL }) => {
     'sns_tokens_per_icp' : IDL.Float32,
     'buyer_total_icp_e8s' : IDL.Nat64,
     'cf_participant_count' : IDL.Opt(IDL.Nat64),
+    'neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'direct_participant_count' : IDL.Opt(IDL.Nat64),
     'cf_neuron_count' : IDL.Opt(IDL.Nat64),
   });
@@ -368,6 +389,18 @@ export const init = ({ IDL }) => {
     'dissolve_delay_interval_seconds' : IDL.Nat64,
     'count' : IDL.Nat64,
   });
+  const LinearScalingCoefficient = IDL.Record({
+    'slope_numerator' : IDL.Opt(IDL.Nat64),
+    'intercept_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'from_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'slope_denominator' : IDL.Opt(IDL.Nat64),
+    'to_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundParticipationConstraints = IDL.Record({
+    'coefficient_intervals' : IDL.Vec(LinearScalingCoefficient),
+    'max_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'min_direct_participation_threshold_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const CfNeuron = IDL.Record({
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
@@ -399,6 +432,9 @@ export const init = ({ IDL }) => {
     'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
     'icp_ledger_canister_id' : IDL.Text,
     'sns_ledger_canister_id' : IDL.Text,
+    'neurons_fund_participation_constraints' : IDL.Opt(
+      NeuronsFundParticipationConstraints
+    ),
     'neurons_fund_participants' : IDL.Opt(NeuronsFundParticipants),
     'should_auto_finalize' : IDL.Opt(IDL.Bool),
     'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),

--- a/packages/sns/candid/sns_swap.d.ts
+++ b/packages/sns/candid/sns_swap.d.ts
@@ -45,6 +45,8 @@ export interface DerivedState {
   sns_tokens_per_icp: number;
   buyer_total_icp_e8s: bigint;
   cf_participant_count: [] | [bigint];
+  neurons_fund_participation_icp_e8s: [] | [bigint];
+  direct_participation_icp_e8s: [] | [bigint];
   direct_participant_count: [] | [bigint];
   cf_neuron_count: [] | [bigint];
 }
@@ -102,6 +104,8 @@ export interface GetDerivedStateResponse {
   sns_tokens_per_icp: [] | [number];
   buyer_total_icp_e8s: [] | [bigint];
   cf_participant_count: [] | [bigint];
+  neurons_fund_participation_icp_e8s: [] | [bigint];
+  direct_participation_icp_e8s: [] | [bigint];
   direct_participant_count: [] | [bigint];
   cf_neuron_count: [] | [bigint];
 }
@@ -149,6 +153,9 @@ export interface Init {
   transaction_fee_e8s: [] | [bigint];
   icp_ledger_canister_id: string;
   sns_ledger_canister_id: string;
+  neurons_fund_participation_constraints:
+    | []
+    | [NeuronsFundParticipationConstraints];
   neurons_fund_participants: [] | [NeuronsFundParticipants];
   should_auto_finalize: [] | [boolean];
   max_participant_icp_e8s: [] | [bigint];
@@ -163,6 +170,13 @@ export interface InvalidUserAmount {
 export type Investor =
   | { CommunityFund: CfInvestment }
   | { Direct: DirectInvestment };
+export interface LinearScalingCoefficient {
+  slope_numerator: [] | [bigint];
+  intercept_icp_e8s: [] | [bigint];
+  from_direct_participation_icp_e8s: [] | [bigint];
+  slope_denominator: [] | [bigint];
+  to_direct_participation_icp_e8s: [] | [bigint];
+}
 export interface ListCommunityFundParticipantsRequest {
   offset: [] | [bigint];
   limit: [] | [number];
@@ -195,6 +209,11 @@ export interface NeuronId {
 }
 export interface NeuronsFundParticipants {
   cf_participants: Array<CfParticipant>;
+}
+export interface NeuronsFundParticipationConstraints {
+  coefficient_intervals: Array<LinearScalingCoefficient>;
+  max_neurons_fund_participation_icp_e8s: [] | [bigint];
+  min_direct_participation_threshold_icp_e8s: [] | [bigint];
 }
 export interface NewSaleTicketRequest {
   subaccount: [] | [Uint8Array];
@@ -277,7 +296,9 @@ export interface Swap {
   cf_participants: Array<CfParticipant>;
   init: [] | [Init];
   already_tried_to_auto_finalize: [] | [boolean];
+  neurons_fund_participation_icp_e8s: [] | [bigint];
   purge_old_tickets_last_completion_timestamp_nanoseconds: [] | [bigint];
+  direct_participation_icp_e8s: [] | [bigint];
   lifecycle: number;
   purge_old_tickets_next_principal: [] | [Uint8Array];
   buyers: Array<[string, BuyerState]>;

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 726b1529fd34a47fcf0627a72301d62a282c788d 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 557b532805beb8d63c5ab65146d4e338849a50e1 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record { icp : opt TransferableAmount };
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterStatusResultV2 = record {
@@ -27,6 +27,8 @@ type DerivedState = record {
   sns_tokens_per_icp : float32;
   buyer_total_icp_e8s : nat64;
   cf_participant_count : opt nat64;
+  neurons_fund_participation_icp_e8s : opt nat64;
+  direct_participation_icp_e8s : opt nat64;
   direct_participant_count : opt nat64;
   cf_neuron_count : opt nat64;
 };
@@ -65,6 +67,8 @@ type GetDerivedStateResponse = record {
   sns_tokens_per_icp : opt float64;
   buyer_total_icp_e8s : opt nat64;
   cf_participant_count : opt nat64;
+  neurons_fund_participation_icp_e8s : opt nat64;
+  direct_participation_icp_e8s : opt nat64;
   direct_participant_count : opt nat64;
   cf_neuron_count : opt nat64;
 };
@@ -95,6 +99,7 @@ type Init = record {
   transaction_fee_e8s : opt nat64;
   icp_ledger_canister_id : text;
   sns_ledger_canister_id : text;
+  neurons_fund_participation_constraints : opt NeuronsFundParticipationConstraints;
   neurons_fund_participants : opt NeuronsFundParticipants;
   should_auto_finalize : opt bool;
   max_participant_icp_e8s : opt nat64;
@@ -109,6 +114,13 @@ type InvalidUserAmount = record {
 type Investor = variant {
   CommunityFund : CfInvestment;
   Direct : DirectInvestment;
+};
+type LinearScalingCoefficient = record {
+  slope_numerator : opt nat64;
+  intercept_icp_e8s : opt nat64;
+  from_direct_participation_icp_e8s : opt nat64;
+  slope_denominator : opt nat64;
+  to_direct_participation_icp_e8s : opt nat64;
 };
 type ListCommunityFundParticipantsRequest = record {
   offset : opt nat64;
@@ -137,6 +149,11 @@ type NeuronBasketConstructionParameters = record {
 };
 type NeuronId = record { id : vec nat8 };
 type NeuronsFundParticipants = record { cf_participants : vec CfParticipant };
+type NeuronsFundParticipationConstraints = record {
+  coefficient_intervals : vec LinearScalingCoefficient;
+  max_neurons_fund_participation_icp_e8s : opt nat64;
+  min_direct_participation_threshold_icp_e8s : opt nat64;
+};
 type NewSaleTicketRequest = record {
   subaccount : opt vec nat8;
   amount_icp_e8s : nat64;
@@ -203,7 +220,9 @@ type Swap = record {
   cf_participants : vec CfParticipant;
   init : opt Init;
   already_tried_to_auto_finalize : opt bool;
+  neurons_fund_participation_icp_e8s : opt nat64;
   purge_old_tickets_last_completion_timestamp_nanoseconds : opt nat64;
+  direct_participation_icp_e8s : opt nat64;
   lifecycle : int32;
   purge_old_tickets_next_principal : opt vec nat8;
   buyers : vec record { text; BuyerState };

--- a/packages/sns/candid/sns_swap.idl.js
+++ b/packages/sns/candid/sns_swap.idl.js
@@ -4,6 +4,18 @@ export const idlFactory = ({ IDL }) => {
     'dissolve_delay_interval_seconds' : IDL.Nat64,
     'count' : IDL.Nat64,
   });
+  const LinearScalingCoefficient = IDL.Record({
+    'slope_numerator' : IDL.Opt(IDL.Nat64),
+    'intercept_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'from_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'slope_denominator' : IDL.Opt(IDL.Nat64),
+    'to_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundParticipationConstraints = IDL.Record({
+    'coefficient_intervals' : IDL.Vec(LinearScalingCoefficient),
+    'max_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'min_direct_participation_threshold_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const CfNeuron = IDL.Record({
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
@@ -35,6 +47,9 @@ export const idlFactory = ({ IDL }) => {
     'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
     'icp_ledger_canister_id' : IDL.Text,
     'sns_ledger_canister_id' : IDL.Text,
+    'neurons_fund_participation_constraints' : IDL.Opt(
+      NeuronsFundParticipationConstraints
+    ),
     'neurons_fund_participants' : IDL.Opt(NeuronsFundParticipants),
     'should_auto_finalize' : IDL.Opt(IDL.Bool),
     'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
@@ -152,6 +167,8 @@ export const idlFactory = ({ IDL }) => {
     'sns_tokens_per_icp' : IDL.Opt(IDL.Float64),
     'buyer_total_icp_e8s' : IDL.Opt(IDL.Nat64),
     'cf_participant_count' : IDL.Opt(IDL.Nat64),
+    'neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'direct_participant_count' : IDL.Opt(IDL.Nat64),
     'cf_neuron_count' : IDL.Opt(IDL.Nat64),
   });
@@ -218,9 +235,11 @@ export const idlFactory = ({ IDL }) => {
     'cf_participants' : IDL.Vec(CfParticipant),
     'init' : IDL.Opt(Init),
     'already_tried_to_auto_finalize' : IDL.Opt(IDL.Bool),
+    'neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'purge_old_tickets_last_completion_timestamp_nanoseconds' : IDL.Opt(
       IDL.Nat64
     ),
+    'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'lifecycle' : IDL.Int32,
     'purge_old_tickets_next_principal' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'buyers' : IDL.Vec(IDL.Tuple(IDL.Text, BuyerState)),
@@ -231,6 +250,8 @@ export const idlFactory = ({ IDL }) => {
     'sns_tokens_per_icp' : IDL.Float32,
     'buyer_total_icp_e8s' : IDL.Nat64,
     'cf_participant_count' : IDL.Opt(IDL.Nat64),
+    'neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'direct_participant_count' : IDL.Opt(IDL.Nat64),
     'cf_neuron_count' : IDL.Opt(IDL.Nat64),
   });
@@ -376,6 +397,18 @@ export const init = ({ IDL }) => {
     'dissolve_delay_interval_seconds' : IDL.Nat64,
     'count' : IDL.Nat64,
   });
+  const LinearScalingCoefficient = IDL.Record({
+    'slope_numerator' : IDL.Opt(IDL.Nat64),
+    'intercept_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'from_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'slope_denominator' : IDL.Opt(IDL.Nat64),
+    'to_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundParticipationConstraints = IDL.Record({
+    'coefficient_intervals' : IDL.Vec(LinearScalingCoefficient),
+    'max_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'min_direct_participation_threshold_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const CfNeuron = IDL.Record({
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
@@ -407,6 +440,9 @@ export const init = ({ IDL }) => {
     'transaction_fee_e8s' : IDL.Opt(IDL.Nat64),
     'icp_ledger_canister_id' : IDL.Text,
     'sns_ledger_canister_id' : IDL.Text,
+    'neurons_fund_participation_constraints' : IDL.Opt(
+      NeuronsFundParticipationConstraints
+    ),
     'neurons_fund_participants' : IDL.Opt(NeuronsFundParticipants),
     'should_auto_finalize' : IDL.Opt(IDL.Bool),
     'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -30,6 +30,7 @@ export type {
   GetSaleParametersResponse as SnsGetSaleParametersResponse,
   InvalidUserAmount as SnsInvalidUserAmount,
   SnsNeuronRecipe,
+  NeuronsFundParticipationConstraints as SnsNeuronsFundParticipationConstraints,
   Params as SnsParams,
   RefreshBuyerTokensResponse as SnsRefreshBuyerTokensResponse,
   Swap as SnsSwap,

--- a/packages/sns/src/swap.canister.spec.ts
+++ b/packages/sns/src/swap.canister.spec.ts
@@ -182,6 +182,8 @@ describe("Swap canister", () => {
       cf_participant_count: [BigInt(3)],
       direct_participant_count: [BigInt(4)],
       cf_neuron_count: [BigInt(6)],
+      neurons_fund_participation_icp_e8s: [],
+      direct_participation_icp_e8s: [],
     };
 
     const service = mock<ActorSubclass<SnsSwapService>>();


### PR DESCRIPTION
# Motivation

Use the new fields for the Neurons' Fund enhancements.

In this PR, upgrade the candid files for sns canisters.

# Changes

## Automatic changes

Script `./scripts/import-candid ../ic`. It uses the local copy of the IC repo.
* Update candid files. Files with extension `.did`.

Script `./scripts/compile-idl-js`.
* Update related candid types and JS files.

## Manual changes

Only the change in `src/index.ts`
* Export new type `NeuronsFundParticipationConstraints` that has the maximum commitment of the Neurons' Fund.

# Tests

* Fixed a mock data with new parameters.
