### PR TITLE
Add retrieveBTCWithApproval to ckbtc minter canister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - support new fields from swap canister response types: `min_direct_participation_icp_e8s` and `max_direct_participation_icp_e8s`
 - support new fields in the `CreateServiceNervousSystem` proposal action `maximum_direct_participation_icp` and `minimum_direct_participation_icp`.
 - support new filter field `omit_large_fields` in `list_proposals`.
+- add support for `retrieve_btc_with_approval` in `@dfinity/ckbtc`.
 
 # 2023.10.02-1515Z
 

--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -78,7 +78,7 @@ Parameters:
 
 ### :factory: CkBTCMinterCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L33)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L35)
 
 #### Methods
 
@@ -87,6 +87,7 @@ Parameters:
 - [updateBalance](#gear-updatebalance)
 - [getWithdrawalAccount](#gear-getwithdrawalaccount)
 - [retrieveBtc](#gear-retrievebtc)
+- [retrieveBtcWithApproval](#gear-retrievebtcwithapproval)
 - [estimateWithdrawalFee](#gear-estimatewithdrawalfee)
 - [getMinterInfo](#gear-getminterinfo)
 
@@ -96,7 +97,7 @@ Parameters:
 | -------- | ------------------------------------------------------------------------ |
 | `create` | `(options: CkBTCMinterCanisterOptions<_SERVICE>) => CkBTCMinterCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L34)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L36)
 
 ##### :gear: getBtcAddress
 
@@ -114,7 +115,7 @@ Parameters:
 - `params.owner`: The owner for which the BTC address should be generated. If not provided, the `caller` will be use instead.
 - `params.subaccount`: An optional subaccount to compute the address.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L55)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L57)
 
 ##### :gear: updateBalance
 
@@ -132,7 +133,7 @@ Parameters:
 - `params.owner`: The owner of the address. If not provided, the `caller` will be use instead.
 - `params.subaccount`: An optional subaccount of the address.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L74)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L76)
 
 ##### :gear: getWithdrawalAccount
 
@@ -142,7 +143,7 @@ Returns the account to which the caller should deposit ckBTC before withdrawing 
 | ---------------------- | ------------------------ |
 | `getWithdrawalAccount` | `() => Promise<Account>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L97)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L99)
 
 ##### :gear: retrieveBtc
 
@@ -166,7 +167,33 @@ Parameters:
 - `params.address`: The bitcoin address.
 - `params.amount`: The ckBTC amount.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L116)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L118)
+
+##### :gear: retrieveBtcWithApproval
+
+Submits a request to convert ckBTC to BTC after making an ICRC-2 approval.
+
+# Note
+
+The BTC retrieval process is slow. Instead of synchronously waiting for a BTC transaction to settle, this method returns a request ([block_index]) that the caller can use to query the request status.
+
+# Preconditions
+
+The caller allowed the minter's principal to spend its funds using
+[icrc2_approve] on the ckBTC ledger.
+
+| Method                    | Type                                                                                                                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `retrieveBtcWithApproval` | `({ address, amount, fromSubaccount, }: { address: string; amount: bigint; fromSubaccount?: Uint8Array; }) => Promise<RetrieveBtcOk>` |
+
+Parameters:
+
+- `params.address`: The bitcoin address.
+- `params.amount`: The ckBTC amount.
+- `params.fromSubaccount`: An optional subaccount from which
+  the ckBTC should be transferred.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L148)
 
 ##### :gear: estimateWithdrawalFee
 
@@ -182,7 +209,7 @@ Parameters:
 - `params.certified`: query or update call
 - `params.amount`: The optional amount for which the fee should be estimated.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L135)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L179)
 
 ##### :gear: getMinterInfo
 
@@ -197,7 +224,7 @@ Parameters:
 - `params`: The parameters to get the deposit fee.
 - `params.certified`: query or update call
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L149)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L193)
 
 <!-- TSDOC_END -->
 

