### PR TITLE
feat: Include tags in label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Features
+- Include timestamp and tags in the candid provenance record.
+
 # 2023.10.15-0600Z
 
 ## Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Features
+
 - Include timestamp and tags in the candid provenance record.
 
 # 2023.10.15-0600Z

--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -51,7 +51,7 @@ test -n "${IC_DIR:-}" || {
   exit 1
 } >&2
 IC_COMMIT="$(cd "${IC_DIR}" && git rev-parse --short HEAD)"
-IC_DATE="$(cd "${IC_DIR}" && git show -s --format=%ci | cut -f1 -d' ')"
+IC_DATE="$(cd "${IC_DIR}" && git show -s --format=%as)"
 IC_TAGS="$(cd "${IC_DIR}" && git tag --points-at HEAD | tr "\n" " ")"
 THIS_SCRIPT_NAME="$(basename "$0")"
 

--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -18,7 +18,7 @@ import_did() {
   local out_path="packages/${pkg}/candid/${out_filename}"
   echo "Copying ${in_fullpath} -> REPO_ROOT/${out_path}"
   {
-    echo "// Generated from IC repo commit ${IC_COMMIT} '${in_path}' by $(basename "${0}")"
+    echo "// Generated from IC repo commit ${IC_COMMIT} (${IC_DATE}${IC_TAGS:+ tags: ${IC_TAGS% }}) '${in_path}' by $(basename "${0}")"
     cat "$in_fullpath"
   } >"${out_path}"
 }
@@ -50,7 +50,9 @@ test -n "${IC_DIR:-}" || {
   echo "       Use --help for usage."
   exit 1
 } >&2
-IC_COMMIT="$(cd "${IC_DIR}" && git rev-parse HEAD)"
+IC_COMMIT="$(cd "${IC_DIR}" && git rev-parse --short HEAD)"
+IC_DATE="$(cd "${IC_DIR}" && git show -s --format=%ci | cut -f1 -d' ')"
+IC_TAGS="$(cd "${IC_DIR}" && git tag --points-at HEAD | tr "\n" " ")"
 THIS_SCRIPT_NAME="$(basename "$0")"
 
 : Import canisters


### PR DESCRIPTION
# Motivation
When candid is imported, the source commit is added to the top of the imported candid files.  This is useful, but the commit date and tags are also useful and it would be convenient if they were included.

# Changes
* Add the commit date after the IC commit.
* Add any tags on the IC commit.
* Shorten the commit.  (Entirely optional - I worried about the line getting too long but it may be fine.)

The annotation changes like this, if the commit is tagged:
```
-// Generated from IC repo commit ec140b74dc4fef2f4bee3fad936e315380fa5af3 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
+// Generated from IC repo commit ec140b74dc (2023-11-08 tags: release-2023-11-08_23-01) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
```
and without tags:
```
-// Generated from IC repo commit ec140b74dc4fef2f4bee3fad936e315380fa5af3 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
+// Generated from IC repo commit ec140b74dc (2023-11-08) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
```

# Tests
I have run this command locally.

# Todos

- [x] Add entry to changelog (if necessary).
