### PR TITLE
Fix: Update nns-js candid types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 - support new fields from swap canister response types: `min_direct_participation_icp_e8s` and `max_direct_participation_icp_e8s`
 - support new fields in the `CreateServiceNervousSystem` proposal action `maximum_direct_participation_icp`, `minimum_direct_participation_icp` and `neurons_fund_participation`.
 - support new filter field `omit_large_fields` in `list_proposals`.
-- support new field `is_genesis` in `Neuron` and `NeuronInfo`.
 - add support for `retrieve_btc_with_approval` in `@dfinity/ckbtc`.
 
 # 2023.10.02-1515Z

--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 15e69667ae983fa92c33794a3954d9ca87518af6 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit 1a01f85fc1994e69dd5ba72b4d87fe9f9c4093ee 'rs/nns/gtc/canister/gtc.did' by import-candid
 type AccountState = record {
   authenticated_principal_id : opt principal;
   successfully_transferred_neurons : vec TransferredNeuron;

--- a/packages/nns/candid/governance.certified.idl.js
+++ b/packages/nns/candid/governance.certified.idl.js
@@ -364,29 +364,12 @@ export const idlFactory = ({ IDL }) => {
     'neuron_indexes_migration' : IDL.Opt(Migration),
     'copy_inactive_neurons_to_stable_memory_migration' : IDL.Opt(Migration),
   });
