### PR TITLE
feat: init ICP index canister in ledger-icp and add account balance function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ## Features
 
-- expose few types - notably `BlockHeight` - for library `@dfinity/ledger-icp`
+- add support for ICP Index canister to library `@dfinity/ledger-icp`. New `IndexCanister` functions: `accountBalance`.
+- expose few types - notably `BlockHeight` - for library `@dfinity/ledger-icp`.
 - support new fields from swap canister response types: `min_direct_participation_icp_e8s`, `max_direct_participation_icp_e8s` and `neurons_fund_participation`.
 - support new fields in the `CreateServiceNervousSystem` proposal action `maximum_direct_participation_icp`, `minimum_direct_participation_icp` and `neurons_fund_participation`.
 - support new filter field `omit_large_fields` in `list_proposals`.

--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -233,6 +233,22 @@ Returns the index of the block containing the tx if it was successful.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L142)
 
+### :factory: IndexCanister
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/index.canister.ts#L7)
+
+#### Methods
+
+- [create](#gear-create)
+
+##### :gear: create
+
+| Method   | Type                                                                                          |
+| -------- | --------------------------------------------------------------------------------------------- |
+| `create` | `({ canisterId: optionsCanisterId, ...options }: CanisterOptions<_SERVICE>) => IndexCanister` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/index.canister.ts#L8)
+
 <!-- TSDOC_END -->
 
 ## Resources

--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -170,7 +170,7 @@ const data = await metadata();
 
 ### :factory: LedgerCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L32)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L34)
 
 #### Methods
 
@@ -186,7 +186,7 @@ const data = await metadata();
 | -------- | ----------------------------------------------------- |
 | `create` | `(options?: LedgerCanisterOptions) => LedgerCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L43)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L45)
 
 ##### :gear: accountBalance
 
@@ -195,11 +195,17 @@ Returns the balance of the specified account identifier.
 If `certified` is true, the request is fetched as an update call, otherwise
 it is fetched using a query call.
 
-| Method           | Type                                                                                                                     |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `accountBalance` | `({ accountIdentifier, certified, }: { accountIdentifier: AccountIdentifier; certified?: boolean; }) => Promise<bigint>` |
+| Method           | Type                                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------------------ |
+| `accountBalance` | `({ accountIdentifier: accountIdentifierParam, certified, }: AccountBalanceParams) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L75)
+Parameters:
+
+- `params`: The parameters to get the balance of an account.
+- `params.accountIdentifier`: The account identifier provided either as hex string or as an AccountIdentifier.
+- `params.certified`: query or update call.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L81)
 
 ##### :gear: transactionFee
 
@@ -209,7 +215,7 @@ Returns the transaction fee of the ledger canister
 | ---------------- | ----------------------- |
 | `transactionFee` | `() => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L99)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L104)
 
 ##### :gear: transfer
 
@@ -220,7 +226,7 @@ Returns the index of the block containing the tx if it was successful.
 | ---------- | ----------------------------------------------- |
 | `transfer` | `(request: TransferRequest) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L112)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L117)
 
 ##### :gear: icrc1Transfer
 
@@ -231,15 +237,16 @@ Returns the index of the block containing the tx if it was successful.
 | --------------- | ---------------------------------------------------- |
 | `icrc1Transfer` | `(request: Icrc1TransferRequest) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L142)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L147)
 
 ### :factory: IndexCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/index.canister.ts#L7)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/index.canister.ts#L9)
 
 #### Methods
 
 - [create](#gear-create)
+- [accountBalance](#gear-accountbalance)
 
 ##### :gear: create
 
@@ -247,7 +254,23 @@ Returns the index of the block containing the tx if it was successful.
 | -------- | --------------------------------------------------------------------------------------------- |
 | `create` | `({ canisterId: optionsCanisterId, ...options }: CanisterOptions<_SERVICE>) => IndexCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/index.canister.ts#L8)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/index.canister.ts#L10)
+
+##### :gear: accountBalance
+
+Returns the balance of the specified account identifier.
+
+| Method           | Type                                                                           |
+| ---------------- | ------------------------------------------------------------------------------ |
+| `accountBalance` | `({ certified, accountIdentifier, }: AccountBalanceParams) => Promise<bigint>` |
+
+Parameters:
+
+- `params`: The parameters to get the balance of an account.
+- `params.accountIdentifier`: The account identifier provided either as hex string or as an AccountIdentifier.
+- `params.certified`: query or update call.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/index.canister.ts#L35)
 
 <!-- TSDOC_END -->
 