--- a/packages/ckbtc/src/minter.canister.spec.ts
+++ b/packages/ckbtc/src/minter.canister.spec.ts
@@ -12,6 +12,7 @@ import {
   MinterAlreadyProcessingError,
   MinterAmountTooLowError,
   MinterGenericError,
+  MinterInsufficientAllowanceError,
   MinterInsufficientFundsError,
   MinterMalformedAddressError,
   MinterNoNewUtxosError,
@@ -265,6 +266,145 @@ describe("ckBTC minter canister", () => {
       const canister = minter(service);
 
       expect(() => canister.getWithdrawalAccount()).toThrowError();
+    });
+  });
+
+  describe("Retrieve BTC", () => {
+    const success: RetrieveBtcOk = {
+      block_index: 1n,
+    };
+    const ok = { Ok: success };
+
+    const params = {
+      address: bitcoinAddressMock,
+      amount: 123n,
+    };
+
+    it("should return Ok", async () => {
+      const service = mock<ActorSubclass<CkBTCMinterService>>();
+      service.retrieve_btc.mockResolvedValue(ok);
+
+      const canister = minter(service);
+
+      const res = await canister.retrieveBtc(params);
+
+      expect(service.retrieve_btc).toBeCalled();
+      expect(res).toEqual(success);
+    });
+
+    it("should throw MinterGenericError", async () => {
+      const service = mock<ActorSubclass<CkBTCMinterService>>();
+
+      const error = {
+        Err: { GenericError: { error_message: "message", error_code: 1n } },
+      };
+      service.retrieve_btc.mockResolvedValue(error);
+
+      const canister = minter(service);
+
+      const call = () => canister.retrieveBtc(params);
+
+      await expect(call).rejects.toThrowError(
+        new MinterGenericError(
+          `${error.Err.GenericError.error_message} (${error.Err.GenericError.error_code})`,
+        ),
+      );
+    });
+
+    it("should throw MinterTemporarilyUnavailable", async () => {
+      const service = mock<ActorSubclass<CkBTCMinterService>>();
+
+      const error = { Err: { TemporarilyUnavailable: "unavailable" } };
+      service.retrieve_btc.mockResolvedValue(error);
+
+      const canister = minter(service);
+
+      const call = () => canister.retrieveBtc(params);
+
+      await expect(call).rejects.toThrowError(
+        new MinterTemporaryUnavailableError(error.Err.TemporarilyUnavailable),
+      );
+    });
+
+    it("should throw MinterAlreadyProcessingError", async () => {
+      const service = mock<ActorSubclass<CkBTCMinterService>>();
+
+      const error = { Err: { AlreadyProcessing: null } };
+      service.retrieve_btc.mockResolvedValue(error);
+
+      const canister = minter(service);
+
+      const call = () => canister.retrieveBtc(params);
+
+      await expect(call).rejects.toThrowError(
+        new MinterAlreadyProcessingError(),
+      );
+    });
+
+    it("should throw MinterMalformedAddress", async () => {
+      const service = mock<ActorSubclass<CkBTCMinterService>>();
+
+      const error = { Err: { MalformedAddress: "malformated" } };
+      service.retrieve_btc.mockResolvedValue(error);
+
+      const canister = minter(service);
+
+      const call = () => canister.retrieveBtc(params);
+
+      await expect(call).rejects.toThrowError(
+        new MinterMalformedAddressError(error.Err.MalformedAddress),
+      );
+    });
+
+    it("should throw MinterAmountTooLowError", async () => {
+      const service = mock<ActorSubclass<CkBTCMinterService>>();
+
+      const error = { Err: { AmountTooLow: 123n } };
+      service.retrieve_btc.mockResolvedValue(error);
+
+      const canister = minter(service);
+
+      const call = () => canister.retrieveBtc(params);
+
+      await expect(call).rejects.toThrowError(
+        new MinterAmountTooLowError(`${error.Err.AmountTooLow}`),
+      );
+    });
+
+    it("should throw MinterInsufficientFundsError", async () => {
+      const service = mock<ActorSubclass<CkBTCMinterService>>();
+
+      const error = { Err: { InsufficientFunds: { balance: 123n } } };
+      service.retrieve_btc.mockResolvedValue(error);
+
+      const canister = minter(service);
+
+      const call = () => canister.retrieveBtc(params);
+
+      await expect(call).rejects.toThrowError(
+        new MinterInsufficientFundsError(
+          `${error.Err.InsufficientFunds.balance}`,
+        ),
+      );
+    });
+
+    it("should throw unsupported response", async () => {
+      const service = mock<ActorSubclass<CkBTCMinterService>>();
+
+      const error = { Err: { Test: null } as unknown as RetrieveBtcError };
+      service.retrieve_btc.mockResolvedValue(error);
+
+      const canister = minter(service);
+
+      const call = () => canister.retrieveBtc(params);
+
+      await expect(call).rejects.toThrowError(
+        new MinterRetrieveBtcError(
+          `Unsupported response type in minter.retrieveBtc ${JSON.stringify(
+            error.Err,
+          )}`,
+        ),
+      );
     });
   });
 

--- a/packages/ckbtc/src/types/minter.responses.ts
+++ b/packages/ckbtc/src/types/minter.responses.ts
@@ -1,6 +1,7 @@
 import type {
   RetrieveBtcError,
   RetrieveBtcOk,
+  RetrieveBtcWithApprovalError,
   UpdateBalanceError,
   UtxoStatus,
 } from "../../candid/minter";
@@ -14,5 +15,9 @@ export type UpdateBalanceResponse =
 export type RetrieveBtcResponse =
   | { Ok: RetrieveBtcOk }
   | { Err: RetrieveBtcError };
+
+export type RetrieveBtcWithApprovalResponse =
+  | { Ok: RetrieveBtcOk }
+  | { Err: RetrieveBtcWithApprovalError };
 
 export type EstimateWithdrawalFee = { minter_fee: bigint; bitcoin_fee: bigint };


### PR DESCRIPTION
# Motivation

We want to use ICRC-2 for BTC withdrawals.

# Changes

1. Add `createRetrieveBtcWithApprovalError` to convert `RetrieveBtcWithApprovalError`.
2. Add `retrieveBtcWithApproval` which calls `retrieve_btc_with_approval` on the minter canister.
3. Add unit tests for `retrieveBtcWithApproval`.
4. Unrelated: Correct a comment about the type of `subaccount` on `getBtcAddress`, which was mentioned as `Principal` but should be `Uint8Array`.

# Tests

Unit tests pass.
Also tested manually by installing the local changes in nns-dapp.

# Todos

- [x] Add entry to changelog (if necessary).
