### PR TITLE
Fix: Add missing swap parameters to SNS proposal action

### DIFF
--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -1213,6 +1213,15 @@ const toSwapParameters = (
         restrictedCountries: toCountries(
           fromNullable(swapParameters.restricted_countries),
         ),
+        maxDirectParticipationIcp: toTokens(
+          fromNullable(swapParameters.maximum_direct_participation_icp),
+        ),
+        minDirectParticipationIcp: toTokens(
+          fromNullable(swapParameters.minimum_direct_participation_icp),
+        ),
+        neuronsFundParticipation: fromNullable(
+          swapParameters.neurons_fund_participation,
+        ),
       };
 };
 

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -557,20 +557,20 @@ export interface NeuronBasketConstructionParameters {
   count?: bigint;
 }
 export interface SwapParameters {
-  minimumParticipants?: bigint;
-  duration?: Duration;
-  neuronBasketConstructionParameters?: NeuronBasketConstructionParameters;
-  confirmationText?: string;
-  maximumParticipantIcp?: Tokens;
-  neuronsFundInvestmentIcp?: Tokens;
-  minimumIcp?: Tokens;
-  minimumParticipantIcp?: Tokens;
-  startTime?: GlobalTimeOfDay;
-  maximumIcp?: Tokens;
-  restrictedCountries?: Countries;
-  maxDirectParticipationIcp?: Tokens;
-  minDirectParticipationIcp?: Tokens;
-  neuronsFundParticipation?: boolean;
+  minimumParticipants: Option<bigint>;
+  duration: Option<Duration>;
+  neuronBasketConstructionParameters: Option<NeuronBasketConstructionParameters>;
+  confirmationText: Option<string>;
+  maximumParticipantIcp: Option<Tokens>;
+  neuronsFundInvestmentIcp: Option<Tokens>;
+  minimumIcp: Option<Tokens>;
+  minimumParticipantIcp: Option<Tokens>;
+  startTime: Option<GlobalTimeOfDay>;
+  maximumIcp: Option<Tokens>;
+  restrictedCountries: Option<Countries>;
+  maxDirectParticipationIcp: Option<Tokens>;
+  minDirectParticipationIcp: Option<Tokens>;
+  neuronsFundParticipation: Option<boolean>;
 }
 
 export interface SwapDistribution {


### PR DESCRIPTION
# Motivation

There were some fields not appearing in the proposal to open an SNS.

The problem was that the fields were considered optional, and the types didn't catch when they were missing from the converters.

Instead, I used the `Option` utility, to ensure that fields are present, but can be `undefined`.

# Changes

* Change optional fields to use `Option` in `SwapParameters` of the `CreateServiceNervousSystem`.
* Add missing fields in the converter of the `SwapParameters` of the `CreateServiceNervousSystem`.

# Tests

After changing the type to `Option`, I run the tests and they were failing to compile because the types didn't match. After adding the fields, the tests pass again.

# Todos

- [ ] Add entry to changelog (if necessary).

It was already in the changelog. But the feature was incomplete.