-  const NeuronsFundNeuron_1 = IDL.Record({
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
-    'is_capped' : IDL.Opt(IDL.Bool),
-    'nns_neuron_id' : IDL.Opt(IDL.Nat64),
-    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
-  });
-  const NeuronsFundSnapshot = IDL.Record({
-    'neurons_fund_neurons' : IDL.Vec(NeuronsFundNeuron_1),
-  });
-  const IdealMatchedParticipationFunction = IDL.Record({
-    'serialized_representation' : IDL.Opt(IDL.Text),
-  });
-  const NeuronsFundParticipation = IDL.Record({
-    'neurons_fund_snapshot' : IDL.Opt(NeuronsFundSnapshot),
-    'ideal_matched_participation_function' : IDL.Opt(
-      IdealMatchedParticipationFunction
-    ),
-  });
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
   });
   const CfNeuron = IDL.Record({
+    'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
@@ -395,6 +378,41 @@ export const idlFactory = ({ IDL }) => {
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
   const Ballot = IDL.Record({ 'vote' : IDL.Int32, 'voting_power' : IDL.Nat64 });
+  const SwapParticipationLimits = IDL.Record({
+    'min_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'min_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundNeuronPortion = IDL.Record({
+    'hotkey_principal' : IDL.Opt(IDL.Principal),
+    'is_capped' : IDL.Opt(IDL.Bool),
+    'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'nns_neuron_id' : IDL.Opt(NeuronId),
+    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundSnapshot = IDL.Record({
+    'neurons_fund_neuron_portions' : IDL.Vec(NeuronsFundNeuronPortion),
+  });
+  const IdealMatchedParticipationFunction = IDL.Record({
+    'serialized_representation' : IDL.Opt(IDL.Text),
+  });
+  const NeuronsFundParticipation = IDL.Record({
+    'total_maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'intended_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'swap_participation_limits' : IDL.Opt(SwapParticipationLimits),
+    'max_neurons_fund_swap_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'neurons_fund_reserves' : IDL.Opt(NeuronsFundSnapshot),
+    'ideal_matched_participation_function' : IDL.Opt(
+      IdealMatchedParticipationFunction
+    ),
+  });
+  const NeuronsFundData = IDL.Record({
+    'final_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'initial_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'neurons_fund_refunds' : IDL.Opt(NeuronsFundSnapshot),
+  });
   const CanisterStatusResultV2 = IDL.Record({
     'status' : IDL.Opt(IDL.Int32),
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
@@ -432,13 +450,13 @@ export const idlFactory = ({ IDL }) => {
   });
   const ProposalData = IDL.Record({
     'id' : IDL.Opt(NeuronId),
-    'neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
     'failure_reason' : IDL.Opt(GovernanceError),
     'cf_participants' : IDL.Vec(CfParticipant),
     'ballots' : IDL.Vec(IDL.Tuple(IDL.Nat64, Ballot)),
     'proposal_timestamp_seconds' : IDL.Nat64,
     'reward_event_round' : IDL.Nat64,
     'failed_timestamp_seconds' : IDL.Nat64,
+    'neurons_fund_data' : IDL.Opt(NeuronsFundData),
     'reject_cost_e8s' : IDL.Nat64,
     'derived_proposal_information' : IDL.Opt(DerivedProposalInformation),
     'latest_tally' : IDL.Opt(Tally),
@@ -487,7 +505,6 @@ export const idlFactory = ({ IDL }) => {
     'created_timestamp_seconds' : IDL.Nat64,
     'auto_stake_maturity' : IDL.Opt(IDL.Bool),
     'aging_since_timestamp_seconds' : IDL.Nat64,
-    'is_genesis' : IDL.Opt(IDL.Bool),
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
@@ -545,7 +562,6 @@ export const idlFactory = ({ IDL }) => {
     'recent_ballots' : IDL.Vec(BallotInfo),
     'created_timestamp_seconds' : IDL.Nat64,
     'state' : IDL.Int32,
-    'is_genesis' : IDL.Opt(IDL.Bool),
     'stake_e8s' : IDL.Nat64,
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'retrieved_at_timestamp_seconds' : IDL.Nat64,
@@ -674,7 +690,7 @@ export const idlFactory = ({ IDL }) => {
     'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
   const Ok = IDL.Record({
-    'neurons_fund_neurons' : IDL.Vec(NeuronsFundNeuron),
+    'neurons_fund_neuron_portions' : IDL.Vec(NeuronsFundNeuron),
   });
   const Result_9 = IDL.Variant({ 'Ok' : Ok, 'Err' : GovernanceError });
   const SettleNeuronsFundParticipationResponse = IDL.Record({
@@ -1113,29 +1129,12 @@ export const init = ({ IDL }) => {
     'neuron_indexes_migration' : IDL.Opt(Migration),
     'copy_inactive_neurons_to_stable_memory_migration' : IDL.Opt(Migration),
   });
-  const NeuronsFundNeuron_1 = IDL.Record({
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
-    'is_capped' : IDL.Opt(IDL.Bool),
-    'nns_neuron_id' : IDL.Opt(IDL.Nat64),
-    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
-  });
-  const NeuronsFundSnapshot = IDL.Record({
-    'neurons_fund_neurons' : IDL.Vec(NeuronsFundNeuron_1),
-  });
-  const IdealMatchedParticipationFunction = IDL.Record({
-    'serialized_representation' : IDL.Opt(IDL.Text),
-  });
-  const NeuronsFundParticipation = IDL.Record({
-    'neurons_fund_snapshot' : IDL.Opt(NeuronsFundSnapshot),
-    'ideal_matched_participation_function' : IDL.Opt(
-      IdealMatchedParticipationFunction
-    ),
-  });
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
   });
   const CfNeuron = IDL.Record({
+    'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
@@ -1144,6 +1143,41 @@ export const init = ({ IDL }) => {
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
   const Ballot = IDL.Record({ 'vote' : IDL.Int32, 'voting_power' : IDL.Nat64 });
+  const SwapParticipationLimits = IDL.Record({
+    'min_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'min_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundNeuronPortion = IDL.Record({
+    'hotkey_principal' : IDL.Opt(IDL.Principal),
+    'is_capped' : IDL.Opt(IDL.Bool),
+    'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'nns_neuron_id' : IDL.Opt(NeuronId),
+    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundSnapshot = IDL.Record({
+    'neurons_fund_neuron_portions' : IDL.Vec(NeuronsFundNeuronPortion),
+  });
+  const IdealMatchedParticipationFunction = IDL.Record({
+    'serialized_representation' : IDL.Opt(IDL.Text),
+  });
+  const NeuronsFundParticipation = IDL.Record({
+    'total_maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'intended_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'swap_participation_limits' : IDL.Opt(SwapParticipationLimits),
+    'max_neurons_fund_swap_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'neurons_fund_reserves' : IDL.Opt(NeuronsFundSnapshot),
+    'ideal_matched_participation_function' : IDL.Opt(
+      IdealMatchedParticipationFunction
+    ),
+  });
+  const NeuronsFundData = IDL.Record({
+    'final_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'initial_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'neurons_fund_refunds' : IDL.Opt(NeuronsFundSnapshot),
+  });
   const CanisterStatusResultV2 = IDL.Record({
     'status' : IDL.Opt(IDL.Int32),
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
@@ -1181,13 +1215,13 @@ export const init = ({ IDL }) => {
   });
   const ProposalData = IDL.Record({
     'id' : IDL.Opt(NeuronId),
-    'neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
     'failure_reason' : IDL.Opt(GovernanceError),
     'cf_participants' : IDL.Vec(CfParticipant),
     'ballots' : IDL.Vec(IDL.Tuple(IDL.Nat64, Ballot)),
     'proposal_timestamp_seconds' : IDL.Nat64,
     'reward_event_round' : IDL.Nat64,
     'failed_timestamp_seconds' : IDL.Nat64,
+    'neurons_fund_data' : IDL.Opt(NeuronsFundData),
     'reject_cost_e8s' : IDL.Nat64,
     'derived_proposal_information' : IDL.Opt(DerivedProposalInformation),
     'latest_tally' : IDL.Opt(Tally),
@@ -1236,7 +1270,6 @@ export const init = ({ IDL }) => {
     'created_timestamp_seconds' : IDL.Nat64,
     'auto_stake_maturity' : IDL.Opt(IDL.Bool),
     'aging_since_timestamp_seconds' : IDL.Nat64,
-    'is_genesis' : IDL.Opt(IDL.Bool),
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -59,6 +59,7 @@ export interface CanisterSummary {
   canister_id: [] | [Principal];
 }
 export interface CfNeuron {
+  has_created_neuron_recipes: [] | [boolean];
   nns_neuron_id: bigint;
   amount_icp_e8s: bigint;
 }
@@ -382,7 +383,6 @@ export interface Neuron {
   created_timestamp_seconds: bigint;
   auto_stake_maturity: [] | [boolean];
   aging_since_timestamp_seconds: bigint;
-  is_genesis: [] | [boolean];
   hot_keys: Array<Principal>;
   account: Uint8Array;
   joined_community_fund_timestamp_seconds: [] | [bigint];
@@ -423,7 +423,6 @@ export interface NeuronInfo {
   recent_ballots: Array<BallotInfo>;
   created_timestamp_seconds: bigint;
   state: number;
-  is_genesis: [] | [boolean];
   stake_e8s: bigint;
   joined_community_fund_timestamp_seconds: [] | [bigint];
   retrieved_at_timestamp_seconds: bigint;
@@ -440,33 +439,44 @@ export interface NeuronStakeTransfer {
   transfer_timestamp: bigint;
   block_height: bigint;
 }
+export interface NeuronsFundData {
+  final_neurons_fund_participation: [] | [NeuronsFundParticipation];
+  initial_neurons_fund_participation: [] | [NeuronsFundParticipation];
+  neurons_fund_refunds: [] | [NeuronsFundSnapshot];
+}
 export interface NeuronsFundNeuron {
   hotkey_principal: [] | [string];
   is_capped: [] | [boolean];
   nns_neuron_id: [] | [bigint];
   amount_icp_e8s: [] | [bigint];
 }
-export interface NeuronsFundNeuron_1 {
+export interface NeuronsFundNeuronPortion {
   hotkey_principal: [] | [Principal];
   is_capped: [] | [boolean];
-  nns_neuron_id: [] | [bigint];
+  maturity_equivalent_icp_e8s: [] | [bigint];
+  nns_neuron_id: [] | [NeuronId];
   amount_icp_e8s: [] | [bigint];
 }
 export interface NeuronsFundParticipation {
-  neurons_fund_snapshot: [] | [NeuronsFundSnapshot];
+  total_maturity_equivalent_icp_e8s: [] | [bigint];
+  intended_neurons_fund_participation_icp_e8s: [] | [bigint];
+  direct_participation_icp_e8s: [] | [bigint];
+  swap_participation_limits: [] | [SwapParticipationLimits];
+  max_neurons_fund_swap_participation_icp_e8s: [] | [bigint];
+  neurons_fund_reserves: [] | [NeuronsFundSnapshot];
   ideal_matched_participation_function:
     | []
     | [IdealMatchedParticipationFunction];
 }
 export interface NeuronsFundSnapshot {
-  neurons_fund_neurons: Array<NeuronsFundNeuron_1>;
+  neurons_fund_neuron_portions: Array<NeuronsFundNeuronPortion>;
 }
 export interface NodeProvider {
   id: [] | [Principal];
   reward_account: [] | [AccountIdentifier];
 }
 export interface Ok {
-  neurons_fund_neurons: Array<NeuronsFundNeuron>;
+  neurons_fund_neuron_portions: Array<NeuronsFundNeuron>;
 }
 export interface OpenSnsTokenSwap {
   community_fund_investment_e8s: [] | [bigint];
@@ -510,13 +520,13 @@ export interface Proposal {
 }
 export interface ProposalData {
   id: [] | [NeuronId];
-  neurons_fund_participation: [] | [NeuronsFundParticipation];
   failure_reason: [] | [GovernanceError];
   cf_participants: Array<CfParticipant>;
   ballots: Array<[bigint, Ballot]>;
   proposal_timestamp_seconds: bigint;
   reward_event_round: bigint;
   failed_timestamp_seconds: bigint;
+  neurons_fund_data: [] | [NeuronsFundData];
   reject_cost_e8s: bigint;
   derived_proposal_information: [] | [DerivedProposalInformation];
   latest_tally: [] | [Tally];
@@ -665,6 +675,12 @@ export interface SwapParameters {
   maximum_icp: [] | [Tokens];
   neurons_fund_investment_icp: [] | [Tokens];
   restricted_countries: [] | [Countries];
+}
+export interface SwapParticipationLimits {
+  min_participant_icp_e8s: [] | [bigint];
+  max_participant_icp_e8s: [] | [bigint];
+  min_direct_participation_icp_e8s: [] | [bigint];
+  max_direct_participation_icp_e8s: [] | [bigint];
 }
 export interface Tally {
   no: bigint;

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 2d57e93dabc5f13258d0dee1ffb2363ddce7fe62 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 1a01f85fc1994e69dd5ba72b4d87fe9f9c4093ee 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record { hash : vec nat8 };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
@@ -40,7 +40,11 @@ type CanisterSummary = record {
   status : opt CanisterStatusResultV2;
   canister_id : opt principal;
 };
-type CfNeuron = record { nns_neuron_id : nat64; amount_icp_e8s : nat64 };
+type CfNeuron = record {
+  has_created_neuron_recipes : opt bool;
+  nns_neuron_id : nat64;
+  amount_icp_e8s : nat64;
+};
 type CfParticipant = record {
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
@@ -317,7 +321,6 @@ type Neuron = record {
   created_timestamp_seconds : nat64;
   auto_stake_maturity : opt bool;
   aging_since_timestamp_seconds : nat64;
-  is_genesis : opt bool;
   hot_keys : vec principal;
   account : vec nat8;
   joined_community_fund_timestamp_seconds : opt nat64;
@@ -357,7 +360,6 @@ type NeuronInfo = record {
   recent_ballots : vec BallotInfo;
   created_timestamp_seconds : nat64;
   state : int32;
-  is_genesis : opt bool;
   stake_e8s : nat64;
   joined_community_fund_timestamp_seconds : opt nat64;
   retrieved_at_timestamp_seconds : nat64;
@@ -374,30 +376,41 @@ type NeuronStakeTransfer = record {
   transfer_timestamp : nat64;
   block_height : nat64;
 };
+type NeuronsFundData = record {
+  final_neurons_fund_participation : opt NeuronsFundParticipation;
+  initial_neurons_fund_participation : opt NeuronsFundParticipation;
+  neurons_fund_refunds : opt NeuronsFundSnapshot;
+};
 type NeuronsFundNeuron = record {
   hotkey_principal : opt text;
   is_capped : opt bool;
   nns_neuron_id : opt nat64;
   amount_icp_e8s : opt nat64;
 };
-type NeuronsFundNeuron_1 = record {
+type NeuronsFundNeuronPortion = record {
   hotkey_principal : opt principal;
   is_capped : opt bool;
-  nns_neuron_id : opt nat64;
+  maturity_equivalent_icp_e8s : opt nat64;
+  nns_neuron_id : opt NeuronId;
   amount_icp_e8s : opt nat64;
 };
 type NeuronsFundParticipation = record {
-  neurons_fund_snapshot : opt NeuronsFundSnapshot;
+  total_maturity_equivalent_icp_e8s : opt nat64;
+  intended_neurons_fund_participation_icp_e8s : opt nat64;
+  direct_participation_icp_e8s : opt nat64;
+  swap_participation_limits : opt SwapParticipationLimits;
+  max_neurons_fund_swap_participation_icp_e8s : opt nat64;
+  neurons_fund_reserves : opt NeuronsFundSnapshot;
   ideal_matched_participation_function : opt IdealMatchedParticipationFunction;
 };
 type NeuronsFundSnapshot = record {
-  neurons_fund_neurons : vec NeuronsFundNeuron_1;
+  neurons_fund_neuron_portions : vec NeuronsFundNeuronPortion;
 };
 type NodeProvider = record {
   id : opt principal;
   reward_account : opt AccountIdentifier;
 };
-type Ok = record { neurons_fund_neurons : vec NeuronsFundNeuron };
+type Ok = record { neurons_fund_neuron_portions : vec NeuronsFundNeuron };
 type OpenSnsTokenSwap = record {
   community_fund_investment_e8s : opt nat64;
   target_swap_canister_id : opt principal;
@@ -437,13 +450,13 @@ type Proposal = record {
 };
 type ProposalData = record {
   id : opt NeuronId;
-  neurons_fund_participation : opt NeuronsFundParticipation;
   failure_reason : opt GovernanceError;
   cf_participants : vec CfParticipant;
   ballots : vec record { nat64; Ballot };
   proposal_timestamp_seconds : nat64;
   reward_event_round : nat64;
   failed_timestamp_seconds : nat64;
+  neurons_fund_data : opt NeuronsFundData;
   reject_cost_e8s : nat64;
   derived_proposal_information : opt DerivedProposalInformation;
   latest_tally : opt Tally;
@@ -566,6 +579,12 @@ type SwapParameters = record {
   maximum_icp : opt Tokens;
   neurons_fund_investment_icp : opt Tokens;
   restricted_countries : opt Countries;
+};
+type SwapParticipationLimits = record {
+  min_participant_icp_e8s : opt nat64;
+  max_participant_icp_e8s : opt nat64;
+  min_direct_participation_icp_e8s : opt nat64;
+  max_direct_participation_icp_e8s : opt nat64;
 };
 type Tally = record {
   no : nat64;

--- a/packages/nns/candid/governance.idl.js
+++ b/packages/nns/candid/governance.idl.js
@@ -364,29 +364,12 @@ export const idlFactory = ({ IDL }) => {
     'neuron_indexes_migration' : IDL.Opt(Migration),
     'copy_inactive_neurons_to_stable_memory_migration' : IDL.Opt(Migration),
   });
-  const NeuronsFundNeuron_1 = IDL.Record({
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
-    'is_capped' : IDL.Opt(IDL.Bool),
-    'nns_neuron_id' : IDL.Opt(IDL.Nat64),
-    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
-  });
-  const NeuronsFundSnapshot = IDL.Record({
-    'neurons_fund_neurons' : IDL.Vec(NeuronsFundNeuron_1),
-  });
-  const IdealMatchedParticipationFunction = IDL.Record({
-    'serialized_representation' : IDL.Opt(IDL.Text),
-  });
-  const NeuronsFundParticipation = IDL.Record({
-    'neurons_fund_snapshot' : IDL.Opt(NeuronsFundSnapshot),
-    'ideal_matched_participation_function' : IDL.Opt(
-      IdealMatchedParticipationFunction
-    ),
-  });
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
   });
   const CfNeuron = IDL.Record({
+    'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
@@ -395,6 +378,41 @@ export const idlFactory = ({ IDL }) => {
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
   const Ballot = IDL.Record({ 'vote' : IDL.Int32, 'voting_power' : IDL.Nat64 });
+  const SwapParticipationLimits = IDL.Record({
+    'min_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'min_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundNeuronPortion = IDL.Record({
+    'hotkey_principal' : IDL.Opt(IDL.Principal),
+    'is_capped' : IDL.Opt(IDL.Bool),
+    'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'nns_neuron_id' : IDL.Opt(NeuronId),
+    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundSnapshot = IDL.Record({
+    'neurons_fund_neuron_portions' : IDL.Vec(NeuronsFundNeuronPortion),
+  });
+  const IdealMatchedParticipationFunction = IDL.Record({
+    'serialized_representation' : IDL.Opt(IDL.Text),
+  });
+  const NeuronsFundParticipation = IDL.Record({
+    'total_maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'intended_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'swap_participation_limits' : IDL.Opt(SwapParticipationLimits),
+    'max_neurons_fund_swap_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'neurons_fund_reserves' : IDL.Opt(NeuronsFundSnapshot),
+    'ideal_matched_participation_function' : IDL.Opt(
+      IdealMatchedParticipationFunction
+    ),
+  });
+  const NeuronsFundData = IDL.Record({
+    'final_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'initial_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'neurons_fund_refunds' : IDL.Opt(NeuronsFundSnapshot),
+  });
   const CanisterStatusResultV2 = IDL.Record({
     'status' : IDL.Opt(IDL.Int32),
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
@@ -432,13 +450,13 @@ export const idlFactory = ({ IDL }) => {
   });
   const ProposalData = IDL.Record({
     'id' : IDL.Opt(NeuronId),
-    'neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
     'failure_reason' : IDL.Opt(GovernanceError),
     'cf_participants' : IDL.Vec(CfParticipant),
     'ballots' : IDL.Vec(IDL.Tuple(IDL.Nat64, Ballot)),
     'proposal_timestamp_seconds' : IDL.Nat64,
     'reward_event_round' : IDL.Nat64,
     'failed_timestamp_seconds' : IDL.Nat64,
+    'neurons_fund_data' : IDL.Opt(NeuronsFundData),
     'reject_cost_e8s' : IDL.Nat64,
     'derived_proposal_information' : IDL.Opt(DerivedProposalInformation),
     'latest_tally' : IDL.Opt(Tally),
@@ -487,7 +505,6 @@ export const idlFactory = ({ IDL }) => {
     'created_timestamp_seconds' : IDL.Nat64,
     'auto_stake_maturity' : IDL.Opt(IDL.Bool),
     'aging_since_timestamp_seconds' : IDL.Nat64,
-    'is_genesis' : IDL.Opt(IDL.Bool),
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
@@ -545,7 +562,6 @@ export const idlFactory = ({ IDL }) => {
     'recent_ballots' : IDL.Vec(BallotInfo),
     'created_timestamp_seconds' : IDL.Nat64,
     'state' : IDL.Int32,
-    'is_genesis' : IDL.Opt(IDL.Bool),
     'stake_e8s' : IDL.Nat64,
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'retrieved_at_timestamp_seconds' : IDL.Nat64,
@@ -674,7 +690,7 @@ export const idlFactory = ({ IDL }) => {
     'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
   const Ok = IDL.Record({
-    'neurons_fund_neurons' : IDL.Vec(NeuronsFundNeuron),
+    'neurons_fund_neuron_portions' : IDL.Vec(NeuronsFundNeuron),
   });
   const Result_9 = IDL.Variant({ 'Ok' : Ok, 'Err' : GovernanceError });
   const SettleNeuronsFundParticipationResponse = IDL.Record({
@@ -1125,29 +1141,12 @@ export const init = ({ IDL }) => {
     'neuron_indexes_migration' : IDL.Opt(Migration),
     'copy_inactive_neurons_to_stable_memory_migration' : IDL.Opt(Migration),
   });
-  const NeuronsFundNeuron_1 = IDL.Record({
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
-    'is_capped' : IDL.Opt(IDL.Bool),
-    'nns_neuron_id' : IDL.Opt(IDL.Nat64),
-    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
-  });
-  const NeuronsFundSnapshot = IDL.Record({
-    'neurons_fund_neurons' : IDL.Vec(NeuronsFundNeuron_1),
-  });
-  const IdealMatchedParticipationFunction = IDL.Record({
-    'serialized_representation' : IDL.Opt(IDL.Text),
-  });
-  const NeuronsFundParticipation = IDL.Record({
-    'neurons_fund_snapshot' : IDL.Opt(NeuronsFundSnapshot),
-    'ideal_matched_participation_function' : IDL.Opt(
-      IdealMatchedParticipationFunction
-    ),
-  });
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
   });
   const CfNeuron = IDL.Record({
+    'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
@@ -1156,6 +1155,41 @@ export const init = ({ IDL }) => {
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
   const Ballot = IDL.Record({ 'vote' : IDL.Int32, 'voting_power' : IDL.Nat64 });
+  const SwapParticipationLimits = IDL.Record({
+    'min_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'min_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundNeuronPortion = IDL.Record({
+    'hotkey_principal' : IDL.Opt(IDL.Principal),
+    'is_capped' : IDL.Opt(IDL.Bool),
+    'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'nns_neuron_id' : IDL.Opt(NeuronId),
+    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundSnapshot = IDL.Record({
+    'neurons_fund_neuron_portions' : IDL.Vec(NeuronsFundNeuronPortion),
+  });
+  const IdealMatchedParticipationFunction = IDL.Record({
+    'serialized_representation' : IDL.Opt(IDL.Text),
+  });
+  const NeuronsFundParticipation = IDL.Record({
+    'total_maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'intended_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'swap_participation_limits' : IDL.Opt(SwapParticipationLimits),
+    'max_neurons_fund_swap_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'neurons_fund_reserves' : IDL.Opt(NeuronsFundSnapshot),
+    'ideal_matched_participation_function' : IDL.Opt(
+      IdealMatchedParticipationFunction
+    ),
+  });
+  const NeuronsFundData = IDL.Record({
+    'final_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'initial_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'neurons_fund_refunds' : IDL.Opt(NeuronsFundSnapshot),
+  });
   const CanisterStatusResultV2 = IDL.Record({
     'status' : IDL.Opt(IDL.Int32),
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
@@ -1193,13 +1227,13 @@ export const init = ({ IDL }) => {
   });
   const ProposalData = IDL.Record({
     'id' : IDL.Opt(NeuronId),
-    'neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
     'failure_reason' : IDL.Opt(GovernanceError),
     'cf_participants' : IDL.Vec(CfParticipant),
     'ballots' : IDL.Vec(IDL.Tuple(IDL.Nat64, Ballot)),
     'proposal_timestamp_seconds' : IDL.Nat64,
     'reward_event_round' : IDL.Nat64,
     'failed_timestamp_seconds' : IDL.Nat64,
+    'neurons_fund_data' : IDL.Opt(NeuronsFundData),
     'reject_cost_e8s' : IDL.Nat64,
     'derived_proposal_information' : IDL.Opt(DerivedProposalInformation),
     'latest_tally' : IDL.Opt(Tally),
@@ -1248,7 +1282,6 @@ export const init = ({ IDL }) => {
     'created_timestamp_seconds' : IDL.Nat64,
     'auto_stake_maturity' : IDL.Opt(IDL.Bool),
     'aging_since_timestamp_seconds' : IDL.Nat64,
-    'is_genesis' : IDL.Opt(IDL.Bool),
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/candid/governance_test.certified.idl.js
+++ b/packages/nns/candid/governance_test.certified.idl.js
@@ -364,29 +364,12 @@ export const idlFactory = ({ IDL }) => {
     'neuron_indexes_migration' : IDL.Opt(Migration),
     'copy_inactive_neurons_to_stable_memory_migration' : IDL.Opt(Migration),
   });
-  const NeuronsFundNeuron_1 = IDL.Record({
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
-    'is_capped' : IDL.Opt(IDL.Bool),
-    'nns_neuron_id' : IDL.Opt(IDL.Nat64),
-    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
-  });
-  const NeuronsFundSnapshot = IDL.Record({
-    'neurons_fund_neurons' : IDL.Vec(NeuronsFundNeuron_1),
-  });
-  const IdealMatchedParticipationFunction = IDL.Record({
-    'serialized_representation' : IDL.Opt(IDL.Text),
-  });
-  const NeuronsFundParticipation = IDL.Record({
-    'neurons_fund_snapshot' : IDL.Opt(NeuronsFundSnapshot),
-    'ideal_matched_participation_function' : IDL.Opt(
-      IdealMatchedParticipationFunction
-    ),
-  });
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
   });
   const CfNeuron = IDL.Record({
+    'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
@@ -395,6 +378,41 @@ export const idlFactory = ({ IDL }) => {
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
   const Ballot = IDL.Record({ 'vote' : IDL.Int32, 'voting_power' : IDL.Nat64 });
+  const SwapParticipationLimits = IDL.Record({
+    'min_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'min_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundNeuronPortion = IDL.Record({
+    'hotkey_principal' : IDL.Opt(IDL.Principal),
+    'is_capped' : IDL.Opt(IDL.Bool),
+    'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'nns_neuron_id' : IDL.Opt(NeuronId),
+    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundSnapshot = IDL.Record({
+    'neurons_fund_neuron_portions' : IDL.Vec(NeuronsFundNeuronPortion),
+  });
+  const IdealMatchedParticipationFunction = IDL.Record({
+    'serialized_representation' : IDL.Opt(IDL.Text),
+  });
+  const NeuronsFundParticipation = IDL.Record({
+    'total_maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'intended_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'swap_participation_limits' : IDL.Opt(SwapParticipationLimits),
+    'max_neurons_fund_swap_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'neurons_fund_reserves' : IDL.Opt(NeuronsFundSnapshot),
+    'ideal_matched_participation_function' : IDL.Opt(
+      IdealMatchedParticipationFunction
+    ),
+  });
+  const NeuronsFundData = IDL.Record({
+    'final_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'initial_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'neurons_fund_refunds' : IDL.Opt(NeuronsFundSnapshot),
+  });
   const CanisterStatusResultV2 = IDL.Record({
     'status' : IDL.Opt(IDL.Int32),
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
@@ -432,13 +450,13 @@ export const idlFactory = ({ IDL }) => {
   });
   const ProposalData = IDL.Record({
     'id' : IDL.Opt(NeuronId),
-    'neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
     'failure_reason' : IDL.Opt(GovernanceError),
     'cf_participants' : IDL.Vec(CfParticipant),
     'ballots' : IDL.Vec(IDL.Tuple(IDL.Nat64, Ballot)),
     'proposal_timestamp_seconds' : IDL.Nat64,
     'reward_event_round' : IDL.Nat64,
     'failed_timestamp_seconds' : IDL.Nat64,
+    'neurons_fund_data' : IDL.Opt(NeuronsFundData),
     'reject_cost_e8s' : IDL.Nat64,
     'derived_proposal_information' : IDL.Opt(DerivedProposalInformation),
     'latest_tally' : IDL.Opt(Tally),
@@ -487,7 +505,6 @@ export const idlFactory = ({ IDL }) => {
     'created_timestamp_seconds' : IDL.Nat64,
     'auto_stake_maturity' : IDL.Opt(IDL.Bool),
     'aging_since_timestamp_seconds' : IDL.Nat64,
-    'is_genesis' : IDL.Opt(IDL.Bool),
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
@@ -545,7 +562,6 @@ export const idlFactory = ({ IDL }) => {
     'recent_ballots' : IDL.Vec(BallotInfo),
     'created_timestamp_seconds' : IDL.Nat64,
     'state' : IDL.Int32,
-    'is_genesis' : IDL.Opt(IDL.Bool),
     'stake_e8s' : IDL.Nat64,
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'retrieved_at_timestamp_seconds' : IDL.Nat64,
@@ -674,7 +690,7 @@ export const idlFactory = ({ IDL }) => {
     'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
   const Ok = IDL.Record({
-    'neurons_fund_neurons' : IDL.Vec(NeuronsFundNeuron),
+    'neurons_fund_neuron_portions' : IDL.Vec(NeuronsFundNeuron),
   });
   const Result_9 = IDL.Variant({ 'Ok' : Ok, 'Err' : GovernanceError });
   const SettleNeuronsFundParticipationResponse = IDL.Record({
@@ -1114,29 +1130,12 @@ export const init = ({ IDL }) => {
     'neuron_indexes_migration' : IDL.Opt(Migration),
     'copy_inactive_neurons_to_stable_memory_migration' : IDL.Opt(Migration),
   });
-  const NeuronsFundNeuron_1 = IDL.Record({
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
-    'is_capped' : IDL.Opt(IDL.Bool),
-    'nns_neuron_id' : IDL.Opt(IDL.Nat64),
-    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
-  });
-  const NeuronsFundSnapshot = IDL.Record({
-    'neurons_fund_neurons' : IDL.Vec(NeuronsFundNeuron_1),
-  });
-  const IdealMatchedParticipationFunction = IDL.Record({
-    'serialized_representation' : IDL.Opt(IDL.Text),
-  });
-  const NeuronsFundParticipation = IDL.Record({
-    'neurons_fund_snapshot' : IDL.Opt(NeuronsFundSnapshot),
-    'ideal_matched_participation_function' : IDL.Opt(
-      IdealMatchedParticipationFunction
-    ),
-  });
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
   });
   const CfNeuron = IDL.Record({
+    'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
@@ -1145,6 +1144,41 @@ export const init = ({ IDL }) => {
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
   const Ballot = IDL.Record({ 'vote' : IDL.Int32, 'voting_power' : IDL.Nat64 });
+  const SwapParticipationLimits = IDL.Record({
+    'min_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'min_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundNeuronPortion = IDL.Record({
+    'hotkey_principal' : IDL.Opt(IDL.Principal),
+    'is_capped' : IDL.Opt(IDL.Bool),
+    'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'nns_neuron_id' : IDL.Opt(NeuronId),
+    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundSnapshot = IDL.Record({
+    'neurons_fund_neuron_portions' : IDL.Vec(NeuronsFundNeuronPortion),
+  });
+  const IdealMatchedParticipationFunction = IDL.Record({
+    'serialized_representation' : IDL.Opt(IDL.Text),
+  });
+  const NeuronsFundParticipation = IDL.Record({
+    'total_maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'intended_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'swap_participation_limits' : IDL.Opt(SwapParticipationLimits),
+    'max_neurons_fund_swap_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'neurons_fund_reserves' : IDL.Opt(NeuronsFundSnapshot),
+    'ideal_matched_participation_function' : IDL.Opt(
+      IdealMatchedParticipationFunction
+    ),
+  });
+  const NeuronsFundData = IDL.Record({
+    'final_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'initial_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'neurons_fund_refunds' : IDL.Opt(NeuronsFundSnapshot),
+  });
   const CanisterStatusResultV2 = IDL.Record({
     'status' : IDL.Opt(IDL.Int32),
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
@@ -1182,13 +1216,13 @@ export const init = ({ IDL }) => {
   });
   const ProposalData = IDL.Record({
     'id' : IDL.Opt(NeuronId),
-    'neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
     'failure_reason' : IDL.Opt(GovernanceError),
     'cf_participants' : IDL.Vec(CfParticipant),
     'ballots' : IDL.Vec(IDL.Tuple(IDL.Nat64, Ballot)),
     'proposal_timestamp_seconds' : IDL.Nat64,
     'reward_event_round' : IDL.Nat64,
     'failed_timestamp_seconds' : IDL.Nat64,
+    'neurons_fund_data' : IDL.Opt(NeuronsFundData),
     'reject_cost_e8s' : IDL.Nat64,
     'derived_proposal_information' : IDL.Opt(DerivedProposalInformation),
     'latest_tally' : IDL.Opt(Tally),
@@ -1237,7 +1271,6 @@ export const init = ({ IDL }) => {
     'created_timestamp_seconds' : IDL.Nat64,
     'auto_stake_maturity' : IDL.Opt(IDL.Bool),
     'aging_since_timestamp_seconds' : IDL.Nat64,
-    'is_genesis' : IDL.Opt(IDL.Bool),
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/candid/governance_test.d.ts
+++ b/packages/nns/candid/governance_test.d.ts
@@ -59,6 +59,7 @@ export interface CanisterSummary {
   canister_id: [] | [Principal];
 }
 export interface CfNeuron {
+  has_created_neuron_recipes: [] | [boolean];
   nns_neuron_id: bigint;
   amount_icp_e8s: bigint;
 }
@@ -382,7 +383,6 @@ export interface Neuron {
   created_timestamp_seconds: bigint;
   auto_stake_maturity: [] | [boolean];
   aging_since_timestamp_seconds: bigint;
-  is_genesis: [] | [boolean];
   hot_keys: Array<Principal>;
   account: Uint8Array;
   joined_community_fund_timestamp_seconds: [] | [bigint];
@@ -423,7 +423,6 @@ export interface NeuronInfo {
   recent_ballots: Array<BallotInfo>;
   created_timestamp_seconds: bigint;
   state: number;
-  is_genesis: [] | [boolean];
   stake_e8s: bigint;
   joined_community_fund_timestamp_seconds: [] | [bigint];
   retrieved_at_timestamp_seconds: bigint;
@@ -440,33 +439,44 @@ export interface NeuronStakeTransfer {
   transfer_timestamp: bigint;
   block_height: bigint;
 }
+export interface NeuronsFundData {
+  final_neurons_fund_participation: [] | [NeuronsFundParticipation];
+  initial_neurons_fund_participation: [] | [NeuronsFundParticipation];
+  neurons_fund_refunds: [] | [NeuronsFundSnapshot];
+}
 export interface NeuronsFundNeuron {
   hotkey_principal: [] | [string];
   is_capped: [] | [boolean];
   nns_neuron_id: [] | [bigint];
   amount_icp_e8s: [] | [bigint];
 }
-export interface NeuronsFundNeuron_1 {
+export interface NeuronsFundNeuronPortion {
   hotkey_principal: [] | [Principal];
   is_capped: [] | [boolean];
-  nns_neuron_id: [] | [bigint];
+  maturity_equivalent_icp_e8s: [] | [bigint];
+  nns_neuron_id: [] | [NeuronId];
   amount_icp_e8s: [] | [bigint];
 }
 export interface NeuronsFundParticipation {
-  neurons_fund_snapshot: [] | [NeuronsFundSnapshot];
+  total_maturity_equivalent_icp_e8s: [] | [bigint];
+  intended_neurons_fund_participation_icp_e8s: [] | [bigint];
+  direct_participation_icp_e8s: [] | [bigint];
+  swap_participation_limits: [] | [SwapParticipationLimits];
+  max_neurons_fund_swap_participation_icp_e8s: [] | [bigint];
+  neurons_fund_reserves: [] | [NeuronsFundSnapshot];
   ideal_matched_participation_function:
     | []
     | [IdealMatchedParticipationFunction];
 }
 export interface NeuronsFundSnapshot {
-  neurons_fund_neurons: Array<NeuronsFundNeuron_1>;
+  neurons_fund_neuron_portions: Array<NeuronsFundNeuronPortion>;
 }
 export interface NodeProvider {
   id: [] | [Principal];
   reward_account: [] | [AccountIdentifier];
 }
 export interface Ok {
-  neurons_fund_neurons: Array<NeuronsFundNeuron>;
+  neurons_fund_neuron_portions: Array<NeuronsFundNeuron>;
 }
 export interface OpenSnsTokenSwap {
   community_fund_investment_e8s: [] | [bigint];
@@ -510,13 +520,13 @@ export interface Proposal {
 }
 export interface ProposalData {
   id: [] | [NeuronId];
-  neurons_fund_participation: [] | [NeuronsFundParticipation];
   failure_reason: [] | [GovernanceError];
   cf_participants: Array<CfParticipant>;
   ballots: Array<[bigint, Ballot]>;
   proposal_timestamp_seconds: bigint;
   reward_event_round: bigint;
   failed_timestamp_seconds: bigint;
+  neurons_fund_data: [] | [NeuronsFundData];
   reject_cost_e8s: bigint;
   derived_proposal_information: [] | [DerivedProposalInformation];
   latest_tally: [] | [Tally];
@@ -665,6 +675,12 @@ export interface SwapParameters {
   maximum_icp: [] | [Tokens];
   neurons_fund_investment_icp: [] | [Tokens];
   restricted_countries: [] | [Countries];
+}
+export interface SwapParticipationLimits {
+  min_participant_icp_e8s: [] | [bigint];
+  max_participant_icp_e8s: [] | [bigint];
+  min_direct_participation_icp_e8s: [] | [bigint];
+  max_direct_participation_icp_e8s: [] | [bigint];
 }
 export interface Tally {
   no: bigint;

--- a/packages/nns/candid/governance_test.did
+++ b/packages/nns/candid/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 2d57e93dabc5f13258d0dee1ffb2363ddce7fe62 'rs/nns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 1a01f85fc1994e69dd5ba72b4d87fe9f9c4093ee 'rs/nns/governance/canister/governance_test.did' by import-candid
 type AccountIdentifier = record { hash : vec nat8 };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
@@ -40,7 +40,11 @@ type CanisterSummary = record {
   status : opt CanisterStatusResultV2;
   canister_id : opt principal;
 };
-type CfNeuron = record { nns_neuron_id : nat64; amount_icp_e8s : nat64 };
+type CfNeuron = record {
+  has_created_neuron_recipes : opt bool;
+  nns_neuron_id : nat64;
+  amount_icp_e8s : nat64;
+};
 type CfParticipant = record {
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
@@ -317,7 +321,6 @@ type Neuron = record {
   created_timestamp_seconds : nat64;
   auto_stake_maturity : opt bool;
   aging_since_timestamp_seconds : nat64;
-  is_genesis : opt bool;
   hot_keys : vec principal;
   account : vec nat8;
   joined_community_fund_timestamp_seconds : opt nat64;
@@ -357,7 +360,6 @@ type NeuronInfo = record {
   recent_ballots : vec BallotInfo;
   created_timestamp_seconds : nat64;
   state : int32;
-  is_genesis : opt bool;
   stake_e8s : nat64;
   joined_community_fund_timestamp_seconds : opt nat64;
   retrieved_at_timestamp_seconds : nat64;
@@ -374,30 +376,41 @@ type NeuronStakeTransfer = record {
   transfer_timestamp : nat64;
   block_height : nat64;
 };
+type NeuronsFundData = record {
+  final_neurons_fund_participation : opt NeuronsFundParticipation;
+  initial_neurons_fund_participation : opt NeuronsFundParticipation;
+  neurons_fund_refunds : opt NeuronsFundSnapshot;
+};
 type NeuronsFundNeuron = record {
   hotkey_principal : opt text;
   is_capped : opt bool;
   nns_neuron_id : opt nat64;
   amount_icp_e8s : opt nat64;
 };
-type NeuronsFundNeuron_1 = record {
+type NeuronsFundNeuronPortion = record {
   hotkey_principal : opt principal;
   is_capped : opt bool;
-  nns_neuron_id : opt nat64;
+  maturity_equivalent_icp_e8s : opt nat64;
+  nns_neuron_id : opt NeuronId;
   amount_icp_e8s : opt nat64;
 };
 type NeuronsFundParticipation = record {
-  neurons_fund_snapshot : opt NeuronsFundSnapshot;
+  total_maturity_equivalent_icp_e8s : opt nat64;
+  intended_neurons_fund_participation_icp_e8s : opt nat64;
+  direct_participation_icp_e8s : opt nat64;
+  swap_participation_limits : opt SwapParticipationLimits;
+  max_neurons_fund_swap_participation_icp_e8s : opt nat64;
+  neurons_fund_reserves : opt NeuronsFundSnapshot;
   ideal_matched_participation_function : opt IdealMatchedParticipationFunction;
 };
 type NeuronsFundSnapshot = record {
-  neurons_fund_neurons : vec NeuronsFundNeuron_1;
+  neurons_fund_neuron_portions : vec NeuronsFundNeuronPortion;
 };
 type NodeProvider = record {
   id : opt principal;
   reward_account : opt AccountIdentifier;
 };
-type Ok = record { neurons_fund_neurons : vec NeuronsFundNeuron };
+type Ok = record { neurons_fund_neuron_portions : vec NeuronsFundNeuron };
 type OpenSnsTokenSwap = record {
   community_fund_investment_e8s : opt nat64;
   target_swap_canister_id : opt principal;
@@ -437,13 +450,13 @@ type Proposal = record {
 };
 type ProposalData = record {
   id : opt NeuronId;
-  neurons_fund_participation : opt NeuronsFundParticipation;
   failure_reason : opt GovernanceError;
   cf_participants : vec CfParticipant;
   ballots : vec record { nat64; Ballot };
   proposal_timestamp_seconds : nat64;
   reward_event_round : nat64;
   failed_timestamp_seconds : nat64;
+  neurons_fund_data : opt NeuronsFundData;
   reject_cost_e8s : nat64;
   derived_proposal_information : opt DerivedProposalInformation;
   latest_tally : opt Tally;
@@ -566,6 +579,12 @@ type SwapParameters = record {
   maximum_icp : opt Tokens;
   neurons_fund_investment_icp : opt Tokens;
   restricted_countries : opt Countries;
+};
+type SwapParticipationLimits = record {
+  min_participant_icp_e8s : opt nat64;
+  max_participant_icp_e8s : opt nat64;
+  min_direct_participation_icp_e8s : opt nat64;
+  max_direct_participation_icp_e8s : opt nat64;
 };
 type Tally = record {
   no : nat64;

--- a/packages/nns/candid/governance_test.idl.js
+++ b/packages/nns/candid/governance_test.idl.js
@@ -364,29 +364,12 @@ export const idlFactory = ({ IDL }) => {
     'neuron_indexes_migration' : IDL.Opt(Migration),
     'copy_inactive_neurons_to_stable_memory_migration' : IDL.Opt(Migration),
   });
-  const NeuronsFundNeuron_1 = IDL.Record({
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
-    'is_capped' : IDL.Opt(IDL.Bool),
-    'nns_neuron_id' : IDL.Opt(IDL.Nat64),
-    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
-  });
-  const NeuronsFundSnapshot = IDL.Record({
-    'neurons_fund_neurons' : IDL.Vec(NeuronsFundNeuron_1),
-  });
-  const IdealMatchedParticipationFunction = IDL.Record({
-    'serialized_representation' : IDL.Opt(IDL.Text),
-  });
-  const NeuronsFundParticipation = IDL.Record({
-    'neurons_fund_snapshot' : IDL.Opt(NeuronsFundSnapshot),
-    'ideal_matched_participation_function' : IDL.Opt(
-      IdealMatchedParticipationFunction
-    ),
-  });
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
   });
   const CfNeuron = IDL.Record({
+    'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
@@ -395,6 +378,41 @@ export const idlFactory = ({ IDL }) => {
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
   const Ballot = IDL.Record({ 'vote' : IDL.Int32, 'voting_power' : IDL.Nat64 });
+  const SwapParticipationLimits = IDL.Record({
+    'min_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'min_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundNeuronPortion = IDL.Record({
+    'hotkey_principal' : IDL.Opt(IDL.Principal),
+    'is_capped' : IDL.Opt(IDL.Bool),
+    'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'nns_neuron_id' : IDL.Opt(NeuronId),
+    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundSnapshot = IDL.Record({
+    'neurons_fund_neuron_portions' : IDL.Vec(NeuronsFundNeuronPortion),
+  });
+  const IdealMatchedParticipationFunction = IDL.Record({
+    'serialized_representation' : IDL.Opt(IDL.Text),
+  });
+  const NeuronsFundParticipation = IDL.Record({
+    'total_maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'intended_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'swap_participation_limits' : IDL.Opt(SwapParticipationLimits),
+    'max_neurons_fund_swap_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'neurons_fund_reserves' : IDL.Opt(NeuronsFundSnapshot),
+    'ideal_matched_participation_function' : IDL.Opt(
+      IdealMatchedParticipationFunction
+    ),
+  });
+  const NeuronsFundData = IDL.Record({
+    'final_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'initial_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'neurons_fund_refunds' : IDL.Opt(NeuronsFundSnapshot),
+  });
   const CanisterStatusResultV2 = IDL.Record({
     'status' : IDL.Opt(IDL.Int32),
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
@@ -432,13 +450,13 @@ export const idlFactory = ({ IDL }) => {
   });
   const ProposalData = IDL.Record({
     'id' : IDL.Opt(NeuronId),
-    'neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
     'failure_reason' : IDL.Opt(GovernanceError),
     'cf_participants' : IDL.Vec(CfParticipant),
     'ballots' : IDL.Vec(IDL.Tuple(IDL.Nat64, Ballot)),
     'proposal_timestamp_seconds' : IDL.Nat64,
     'reward_event_round' : IDL.Nat64,
     'failed_timestamp_seconds' : IDL.Nat64,
+    'neurons_fund_data' : IDL.Opt(NeuronsFundData),
     'reject_cost_e8s' : IDL.Nat64,
     'derived_proposal_information' : IDL.Opt(DerivedProposalInformation),
     'latest_tally' : IDL.Opt(Tally),
@@ -487,7 +505,6 @@ export const idlFactory = ({ IDL }) => {
     'created_timestamp_seconds' : IDL.Nat64,
     'auto_stake_maturity' : IDL.Opt(IDL.Bool),
     'aging_since_timestamp_seconds' : IDL.Nat64,
-    'is_genesis' : IDL.Opt(IDL.Bool),
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
@@ -545,7 +562,6 @@ export const idlFactory = ({ IDL }) => {
     'recent_ballots' : IDL.Vec(BallotInfo),
     'created_timestamp_seconds' : IDL.Nat64,
     'state' : IDL.Int32,
-    'is_genesis' : IDL.Opt(IDL.Bool),
     'stake_e8s' : IDL.Nat64,
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'retrieved_at_timestamp_seconds' : IDL.Nat64,
@@ -674,7 +690,7 @@ export const idlFactory = ({ IDL }) => {
     'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
   const Ok = IDL.Record({
-    'neurons_fund_neurons' : IDL.Vec(NeuronsFundNeuron),
+    'neurons_fund_neuron_portions' : IDL.Vec(NeuronsFundNeuron),
   });
   const Result_9 = IDL.Variant({ 'Ok' : Ok, 'Err' : GovernanceError });
   const SettleNeuronsFundParticipationResponse = IDL.Record({
@@ -1126,29 +1142,12 @@ export const init = ({ IDL }) => {
     'neuron_indexes_migration' : IDL.Opt(Migration),
     'copy_inactive_neurons_to_stable_memory_migration' : IDL.Opt(Migration),
   });
-  const NeuronsFundNeuron_1 = IDL.Record({
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
-    'is_capped' : IDL.Opt(IDL.Bool),
-    'nns_neuron_id' : IDL.Opt(IDL.Nat64),
-    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
-  });
-  const NeuronsFundSnapshot = IDL.Record({
-    'neurons_fund_neurons' : IDL.Vec(NeuronsFundNeuron_1),
-  });
-  const IdealMatchedParticipationFunction = IDL.Record({
-    'serialized_representation' : IDL.Opt(IDL.Text),
-  });
-  const NeuronsFundParticipation = IDL.Record({
-    'neurons_fund_snapshot' : IDL.Opt(NeuronsFundSnapshot),
-    'ideal_matched_participation_function' : IDL.Opt(
-      IdealMatchedParticipationFunction
-    ),
-  });
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
   });
   const CfNeuron = IDL.Record({
+    'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
@@ -1157,6 +1156,41 @@ export const init = ({ IDL }) => {
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
   const Ballot = IDL.Record({ 'vote' : IDL.Int32, 'voting_power' : IDL.Nat64 });
+  const SwapParticipationLimits = IDL.Record({
+    'min_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'min_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'max_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundNeuronPortion = IDL.Record({
+    'hotkey_principal' : IDL.Opt(IDL.Principal),
+    'is_capped' : IDL.Opt(IDL.Bool),
+    'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'nns_neuron_id' : IDL.Opt(NeuronId),
+    'amount_icp_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const NeuronsFundSnapshot = IDL.Record({
+    'neurons_fund_neuron_portions' : IDL.Vec(NeuronsFundNeuronPortion),
+  });
+  const IdealMatchedParticipationFunction = IDL.Record({
+    'serialized_representation' : IDL.Opt(IDL.Text),
+  });
+  const NeuronsFundParticipation = IDL.Record({
+    'total_maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'intended_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'swap_participation_limits' : IDL.Opt(SwapParticipationLimits),
+    'max_neurons_fund_swap_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'neurons_fund_reserves' : IDL.Opt(NeuronsFundSnapshot),
+    'ideal_matched_participation_function' : IDL.Opt(
+      IdealMatchedParticipationFunction
+    ),
+  });
+  const NeuronsFundData = IDL.Record({
+    'final_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'initial_neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
+    'neurons_fund_refunds' : IDL.Opt(NeuronsFundSnapshot),
+  });
   const CanisterStatusResultV2 = IDL.Record({
     'status' : IDL.Opt(IDL.Int32),
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
@@ -1194,13 +1228,13 @@ export const init = ({ IDL }) => {
   });
   const ProposalData = IDL.Record({
     'id' : IDL.Opt(NeuronId),
-    'neurons_fund_participation' : IDL.Opt(NeuronsFundParticipation),
     'failure_reason' : IDL.Opt(GovernanceError),
     'cf_participants' : IDL.Vec(CfParticipant),
     'ballots' : IDL.Vec(IDL.Tuple(IDL.Nat64, Ballot)),
     'proposal_timestamp_seconds' : IDL.Nat64,
     'reward_event_round' : IDL.Nat64,
     'failed_timestamp_seconds' : IDL.Nat64,
+    'neurons_fund_data' : IDL.Opt(NeuronsFundData),
     'reject_cost_e8s' : IDL.Nat64,
     'derived_proposal_information' : IDL.Opt(DerivedProposalInformation),
     'latest_tally' : IDL.Opt(Tally),
@@ -1249,7 +1283,6 @@ export const init = ({ IDL }) => {
     'created_timestamp_seconds' : IDL.Nat64,
     'auto_stake_maturity' : IDL.Opt(IDL.Bool),
     'aging_since_timestamp_seconds' : IDL.Nat64,
-    'is_genesis' : IDL.Opt(IDL.Bool),
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -135,7 +135,6 @@ export const toNeuronInfo = ({
     votingPower: neuronInfo.voting_power,
     ageSeconds: neuronInfo.age_seconds,
     fullNeuron: fullNeuron,
-    isGenesis: fromNullable(neuronInfo.is_genesis),
   };
 };
 
@@ -218,7 +217,6 @@ export const toRawNeuron = (neuron: Neuron): RawNeuron => ({
   transfer: [],
   // Not kept when converted to Neuron.
   known_neuron_data: [],
-  is_genesis: toNullable(neuron.isGenesis),
 });
 
 const toBallotInfo = ({ vote, proposal_id }: RawBallotInfo): BallotInfo => ({

--- a/packages/nns/src/mocks/governance.mock.ts
+++ b/packages/nns/src/mocks/governance.mock.ts
@@ -18,7 +18,6 @@ export const mockNeuronInfo: NeuronInfo = {
   known_neuron_data: [],
   voting_power: one,
   age_seconds: one,
-  is_genesis: [],
 };
 export const mockNeuron: Neuron = {
   id: [{ id: mockNeuronId }],
@@ -41,7 +40,6 @@ export const mockNeuron: Neuron = {
   transfer: [],
   known_neuron_data: [],
   spawn_at_timestamp_seconds: [],
-  is_genesis: [],
 };
 export const mockListNeuronsResponse: ListNeuronsResponse = {
   neuron_infos: [[mockNeuronId, mockNeuronInfo]],

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -275,7 +275,6 @@ export interface Neuron {
   joinedCommunityFundTimestampSeconds: Option<bigint>;
   dissolveState: Option<DissolveState>;
   followees: Array<Followees>;
-  isGenesis?: boolean;
 }
 export type NeuronIdOrSubaccount =
   | { Subaccount: Array<number> }
@@ -290,7 +289,6 @@ export interface NeuronInfo {
   retrievedAtTimestampSeconds: bigint;
   votingPower: bigint;
   ageSeconds: bigint;
-  isGenesis?: boolean;
   fullNeuron: Option<Neuron>;
 }
 


### PR DESCRIPTION
# Motivation

The field `is_genesis` has been reverted. Therefore, I updated the candid files to the latest commit for nns-js.

# Changes

## Automatic changes

* `.did` files with `./scripts/import-candid`.
* Candid related js and type files with `./scripts/compile-idl-js`.

## Manual changes

* Fix converters.

# Tests

* Remove field from neuron mock

# Todos

- [ ] Add entry to changelog (if necessary).
I removed a previous entry.
