### PR TITLE
Expose pending UTXOs returned by the minter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Include timestamp and tags in the candid provenance record.
 - Upgrade `didc` to `0.3.5`.
 - Update ckbtc candid to ic commit `4de99bc27be74048f80d13200f3c75cf2a43438c`.
+- Include pending UTXOs in MinterNoNewUtxosError.
 
 # 2023.10.15-0600Z
 

--- a/packages/ckbtc/src/errors/minter.errors.ts
+++ b/packages/ckbtc/src/errors/minter.errors.ts
@@ -1,5 +1,6 @@
-import { nonNullish } from "@dfinity/utils";
+import { fromNullable, nonNullish } from "@dfinity/utils";
 import type {
+  PendingUtxo,
   RetrieveBtcError,
   RetrieveBtcWithApprovalError,
   UpdateBalanceError,
@@ -10,7 +11,21 @@ export class MinterTemporaryUnavailableError extends MinterGenericError {}
 export class MinterAlreadyProcessingError extends MinterGenericError {}
 
 export class MinterUpdateBalanceError extends MinterGenericError {}
-export class MinterNoNewUtxosError extends MinterUpdateBalanceError {}
+export class MinterNoNewUtxosError extends MinterUpdateBalanceError {
+  readonly pendingUtxos: PendingUtxo[];
+  readonly requiredConfirmations: number;
+  constructor({
+    pending_utxos,
+    required_confirmations,
+  }: {
+    pending_utxos: [] | [PendingUtxo[]];
+    required_confirmations: number;
+  }) {
+    super();
+    this.pendingUtxos = fromNullable(pending_utxos) || [];
+    this.requiredConfirmations = required_confirmations;
+  }
+}
 
 export class MinterRetrieveBtcError extends MinterGenericError {}
 export class MinterMalformedAddressError extends MinterRetrieveBtcError {}
@@ -49,7 +64,7 @@ export const createUpdateBalanceError = (
   }
 
   if ("NoNewUtxos" in Err) {
-    return new MinterNoNewUtxosError();
+    return new MinterNoNewUtxosError(Err.NoNewUtxos);
   }
 
   // Handle types added in the backend but not yet added in the frontend

--- a/packages/ckbtc/src/index.ts
+++ b/packages/ckbtc/src/index.ts
@@ -1,5 +1,6 @@
 export type {
   MinterInfo,
+  PendingUtxo,
   RetrieveBtcOk,
   Account as WithdrawalAccount,
 } from "../candid/minter";

--- a/packages/ckbtc/src/minter.canister.spec.ts
+++ b/packages/ckbtc/src/minter.canister.spec.ts
@@ -225,6 +225,36 @@ describe("ckBTC minter canister", () => {
       );
     });
 
+    it("should throw MinterNoNewUtxosError without pending UTXOs", async () => {
+      const service = mock<ActorSubclass<CkBTCMinterService>>();
+      const error = {
+        Err: {
+          NoNewUtxos: {
+            required_confirmations: 123,
+            current_confirmations: toNullable(456),
+            pending_utxos: [],
+          },
+        } as UpdateBalanceError,
+      };
+      service.update_balance.mockResolvedValue(error);
+
+      const canister = minter(service);
+
+      const owner = Principal.fromText("aaaaa-aa");
+
+      const call = () =>
+        canister.updateBalance({
+          owner,
+        });
+
+      await expect(call).rejects.toThrowError(
+        new MinterNoNewUtxosError({
+          pending_utxos: [],
+          required_confirmations: 12,
+        }),
+      );
+    });
+
     it("should throw unsupported response", async () => {
       const service = mock<ActorSubclass<CkBTCMinterService>>();
 

--- a/packages/ckbtc/src/minter.canister.spec.ts
+++ b/packages/ckbtc/src/minter.canister.spec.ts
@@ -188,13 +188,21 @@ describe("ckBTC minter canister", () => {
 
     it("should throw MinterNoNewUtxosError", async () => {
       const service = mock<ActorSubclass<CkBTCMinterService>>();
+      const pendingUtxo = {
+        confirmations: 3,
+        value: 3_2000_000n,
+        outpoint: {
+          txid: new Uint8Array([6, 5, 2, 7]),
+          vout: 1,
+        },
+      };
 
       const error = {
         Err: {
           NoNewUtxos: {
             required_confirmations: 123,
             current_confirmations: toNullable(456),
-            pending_utxos: [],
+            pending_utxos: [[pendingUtxo]],
           },
         } as UpdateBalanceError,
       };
@@ -209,7 +217,12 @@ describe("ckBTC minter canister", () => {
           owner,
         });
 
-      await expect(call).rejects.toThrowError(new MinterNoNewUtxosError());
+      await expect(call).rejects.toThrowError(
+        new MinterNoNewUtxosError({
+          pending_utxos: [[pendingUtxo]],
+          required_confirmations: 12,
+        }),
+      );
     });
 
     it("should throw unsupported response", async () => {


### PR DESCRIPTION
# Motivation

When we call `update_balace` on the ckBTC minter, it will credit deposited BTC from transactions with at least 12 confirmations.
If there are no new transactions with at least 12 confirmations, it will return an error.
If there are transactions with fewer than 12 confirmations, the error will contain the pending UTXOs of those transaction.

# Changes

Forward the pending UTXOs returned by the minter, in the mapped error.

# Tests

Existing unit test has been updated.

# Todos

- [x] Add entry to changelog (if necessary).
