### PR TITLE
Chore: Upgrade didc

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install didc
         run: |
           mkdir -p .bin
-          curl -L https://github.com/dfinity/candid/releases/download/2022-08-09/didc-linux64 > .bin/didc
+          curl -L https://github.com/dfinity/candid/releases/download/2023-09-27/didc-linux64 > .bin/didc
           chmod +x .bin/didc
       - name: Add didc to the PATH
         run: echo "${PWD}/.bin" >> $GITHUB_PATH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - Include timestamp and tags in the candid provenance record.
+- Upgrade `didc` to `0.3.5`.
 
 # 2023.10.15-0600Z
 

--- a/packages/ckbtc/candid/minter.d.ts
+++ b/packages/ckbtc/candid/minter.d.ts
@@ -3,14 +3,14 @@ import type { Principal } from "@dfinity/principal";
 
 export interface Account {
   owner: Principal;
-  subaccount: [] | [Uint8Array];
+  subaccount: [] | [Uint8Array | number[]];
 }
 export type BitcoinAddress =
-  | { p2wsh_v0: Uint8Array }
-  | { p2tr_v1: Uint8Array }
-  | { p2sh: Uint8Array }
-  | { p2wpkh_v0: Uint8Array }
-  | { p2pkh: Uint8Array };
+  | { p2wsh_v0: Uint8Array | number[] }
+  | { p2tr_v1: Uint8Array | number[] }
+  | { p2sh: Uint8Array | number[] }
+  | { p2wpkh_v0: Uint8Array | number[] }
+  | { p2pkh: Uint8Array | number[] };
 export type BtcNetwork =
   | { Mainnet: null }
   | { Regtest: null }
@@ -21,7 +21,7 @@ export interface CanisterStatusResponse {
   cycles: bigint;
   settings: DefiniteCanisterSettings;
   idle_cycles_burned_per_day: bigint;
-  module_hash: [] | [Uint8Array];
+  module_hash: [] | [Uint8Array | number[]];
 }
 export type CanisterStatusType =
   | { stopped: null }
@@ -53,9 +53,9 @@ export type Event =
       sent_transaction: {
         fee: [] | [bigint];
         change_output: [] | [{ value: bigint; vout: number }];
-        txid: Uint8Array;
+        txid: Uint8Array | number[];
         utxos: Array<Utxo>;
-        requests: BigUint64Array;
+        requests: BigUint64Array | bigint[];
         submitted_at: bigint;
       };
     }
@@ -96,13 +96,13 @@ export type Event =
       };
     }
   | { removed_retrieve_btc_request: { block_index: bigint } }
-  | { confirmed_transaction: { txid: Uint8Array } }
+  | { confirmed_transaction: { txid: Uint8Array | number[] } }
   | {
       replaced_transaction: {
         fee: bigint;
         change_output: { value: bigint; vout: number };
-        old_txid: Uint8Array;
-        new_txid: Uint8Array;
+        old_txid: Uint8Array | number[];
+        new_txid: Uint8Array | number[];
         submitted_at: bigint;
       };
     }
@@ -154,14 +154,14 @@ export interface RetrieveBtcOk {
 }
 export type RetrieveBtcStatus =
   | { Signing: null }
-  | { Confirmed: { txid: Uint8Array } }
-  | { Sending: { txid: Uint8Array } }
+  | { Confirmed: { txid: Uint8Array | number[] } }
+  | { Sending: { txid: Uint8Array | number[] } }
   | { AmountTooLow: null }
   | { Unknown: null }
-  | { Submitted: { txid: Uint8Array } }
+  | { Submitted: { txid: Uint8Array | number[] } }
   | { Pending: null };
 export interface RetrieveBtcWithApprovalArgs {
-  from_subaccount: [] | [Uint8Array];
+  from_subaccount: [] | [Uint8Array | number[]];
   address: string;
   amount: bigint;
 }
