### PR TITLE
Update ckbtc candid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Include timestamp and tags in the candid provenance record.
 - Upgrade `didc` to `0.3.5`.
+- Update ckbtc candid to ic commit `4de99bc27be74048f80d13200f3c75cf2a43438c`.
 
 # 2023.10.15-0600Z
 

--- a/packages/ckbtc/candid/minter.certified.idl.js
+++ b/packages/ckbtc/candid/minter.certified.idl.js
@@ -198,6 +198,11 @@ export const idlFactory = ({ IDL }) => {
     }),
     'Checked' : Utxo,
   });
+  const PendingUtxo = IDL.Record({
+    'confirmations' : IDL.Nat32,
+    'value' : IDL.Nat64,
+    'outpoint' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8), 'vout' : IDL.Nat32 }),
+  });
   const UpdateBalanceError = IDL.Variant({
     'GenericError' : IDL.Record({
       'error_message' : IDL.Text,
@@ -207,6 +212,7 @@ export const idlFactory = ({ IDL }) => {
     'AlreadyProcessing' : IDL.Null,
     'NoNewUtxos' : IDL.Record({
       'required_confirmations' : IDL.Nat32,
+      'pending_utxos' : IDL.Opt(IDL.Vec(PendingUtxo)),
       'current_confirmations' : IDL.Opt(IDL.Nat32),
     }),
   });

--- a/packages/ckbtc/candid/minter.d.ts
+++ b/packages/ckbtc/candid/minter.d.ts
@@ -135,6 +135,11 @@ export type Mode =
   | { DepositsRestrictedTo: Array<Principal> }
   | { ReadOnly: null }
   | { GeneralAvailability: null };
+export interface PendingUtxo {
+  confirmations: number;
+  value: bigint;
+  outpoint: { txid: Uint8Array | number[]; vout: number };
+}
 export type ReimbursementReason =
   | { CallFailed: null }
   | { TaintedDestination: { kyt_fee: bigint; kyt_provider: Principal } };
@@ -182,6 +187,7 @@ export type UpdateBalanceError =
   | {
       NoNewUtxos: {
         required_confirmations: number;
+        pending_utxos: [] | [Array<PendingUtxo>];
         current_confirmations: [] | [number];
       };
     };

--- a/packages/ckbtc/candid/minter.did
+++ b/packages/ckbtc/candid/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 8be68bc88db7332dd39a26509ddf62c564ca3415 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
+// Generated from IC repo commit 4de99bc27b (2023-11-20) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
 // Represents an account on the ckBTC ledger.
 type Account = record { owner : principal; subaccount : opt blob };
 
@@ -101,11 +101,19 @@ type UtxoStatus = variant {
     };
 };
 
+// Utxos that don't have enough confirmations to be processed.
+type PendingUtxo = record {
+    outpoint : record { txid : vec nat8; vout : nat32 };
+    value : nat64;
+    confirmations: nat32;
+};
+
 type UpdateBalanceError = variant {
     // There are no new UTXOs to process.
     NoNewUtxos : record {
         current_confirmations: opt nat32;
-        required_confirmations: nat32
+        required_confirmations: nat32;
+        pending_utxos: opt vec PendingUtxo;
     };
     // The minter is already processing another update balance request for the caller.
     AlreadyProcessing;

--- a/packages/ckbtc/candid/minter.idl.js
+++ b/packages/ckbtc/candid/minter.idl.js
@@ -198,6 +198,11 @@ export const idlFactory = ({ IDL }) => {
     }),
     'Checked' : Utxo,
   });
+  const PendingUtxo = IDL.Record({
+    'confirmations' : IDL.Nat32,
+    'value' : IDL.Nat64,
+    'outpoint' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8), 'vout' : IDL.Nat32 }),
+  });
   const UpdateBalanceError = IDL.Variant({
     'GenericError' : IDL.Record({
       'error_message' : IDL.Text,
@@ -207,6 +212,7 @@ export const idlFactory = ({ IDL }) => {
     'AlreadyProcessing' : IDL.Null,
     'NoNewUtxos' : IDL.Record({
       'required_confirmations' : IDL.Nat32,
+      'pending_utxos' : IDL.Opt(IDL.Vec(PendingUtxo)),
       'current_confirmations' : IDL.Opt(IDL.Nat32),
     }),
   });

--- a/packages/ckbtc/src/minter.canister.spec.ts
+++ b/packages/ckbtc/src/minter.canister.spec.ts
@@ -194,8 +194,9 @@ describe("ckBTC minter canister", () => {
           NoNewUtxos: {
             required_confirmations: 123,
             current_confirmations: toNullable(456),
+            pending_utxos: [],
           },
-        },
+        } as UpdateBalanceError,
       };
       service.update_balance.mockResolvedValue(error);
 


### PR DESCRIPTION
# Motivation

Make `PendingUtxo` candid type available.

# Changes

## Automated

1. In `~/gitlab/ic` run `git checkout 4de99bc27be74048f80d13200f3c75cf2a43438c`
2. In `ic-js` run:
```
$ scripts/import-candid ~/gitlab/ic
$ scripts/compile-idl-js
$ git checkout packages/{cmc,ic-management,ledger-icp,ledger-icrc,nns,sns}
```

## Manual

Fixed `packages/ckbtc/src/minter.canister.spec.ts` to include `pending_utxos` as an empty array.
Optional fields are not really optional in TypeScript generated from Candid.

# Tests

In ic-js:
```
npm ci
npm run build --workspace packages/utils && \
  npm run build --workspace packages/nns-proto &&
  npm run build --workspace packages/ledger-icrc && \
  npm run build --workspace packages/ledger-icp && \
  npm run build --workspaces
```

In nns-dapp:
```
cd frontend
rm -rf node_modules
npm ci

for x in utils ckbtc; do
  npm rm @dfinity/$x && npm i $IC_JS_PATH/packages/$x
done
```

Then tested manually that things look find without errors.

# Todos

- [x] Add entry to changelog (if necessary).
