### PR TITLE
Update ckBTC Candid

### DIFF
--- a/packages/ckbtc/candid/minter.certified.idl.js
+++ b/packages/ckbtc/candid/minter.certified.idl.js
@@ -34,6 +34,25 @@ export const idlFactory = ({ IDL }) => {
     'Upgrade' : IDL.Opt(UpgradeArgs),
     'Init' : InitArgs,
   });
+  const CanisterStatusType = IDL.Variant({
+    'stopped' : IDL.Null,
+    'stopping' : IDL.Null,
+    'running' : IDL.Null,
+  });
+  const DefiniteCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Nat,
+    'controllers' : IDL.Vec(IDL.Principal),
+    'memory_allocation' : IDL.Nat,
+    'compute_allocation' : IDL.Nat,
+  });
+  const CanisterStatusResponse = IDL.Record({
+    'status' : CanisterStatusType,
+    'memory_size' : IDL.Nat,
+    'cycles' : IDL.Nat,
+    'settings' : DefiniteCanisterSettings,
+    'idle_cycles_burned_per_day' : IDL.Nat,
+    'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
   const Account = IDL.Record({
     'owner' : IDL.Principal,
     'subaccount' : IDL.Opt(IDL.Vec(IDL.Nat8)),
@@ -43,7 +62,16 @@ export const idlFactory = ({ IDL }) => {
     'value' : IDL.Nat64,
     'outpoint' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8), 'vout' : IDL.Nat32 }),
   });
