### PR TITLE
build: fix next publication by integrating ledger-icrc/icp in version update script

### DIFF
--- a/scripts/build-next
+++ b/scripts/build-next
@@ -6,9 +6,8 @@ npm ci
 : Update the package.json version before build and publish
 node ./scripts/update-version.mjs utils
 node ./scripts/update-version.mjs nns-proto
-node ./scripts/update-version.mjs ledger
-# TODO: uncomment when new @dfinity/ledger-icp will be released
-# node ./scripts/update-version.mjs ledger-icp
+node ./scripts/update-version.mjs ledger-icp
+node ./scripts/update-version.mjs ledger-icrc
 node ./scripts/update-version.mjs nns
 node ./scripts/update-version.mjs sns
 node ./scripts/update-version.mjs cmc


### PR DESCRIPTION
# Motivation

Publishing next version failed (see https://github.com/dfinity/ic-js/actions/runs/6391122469/job/17345744326) because the script that manippulate the package.json to update the version number with the "next" prefix was not updated with the new ledger-icrc/icp libs.
