### PR TITLE
GIX-1928: Add GovernanceTest Canister and updateNeuron method

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     {
       "name": "@dfinity/nns",
       "path": "./packages/nns/dist/index.js",
-      "limit": "32 kB",
+      "limit": "35 kB",
       "ignore": [
         "@dfinity/agent",
         "@dfinity/candid",

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -15,6 +15,8 @@ import { Principal } from "@dfinity/principal";
 import {
   fromDefinedNullable,
   fromNullable,
+  nonNullish,
+  toNullable,
   uint8ArrayToArrayOfNumber,
 } from "@dfinity/utils";
 import type { Map } from "google-protobuf";
@@ -172,6 +174,49 @@ const toNeuron = ({
   followees: neuron.followees.map(([topic, followees]) =>
     toFollowees({ topic, followees }),
   ),
+});
+
+export const toRawNeuron = (neuron: Neuron): RawNeuron => ({
+  id: nonNullish(neuron.id) ? toNullable({ id: neuron.id }) : [],
+  staked_maturity_e8s_equivalent: toNullable(
+    neuron.stakedMaturityE8sEquivalent,
+  ),
+  controller: nonNullish(neuron.controller)
+    ? toNullable(Principal.from(neuron.controller))
+    : [],
+  recent_ballots: neuron.recentBallots.map((ballot) => ({
+    vote: ballot.vote,
+    proposal_id: nonNullish(ballot.proposalId)
+      ? toNullable({ id: ballot.proposalId })
+      : [],
+  })),
+  kyc_verified: neuron.kycVerified,
+  not_for_profit: neuron.notForProfit,
+  cached_neuron_stake_e8s: neuron.cachedNeuronStake,
+  created_timestamp_seconds: neuron.createdTimestampSeconds,
+  auto_stake_maturity: toNullable(neuron.autoStakeMaturity),
+  maturity_e8s_equivalent: neuron.maturityE8sEquivalent,
+  aging_since_timestamp_seconds: neuron.agingSinceTimestampSeconds,
+  neuron_fees_e8s: neuron.neuronFees,
+  hot_keys: neuron.hotKeys.map((p) => Principal.from(p)),
+  account: AccountIdentifier.fromHex(neuron.accountIdentifier).toUint8Array(),
+  joined_community_fund_timestamp_seconds: toNullable(
+    neuron.joinedCommunityFundTimestampSeconds,
+  ),
+  dissolve_state: nonNullish(neuron.dissolveState)
+    ? [neuron.dissolveState]
+    : [],
+  spawn_at_timestamp_seconds: toNullable(neuron.spawnAtTimesSeconds),
+  followees: neuron.followees.map((followeesTopic) => [
+    followeesTopic.topic as number,
+    {
+      followees: followeesTopic.followees.map((followee) => ({ id: followee })),
+    },
+  ]),
+  // Not kept when converted to Neuron.
+  transfer: [],
+  // Not kept when converted to Neuron.
+  known_neuron_data: [],
 });
 
 const toBallotInfo = ({ vote, proposal_id }: RawBallotInfo): BallotInfo => ({

--- a/packages/nns/src/governance_test.canister.ts
+++ b/packages/nns/src/governance_test.canister.ts
@@ -1,0 +1,42 @@
+import type { ActorSubclass } from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+import { createServices, type CanisterOptions } from "@dfinity/utils";
+import { idlFactory } from "../candid/governance.idl";
+import type { _SERVICE as GovernanceService } from "../candid/governance_test";
+import { idlFactory as certifiedIdlFactory } from "../candid/governance_test.certified.idl";
+import { toRawNeuron } from "./canisters/governance/response.converters";
+import { MAINNET_GOVERNANCE_CANISTER_ID } from "./constants/canister_ids";
+import type { Neuron } from "./types/governance_converters";
+
+export class GovernanceTestCanister {
+  private constructor(
+    private readonly certifiedService: ActorSubclass<GovernanceService>,
+  ) {
+    this.certifiedService = certifiedService;
+  }
+
+  public static create(options: CanisterOptions<GovernanceService> = {}) {
+    const canisterId: Principal =
+      options.canisterId ?? MAINNET_GOVERNANCE_CANISTER_ID;
+
+    const { certifiedService } = createServices<GovernanceService>({
+      options: {
+        ...options,
+        canisterId,
+      },
+      idlFactory,
+      certifiedIdlFactory,
+    });
+
+    return new GovernanceTestCanister(certifiedService);
+  }
+
+  /**
+   * Test method to update fields of a neuron.
+   *
+   * Only available in the governance test canister.
+   */
+  updateNeuron(neuron: Neuron) {
+    this.certifiedService.update_neuron(toRawNeuron(neuron));
+  }
+}

--- a/packages/nns/src/index.ts
+++ b/packages/nns/src/index.ts
@@ -4,6 +4,7 @@ export * from "./enums/governance.enums";
 export * from "./errors/governance.errors";
 export { GenesisTokenCanister } from "./genesis_token.canister";
 export { GovernanceCanister } from "./governance.canister";
+export { GovernanceTestCanister } from "./governance_test.canister";
 export { SnsWasmCanister } from "./sns_wasm.canister";
 export * from "./types/common";
 export * from "./types/governance.options";


### PR DESCRIPTION
# Motivation

We want to test maturity related features for NNS neurons easily.

In this PR, we expose a new GovernanceTestCanister class for the governance test canister. This canister exposes the `update_neuron` method.

# Changes

* New `toRawNeuron` converter.
* New `GovernanceTestCanister` with `updateNeuron` method.

# Tests

No tests. Used only for development and testing environments.