@@ -196,7 +196,7 @@ export interface UpgradeArgs {
 export interface Utxo {
   height: number;
   value: bigint;
-  outpoint: { txid: Uint8Array; vout: number };
+  outpoint: { txid: Uint8Array | number[]; vout: number };
 }
 export type UtxoStatus =
   | { ValueTooSmall: Utxo }
@@ -215,7 +215,12 @@ export interface _SERVICE {
     { minter_fee: bigint; bitcoin_fee: bigint }
   >;
   get_btc_address: ActorMethod<
-    [{ owner: [] | [Principal]; subaccount: [] | [Uint8Array] }],
+    [
+      {
+        owner: [] | [Principal];
+        subaccount: [] | [Uint8Array | number[]];
+      },
+    ],
     string
   >;
   get_canister_status: ActorMethod<[], CanisterStatusResponse>;
@@ -236,7 +241,12 @@ export interface _SERVICE {
     { Ok: RetrieveBtcOk } | { Err: RetrieveBtcWithApprovalError }
   >;
   update_balance: ActorMethod<
-    [{ owner: [] | [Principal]; subaccount: [] | [Uint8Array] }],
+    [
+      {
+        owner: [] | [Principal];
+        subaccount: [] | [Uint8Array | number[]];
+      },
+    ],
     { Ok: Array<UtxoStatus> } | { Err: UpdateBalanceError }
   >;
 }

--- a/packages/cmc/candid/cmc.d.ts
+++ b/packages/cmc/candid/cmc.d.ts
@@ -2,7 +2,7 @@ import type { ActorMethod } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 
 export interface AccountIdentifier {
-  bytes: Uint8Array;
+  bytes: Uint8Array | number[];
 }
 export type BlockIndex = bigint;
 export type Cycles = bigint;
@@ -19,9 +19,9 @@ export interface IcpXdrConversionRate {
   timestamp_seconds: bigint;
 }
 export interface IcpXdrConversionRateResponse {
-  certificate: Uint8Array;
+  certificate: Uint8Array | number[];
   data: IcpXdrConversionRate;
-  hash_tree: Uint8Array;
+  hash_tree: Uint8Array | number[];
 }
 export interface NotifyCreateCanisterArg {
   controller: Principal;

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -152,9 +152,9 @@ Get canister details (memory size, status, etc.)
 
 Get canister info (controllers, module hash, changes, etc.)
 
-| Method         | Type                                                                                                                                                                                       |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `canisterInfo` | `({ canisterId, numRequestChanges, }: CanisterInfoParams) => Promise<{ controllers: Principal[]; module_hash: [] or [Uint8Array]; recent_changes: change[]; total_num_changes: bigint; }>` |
+| Method         | Type                                                                                                                            |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `canisterInfo` | `({ canisterId, numRequestChanges, }: CanisterInfoParams) => Promise<{ controllers: Principal[]; module_hash: [] or [Uint8Array | number[]]; recent_changes: change[]; total_num_changes: bigint; }>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L182)
 

--- a/packages/ic-management/candid/ic-management.d.ts
+++ b/packages/ic-management/candid/ic-management.d.ts
@@ -3,7 +3,7 @@ import type { Principal } from "@dfinity/principal";
 
 export type bitcoin_address = string;
 export type bitcoin_network = { mainnet: null } | { testnet: null };
-export type block_hash = Uint8Array;
+export type block_hash = Uint8Array | number[];
 export type canister_id = Principal;
 export interface canister_settings {
   freezing_threshold: [] | [bigint];
@@ -24,7 +24,7 @@ export type change_details =
   | {
       code_deployment: {
         mode: { reinstall: null } | { upgrade: null } | { install: null };
-        module_hash: Uint8Array;
+        module_hash: Uint8Array | number[];
       };
     }
   | { controllers_change: { controllers: Array<Principal> } }
@@ -54,11 +54,13 @@ export interface get_current_fee_percentiles_request {
 }
 export interface get_utxos_request {
   network: bitcoin_network;
-  filter: [] | [{ page: Uint8Array } | { min_confirmations: number }];
+  filter:
+    | []
+    | [{ page: Uint8Array | number[] } | { min_confirmations: number }];
   address: bitcoin_address;
 }
 export interface get_utxos_response {
-  next_page: [] | [Uint8Array];
+  next_page: [] | [Uint8Array | number[]];
   tip_height: number;
   tip_block_hash: block_hash;
   utxos: Array<utxo>;
@@ -69,17 +71,17 @@ export interface http_header {
 }
 export interface http_response {
   status: bigint;
-  body: Uint8Array;
+  body: Uint8Array | number[];
   headers: Array<http_header>;
 }
 export type millisatoshi_per_byte = bigint;
 export interface outpoint {
-  txid: Uint8Array;
+  txid: Uint8Array | number[];
   vout: number;
 }
 export type satoshi = bigint;
 export interface send_transaction_request {
-  transaction: Uint8Array;
+  transaction: Uint8Array | number[];
   network: bitcoin_network;
 }
 export interface utxo {
@@ -87,12 +89,12 @@ export interface utxo {
   value: satoshi;
   outpoint: outpoint;
 }
-export type wasm_module = Uint8Array;
+export type wasm_module = Uint8Array | number[];
 export interface _SERVICE {
   bitcoin_get_balance: ActorMethod<[get_balance_request], satoshi>;
   bitcoin_get_current_fee_percentiles: ActorMethod<
     [get_current_fee_percentiles_request],
-    BigUint64Array
+    BigUint64Array | bigint[]
   >;
   bitcoin_get_utxos: ActorMethod<[get_utxos_request], get_utxos_response>;
   bitcoin_send_transaction: ActorMethod<[send_transaction_request], undefined>;
@@ -100,7 +102,7 @@ export interface _SERVICE {
     [{ canister_id: canister_id; num_requested_changes: [] | [bigint] }],
     {
       controllers: Array<Principal>;
-      module_hash: [] | [Uint8Array];
+      module_hash: [] | [Uint8Array | number[]];
       recent_changes: Array<change>;
       total_num_changes: bigint;
     }
@@ -113,7 +115,7 @@ export interface _SERVICE {
       cycles: bigint;
       settings: definite_canister_settings;
       idle_cycles_burned_per_day: bigint;
-      module_hash: [] | [Uint8Array];
+      module_hash: [] | [Uint8Array | number[]];
     }
   >;
   create_canister: ActorMethod<
@@ -132,10 +134,13 @@ export interface _SERVICE {
       {
         key_id: { name: string; curve: ecdsa_curve };
         canister_id: [] | [canister_id];
-        derivation_path: Array<Uint8Array>;
+        derivation_path: Array<Uint8Array | number[]>;
       },
     ],
-    { public_key: Uint8Array; chain_code: Uint8Array }
+    {
+      public_key: Uint8Array | number[];
+      chain_code: Uint8Array | number[];
+    }
   >;
   http_request: ActorMethod<
     [
@@ -143,10 +148,15 @@ export interface _SERVICE {
         url: string;
         method: { get: null } | { head: null } | { post: null };
         max_response_bytes: [] | [bigint];
-        body: [] | [Uint8Array];
+        body: [] | [Uint8Array | number[]];
         transform:
           | []
-          | [{ function: [Principal, string]; context: Uint8Array }];
+          | [
+              {
+                function: [Principal, string];
+                context: Uint8Array | number[];
+              },
+            ];
         headers: Array<http_header>;
       },
     ],
@@ -155,7 +165,7 @@ export interface _SERVICE {
   install_code: ActorMethod<
     [
       {
-        arg: Uint8Array;
+        arg: Uint8Array | number[];
         wasm_module: wasm_module;
         mode: { reinstall: null } | { upgrade: null } | { install: null };
         canister_id: canister_id;
@@ -179,16 +189,16 @@ export interface _SERVICE {
     [{ canister_id: canister_id; amount: bigint }],
     undefined
   >;
-  raw_rand: ActorMethod<[], Uint8Array>;
+  raw_rand: ActorMethod<[], Uint8Array | number[]>;
   sign_with_ecdsa: ActorMethod<
     [
       {
         key_id: { name: string; curve: ecdsa_curve };
-        derivation_path: Array<Uint8Array>;
-        message_hash: Uint8Array;
+        derivation_path: Array<Uint8Array | number[]>;
+        message_hash: Uint8Array | number[];
       },
     ],
-    { signature: Uint8Array }
+    { signature: Uint8Array | number[] }
   >;
   start_canister: ActorMethod<[{ canister_id: canister_id }], undefined>;
   stop_canister: ActorMethod<[{ canister_id: canister_id }], undefined>;

--- a/packages/ledger-icp/candid/index.d.ts
+++ b/packages/ledger-icp/candid/index.d.ts
@@ -3,7 +3,7 @@ import type { Principal } from "@dfinity/principal";
 
 export interface Account {
   owner: Principal;
-  subaccount: [] | [Uint8Array];
+  subaccount: [] | [Uint8Array | number[]];
 }
 export interface GetAccountIdentifierTransactionsArgs {
   max_results: bigint;
@@ -33,17 +33,17 @@ export interface GetBlocksRequest {
   length: bigint;
 }
 export interface GetBlocksResponse {
-  blocks: Array<Uint8Array>;
+  blocks: Array<Uint8Array | number[]>;
   chain_length: bigint;
 }
 export interface HttpRequest {
   url: string;
   method: string;
-  body: Uint8Array;
+  body: Uint8Array | number[];
   headers: Array<[string, string]>;
 }
 export interface HttpResponse {
-  body: Uint8Array;
+  body: Uint8Array | number[];
   headers: Array<[string, string]>;
   status_code: number;
 }
@@ -90,7 +90,7 @@ export interface Tokens {
 }
 export interface Transaction {
   memo: bigint;
-  icrc1_memo: [] | [Uint8Array];
+  icrc1_memo: [] | [Uint8Array | number[]];
   operation: Operation;
   created_at_time: [] | [TimeStamp];
 }

--- a/packages/ledger-icp/candid/ledger.d.ts
+++ b/packages/ledger-icp/candid/ledger.d.ts
@@ -11,7 +11,7 @@ export interface AccountBalanceArgs {
 export interface AccountBalanceArgsDfx {
   account: TextAccountIdentifier;
 }
-export type AccountIdentifier = Uint8Array;
+export type AccountIdentifier = Uint8Array | number[];
 export interface Allowance {
   allowance: Icrc1Tokens;
   expires_at: [] | [TimeStamp];
@@ -22,7 +22,7 @@ export interface AllowanceArgs {
 }
 export interface ApproveArgs {
   fee: [] | [Icrc1Tokens];
-  memo: [] | [Uint8Array];
+  memo: [] | [Uint8Array | number[]];
   from_subaccount: [] | [SubAccount];
   created_at_time: [] | [TimeStamp];
   amount: Icrc1Tokens;
@@ -70,7 +70,7 @@ export interface Archives {
 export interface Block {
   transaction: Transaction;
   timestamp: TimeStamp;
-  parent_hash: [] | [Uint8Array];
+  parent_hash: [] | [Uint8Array | number[]];
 }
 export type BlockIndex = bigint;
 export interface BlockRange {
@@ -172,15 +172,15 @@ export type QueryArchiveResult =
   | { Ok: BlockRange }
   | { Err: QueryArchiveError };
 export interface QueryBlocksResponse {
-  certificate: [] | [Uint8Array];
+  certificate: [] | [Uint8Array | number[]];
   blocks: Array<Block>;
   chain_length: bigint;
   first_block_index: BlockIndex;
   archived_blocks: Array<ArchivedBlocksRange>;
 }
 export interface QueryEncodedBlocksResponse {
-  certificate: [] | [Uint8Array];
-  blocks: Array<Uint8Array>;
+  certificate: [] | [Uint8Array | number[]];
+  blocks: Array<Uint8Array | number[]>;
   chain_length: bigint;
   first_block_index: bigint;
   archived_blocks: Array<ArchivedEncodedBlocksRange>;
@@ -193,7 +193,7 @@ export interface SendArgs {
   created_at_time: [] | [TimeStamp];
   amount: Tokens;
 }
-export type SubAccount = Uint8Array;
+export type SubAccount = Uint8Array | number[];
 export type TextAccountIdentifier = string;
 export interface TimeStamp {
   timestamp_nanos: bigint;
@@ -203,14 +203,14 @@ export interface Tokens {
 }
 export interface Transaction {
   memo: Memo;
-  icrc1_memo: [] | [Uint8Array];
+  icrc1_memo: [] | [Uint8Array | number[]];
   operation: [] | [Operation];
   created_at_time: TimeStamp;
 }
 export interface TransferArg {
   to: Account;
   fee: [] | [Icrc1Tokens];
-  memo: [] | [Uint8Array];
+  memo: [] | [Uint8Array | number[]];
   from_subaccount: [] | [SubAccount];
   created_at_time: [] | [Icrc1Timestamp];
   amount: Icrc1Tokens;
@@ -244,7 +244,7 @@ export interface UpgradeArgs {
 export type Value =
   | { Int: bigint }
   | { Nat: bigint }
-  | { Blob: Uint8Array }
+  | { Blob: Uint8Array | number[] }
   | { Text: string };
 export interface _SERVICE {
   account_balance: ActorMethod<[AccountBalanceArgs], Tokens>;

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -88,7 +88,7 @@ Parameters:
 
 - `accountString`: string
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/utils/ledger.utils.ts#L59)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/utils/ledger.utils.ts#L61)
 
 #### :gear: decodePayment
 

--- a/packages/ledger-icrc/candid/icrc_index.d.ts
+++ b/packages/ledger-icrc/candid/icrc_index.d.ts
@@ -3,12 +3,12 @@ import type { Principal } from "@dfinity/principal";
 
 export interface Account {
   owner: Principal;
-  subaccount: [] | [Uint8Array];
+  subaccount: [] | [Uint8Array | number[]];
 }
 export interface Approve {
   fee: [] | [bigint];
   from: Account;
-  memo: [] | [Uint8Array];
+  memo: [] | [Uint8Array | number[]];
   created_at_time: [] | [bigint];
   amount: bigint;
   expected_allowance: [] | [bigint];
@@ -17,7 +17,7 @@ export interface Approve {
 }
 export interface Burn {
   from: Account;
-  memo: [] | [Uint8Array];
+  memo: [] | [Uint8Array | number[]];
   created_at_time: [] | [bigint];
   amount: bigint;
   spender: [] | [Account];
@@ -46,11 +46,11 @@ export interface ListSubaccountsArgs {
 }
 export interface Mint {
   to: Account;
-  memo: [] | [Uint8Array];
+  memo: [] | [Uint8Array | number[]];
   created_at_time: [] | [bigint];
   amount: bigint;
 }
-export type SubAccount = Uint8Array;
+export type SubAccount = Uint8Array | number[];
 export interface Transaction {
   burn: [] | [Burn];
   kind: string;
@@ -67,7 +67,7 @@ export interface Transfer {
   to: Account;
   fee: [] | [bigint];
   from: Account;
-  memo: [] | [Uint8Array];
+  memo: [] | [Uint8Array | number[]];
   created_at_time: [] | [bigint];
   amount: bigint;
   spender: [] | [Account];

--- a/packages/ledger-icrc/candid/icrc_ledger.d.ts
+++ b/packages/ledger-icrc/candid/icrc_ledger.d.ts
@@ -16,7 +16,7 @@ export interface AllowanceArgs {
 export interface Approve {
   fee: [] | [bigint];
   from: Account;
-  memo: [] | [Uint8Array];
+  memo: [] | [Uint8Array | number[]];
   created_at_time: [] | [Timestamp];
   amount: bigint;
   expected_allowance: [] | [bigint];
@@ -25,8 +25,8 @@ export interface Approve {
 }
 export interface ApproveArgs {
   fee: [] | [bigint];
-  memo: [] | [Uint8Array];
-  from_subaccount: [] | [Uint8Array];
+  memo: [] | [Uint8Array | number[]];
+  from_subaccount: [] | [Uint8Array | number[]];
   created_at_time: [] | [Timestamp];
   amount: bigint;
   expected_allowance: [] | [bigint];
@@ -53,15 +53,15 @@ export interface BlockRange {
 }
 export interface Burn {
   from: Account;
-  memo: [] | [Uint8Array];
+  memo: [] | [Uint8Array | number[]];
   created_at_time: [] | [Timestamp];
   amount: bigint;
   spender: [] | [Account];
 }
 export type ChangeFeeCollector = { SetTo: Account } | { Unset: null };
 export interface DataCertificate {
-  certificate: [] | [Uint8Array];
-  hash_tree: Uint8Array;
+  certificate: [] | [Uint8Array | number[]];
+  hash_tree: Uint8Array | number[];
 }
 export type Duration = bigint;
 export interface FeatureFlags {
@@ -72,7 +72,7 @@ export interface GetBlocksArgs {
   length: bigint;
 }
 export interface GetBlocksResponse {
-  certificate: [] | [Uint8Array];
+  certificate: [] | [Uint8Array | number[]];
   first_index: BlockIndex;
   blocks: Array<Block>;
   chain_length: bigint;
@@ -99,11 +99,11 @@ export interface GetTransactionsResponse {
 export interface HttpRequest {
   url: string;
   method: string;
-  body: Uint8Array;
+  body: Uint8Array | number[];
   headers: Array<[string, string]>;
 }
 export interface HttpResponse {
-  body: Uint8Array;
+  body: Uint8Array | number[];
   headers: Array<[string, string]>;
   status_code: number;
 }
@@ -135,11 +135,11 @@ export type Map = Array<[string, Value]>;
 export type MetadataValue =
   | { Int: bigint }
   | { Nat: bigint }
-  | { Blob: Uint8Array }
+  | { Blob: Uint8Array | number[] }
   | { Text: string };
 export interface Mint {
   to: Account;
-  memo: [] | [Uint8Array];
+  memo: [] | [Uint8Array | number[]];
   created_at_time: [] | [Timestamp];
   amount: bigint;
 }
@@ -152,7 +152,7 @@ export interface StandardRecord {
   url: string;
   name: string;
 }
-export type Subaccount = Uint8Array;
+export type Subaccount = Uint8Array | number[];
 export type Timestamp = bigint;
 export type Tokens = bigint;
 export interface Transaction {
@@ -170,7 +170,7 @@ export interface Transfer {
   to: Account;
   fee: [] | [bigint];
   from: Account;
-  memo: [] | [Uint8Array];
+  memo: [] | [Uint8Array | number[]];
   created_at_time: [] | [Timestamp];
   amount: bigint;
   spender: [] | [Account];
@@ -178,7 +178,7 @@ export interface Transfer {
 export interface TransferArg {
   to: Account;
   fee: [] | [Tokens];
-  memo: [] | [Uint8Array];
+  memo: [] | [Uint8Array | number[]];
   from_subaccount: [] | [Subaccount];
   created_at_time: [] | [Timestamp];
   amount: Tokens;
@@ -199,7 +199,7 @@ export interface TransferFromArgs {
   fee: [] | [Tokens];
   spender_subaccount: [] | [Subaccount];
   from: Account;
-  memo: [] | [Uint8Array];
+  memo: [] | [Uint8Array | number[]];
   created_at_time: [] | [Timestamp];
   amount: Tokens;
 }
@@ -236,7 +236,7 @@ export type Value =
   | { Map: Map }
   | { Nat: bigint }
   | { Nat64: bigint }
-  | { Blob: Uint8Array }
+  | { Blob: Uint8Array | number[] }
   | { Text: string }
   | { Array: Array<Value> };
 export interface _SERVICE {

--- a/packages/ledger-icrc/src/utils/ledger.utils.ts
+++ b/packages/ledger-icrc/src/utils/ledger.utils.ts
@@ -28,7 +28,9 @@ export const encodeIcrcAccount = ({
 
   const removeLeadingZeros = (text: string): string => text.replace(/^0+/, "");
 
-  const subaccountText = removeLeadingZeros(uint8ArrayToHexString(subaccount));
+  const subaccountText = removeLeadingZeros(
+    uint8ArrayToHexString(Uint8Array.from(subaccount)),
+  );
 
   if (subaccountText.length === 0) {
     return owner.toText();

--- a/packages/ledger-icrc/src/utils/ledger.utils.ts
+++ b/packages/ledger-icrc/src/utils/ledger.utils.ts
@@ -29,7 +29,7 @@ export const encodeIcrcAccount = ({
   const removeLeadingZeros = (text: string): string => text.replace(/^0+/, "");
 
   const subaccountText = removeLeadingZeros(
-    uint8ArrayToHexString(Uint8Array.from(subaccount)),
+    uint8ArrayToHexString(Uint8Array.from(subaccount ?? [])),
   );
 
   if (subaccountText.length === 0) {

--- a/packages/ledger-icrc/src/utils/ledger.utils.ts
+++ b/packages/ledger-icrc/src/utils/ledger.utils.ts
@@ -29,7 +29,7 @@ export const encodeIcrcAccount = ({
   const removeLeadingZeros = (text: string): string => text.replace(/^0+/, "");
 
   const subaccountText = removeLeadingZeros(
-    uint8ArrayToHexString(Uint8Array.from(subaccount ?? [])),
+    uint8ArrayToHexString(Uint8Array.from(subaccount)),
   );
 
   if (subaccountText.length === 0) {

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -2,7 +2,7 @@ import type { ActorMethod } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 
 export interface AccountIdentifier {
-  hash: Uint8Array;
+  hash: Uint8Array | number[];
 }
 export type Action =
   | { RegisterKnownNeuron: KnownNeuron }
@@ -52,7 +52,7 @@ export interface CanisterStatusResultV2 {
   memory_size: [] | [bigint];
   cycles: [] | [bigint];
   idle_cycles_burned_per_day: [] | [bigint];
-  module_hash: Uint8Array;
+  module_hash: Uint8Array | number[];
 }
 export interface CanisterSummary {
   status: [] | [CanisterStatusResultV2];
@@ -177,7 +177,7 @@ export interface Duration {
 }
 export interface ExecuteNnsFunction {
   nns_function: number;
-  payload: Uint8Array;
+  payload: Uint8Array | number[];
 }
 export interface Follow {
   topic: number;
@@ -291,7 +291,7 @@ export interface ListKnownNeuronsResponse {
   known_neurons: Array<KnownNeuron>;
 }
 export interface ListNeurons {
-  neuron_ids: BigUint64Array;
+  neuron_ids: BigUint64Array | bigint[];
   include_neurons_readable_by_caller: boolean;
 }
 export interface ListNeuronsResponse {
@@ -302,13 +302,13 @@ export interface ListNodeProvidersResponse {
   node_providers: Array<NodeProvider>;
 }
 export interface ListProposalInfo {
-  include_reward_status: Int32Array;
+  include_reward_status: Int32Array | number[];
   omit_large_fields: [] | [boolean];
   before_proposal: [] | [NeuronId];
   limit: number;
-  exclude_topic: Int32Array;
+  exclude_topic: Int32Array | number[];
   include_all_manage_neuron_proposals: [] | [boolean];
-  include_status: Int32Array;
+  include_status: Int32Array | number[];
 }
 export interface ListProposalInfoResponse {
   proposal_info: Array<ProposalInfo>;
@@ -384,7 +384,7 @@ export interface Neuron {
   auto_stake_maturity: [] | [boolean];
   aging_since_timestamp_seconds: bigint;
   hot_keys: Array<Principal>;
-  account: Uint8Array;
+  account: Uint8Array | number[];
   joined_community_fund_timestamp_seconds: [] | [bigint];
   dissolve_state: [] | [DissolveState];
   followees: Array<[number, Followees]>;
@@ -412,7 +412,7 @@ export interface NeuronId {
   id: bigint;
 }
 export type NeuronIdOrSubaccount =
-  | { Subaccount: Uint8Array }
+  | { Subaccount: Uint8Array | number[] }
   | { NeuronId: NeuronId };
 export interface NeuronInFlightCommand {
   command: [] | [Command_2];
@@ -431,11 +431,11 @@ export interface NeuronInfo {
   age_seconds: bigint;
 }
 export interface NeuronStakeTransfer {
-  to_subaccount: Uint8Array;
+  to_subaccount: Uint8Array | number[];
   neuron_stake_e8s: bigint;
   from: [] | [Principal];
   memo: bigint;
-  from_subaccount: Uint8Array;
+  from_subaccount: Uint8Array | number[];
   transfer_timestamp: bigint;
   block_height: bigint;
 }
@@ -726,7 +726,7 @@ export interface _SERVICE {
     [] | [MostRecentMonthlyNodeProviderRewards]
   >;
   get_network_economics_parameters: ActorMethod<[], NetworkEconomics>;
-  get_neuron_ids: ActorMethod<[], BigUint64Array>;
+  get_neuron_ids: ActorMethod<[], BigUint64Array | bigint[]>;
   get_neuron_info: ActorMethod<[bigint], Result_5>;
   get_neuron_info_by_id_or_subaccount: ActorMethod<
     [NeuronIdOrSubaccount],

--- a/packages/nns/candid/governance_test.d.ts
+++ b/packages/nns/candid/governance_test.d.ts
@@ -2,7 +2,7 @@ import type { ActorMethod } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 
 export interface AccountIdentifier {
-  hash: Uint8Array;
+  hash: Uint8Array | number[];
 }
 export type Action =
   | { RegisterKnownNeuron: KnownNeuron }
@@ -52,7 +52,7 @@ export interface CanisterStatusResultV2 {
   memory_size: [] | [bigint];
   cycles: [] | [bigint];
   idle_cycles_burned_per_day: [] | [bigint];
-  module_hash: Uint8Array;
+  module_hash: Uint8Array | number[];
 }
 export interface CanisterSummary {
   status: [] | [CanisterStatusResultV2];
@@ -177,7 +177,7 @@ export interface Duration {
 }
 export interface ExecuteNnsFunction {
   nns_function: number;
-  payload: Uint8Array;
+  payload: Uint8Array | number[];
 }
 export interface Follow {
   topic: number;
@@ -291,7 +291,7 @@ export interface ListKnownNeuronsResponse {
   known_neurons: Array<KnownNeuron>;
 }
 export interface ListNeurons {
-  neuron_ids: BigUint64Array;
+  neuron_ids: BigUint64Array | bigint[];
   include_neurons_readable_by_caller: boolean;
 }
 export interface ListNeuronsResponse {
@@ -302,13 +302,13 @@ export interface ListNodeProvidersResponse {
   node_providers: Array<NodeProvider>;
 }
 export interface ListProposalInfo {
-  include_reward_status: Int32Array;
+  include_reward_status: Int32Array | number[];
   omit_large_fields: [] | [boolean];
   before_proposal: [] | [NeuronId];
   limit: number;
-  exclude_topic: Int32Array;
+  exclude_topic: Int32Array | number[];
   include_all_manage_neuron_proposals: [] | [boolean];
-  include_status: Int32Array;
+  include_status: Int32Array | number[];
 }
 export interface ListProposalInfoResponse {
   proposal_info: Array<ProposalInfo>;
@@ -384,7 +384,7 @@ export interface Neuron {
   auto_stake_maturity: [] | [boolean];
   aging_since_timestamp_seconds: bigint;
   hot_keys: Array<Principal>;
-  account: Uint8Array;
+  account: Uint8Array | number[];
   joined_community_fund_timestamp_seconds: [] | [bigint];
   dissolve_state: [] | [DissolveState];
   followees: Array<[number, Followees]>;
@@ -412,7 +412,7 @@ export interface NeuronId {
   id: bigint;
 }
 export type NeuronIdOrSubaccount =
-  | { Subaccount: Uint8Array }
+  | { Subaccount: Uint8Array | number[] }
   | { NeuronId: NeuronId };
 export interface NeuronInFlightCommand {
   command: [] | [Command_2];
@@ -431,11 +431,11 @@ export interface NeuronInfo {
   age_seconds: bigint;
 }
 export interface NeuronStakeTransfer {
-  to_subaccount: Uint8Array;
+  to_subaccount: Uint8Array | number[];
   neuron_stake_e8s: bigint;
   from: [] | [Principal];
   memo: bigint;
-  from_subaccount: Uint8Array;
+  from_subaccount: Uint8Array | number[];
   transfer_timestamp: bigint;
   block_height: bigint;
 }
@@ -726,7 +726,7 @@ export interface _SERVICE {
     [] | [MostRecentMonthlyNodeProviderRewards]
   >;
   get_network_economics_parameters: ActorMethod<[], NetworkEconomics>;
-  get_neuron_ids: ActorMethod<[], BigUint64Array>;
+  get_neuron_ids: ActorMethod<[], BigUint64Array | bigint[]>;
   get_neuron_info: ActorMethod<[bigint], Result_5>;
   get_neuron_info_by_id_or_subaccount: ActorMethod<
     [NeuronIdOrSubaccount],

--- a/packages/nns/candid/sns_wasm.d.ts
+++ b/packages/nns/candid/sns_wasm.d.ts
@@ -2,7 +2,7 @@ import type { ActorMethod } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 
 export interface AddWasmRequest {
-  hash: Uint8Array;
+  hash: Uint8Array | number[];
   wasm: [] | [SnsWasm];
 }
 export interface AddWasmResponse {
@@ -72,7 +72,7 @@ export interface GetSnsSubnetIdsResponse {
   sns_subnet_ids: Array<Principal>;
 }
 export interface GetWasmRequest {
-  hash: Uint8Array;
+  hash: Uint8Array | number[];
 }
 export interface GetWasmResponse {
   wasm: [] | [SnsWasm];
@@ -136,7 +136,7 @@ export interface PrettySnsVersion {
   governance_wasm_hash: string;
   index_wasm_hash: string;
 }
-export type Result = { Error: SnsWasmError } | { Hash: Uint8Array };
+export type Result = { Error: SnsWasmError } | { Hash: Uint8Array | number[] };
 export interface SnsCanisterIds {
   root: [] | [Principal];
   swap: [] | [Principal];
@@ -193,15 +193,15 @@ export interface SnsUpgrade {
   current_version: [] | [SnsVersion];
 }
 export interface SnsVersion {
-  archive_wasm_hash: Uint8Array;
-  root_wasm_hash: Uint8Array;
-  swap_wasm_hash: Uint8Array;
-  ledger_wasm_hash: Uint8Array;
-  governance_wasm_hash: Uint8Array;
-  index_wasm_hash: Uint8Array;
+  archive_wasm_hash: Uint8Array | number[];
+  root_wasm_hash: Uint8Array | number[];
+  swap_wasm_hash: Uint8Array | number[];
+  ledger_wasm_hash: Uint8Array | number[];
+  governance_wasm_hash: Uint8Array | number[];
+  index_wasm_hash: Uint8Array | number[];
 }
 export interface SnsWasm {
-  wasm: Uint8Array;
+  wasm: Uint8Array | number[];
   canister_type: number;
 }
 export interface SnsWasmCanisterInitPayload {

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -162,7 +162,10 @@ const toNeuron = ({
   agingSinceTimestampSeconds: neuron.aging_since_timestamp_seconds,
   neuronFees: neuron.neuron_fees_e8s,
   hotKeys: neuron.hot_keys.map((p) => p.toString()),
-  accountIdentifier: principalToAccountIdentifier(canisterId, neuron.account),
+  accountIdentifier: principalToAccountIdentifier(
+    canisterId,
+    Uint8Array.from(neuron.account),
+  ),
   joinedCommunityFundTimestampSeconds: neuron
     .joined_community_fund_timestamp_seconds.length
     ? neuron.joined_community_fund_timestamp_seconds[0]
@@ -258,7 +261,9 @@ const toNeuronIdOrSubaccount = (
   }
   if ("Subaccount" in neuronIdOrSubaccount) {
     return {
-      Subaccount: uint8ArrayToArrayOfNumber(neuronIdOrSubaccount.Subaccount),
+      Subaccount: uint8ArrayToArrayOfNumber(
+        Uint8Array.from(neuronIdOrSubaccount.Subaccount),
+      ),
     };
   }
   throw new UnsupportedValueError(neuronIdOrSubaccount);

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -41,7 +41,7 @@ export interface CanisterStatusResultV2 {
   cycles: bigint;
   settings: DefiniteCanisterSettingsArgs;
   idle_cycles_burned_per_day: bigint;
-  module_hash: [] | [Uint8Array];
+  module_hash: [] | [Uint8Array | number[]];
 }
 export type CanisterStatusType =
   | { stopped: null }
@@ -150,7 +150,7 @@ export type DissolveState =
   | { WhenDissolvedTimestampSeconds: bigint };
 export interface ExecuteGenericNervousSystemFunction {
   function_id: bigint;
-  payload: Uint8Array;
+  payload: Uint8Array | number[];
 }
 export interface FinalizeDisburseMaturity {
   amount_to_be_disbursed_e8s: bigint;
@@ -248,7 +248,7 @@ export interface IncreaseDissolveDelay {
   additional_dissolve_delay_seconds: number;
 }
 export interface ListNervousSystemFunctionsResponse {
-  reserved_ids: BigUint64Array;
+  reserved_ids: BigUint64Array | bigint[];
   functions: Array<NervousSystemFunction>;
 }
 export interface ListNeurons {
@@ -260,17 +260,17 @@ export interface ListNeuronsResponse {
   neurons: Array<Neuron>;
 }
 export interface ListProposals {
-  include_reward_status: Int32Array;
+  include_reward_status: Int32Array | number[];
   before_proposal: [] | [ProposalId];
   limit: number;
-  exclude_type: BigUint64Array;
-  include_status: Int32Array;
+  exclude_type: BigUint64Array | bigint[];
+  include_status: Int32Array | number[];
 }
 export interface ListProposalsResponse {
   proposals: Array<ProposalData>;
 }
 export interface ManageNeuron {
-  subaccount: Uint8Array;
+  subaccount: Uint8Array | number[];
   command: [] | [Command];
 }
 export interface ManageNeuronResponse {
@@ -346,7 +346,7 @@ export interface Neuron {
   neuron_fees_e8s: bigint;
 }
 export interface NeuronId {
-  id: Uint8Array;
+  id: Uint8Array | number[];
 }
 export interface NeuronInFlightCommand {
   command: [] | [Command_2];
@@ -363,10 +363,10 @@ export interface NeuronParameters {
 }
 export interface NeuronPermission {
   principal: [] | [Principal];
-  permission_type: Int32Array;
+  permission_type: Int32Array | number[];
 }
 export interface NeuronPermissionList {
-  permissions: Int32Array;
+  permissions: Int32Array | number[];
 }
 export type Operation =
   | {
@@ -448,7 +448,7 @@ export interface StakeMaturityResponse {
   staked_maturity_e8s: bigint;
 }
 export interface Subaccount {
-  subaccount: Uint8Array;
+  subaccount: Uint8Array | number[];
 }
 export interface SwapNeuron {
   id: [] | [NeuronId];
@@ -474,18 +474,18 @@ export interface UpgradeInProgress {
   target_version: [] | [Version];
 }
 export interface UpgradeSnsControlledCanister {
-  new_canister_wasm: Uint8Array;
+  new_canister_wasm: Uint8Array | number[];
   mode: [] | [number];
   canister_id: [] | [Principal];
-  canister_upgrade_arg: [] | [Uint8Array];
+  canister_upgrade_arg: [] | [Uint8Array | number[]];
 }
 export interface Version {
-  archive_wasm_hash: Uint8Array;
-  root_wasm_hash: Uint8Array;
-  swap_wasm_hash: Uint8Array;
-  ledger_wasm_hash: Uint8Array;
-  governance_wasm_hash: Uint8Array;
-  index_wasm_hash: Uint8Array;
+  archive_wasm_hash: Uint8Array | number[];
+  root_wasm_hash: Uint8Array | number[];
+  swap_wasm_hash: Uint8Array | number[];
+  ledger_wasm_hash: Uint8Array | number[];
+  governance_wasm_hash: Uint8Array | number[];
+  index_wasm_hash: Uint8Array | number[];
 }
 export interface VotingRewardsParameters {
   final_reward_rate_basis_points: [] | [bigint];

--- a/packages/sns/candid/sns_governance_test.d.ts
+++ b/packages/sns/candid/sns_governance_test.d.ts
@@ -48,7 +48,7 @@ export interface CanisterStatusResultV2 {
   cycles: bigint;
   settings: DefiniteCanisterSettingsArgs;
   idle_cycles_burned_per_day: bigint;
-  module_hash: [] | [Uint8Array];
+  module_hash: [] | [Uint8Array | number[]];
 }
 export type CanisterStatusType =
   | { stopped: null }
@@ -157,7 +157,7 @@ export type DissolveState =
   | { WhenDissolvedTimestampSeconds: bigint };
 export interface ExecuteGenericNervousSystemFunction {
   function_id: bigint;
-  payload: Uint8Array;
+  payload: Uint8Array | number[];
 }
 export interface FinalizeDisburseMaturity {
   amount_to_be_disbursed_e8s: bigint;
@@ -255,7 +255,7 @@ export interface IncreaseDissolveDelay {
   additional_dissolve_delay_seconds: number;
 }
 export interface ListNervousSystemFunctionsResponse {
-  reserved_ids: BigUint64Array;
+  reserved_ids: BigUint64Array | bigint[];
   functions: Array<NervousSystemFunction>;
 }
 export interface ListNeurons {
@@ -267,17 +267,17 @@ export interface ListNeuronsResponse {
   neurons: Array<Neuron>;
 }
 export interface ListProposals {
-  include_reward_status: Int32Array;
+  include_reward_status: Int32Array | number[];
   before_proposal: [] | [ProposalId];
   limit: number;
-  exclude_type: BigUint64Array;
-  include_status: Int32Array;
+  exclude_type: BigUint64Array | bigint[];
+  include_status: Int32Array | number[];
 }
 export interface ListProposalsResponse {
   proposals: Array<ProposalData>;
 }
 export interface ManageNeuron {
-  subaccount: Uint8Array;
+  subaccount: Uint8Array | number[];
   command: [] | [Command];
 }
 export interface ManageNeuronResponse {
@@ -357,7 +357,7 @@ export interface Neuron {
   neuron_fees_e8s: bigint;
 }
 export interface NeuronId {
-  id: Uint8Array;
+  id: Uint8Array | number[];
 }
 export interface NeuronInFlightCommand {
   command: [] | [Command_2];
@@ -374,10 +374,10 @@ export interface NeuronParameters {
 }
 export interface NeuronPermission {
   principal: [] | [Principal];
-  permission_type: Int32Array;
+  permission_type: Int32Array | number[];
 }
 export interface NeuronPermissionList {
-  permissions: Int32Array;
+  permissions: Int32Array | number[];
 }
 export type Operation =
   | {
@@ -459,7 +459,7 @@ export interface StakeMaturityResponse {
   staked_maturity_e8s: bigint;
 }
 export interface Subaccount {
-  subaccount: Uint8Array;
+  subaccount: Uint8Array | number[];
 }
 export interface SwapNeuron {
   id: [] | [NeuronId];
@@ -485,18 +485,18 @@ export interface UpgradeInProgress {
   target_version: [] | [Version];
 }
 export interface UpgradeSnsControlledCanister {
-  new_canister_wasm: Uint8Array;
+  new_canister_wasm: Uint8Array | number[];
   mode: [] | [number];
   canister_id: [] | [Principal];
-  canister_upgrade_arg: [] | [Uint8Array];
+  canister_upgrade_arg: [] | [Uint8Array | number[]];
 }
 export interface Version {
-  archive_wasm_hash: Uint8Array;
-  root_wasm_hash: Uint8Array;
-  swap_wasm_hash: Uint8Array;
-  ledger_wasm_hash: Uint8Array;
-  governance_wasm_hash: Uint8Array;
-  index_wasm_hash: Uint8Array;
+  archive_wasm_hash: Uint8Array | number[];
+  root_wasm_hash: Uint8Array | number[];
+  swap_wasm_hash: Uint8Array | number[];
+  ledger_wasm_hash: Uint8Array | number[];
+  governance_wasm_hash: Uint8Array | number[];
+  index_wasm_hash: Uint8Array | number[];
 }
 export interface VotingRewardsParameters {
   final_reward_rate_basis_points: [] | [bigint];

--- a/packages/sns/candid/sns_root.d.ts
+++ b/packages/sns/candid/sns_root.d.ts
@@ -20,7 +20,7 @@ export interface CanisterStatusResult {
   memory_size: bigint;
   cycles: bigint;
   settings: DefiniteCanisterSettings;
-  module_hash: [] | [Uint8Array];
+  module_hash: [] | [Uint8Array | number[]];
 }
 export interface CanisterStatusResultV2 {
   status: CanisterStatusType;
@@ -28,7 +28,7 @@ export interface CanisterStatusResultV2 {
   cycles: bigint;
   settings: DefiniteCanisterSettingsArgs;
   idle_cycles_burned_per_day: bigint;
-  module_hash: [] | [Uint8Array];
+  module_hash: [] | [Uint8Array | number[]];
 }
 export type CanisterStatusType =
   | { stopped: null }
@@ -39,8 +39,8 @@ export interface CanisterSummary {
   canister_id: [] | [Principal];
 }
 export interface ChangeCanisterProposal {
-  arg: Uint8Array;
-  wasm_module: Uint8Array;
+  arg: Uint8Array | number[];
+  wasm_module: Uint8Array | number[];
   stop_before_installing: boolean;
   mode: CanisterInstallMode;
   canister_id: Principal;

--- a/packages/sns/candid/sns_swap.d.ts
+++ b/packages/sns/candid/sns_swap.d.ts
@@ -15,7 +15,7 @@ export interface CanisterStatusResultV2 {
   cycles: bigint;
   settings: DefiniteCanisterSettingsArgs;
   idle_cycles_burned_per_day: bigint;
-  module_hash: [] | [Uint8Array];
+  module_hash: [] | [Uint8Array | number[]];
 }
 export type CanisterStatusType =
   | { stopped: null }
@@ -134,7 +134,7 @@ export interface GovernanceError {
 }
 export interface Icrc1Account {
   owner: [] | [Principal];
-  subaccount: [] | [Uint8Array];
+  subaccount: [] | [Uint8Array | number[]];
 }
 export interface Init {
   nns_proposal_id: [] | [bigint];
@@ -210,7 +210,7 @@ export interface NeuronBasketConstructionParameters {
   count: bigint;
 }
 export interface NeuronId {
-  id: Uint8Array;
+  id: Uint8Array | number[];
 }
 export interface NeuronsFundParticipants {
   cf_participants: Array<CfParticipant>;
@@ -221,7 +221,7 @@ export interface NeuronsFundParticipationConstraints {
   min_direct_participation_threshold_icp_e8s: [] | [bigint];
 }
 export interface NewSaleTicketRequest {
-  subaccount: [] | [Uint8Array];
+  subaccount: [] | [Uint8Array | number[]];
   amount_icp_e8s: bigint;
 }
 export interface NewSaleTicketResponse {
@@ -307,7 +307,7 @@ export interface Swap {
   purge_old_tickets_last_completion_timestamp_nanoseconds: [] | [bigint];
   direct_participation_icp_e8s: [] | [bigint];
   lifecycle: number;
-  purge_old_tickets_next_principal: [] | [Uint8Array];
+  purge_old_tickets_next_principal: [] | [Uint8Array | number[]];
   buyers: Array<[string, BuyerState]>;
   params: [] | [Params];
   open_sns_token_swap_proposal_id: [] | [bigint];

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -311,7 +311,7 @@ export class SnsWrapper {
       amount: stakeE8s,
       to: {
         ...this.owner,
-        subaccount: toNullable(neuronId.id),
+        subaccount: toNullable(Uint8Array.from(neuronId.id)),
       },
       from_subaccount: source.subaccount,
     });
@@ -322,7 +322,7 @@ export class SnsWrapper {
   getNeuronBalance = async (neuronId: NeuronId): Promise<IcrcTokens> => {
     const account = {
       ...this.owner,
-      subaccount: neuronId.id,
+      subaccount: Uint8Array.from(neuronId.id),
     };
     return this.ledger.balance({ ...account, certified: this.certified });
   };

--- a/packages/sns/src/types/actions.ts
+++ b/packages/sns/src/types/actions.ts
@@ -84,9 +84,9 @@ export interface TransferSnsTreasuryFunds {
 }
 
 export interface UpgradeSnsControlledCanister {
-  new_canister_wasm: Uint8Array;
+  new_canister_wasm: Uint8Array | number[];
   canister_id: Option<Principal>;
-  canister_upgrade_arg: Option<Uint8Array>;
+  canister_upgrade_arg: Option<Uint8Array | number[]>;
   mode: Option<number>;
 }
 

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -84,7 +84,7 @@ export interface SnsIncreaseStakeNeuronParams
 
 // Type to transform to a ClaimOrRefresh command
 export interface SnsClaimOrRefreshArgs extends Omit<QueryParams, "certified"> {
-  subaccount: Uint8Array;
+  subaccount: Uint8Array | number[];
   memo?: bigint;
   controller?: Principal;
 }

--- a/scripts/compile-idl-js
+++ b/scripts/compile-idl-js
@@ -4,10 +4,10 @@
 
 set -euo pipefail
 
-if [ "$(didc --version)" != "didc 0.1.4" ]; then
+if [ "$(didc --version)" != "didc 0.3.5" ]; then
   {
-    echo "didc version 0.1.4 is required. To install it on Mac:"
-    echo "curl -Lf https://github.com/dfinity/candid/releases/download/2022-08-09/didc-macos -o install_didc"
+    echo "didc version 0.3.5 is required. To install it on Mac:"
+    echo "curl -Lf https://github.com/dfinity/candid/releases/download/2023-09-27/didc-macos -o install_didc"
     echo "install -m 755 install_didc /$HOME/.local/bin/didc"
   } >&2
   exit 1


### PR DESCRIPTION
# Motivation

Keep tools up to date.

In this PR, upgrade `didc` to latest version `0.3.5`.

The change is that types of `Uint8Array` are now `Uint8Array | number[]`.

Which means that in some places I had to convert to `Uint8Array` to have a common type for simplicity.

# Changes

## Automatic changes

* All files in `*/candid/*` directories. By running `compile-idl-js` with the new `didc` version.
* Readme files with the docs workflow.

## Manual changes

* `compile-idl-js` to expect latest `didc`.
* Convert types `Uint8Array | number[]` to `Uint8array` with `Uint8Array.from` where needed.

# Tests

Still passing.

# Todos

- [x] Add entry to changelog (if necessary).
