### PR TITLE
Support number[] in uint8ArrayToHexString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Substitute `?` fields with `Option` fields in the converters related to NNS proposals.
 - Add retrieveBtcStatus to ckbtc minter canister.
+- Make uint8ArrayToHexString also accept `number[]` as input.
 
 ## Operations
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -192,9 +192,9 @@ Parameters:
 
 #### :gear: uint8ArrayToHexString
 
-| Function                | Type                            |
-| ----------------------- | ------------------------------- |
-| `uint8ArrayToHexString` | `(bytes: Uint8Array) => string` |
+| Function                | Type                                        |
+| ----------------------- | ------------------------------------------- |
+| `uint8ArrayToHexString` | `(bytes: Uint8Array or number[]) => string` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/arrays.utils.ts#L60)
 

--- a/packages/utils/src/utils/arrays.utils.spec.ts
+++ b/packages/utils/src/utils/arrays.utils.spec.ts
@@ -71,4 +71,8 @@ describe("arrays-utils", () => {
   it("should convert hex uint8array to string", () => {
     expect(uint8ArrayToHexString(hexArray)).toEqual(hex);
   });
+
+  it("should convert array of numbers to string", () => {
+    expect(uint8ArrayToHexString(Array.from(hexArray))).toEqual(hex);
+  });
 });

--- a/packages/utils/src/utils/arrays.utils.ts
+++ b/packages/utils/src/utils/arrays.utils.ts
@@ -57,5 +57,12 @@ export const hexStringToUint8Array = (hexString: string): Uint8Array => {
   return Uint8Array.from(matches.map((byte) => parseInt(byte, 16)));
 };
 
-export const uint8ArrayToHexString = (bytes: Uint8Array) =>
-  bytes.reduce((str, byte) => str + byte.toString(16).padStart(2, "0"), "");
+export const uint8ArrayToHexString = (bytes: Uint8Array | number[]) => {
+  if (!(bytes instanceof Uint8Array)) {
+    bytes = Uint8Array.from(bytes);
+  }
+  return bytes.reduce(
+    (str, byte) => str + byte.toString(16).padStart(2, "0"),
+    "",
+  );
+};


### PR DESCRIPTION
# Motivation

Candid changed what used to be `Uint8Array` to `Uint8Array | number[]`.
This means we often have to convert a field to `Uint8Array` just to get rid of the `| number[]` bit.
To make this slightly less painful we can make some functions accept both.

# Changes

Make `uint8ArrayToHexString` accept both `Uint8Array | number[]`.
I considered changing the name but in that case I don't think it's worth it anymore. What do you think?

# Tests

Unit test added

# Todos

- [x] Add entry to changelog (if necessary).
