### PR TITLE
GIX-1960: Upgrade candid sns-js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## Features
 
 - expose few types - notably `BlockHeight` - for library `@dfinity/ledger-icp`
-- support new fields from swap canister response types: `min_direct_participation_icp_e8s` and `max_direct_participation_icp_e8s`
+- support new fields from swap canister response types: `min_direct_participation_icp_e8s`, `max_direct_participation_icp_e8s` and `neurons_fund_participation`.
 - support new fields in the `CreateServiceNervousSystem` proposal action `maximum_direct_participation_icp`, `minimum_direct_participation_icp` and `neurons_fund_participation`.
 - support new filter field `omit_large_fields` in `list_proposals`.
 - add support for `retrieve_btc_with_approval` in `@dfinity/ckbtc`.

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 15e69667ae983fa92c33794a3954d9ca87518af6 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit dd51544944987556c978e774aa7a1992e5c11542 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 15e69667ae983fa92c33794a3954d9ca87518af6 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit dd51544944987556c978e774aa7a1992e5c11542 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 15e69667ae983fa92c33794a3954d9ca87518af6 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit dd51544944987556c978e774aa7a1992e5c11542 'rs/sns/root/canister/root.did' by import-candid
 type AuthzChangeOp = variant {
   Authorize : record { add_self : bool };
   Deauthorize;

--- a/packages/sns/candid/sns_swap.certified.idl.js
+++ b/packages/sns/candid/sns_swap.certified.idl.js
@@ -17,6 +17,7 @@ export const idlFactory = ({ IDL }) => {
     'min_direct_participation_threshold_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
   const CfNeuron = IDL.Record({
+    'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
@@ -31,6 +32,7 @@ export const idlFactory = ({ IDL }) => {
   const Init = IDL.Record({
     'nns_proposal_id' : IDL.Opt(IDL.Nat64),
     'sns_root_canister_id' : IDL.Text,
+    'neurons_fund_participation' : IDL.Opt(IDL.Bool),
     'min_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
     'neuron_basket_construction_parameters' : IDL.Opt(
       NeuronBasketConstructionParameters
@@ -141,7 +143,10 @@ export const idlFactory = ({ IDL }) => {
     'amount_transferred_e8s' : IDL.Opt(IDL.Nat64),
     'transfer_success_timestamp_seconds' : IDL.Nat64,
   });
-  const BuyerState = IDL.Record({ 'icp' : IDL.Opt(TransferableAmount) });
+  const BuyerState = IDL.Record({
+    'icp' : IDL.Opt(TransferableAmount),
+    'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
+  });
   const GetBuyerStateResponse = IDL.Record({
     'buyer_state' : IDL.Opt(BuyerState),
   });
@@ -406,6 +411,7 @@ export const init = ({ IDL }) => {
     'min_direct_participation_threshold_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
   const CfNeuron = IDL.Record({
+    'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
@@ -420,6 +426,7 @@ export const init = ({ IDL }) => {
   const Init = IDL.Record({
     'nns_proposal_id' : IDL.Opt(IDL.Nat64),
     'sns_root_canister_id' : IDL.Text,
+    'neurons_fund_participation' : IDL.Opt(IDL.Bool),
     'min_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
     'neuron_basket_construction_parameters' : IDL.Opt(
       NeuronBasketConstructionParameters

--- a/packages/sns/candid/sns_swap.d.ts
+++ b/packages/sns/candid/sns_swap.d.ts
@@ -3,6 +3,7 @@ import type { Principal } from "@dfinity/principal";
 
 export interface BuyerState {
   icp: [] | [TransferableAmount];
+  has_created_neuron_recipes: [] | [boolean];
 }
 export interface CanisterCallError {
   code: [] | [number];
@@ -25,6 +26,7 @@ export interface CfInvestment {
   nns_neuron_id: bigint;
 }
 export interface CfNeuron {
+  has_created_neuron_recipes: [] | [boolean];
   nns_neuron_id: bigint;
   amount_icp_e8s: bigint;
 }
@@ -137,6 +139,7 @@ export interface Icrc1Account {
 export interface Init {
   nns_proposal_id: [] | [bigint];
   sns_root_canister_id: string;
+  neurons_fund_participation: [] | [boolean];
   min_participant_icp_e8s: [] | [bigint];
   neuron_basket_construction_parameters:
     | []

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,5 +1,8 @@
-// Generated from IC repo commit 15e69667ae983fa92c33794a3954d9ca87518af6 'rs/sns/swap/canister/swap.did' by import-candid
-type BuyerState = record { icp : opt TransferableAmount };
+// Generated from IC repo commit dd51544944987556c978e774aa7a1992e5c11542 'rs/sns/swap/canister/swap.did' by import-candid
+type BuyerState = record {
+  icp : opt TransferableAmount;
+  has_created_neuron_recipes : opt bool;
+};
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterStatusResultV2 = record {
   status : CanisterStatusType;
@@ -11,7 +14,11 @@ type CanisterStatusResultV2 = record {
 };
 type CanisterStatusType = variant { stopped; stopping; running };
 type CfInvestment = record { hotkey_principal : text; nns_neuron_id : nat64 };
-type CfNeuron = record { nns_neuron_id : nat64; amount_icp_e8s : nat64 };
+type CfNeuron = record {
+  has_created_neuron_recipes : opt bool;
+  nns_neuron_id : nat64;
+  amount_icp_e8s : nat64;
+};
 type CfParticipant = record {
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
@@ -85,6 +92,7 @@ type Icrc1Account = record { owner : opt principal; subaccount : opt vec nat8 };
 type Init = record {
   nns_proposal_id : opt nat64;
   sns_root_canister_id : text;
+  neurons_fund_participation : opt bool;
   min_participant_icp_e8s : opt nat64;
   neuron_basket_construction_parameters : opt NeuronBasketConstructionParameters;
   fallback_controller_principal_ids : vec text;

--- a/packages/sns/candid/sns_swap.idl.js
+++ b/packages/sns/candid/sns_swap.idl.js
@@ -17,6 +17,7 @@ export const idlFactory = ({ IDL }) => {
     'min_direct_participation_threshold_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
   const CfNeuron = IDL.Record({
+    'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
@@ -31,6 +32,7 @@ export const idlFactory = ({ IDL }) => {
   const Init = IDL.Record({
     'nns_proposal_id' : IDL.Opt(IDL.Nat64),
     'sns_root_canister_id' : IDL.Text,
+    'neurons_fund_participation' : IDL.Opt(IDL.Bool),
     'min_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
     'neuron_basket_construction_parameters' : IDL.Opt(
       NeuronBasketConstructionParameters
@@ -141,7 +143,10 @@ export const idlFactory = ({ IDL }) => {
     'amount_transferred_e8s' : IDL.Opt(IDL.Nat64),
     'transfer_success_timestamp_seconds' : IDL.Nat64,
   });
-  const BuyerState = IDL.Record({ 'icp' : IDL.Opt(TransferableAmount) });
+  const BuyerState = IDL.Record({
+    'icp' : IDL.Opt(TransferableAmount),
+    'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
+  });
   const GetBuyerStateResponse = IDL.Record({
     'buyer_state' : IDL.Opt(BuyerState),
   });
@@ -414,6 +419,7 @@ export const init = ({ IDL }) => {
     'min_direct_participation_threshold_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
   const CfNeuron = IDL.Record({
+    'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
@@ -428,6 +434,7 @@ export const init = ({ IDL }) => {
   const Init = IDL.Record({
     'nns_proposal_id' : IDL.Opt(IDL.Nat64),
     'sns_root_canister_id' : IDL.Text,
+    'neurons_fund_participation' : IDL.Opt(IDL.Bool),
     'min_participant_icp_e8s' : IDL.Opt(IDL.Nat64),
     'neuron_basket_construction_parameters' : IDL.Opt(
       NeuronBasketConstructionParameters

--- a/packages/sns/src/swap.canister.spec.ts
+++ b/packages/sns/src/swap.canister.spec.ts
@@ -330,6 +330,7 @@ describe("Swap canister", () => {
           amount_transferred_e8s: [BigInt(99900000)],
         },
       ],
+      has_created_neuron_recipes: [false],
     };
     const service = mock<ActorSubclass<SnsSwapService>>();
     service.get_buyer_state.mockResolvedValue({


### PR DESCRIPTION
# Motivation

Support latest fields for Neurons' Fund enhancements.

In this PR, upgrade candid for sns-js

# Changes

## Automatic changes

* `.did` files with `./scripts/import-candid`.
* Types and idl files related to candid: `./scripts/compile-idl-js`.

## Manual changes

* Reverted changes in packages other than `sns`.
* Add field to mock data.

# Tests

Still passing.

# Todos

- [ ] Add entry to changelog (if necessary).
