### PR TITLE
feat: export blockheight types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2023.XX.YY
+
+## Overview
+
+<!-- TODO: To be documented. -->
+
+## Features
+
+- expose few types - notably `BlockHeight` - for library `@dfinity/ledger-icp`
+
 # 2023.10.02-1515Z
 
 ## Overview

--- a/packages/ledger-icp/src/index.ts
+++ b/packages/ledger-icp/src/index.ts
@@ -1,6 +1,7 @@
 export { AccountIdentifier, SubAccount } from "./account_identifier";
 export * from "./errors/ledger.errors";
 export { LedgerCanister } from "./ledger.canister";
+export type * from "./types/common";
 export * from "./types/ledger.options";
 export * from "./utils/account_identifier.utils";
 export * from "./utils/accounts.utils";


### PR DESCRIPTION
# Motivation

While integrating the new lib in NNS dapp ([PR](https://github.com/dfinity/nns-dapp/pull/3435)) we noticed that few more types need to be exposed by `@dfinity/ledger-icp`.
