### PR TITLE
build: build ledger-icrc/icp next

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish Ledger
-        run: npm publish --provenance --tag next --workspace=packages/ledger
+        run: npm publish --provenance --tag next --workspace=packages/ledger-icrc
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - name: Publish Ledger
+        run: npm publish --provenance --tag next --workspace=packages/ledger-icp
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish NNS-proto

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,11 +23,11 @@ jobs:
         run: npm publish --provenance --tag next --workspace=packages/utils
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - name: Publish Ledger
+      - name: Publish Ledger ICRC
         run: npm publish --provenance --tag next --workspace=packages/ledger-icrc
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - name: Publish Ledger
+      - name: Publish Ledger ICP
         run: npm publish --provenance --tag next --workspace=packages/ledger-icp
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
# Motivation

Now that ledger-icp/icrc are offically published to npm, we can adjust the CI to build also their next version.