--- a/packages/ledger-icp/candid/index.certified.idl.d.ts
+++ b/packages/ledger-icp/candid/index.certified.idl.d.ts
@@ -1,0 +1,2 @@
+import type { IDL } from "@dfinity/candid";
+export const idlFactory: IDL.InterfaceFactory;

--- a/packages/ledger-icp/candid/index.certified.idl.js
+++ b/packages/ledger-icp/candid/index.certified.idl.js
@@ -1,0 +1,108 @@
+/* Do not edit.  Compiled with ./scripts/compile-idl-js from packages/ledger-icp/candid/index.did */
+export const idlFactory = ({ IDL }) => {
+  const InitArg = IDL.Record({ 'ledger_id' : IDL.Principal });
+  const GetAccountIdentifierTransactionsArgs = IDL.Record({
+    'max_results' : IDL.Nat64,
+    'start' : IDL.Opt(IDL.Nat64),
+    'account_identifier' : IDL.Text,
+  });
+  const Tokens = IDL.Record({ 'e8s' : IDL.Nat64 });
+  const TimeStamp = IDL.Record({ 'timestamp_nanos' : IDL.Nat64 });
+  const Operation = IDL.Variant({
+    'Approve' : IDL.Record({
+      'fee' : Tokens,
+      'from' : IDL.Text,
+      'allowance' : Tokens,
+      'expires_at' : IDL.Opt(TimeStamp),
+      'spender' : IDL.Text,
+    }),
+    'Burn' : IDL.Record({ 'from' : IDL.Text, 'amount' : Tokens }),
+    'Mint' : IDL.Record({ 'to' : IDL.Text, 'amount' : Tokens }),
+    'Transfer' : IDL.Record({
+      'to' : IDL.Text,
+      'fee' : Tokens,
+      'from' : IDL.Text,
+      'amount' : Tokens,
+    }),
+    'TransferFrom' : IDL.Record({
+      'to' : IDL.Text,
+      'fee' : Tokens,
+      'from' : IDL.Text,
+      'amount' : Tokens,
+      'spender' : IDL.Text,
+    }),
+  });
+  const Transaction = IDL.Record({
+    'memo' : IDL.Nat64,
+    'icrc1_memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'operation' : Operation,
+    'created_at_time' : IDL.Opt(TimeStamp),
+  });
+  const TransactionWithId = IDL.Record({
+    'id' : IDL.Nat64,
+    'transaction' : Transaction,
+  });
+  const GetAccountIdentifierTransactionsResponse = IDL.Record({
+    'balance' : IDL.Nat64,
+    'transactions' : IDL.Vec(TransactionWithId),
+    'oldest_tx_id' : IDL.Opt(IDL.Nat64),
+  });
+  const GetAccountIdentifierTransactionsError = IDL.Record({
+    'message' : IDL.Text,
+  });
+  const GetAccountIdentifierTransactionsResult = IDL.Variant({
+    'Ok' : GetAccountIdentifierTransactionsResponse,
+    'Err' : GetAccountIdentifierTransactionsError,
+  });
+  const Account = IDL.Record({
+    'owner' : IDL.Principal,
+    'subaccount' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
+  const GetAccountTransactionsArgs = IDL.Record({
+    'max_results' : IDL.Nat,
+    'start' : IDL.Opt(IDL.Nat),
+    'account' : Account,
+  });
+  const GetBlocksRequest = IDL.Record({
+    'start' : IDL.Nat,
+    'length' : IDL.Nat,
+  });
+  const GetBlocksResponse = IDL.Record({
+    'blocks' : IDL.Vec(IDL.Vec(IDL.Nat8)),
+    'chain_length' : IDL.Nat64,
+  });
+  const HttpRequest = IDL.Record({
+    'url' : IDL.Text,
+    'method' : IDL.Text,
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+  });
+  const HttpResponse = IDL.Record({
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+    'status_code' : IDL.Nat16,
+  });
+  const Status = IDL.Record({ 'num_blocks_synced' : IDL.Nat64 });
+  return IDL.Service({
+    'get_account_identifier_balance' : IDL.Func([IDL.Text], [IDL.Nat64], []),
+    'get_account_identifier_transactions' : IDL.Func(
+        [GetAccountIdentifierTransactionsArgs],
+        [GetAccountIdentifierTransactionsResult],
+        [],
+      ),
+    'get_account_transactions' : IDL.Func(
+        [GetAccountTransactionsArgs],
+        [GetAccountIdentifierTransactionsResult],
+        [],
+      ),
+    'get_blocks' : IDL.Func([GetBlocksRequest], [GetBlocksResponse], []),
+    'http_request' : IDL.Func([HttpRequest], [HttpResponse], []),
+    'icrc1_balance_of' : IDL.Func([Account], [IDL.Nat64], []),
+    'ledger_id' : IDL.Func([], [IDL.Principal], []),
+    'status' : IDL.Func([], [Status], []),
+  });
+};
+export const init = ({ IDL }) => {
+  const InitArg = IDL.Record({ 'ledger_id' : IDL.Principal });
+  return [InitArg];
+};

--- a/packages/ledger-icp/candid/index.d.ts
+++ b/packages/ledger-icp/candid/index.d.ts
@@ -1,0 +1,116 @@
+import type { ActorMethod } from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+
+export interface Account {
+  owner: Principal;
+  subaccount: [] | [Uint8Array];
+}
+export interface GetAccountIdentifierTransactionsArgs {
+  max_results: bigint;
+  start: [] | [bigint];
+  account_identifier: string;
+}
+export interface GetAccountIdentifierTransactionsError {
+  message: string;
+}
+export interface GetAccountIdentifierTransactionsResponse {
+  balance: bigint;
+  transactions: Array<TransactionWithId>;
+  oldest_tx_id: [] | [bigint];
+}
+export type GetAccountIdentifierTransactionsResult =
+  | {
+      Ok: GetAccountIdentifierTransactionsResponse;
+    }
+  | { Err: GetAccountIdentifierTransactionsError };
+export interface GetAccountTransactionsArgs {
+  max_results: bigint;
+  start: [] | [bigint];
+  account: Account;
+}
+export interface GetBlocksRequest {
+  start: bigint;
+  length: bigint;
+}
+export interface GetBlocksResponse {
+  blocks: Array<Uint8Array>;
+  chain_length: bigint;
+}
+export interface HttpRequest {
+  url: string;
+  method: string;
+  body: Uint8Array;
+  headers: Array<[string, string]>;
+}
+export interface HttpResponse {
+  body: Uint8Array;
+  headers: Array<[string, string]>;
+  status_code: number;
+}
+export interface InitArg {
+  ledger_id: Principal;
+}
+export type Operation =
+  | {
+      Approve: {
+        fee: Tokens;
+        from: string;
+        allowance: Tokens;
+        expires_at: [] | [TimeStamp];
+        spender: string;
+      };
+    }
+  | { Burn: { from: string; amount: Tokens } }
+  | { Mint: { to: string; amount: Tokens } }
+  | {
+      Transfer: {
+        to: string;
+        fee: Tokens;
+        from: string;
+        amount: Tokens;
+      };
+    }
+  | {
+      TransferFrom: {
+        to: string;
+        fee: Tokens;
+        from: string;
+        amount: Tokens;
+        spender: string;
+      };
+    };
+export interface Status {
+  num_blocks_synced: bigint;
+}
+export interface TimeStamp {
+  timestamp_nanos: bigint;
+}
+export interface Tokens {
+  e8s: bigint;
+}
+export interface Transaction {
+  memo: bigint;
+  icrc1_memo: [] | [Uint8Array];
+  operation: Operation;
+  created_at_time: [] | [TimeStamp];
+}
+export interface TransactionWithId {
+  id: bigint;
+  transaction: Transaction;
+}
+export interface _SERVICE {
+  get_account_identifier_balance: ActorMethod<[string], bigint>;
+  get_account_identifier_transactions: ActorMethod<
+    [GetAccountIdentifierTransactionsArgs],
+    GetAccountIdentifierTransactionsResult
+  >;
+  get_account_transactions: ActorMethod<
+    [GetAccountTransactionsArgs],
+    GetAccountIdentifierTransactionsResult
+  >;
+  get_blocks: ActorMethod<[GetBlocksRequest], GetBlocksResponse>;
+  http_request: ActorMethod<[HttpRequest], HttpResponse>;
+  icrc1_balance_of: ActorMethod<[Account], bigint>;
+  ledger_id: ActorMethod<[], Principal>;
+  status: ActorMethod<[], Status>;
+}

--- a/packages/ledger-icp/candid/index.did
+++ b/packages/ledger-icp/candid/index.did
@@ -1,0 +1,81 @@
+// Generated from IC repo commit b501a71346fa465cb5d7817c895295150979c180 'rs/rosetta-api/icp_ledger/index/index.did' by import-candid
+type Account = record { owner : principal; subaccount : opt vec nat8 };
+type GetAccountIdentifierTransactionsArgs = record {
+  max_results : nat64;
+  start : opt nat64;
+  account_identifier : text;
+};
+type GetAccountTransactionsArgs = record {
+    account : Account;
+    // The txid of the last transaction seen by the client.
+    // If None then the results will start from the most recent
+    // txid.
+    start : opt nat;
+    // Maximum number of transactions to fetch.
+    max_results : nat;
+};
+type GetAccountIdentifierTransactionsError = record { message : text };
+type GetAccountIdentifierTransactionsResponse = record {
+  balance : nat64;
+  transactions : vec TransactionWithId;
+  oldest_tx_id : opt nat64;
+};
+type GetBlocksRequest = record { start : nat; length : nat };
+type GetBlocksResponse = record { blocks : vec vec nat8; chain_length : nat64 };
+type HttpRequest = record {
+  url : text;
+  method : text;
+  body : vec nat8;
+  headers : vec record { text; text };
+};
+type HttpResponse = record {
+  body : vec nat8;
+  headers : vec record { text; text };
+  status_code : nat16;
+};
+type InitArg = record { ledger_id : principal };
+type Operation = variant {
+  Approve : record {
+    fee : Tokens;
+    from : text;
+    allowance : Tokens;
+    expires_at : opt TimeStamp;
+    spender : text;
+  };
+  Burn : record { from : text; amount : Tokens };
+  Mint : record { to : text; amount : Tokens };
+  Transfer : record { to : text; fee : Tokens; from : text; amount : Tokens };
+  TransferFrom : record {
+    to : text;
+    fee : Tokens;
+    from : text;
+    amount : Tokens;
+    spender : text;
+  };
+};
+type GetAccountIdentifierTransactionsResult = variant {
+  Ok : GetAccountIdentifierTransactionsResponse;
+  Err : GetAccountIdentifierTransactionsError;
+};
+type Status = record { num_blocks_synced : nat64 };
+type TimeStamp = record { timestamp_nanos : nat64 };
+type Tokens = record { e8s : nat64 };
+type Transaction = record {
+  memo : nat64;
+  icrc1_memo : opt vec nat8;
+  operation : Operation;
+  created_at_time : opt TimeStamp;
+};
+type TransactionWithId = record { id : nat64; transaction : Transaction };
+service : (InitArg) -> {
+  get_account_identifier_balance : (text) -> (nat64) query;
+  get_account_identifier_transactions : (
+      GetAccountIdentifierTransactionsArgs,
+    ) -> (GetAccountIdentifierTransactionsResult) query;
+  get_account_transactions : (GetAccountTransactionsArgs) -> (GetAccountIdentifierTransactionsResult) query;
+  get_blocks : (GetBlocksRequest) -> (GetBlocksResponse) query;
+  http_request : (HttpRequest) -> (HttpResponse) query;
+  ledger_id : () -> (principal) query;
+  status : () -> (Status) query;
+  icrc1_balance_of : (Account) -> (nat64) query;
+}

--- a/packages/ledger-icp/candid/index.idl.d.ts
+++ b/packages/ledger-icp/candid/index.idl.d.ts
@@ -1,0 +1,2 @@
+import type { IDL } from "@dfinity/candid";
+export const idlFactory: IDL.InterfaceFactory;

--- a/packages/ledger-icp/candid/index.idl.js
+++ b/packages/ledger-icp/candid/index.idl.js
@@ -1,0 +1,112 @@
+/* Do not edit.  Compiled with ./scripts/compile-idl-js from packages/ledger-icp/candid/index.did */
+export const idlFactory = ({ IDL }) => {
+  const InitArg = IDL.Record({ 'ledger_id' : IDL.Principal });
+  const GetAccountIdentifierTransactionsArgs = IDL.Record({
+    'max_results' : IDL.Nat64,
+    'start' : IDL.Opt(IDL.Nat64),
+    'account_identifier' : IDL.Text,
+  });
+  const Tokens = IDL.Record({ 'e8s' : IDL.Nat64 });
+  const TimeStamp = IDL.Record({ 'timestamp_nanos' : IDL.Nat64 });
+  const Operation = IDL.Variant({
+    'Approve' : IDL.Record({
+      'fee' : Tokens,
+      'from' : IDL.Text,
+      'allowance' : Tokens,
+      'expires_at' : IDL.Opt(TimeStamp),
+      'spender' : IDL.Text,
+    }),
+    'Burn' : IDL.Record({ 'from' : IDL.Text, 'amount' : Tokens }),
+    'Mint' : IDL.Record({ 'to' : IDL.Text, 'amount' : Tokens }),
+    'Transfer' : IDL.Record({
+      'to' : IDL.Text,
+      'fee' : Tokens,
+      'from' : IDL.Text,
+      'amount' : Tokens,
+    }),
+    'TransferFrom' : IDL.Record({
+      'to' : IDL.Text,
+      'fee' : Tokens,
+      'from' : IDL.Text,
+      'amount' : Tokens,
+      'spender' : IDL.Text,
+    }),
+  });
+  const Transaction = IDL.Record({
+    'memo' : IDL.Nat64,
+    'icrc1_memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'operation' : Operation,
+    'created_at_time' : IDL.Opt(TimeStamp),
+  });
+  const TransactionWithId = IDL.Record({
+    'id' : IDL.Nat64,
+    'transaction' : Transaction,
+  });
+  const GetAccountIdentifierTransactionsResponse = IDL.Record({
+    'balance' : IDL.Nat64,
+    'transactions' : IDL.Vec(TransactionWithId),
+    'oldest_tx_id' : IDL.Opt(IDL.Nat64),
+  });
+  const GetAccountIdentifierTransactionsError = IDL.Record({
+    'message' : IDL.Text,
+  });
+  const GetAccountIdentifierTransactionsResult = IDL.Variant({
+    'Ok' : GetAccountIdentifierTransactionsResponse,
+    'Err' : GetAccountIdentifierTransactionsError,
+  });
+  const Account = IDL.Record({
+    'owner' : IDL.Principal,
+    'subaccount' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
+  const GetAccountTransactionsArgs = IDL.Record({
+    'max_results' : IDL.Nat,
+    'start' : IDL.Opt(IDL.Nat),
+    'account' : Account,
+  });
+  const GetBlocksRequest = IDL.Record({
+    'start' : IDL.Nat,
+    'length' : IDL.Nat,
+  });
+  const GetBlocksResponse = IDL.Record({
+    'blocks' : IDL.Vec(IDL.Vec(IDL.Nat8)),
+    'chain_length' : IDL.Nat64,
+  });
+  const HttpRequest = IDL.Record({
+    'url' : IDL.Text,
+    'method' : IDL.Text,
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+  });
+  const HttpResponse = IDL.Record({
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+    'status_code' : IDL.Nat16,
+  });
+  const Status = IDL.Record({ 'num_blocks_synced' : IDL.Nat64 });
+  return IDL.Service({
+    'get_account_identifier_balance' : IDL.Func(
+        [IDL.Text],
+        [IDL.Nat64],
+        ['query'],
+      ),
+    'get_account_identifier_transactions' : IDL.Func(
+        [GetAccountIdentifierTransactionsArgs],
+        [GetAccountIdentifierTransactionsResult],
+        ['query'],
+      ),
+    'get_account_transactions' : IDL.Func(
+        [GetAccountTransactionsArgs],
+        [GetAccountIdentifierTransactionsResult],
+        ['query'],
+      ),
+    'get_blocks' : IDL.Func([GetBlocksRequest], [GetBlocksResponse], ['query']),
+    'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
+    'icrc1_balance_of' : IDL.Func([Account], [IDL.Nat64], ['query']),
+    'ledger_id' : IDL.Func([], [IDL.Principal], ['query']),
+    'status' : IDL.Func([], [Status], ['query']),
+  });
+};
+export const init = ({ IDL }) => {
+  const InitArg = IDL.Record({ 'ledger_id' : IDL.Principal });
+  return [InitArg];
+};

--- a/packages/ledger-icp/src/constants/canister_ids.ts
+++ b/packages/ledger-icp/src/constants/canister_ids.ts
@@ -3,3 +3,7 @@ import { Principal } from "@dfinity/principal";
 export const MAINNET_LEDGER_CANISTER_ID = Principal.fromText(
   "ryjl3-tyaaa-aaaaa-aaaba-cai",
 );
+
+export const MAINNET_INDEX_CANISTER_ID = Principal.fromText(
+    "qhbym-qaaaa-aaaaa-aaafq-cai",
+);

--- a/packages/ledger-icp/src/constants/canister_ids.ts
+++ b/packages/ledger-icp/src/constants/canister_ids.ts
@@ -5,5 +5,5 @@ export const MAINNET_LEDGER_CANISTER_ID = Principal.fromText(
 );
 
 export const MAINNET_INDEX_CANISTER_ID = Principal.fromText(
-    "qhbym-qaaaa-aaaaa-aaafq-cai",
+  "qhbym-qaaaa-aaaaa-aaafq-cai",
 );

--- a/packages/ledger-icp/src/index.canister.spec.ts
+++ b/packages/ledger-icp/src/index.canister.spec.ts
@@ -1,0 +1,74 @@
+import { ActorSubclass } from "@dfinity/agent";
+import { mock } from "jest-mock-extended";
+import { _SERVICE as IndexService } from "../candid/index";
+import { IndexCanister } from "./index.canister";
+import { mockAccountIdentifier } from "./mocks/ledger.mock";
+
+describe("IndexCanister", () => {
+  describe("accountBalance", () => {
+    const balanceMock = 30_000_000n;
+
+    it("returns account balance with query call", async () => {
+      const service = mock<ActorSubclass<IndexService>>();
+      service.get_account_identifier_balance.mockResolvedValue(balanceMock);
+      const index = IndexCanister.create({
+        serviceOverride: service,
+      });
+
+      const balance = await index.accountBalance({
+        accountIdentifier: mockAccountIdentifier,
+        certified: false,
+      });
+      expect(balance).toEqual(balanceMock);
+      expect(service.get_account_identifier_balance).toBeCalled();
+    });
+
+    it("returns account balance with update call", async () => {
+      const service = mock<ActorSubclass<IndexService>>();
+      service.get_account_identifier_balance.mockResolvedValue(balanceMock);
+      const index = IndexCanister.create({
+        certifiedServiceOverride: service,
+      });
+
+      const balance = await index.accountBalance({
+        accountIdentifier: mockAccountIdentifier,
+        certified: true,
+      });
+      expect(balance).toEqual(balanceMock);
+      expect(service.get_account_identifier_balance).toBeCalled();
+    });
+
+    it("returns account balance with account identifier as hex", async () => {
+      const service = mock<ActorSubclass<IndexService>>();
+      service.get_account_identifier_balance.mockResolvedValue(balanceMock);
+      const index = IndexCanister.create({
+        serviceOverride: service,
+      });
+
+      const balance = await index.accountBalance({
+        accountIdentifier: mockAccountIdentifier.toHex(),
+        certified: false,
+      });
+      expect(balance).toEqual(balanceMock);
+      expect(service.get_account_identifier_balance).toBeCalled();
+    });
+
+    it("should bubble errors", () => {
+      const service = mock<ActorSubclass<IndexService>>();
+      service.get_account_identifier_balance.mockImplementation(() => {
+        throw new Error();
+      });
+
+      const index = IndexCanister.create({
+        serviceOverride: service,
+      });
+
+      expect(() =>
+        index.accountBalance({
+          accountIdentifier: mockAccountIdentifier.toHex(),
+          certified: false,
+        }),
+      ).toThrowError();
+    });
+  });
+});

--- a/packages/ledger-icp/src/index.canister.ts
+++ b/packages/ledger-icp/src/index.canister.ts
@@ -1,0 +1,24 @@
+import { Canister, createServices, type CanisterOptions } from "@dfinity/utils";
+import type { _SERVICE as IndexService } from "../candid/index";
+import { idlFactory as certifiedIdlFactory } from "../candid/ledger.certified.idl";
+import { idlFactory } from "../candid/ledger.idl";
+import { MAINNET_INDEX_CANISTER_ID } from "./constants/canister_ids";
+
+export class IndexCanister extends Canister<IndexService> {
+  static create({
+    canisterId: optionsCanisterId,
+    ...options
+  }: CanisterOptions<IndexService>) {
+    const { service, certifiedService, canisterId } =
+      createServices<IndexService>({
+        options: {
+          ...options,
+          canisterId: optionsCanisterId ?? MAINNET_INDEX_CANISTER_ID,
+        },
+        idlFactory,
+        certifiedIdlFactory,
+      });
+
+    return new IndexCanister(canisterId, service, certifiedService);
+  }
+}

--- a/packages/ledger-icp/src/index.canister.ts
+++ b/packages/ledger-icp/src/index.canister.ts
@@ -3,6 +3,8 @@ import type { _SERVICE as IndexService } from "../candid/index";
 import { idlFactory as certifiedIdlFactory } from "../candid/ledger.certified.idl";
 import { idlFactory } from "../candid/ledger.idl";
 import { MAINNET_INDEX_CANISTER_ID } from "./constants/canister_ids";
+import type { AccountBalanceParams } from "./types/ledger.params";
+import { paramToAccountIdentifier } from "./utils/params.utils";
 
 export class IndexCanister extends Canister<IndexService> {
   static create({
@@ -21,4 +23,20 @@ export class IndexCanister extends Canister<IndexService> {
 
     return new IndexCanister(canisterId, service, certifiedService);
   }
+
+  /**
+   * Returns the balance of the specified account identifier.
+   *
+   * @param {AccountBalanceParams} params The parameters to get the balance of an account.
+   * @param {AccountIdentifierParam} params.accountIdentifier The account identifier provided either as hex string or as an AccountIdentifier.
+   * @param {boolean} params.certified query or update call.
+   * @returns {Promise<bigint>} The balance of the given account.
+   */
+  accountBalance = ({
+    certified,
+    accountIdentifier,
+  }: AccountBalanceParams): Promise<bigint> =>
+    this.caller({ certified }).get_account_identifier_balance(
+      paramToAccountIdentifier(accountIdentifier).toHex(),
+    );
 }

--- a/packages/ledger-icp/src/index.ts
+++ b/packages/ledger-icp/src/index.ts
@@ -1,5 +1,6 @@
 export { AccountIdentifier, SubAccount } from "./account_identifier";
 export * from "./errors/ledger.errors";
+export { IndexCanister } from "./index.canister";
 export { LedgerCanister } from "./ledger.canister";
 export type * from "./types/common";
 export * from "./types/ledger.options";

--- a/packages/ledger-icp/src/ledger.canister.ts
+++ b/packages/ledger-icp/src/ledger.canister.ts
@@ -23,10 +23,12 @@ import type {
   LedgerCanisterCall,
   LedgerCanisterOptions,
 } from "./types/ledger.options";
+import type { AccountBalanceParams } from "./types/ledger.params";
 import type {
   Icrc1TransferRequest,
   TransferRequest,
 } from "./types/ledger_converters";
+import { paramToAccountIdentifier } from "./utils/params.utils";
 import { importNnsProto, queryCall, updateCall } from "./utils/proto.utils";
 
 export class LedgerCanister {
@@ -70,15 +72,18 @@ export class LedgerCanister {
    * If `certified` is true, the request is fetched as an update call, otherwise
    * it is fetched using a query call.
    *
+   * @param {AccountBalanceParams} params The parameters to get the balance of an account.
+   * @param {AccountIdentifierParam} params.accountIdentifier The account identifier provided either as hex string or as an AccountIdentifier.
+   * @param {boolean} params.certified query or update call.
+   * @returns {Promise<bigint>} The balance of the given account.
    * @throws {@link Error}
    */
   public accountBalance = async ({
-    accountIdentifier,
+    accountIdentifier: accountIdentifierParam,
     certified = true,
-  }: {
-    accountIdentifier: AccountIdentifier;
-    certified?: boolean;
-  }): Promise<bigint> => {
+  }: AccountBalanceParams): Promise<bigint> => {
+    const accountIdentifier = paramToAccountIdentifier(accountIdentifierParam);
+
     if (this.hardwareWallet) {
       return this.accountBalanceHardwareWallet({
         accountIdentifier,

--- a/packages/ledger-icp/src/mocks/ledger.mock.ts
+++ b/packages/ledger-icp/src/mocks/ledger.mock.ts
@@ -1,0 +1,5 @@
+import { AccountIdentifier } from "../account_identifier";
+
+export const mockAccountIdentifier = AccountIdentifier.fromHex(
+  "3e8bbceef8b9338e56a1b561a127326e6614894ab9b0739df4cc3664d40a5958",
+);

--- a/packages/ledger-icp/src/types/common.ts
+++ b/packages/ledger-icp/src/types/common.ts
@@ -1,3 +1,3 @@
-export type AccountIdentifier = string;
+export type AccountIdentifierHex = string;
 export type BlockHeight = bigint;
 export type E8s = bigint;

--- a/packages/ledger-icp/src/types/ledger.params.ts
+++ b/packages/ledger-icp/src/types/ledger.params.ts
@@ -1,0 +1,9 @@
+import type { QueryParams } from "@dfinity/utils";
+import type { AccountIdentifier } from "../account_identifier";
+import type { AccountIdentifierHex } from "./common";
+
+export type AccountIdentifierParam = AccountIdentifier | AccountIdentifierHex;
+
+export type AccountBalanceParams = {
+  accountIdentifier: AccountIdentifierParam;
+} & QueryParams;

--- a/packages/ledger-icp/src/utils/account_identifier.utils.ts
+++ b/packages/ledger-icp/src/utils/account_identifier.utils.ts
@@ -7,16 +7,16 @@ import {
 } from "@dfinity/utils";
 import { sha224 } from "@noble/hashes/sha256";
 import { Buffer } from "buffer";
-import type { AccountIdentifier } from "../types/common";
+import type { AccountIdentifierHex } from "../types/common";
 
 export const accountIdentifierToBytes = (
-  accountIdentifier: AccountIdentifier,
+  accountIdentifier: AccountIdentifierHex,
 ): Uint8Array =>
   Uint8Array.from(Buffer.from(accountIdentifier, "hex")).subarray(4);
 
 export const accountIdentifierFromBytes = (
   accountIdentifier: Uint8Array,
-): AccountIdentifier => Buffer.from(accountIdentifier).toString("hex");
+): AccountIdentifierHex => Buffer.from(accountIdentifier).toString("hex");
 
 export const principalToAccountIdentifier = (
   principal: Principal,

--- a/packages/ledger-icp/src/utils/params.utils.ts
+++ b/packages/ledger-icp/src/utils/params.utils.ts
@@ -1,0 +1,7 @@
+import { AccountIdentifier } from "../account_identifier";
+import type { AccountIdentifierParam } from "../types/ledger.params";
+
+export const paramToAccountIdentifier = (
+  param: AccountIdentifierParam,
+): AccountIdentifier =>
+  param instanceof AccountIdentifier ? param : AccountIdentifier.fromHex(param);

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -31,6 +31,7 @@ const ledgerIcrcInputFiles = [
 
 const ledgerICPInputFiles = [
   "./packages/ledger-icp/src/ledger.canister.ts",
+  "./packages/ledger-icp/src/index.canister.ts",
   "./packages/ledger-icp/src/account_identifier.ts",
 ];
 

--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -71,6 +71,7 @@ import_did "rs/nns/cmc/cmc.did" "cmc.did" "cmc"
 
 mkdir -p packages/ledger-icp/candid
 import_did "rs/rosetta-api/icp_ledger/ledger.did" "ledger.did" "ledger-icp"
+import_did "rs/rosetta-api/icp_ledger/index/index.did" "index.did" "ledger-icp"
 
 mkdir -p packages/ledger-icrc/candid
 import_did "rs/rosetta-api/icrc1/ledger/ledger.did" "icrc_ledger.did" "ledger-icrc"


### PR DESCRIPTION
# Motivation

Add support for ICP index canister in `@dfinity/ledger-icp`.

# Notes

The ledger and the index canisters providing both a way to fetch the balance, the idea is to use the same function name and same parameters in both canister JS code.

# Changes

- add did file to import candid and generate idl scripts
- init `IndexCanister`
- implement `accountBalance` function for the new canister
- refactor type `AccountIdentifier` to `AccountIdentiferHex` to avoid conflicts
- refactor `Ledger.accountBalance` params to support account identifier as hex or class
