### PR TITLE
GIX-1934: New SNS fields for NF enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Features
 
 - expose few types - notably `BlockHeight` - for library `@dfinity/ledger-icp`
+- support new fields from swap canister response types: `min_direct_participation_icp_e8s` and `max_direct_participation_icp_e8s`
 
 # 2023.10.02-1515Z
 

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 557b532805beb8d63c5ab65146d4e338849a50e1 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 15e69667ae983fa92c33794a3954d9ca87518af6 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 557b532805beb8d63c5ab65146d4e338849a50e1 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 15e69667ae983fa92c33794a3954d9ca87518af6 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 557b532805beb8d63c5ab65146d4e338849a50e1 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit 15e69667ae983fa92c33794a3954d9ca87518af6 'rs/sns/root/canister/root.did' by import-candid
 type AuthzChangeOp = variant {
   Authorize : record { add_self : bool };
   Deauthorize;

--- a/packages/sns/candid/sns_swap.certified.idl.js
+++ b/packages/sns/candid/sns_swap.certified.idl.js
@@ -54,8 +54,10 @@ export const idlFactory = ({ IDL }) => {
     'should_auto_finalize' : IDL.Opt(IDL.Bool),
     'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
     'sns_governance_canister_id' : IDL.Text,
+    'min_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'restricted_countries' : IDL.Opt(Countries),
     'min_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
   const ErrorRefundIcpRequest = IDL.Record({
     'source_principal_id' : IDL.Opt(IDL.Principal),
@@ -202,7 +204,9 @@ export const idlFactory = ({ IDL }) => {
     'sns_token_e8s' : IDL.Nat64,
     'sale_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_participant_icp_e8s' : IDL.Nat64,
+    'min_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'min_icp_e8s' : IDL.Nat64,
+    'max_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
   const GetSaleParametersResponse = IDL.Record({ 'params' : IDL.Opt(Params) });
   const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
@@ -439,8 +443,10 @@ export const init = ({ IDL }) => {
     'should_auto_finalize' : IDL.Opt(IDL.Bool),
     'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
     'sns_governance_canister_id' : IDL.Text,
+    'min_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'restricted_countries' : IDL.Opt(Countries),
     'min_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
   return [Init];
 };

--- a/packages/sns/candid/sns_swap.d.ts
+++ b/packages/sns/candid/sns_swap.d.ts
@@ -160,8 +160,10 @@ export interface Init {
   should_auto_finalize: [] | [boolean];
   max_participant_icp_e8s: [] | [bigint];
   sns_governance_canister_id: string;
+  min_direct_participation_icp_e8s: [] | [bigint];
   restricted_countries: [] | [Countries];
   min_icp_e8s: [] | [bigint];
+  max_direct_participation_icp_e8s: [] | [bigint];
 }
 export interface InvalidUserAmount {
   min_amount_icp_e8s_included: bigint;
@@ -244,7 +246,9 @@ export interface Params {
   sns_token_e8s: bigint;
   sale_delay_seconds: [] | [bigint];
   max_participant_icp_e8s: bigint;
+  min_direct_participation_icp_e8s: [] | [bigint];
   min_icp_e8s: bigint;
+  max_direct_participation_icp_e8s: [] | [bigint];
 }
 export interface Participant {
   participation: [] | [BuyerState];

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 557b532805beb8d63c5ab65146d4e338849a50e1 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 15e69667ae983fa92c33794a3954d9ca87518af6 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record { icp : opt TransferableAmount };
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterStatusResultV2 = record {
@@ -104,8 +104,10 @@ type Init = record {
   should_auto_finalize : opt bool;
   max_participant_icp_e8s : opt nat64;
   sns_governance_canister_id : text;
+  min_direct_participation_icp_e8s : opt nat64;
   restricted_countries : opt Countries;
   min_icp_e8s : opt nat64;
+  max_direct_participation_icp_e8s : opt nat64;
 };
 type InvalidUserAmount = record {
   min_amount_icp_e8s_included : nat64;
@@ -175,7 +177,9 @@ type Params = record {
   sns_token_e8s : nat64;
   sale_delay_seconds : opt nat64;
   max_participant_icp_e8s : nat64;
+  min_direct_participation_icp_e8s : opt nat64;
   min_icp_e8s : nat64;
+  max_direct_participation_icp_e8s : opt nat64;
 };
 type Participant = record {
   participation : opt BuyerState;

--- a/packages/sns/candid/sns_swap.idl.js
+++ b/packages/sns/candid/sns_swap.idl.js
@@ -54,8 +54,10 @@ export const idlFactory = ({ IDL }) => {
     'should_auto_finalize' : IDL.Opt(IDL.Bool),
     'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
     'sns_governance_canister_id' : IDL.Text,
+    'min_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'restricted_countries' : IDL.Opt(Countries),
     'min_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
   const ErrorRefundIcpRequest = IDL.Record({
     'source_principal_id' : IDL.Opt(IDL.Principal),
@@ -202,7 +204,9 @@ export const idlFactory = ({ IDL }) => {
     'sns_token_e8s' : IDL.Nat64,
     'sale_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_participant_icp_e8s' : IDL.Nat64,
+    'min_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'min_icp_e8s' : IDL.Nat64,
+    'max_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
   const GetSaleParametersResponse = IDL.Record({ 'params' : IDL.Opt(Params) });
   const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
@@ -447,8 +451,10 @@ export const init = ({ IDL }) => {
     'should_auto_finalize' : IDL.Opt(IDL.Bool),
     'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
     'sns_governance_canister_id' : IDL.Text,
+    'min_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'restricted_countries' : IDL.Opt(Countries),
     'min_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
   return [Init];
 };

--- a/packages/sns/src/swap.canister.spec.ts
+++ b/packages/sns/src/swap.canister.spec.ts
@@ -210,6 +210,8 @@ describe("Swap canister", () => {
           sale_delay_seconds: [],
           max_participant_icp_e8s: BigInt(500_000_000),
           min_icp_e8s: BigInt(200_000_000),
+          min_direct_participation_icp_e8s: [1_000_000_000n],
+          max_direct_participation_icp_e8s: [2_000_000_000n],
         },
       ],
     };


### PR DESCRIPTION
# Motivation

Support the new Neurons' Fund enhancements.

In this PR, we upgrade sns-js to the latest IC commit which includes two new fields in the swap canister.

# Changes

Automatic changes:

* Changes in `.did` files by running `./scripts/import-candid` and then reverting the non sns-js files.
* The rest of the changes by running `./scripts/compile-idl-js`.

# Tests

Fix failing test.