+  const ReimbursementReason = IDL.Variant({
+    'CallFailed' : IDL.Null,
+    'TaintedDestination' : IDL.Record({
+      'kyt_fee' : IDL.Nat64,
+      'kyt_provider' : IDL.Principal,
+    }),
+  });
   const BitcoinAddress = IDL.Variant({
+    'p2wsh_v0' : IDL.Vec(IDL.Nat8),
+    'p2tr_v1' : IDL.Vec(IDL.Nat8),
     'p2sh' : IDL.Vec(IDL.Nat8),
     'p2wpkh_v0' : IDL.Vec(IDL.Nat8),
     'p2pkh' : IDL.Vec(IDL.Nat8),
@@ -51,7 +79,14 @@ export const idlFactory = ({ IDL }) => {
   const Event = IDL.Variant({
     'received_utxos' : IDL.Record({
       'to_account' : Account,
+      'mint_txid' : IDL.Opt(IDL.Nat64),
       'utxos' : IDL.Vec(Utxo),
+    }),
+    'schedule_deposit_reimbursement' : IDL.Record({
+      'burn_block_index' : IDL.Nat64,
+      'account' : Account,
+      'amount' : IDL.Nat64,
+      'reason' : ReimbursementReason,
     }),
     'sent_transaction' : IDL.Record({
       'fee' : IDL.Opt(IDL.Nat64),
@@ -72,6 +107,7 @@ export const idlFactory = ({ IDL }) => {
     'upgrade' : UpgradeArgs,
     'retrieve_btc_kyt_failed' : IDL.Record({
       'block_index' : IDL.Nat64,
+      'owner' : IDL.Principal,
       'uuid' : IDL.Text,
       'address' : IDL.Text,
       'amount' : IDL.Nat64,
@@ -100,6 +136,10 @@ export const idlFactory = ({ IDL }) => {
       'submitted_at' : IDL.Nat64,
     }),
     'ignored_utxo' : IDL.Record({ 'utxo' : Utxo }),
+    'reimbursed_failed_deposit' : IDL.Record({
+      'burn_block_index' : IDL.Nat64,
+      'mint_block_index' : IDL.Nat64,
+    }),
   });
   const MinterInfo = IDL.Record({
     'retrieve_btc_min_amount' : IDL.Nat64,
@@ -130,6 +170,23 @@ export const idlFactory = ({ IDL }) => {
     'Unknown' : IDL.Null,
     'Submitted' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8) }),
     'Pending' : IDL.Null,
+  });
+  const RetrieveBtcWithApprovalArgs = IDL.Record({
+    'from_subaccount' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'address' : IDL.Text,
+    'amount' : IDL.Nat64,
+  });
+  const RetrieveBtcWithApprovalError = IDL.Variant({
+    'MalformedAddress' : IDL.Text,
+    'GenericError' : IDL.Record({
+      'error_message' : IDL.Text,
+      'error_code' : IDL.Nat64,
+    }),
+    'TemporarilyUnavailable' : IDL.Text,
+    'InsufficientAllowance' : IDL.Record({ 'allowance' : IDL.Nat64 }),
+    'AlreadyProcessing' : IDL.Null,
+    'AmountTooLow' : IDL.Nat64,
+    'InsufficientFunds' : IDL.Record({ 'balance' : IDL.Nat64 }),
   });
   const UtxoStatus = IDL.Variant({
     'ValueTooSmall' : Utxo,
@@ -169,6 +226,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Text],
         [],
       ),
+    'get_canister_status' : IDL.Func([], [CanisterStatusResponse], []),
     'get_deposit_fee' : IDL.Func([], [IDL.Nat64], []),
     'get_events' : IDL.Func(
         [IDL.Record({ 'start' : IDL.Nat64, 'length' : IDL.Nat64 })],
@@ -185,6 +243,16 @@ export const idlFactory = ({ IDL }) => {
     'retrieve_btc_status' : IDL.Func(
         [IDL.Record({ 'block_index' : IDL.Nat64 })],
         [RetrieveBtcStatus],
+        [],
+      ),
+    'retrieve_btc_with_approval' : IDL.Func(
+        [RetrieveBtcWithApprovalArgs],
+        [
+          IDL.Variant({
+            'Ok' : RetrieveBtcOk,
+            'Err' : RetrieveBtcWithApprovalError,
+          }),
+        ],
         [],
       ),
     'update_balance' : IDL.Func(

--- a/packages/ckbtc/candid/minter.did
+++ b/packages/ckbtc/candid/minter.did
@@ -1,16 +1,39 @@
-// Generated from IC repo commit 010a489c530137d893222ccac356b704b32f007a 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
+// Generated from IC repo commit 8be68bc88db7332dd39a26509ddf62c564ca3415 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
 // Represents an account on the ckBTC ledger.
 type Account = record { owner : principal; subaccount : opt blob };
 
+type CanisterStatusResponse = record {
+  status : CanisterStatusType;
+  memory_size : nat;
+  cycles : nat;
+  settings : DefiniteCanisterSettings;
+  idle_cycles_burned_per_day : nat;
+  module_hash : opt vec nat8;
+};
+
+type CanisterStatusType = variant { stopped; stopping; running };
+
+type DefiniteCanisterSettings = record {
+  freezing_threshold : nat;
+  controllers : vec principal;
+  memory_allocation : nat;
+  compute_allocation : nat;
+};
+
 type RetrieveBtcArgs = record {
     // The address to which the ckBTC minter should deposit BTC.
-    // Currently, the minter understands only the following types of addresses:
-    //   * P2WPKH addresses (they start with the "bc1q" prefix on the Bitcoin mainnet).
-    //   * P2PKH addresses (they start with the "1" prefix on the Bitcoin mainnet).
-    //   * P2SH addresses (they start with the "3" prefix on the Bitcoin mainnet).
     address : text;
     // The amount of BTC in Satoshis that the client wants to withdraw.
     amount : nat64;
+};
+
+type RetrieveBtcWithApprovalArgs = record {
+    // The address to which the ckBTC minter should deposit BTC.
+    address : text;
+    // The amount of BTC in Satoshis that the client wants to withdraw.
+    amount : nat64;
+    // The subaccount to burn ckBTC from.
+    from_subaccount : opt blob;
 };
 
 type RetrieveBtcError = variant {
@@ -31,6 +54,26 @@ type RetrieveBtcError = variant {
     GenericError : record { error_message : text; error_code : nat64 };
 };
 
+type RetrieveBtcWithApprovalError = variant {
+    // The minter failed to parse the destination address.
+    MalformedAddress : text;
+    // The minter is already processing another retrieval request for the same
+    // principal.
+    AlreadyProcessing;
+    // The withdrawal amount is too low.
+    // The payload contains the minimal withdrawal amount.
+    AmountTooLow : nat64;
+    // The ckBTC balance of the withdrawal account is too low.
+    InsufficientFunds : record { balance : nat64 };
+    // The allowance given to the minter is too low.
+    InsufficientAllowance : record { allowance : nat64 };
+    // The minter is overloaded, retry the request.
+    // The payload contains a human-readable message explaining what caused the unavailability.
+    TemporarilyUnavailable : text;
+    // A generic error reserved for future extensions.
+    GenericError : record { error_message : text; error_code : nat64 };
+};
+
 type RetrieveBtcOk = record {
     // Returns the burn transaction index corresponding to the withdrawal.
     // You can use this index to query the withdrawal status.
@@ -43,7 +86,7 @@ type UtxoStatus = variant {
     // the KYT fees. This state is final, retrying [update_balance] call will
     // have no effect on this UTXO.
     ValueTooSmall : Utxo;
-    // The KYT provider considered this UTXO to be tained. This UTXO state is
+    // The KYT provider considered this UTXO to be tainted. This UTXO state is
     // final, retrying [update_balance] call will have no effect on this UTXO.
     Tainted : Utxo;
     // The UTXO passed the KYT check, but the minter failed to mint ckBTC
@@ -121,7 +164,7 @@ type InitArgs = record {
     /// The minter's operation mode.
     mode : Mode;
 
-    /// The fee paid per check by the KYT cansiter.
+    /// The fee paid per check by the KYT canister.
     kyt_fee : opt nat64;
 
     /// The canister id of the KYT canister.
@@ -144,7 +187,7 @@ type UpgradeArgs = record {
     /// If set, overrides the current minter's operation mode.
     mode : opt Mode;
 
-    /// The fee per check by the KYT cansiter.
+    /// The fee per check by the KYT canister.
     kyt_fee : opt nat64;
 
     /// The principal of the KYT canister.
@@ -190,6 +233,8 @@ type Utxo = record {
 
 type BitcoinAddress = variant {
     p2wpkh_v0 : blob;
+    p2wsh_v0 : blob;
+    p2tr_v1 : blob;
     p2pkh : blob;
     p2sh : blob;
 };
@@ -200,10 +245,18 @@ type MinterInfo = record {
     kyt_fee : nat64;
 };
 
+type ReimbursementReason = variant {
+    CallFailed;
+    TaintedDestination : record {
+        kyt_fee : nat64;
+        kyt_provider: principal;
+    };
+};
+
 type Event = variant {
     init : InitArgs;
     upgrade : UpgradeArgs;
-    received_utxos : record { to_account : Account; utxos : vec Utxo };
+    received_utxos : record { to_account : Account; mint_txid : opt nat64; utxos : vec Utxo };
     accepted_retrieve_btc_request : record {
         amount : nat64;
         address : BitcoinAddress;
@@ -243,10 +296,18 @@ type Event = variant {
     retrieve_btc_kyt_failed : record {
         address : text;
         amount : nat64;
+        owner : principal;
         kyt_provider : principal;
         uuid : text;
         block_index : nat64;
     };
+    schedule_deposit_reimbursement : record {
+        account : Account;
+        burn_block_index : nat64;
+        amount : nat64;
+        reason : ReimbursementReason;
+    };
+    reimbursed_failed_deposit : record { burn_block_index : nat64; mint_block_index : nat64 };
 };
 
 type MinterArg = variant {
@@ -305,6 +366,21 @@ service : (minter_arg : MinterArg) -> {
     //   that the [get_withdrawal_account] endpoint returns.
     retrieve_btc : (RetrieveBtcArgs) -> (variant { Ok : RetrieveBtcOk; Err : RetrieveBtcError });
 
+    // Submits a request to convert ckBTC to BTC.
+    //
+    // # Note
+    //
+    // The BTC retrieval process is slow.  Instead of
+    // synchronously waiting for a BTC transaction to settle, this
+    // method returns a request ([block_index]) that the caller can use
+    // to query the request status.
+    //
+    // # Preconditions
+    //
+    // * The caller allowed the minter's principal to spend its funds
+    //   using [icrc2_approve] on the ckBTC ledger.
+    retrieve_btc_with_approval : (RetrieveBtcWithApprovalArgs) -> (variant { Ok : RetrieveBtcOk; Err : RetrieveBtcWithApprovalError });
+
     /// Returns the status of a [retrieve_btc] request.
     retrieve_btc_status : (record { block_index : nat64 }) -> (RetrieveBtcStatus) query;
 
@@ -313,6 +389,8 @@ service : (minter_arg : MinterArg) -> {
     // Section "Minter Information" {{{
     // Returns internal minter parameters.
     get_minter_info : () -> (MinterInfo) query;
+
+    get_canister_status : () -> (CanisterStatusResponse);
     // }}}
 
     // Section "Event log" {{{

--- a/packages/ckbtc/candid/minter.idl.js
+++ b/packages/ckbtc/candid/minter.idl.js
@@ -34,6 +34,25 @@ export const idlFactory = ({ IDL }) => {
     'Upgrade' : IDL.Opt(UpgradeArgs),
     'Init' : InitArgs,
   });
+  const CanisterStatusType = IDL.Variant({
+    'stopped' : IDL.Null,
+    'stopping' : IDL.Null,
+    'running' : IDL.Null,
+  });
+  const DefiniteCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Nat,
+    'controllers' : IDL.Vec(IDL.Principal),
+    'memory_allocation' : IDL.Nat,
+    'compute_allocation' : IDL.Nat,
+  });
+  const CanisterStatusResponse = IDL.Record({
+    'status' : CanisterStatusType,
+    'memory_size' : IDL.Nat,
+    'cycles' : IDL.Nat,
+    'settings' : DefiniteCanisterSettings,
+    'idle_cycles_burned_per_day' : IDL.Nat,
+    'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
   const Account = IDL.Record({
     'owner' : IDL.Principal,
     'subaccount' : IDL.Opt(IDL.Vec(IDL.Nat8)),
@@ -43,7 +62,16 @@ export const idlFactory = ({ IDL }) => {
     'value' : IDL.Nat64,
     'outpoint' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8), 'vout' : IDL.Nat32 }),
   });
+  const ReimbursementReason = IDL.Variant({
+    'CallFailed' : IDL.Null,
+    'TaintedDestination' : IDL.Record({
+      'kyt_fee' : IDL.Nat64,
+      'kyt_provider' : IDL.Principal,
+    }),
+  });
   const BitcoinAddress = IDL.Variant({
+    'p2wsh_v0' : IDL.Vec(IDL.Nat8),
+    'p2tr_v1' : IDL.Vec(IDL.Nat8),
     'p2sh' : IDL.Vec(IDL.Nat8),
     'p2wpkh_v0' : IDL.Vec(IDL.Nat8),
     'p2pkh' : IDL.Vec(IDL.Nat8),
@@ -51,7 +79,14 @@ export const idlFactory = ({ IDL }) => {
   const Event = IDL.Variant({
     'received_utxos' : IDL.Record({
       'to_account' : Account,
+      'mint_txid' : IDL.Opt(IDL.Nat64),
       'utxos' : IDL.Vec(Utxo),
+    }),
+    'schedule_deposit_reimbursement' : IDL.Record({
+      'burn_block_index' : IDL.Nat64,
+      'account' : Account,
+      'amount' : IDL.Nat64,
+      'reason' : ReimbursementReason,
     }),
     'sent_transaction' : IDL.Record({
       'fee' : IDL.Opt(IDL.Nat64),
@@ -72,6 +107,7 @@ export const idlFactory = ({ IDL }) => {
     'upgrade' : UpgradeArgs,
     'retrieve_btc_kyt_failed' : IDL.Record({
       'block_index' : IDL.Nat64,
+      'owner' : IDL.Principal,
       'uuid' : IDL.Text,
       'address' : IDL.Text,
       'amount' : IDL.Nat64,
@@ -100,6 +136,10 @@ export const idlFactory = ({ IDL }) => {
       'submitted_at' : IDL.Nat64,
     }),
     'ignored_utxo' : IDL.Record({ 'utxo' : Utxo }),
+    'reimbursed_failed_deposit' : IDL.Record({
+      'burn_block_index' : IDL.Nat64,
+      'mint_block_index' : IDL.Nat64,
+    }),
   });
   const MinterInfo = IDL.Record({
     'retrieve_btc_min_amount' : IDL.Nat64,
@@ -130,6 +170,23 @@ export const idlFactory = ({ IDL }) => {
     'Unknown' : IDL.Null,
     'Submitted' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8) }),
     'Pending' : IDL.Null,
+  });
+  const RetrieveBtcWithApprovalArgs = IDL.Record({
+    'from_subaccount' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'address' : IDL.Text,
+    'amount' : IDL.Nat64,
+  });
+  const RetrieveBtcWithApprovalError = IDL.Variant({
+    'MalformedAddress' : IDL.Text,
+    'GenericError' : IDL.Record({
+      'error_message' : IDL.Text,
+      'error_code' : IDL.Nat64,
+    }),
+    'TemporarilyUnavailable' : IDL.Text,
+    'InsufficientAllowance' : IDL.Record({ 'allowance' : IDL.Nat64 }),
+    'AlreadyProcessing' : IDL.Null,
+    'AmountTooLow' : IDL.Nat64,
+    'InsufficientFunds' : IDL.Record({ 'balance' : IDL.Nat64 }),
   });
   const UtxoStatus = IDL.Variant({
     'ValueTooSmall' : Utxo,
@@ -169,6 +226,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Text],
         [],
       ),
+    'get_canister_status' : IDL.Func([], [CanisterStatusResponse], []),
     'get_deposit_fee' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_events' : IDL.Func(
         [IDL.Record({ 'start' : IDL.Nat64, 'length' : IDL.Nat64 })],
@@ -186,6 +244,16 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Record({ 'block_index' : IDL.Nat64 })],
         [RetrieveBtcStatus],
         ['query'],
+      ),
+    'retrieve_btc_with_approval' : IDL.Func(
+        [RetrieveBtcWithApprovalArgs],
+        [
+          IDL.Variant({
+            'Ok' : RetrieveBtcOk,
+            'Err' : RetrieveBtcWithApprovalError,
+          }),
+        ],
+        [],
       ),
     'update_balance' : IDL.Func(
         [


### PR DESCRIPTION
# Motivation

We want to use the ICRC-2 flow for BTC withdrawal.
This is not available in the current Candid interface we have in ic-js.
So we update minter.did to the newest version.

# Changes

1. Pulled my IC repo to commit `8be68bc88db7332dd39a26509ddf62c564ca3415`.
2. Ran `scripts/import-candid ../../ic`
3. Reverted everything outside `packages/ckbtc/`
4. Ran `scripts/compile-idl-js`
5. Reverted everything outside `packages/ckbtc/`

# Tests

I installed @dinifty/ckbtc from local path in nns-dapp and manually tested receiving BTC and sending ckBTC.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary?