### PR TITLE
feat: makeProposal return created proposal ID

### DIFF
--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -329,7 +329,7 @@ Neuron leaves the community fund
 | -------------------- | ------------------------------------- |
 | `leaveCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L501)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L502)
 
 ##### :gear: setNodeProviderAccount
 
@@ -340,7 +340,7 @@ Where the reward is paid to.
 | ------------------------ | ---------------------------------------------- |
 | `setNodeProviderAccount` | `(accountIdentifier: string) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L518)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L519)
 
 ##### :gear: mergeNeurons
 
@@ -350,7 +350,7 @@ Merge two neurons
 | -------------- | --------------------------------------------------------------------------------- |
 | `mergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L538)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L539)
 
 ##### :gear: simulateMergeNeurons
 
@@ -360,7 +360,7 @@ Simulate merging two neurons
 | ---------------------- | --------------------------------------------------------------------------------------- |
 | `simulateMergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<NeuronInfo>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L555)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L556)
 
 ##### :gear: splitNeuron
 
@@ -370,7 +370,7 @@ Splits a neuron creating a new one
 | ------------- | ----------------------------------------------------------------------------------- |
 | `splitNeuron` | `({ neuronId, amount, }: { neuronId: bigint; amount: bigint; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L600)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L601)
 
 ##### :gear: getProposal
 
@@ -383,17 +383,17 @@ it is fetched using a query call.
 | ------------- | ----------------------------------------------------------------------------------------------------- |
 | `getProposal` | `({ proposalId, certified, }: { proposalId: bigint; certified?: boolean; }) => Promise<ProposalInfo>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L640)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L641)
 
 ##### :gear: makeProposal
 
 Create new proposal
 
-| Method         | Type                                              |
-| -------------- | ------------------------------------------------- |
-| `makeProposal` | `(request: MakeProposalRequest) => Promise<void>` |
+| Method         | Type                                                |
+| -------------- | --------------------------------------------------- |
+| `makeProposal` | `(request: MakeProposalRequest) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L657)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L659)
 
 ##### :gear: registerVote
 
@@ -403,7 +403,7 @@ Registers vote for a proposal from the neuron passed.
 | -------------- | ----------------------------------------------------------------------------------------------------------- |
 | `registerVote` | `({ neuronId, vote, proposalId, }: { neuronId: bigint; vote: Vote; proposalId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L672)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L680)
 
 ##### :gear: setFollowees
 
@@ -413,7 +413,7 @@ Edit neuron followees per topic
 | -------------- | ------------------------------------------------- |
 | `setFollowees` | `(followRequest: FollowRequest) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L694)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L702)
 
 ##### :gear: disburse
 
@@ -423,7 +423,7 @@ Disburse neuron on Account
 | ---------- | --------------------------------------------------------------------------------------------------------------------- |
 | `disburse` | `({ neuronId, toAccountId, amount, }: { neuronId: bigint; toAccountId?: string; amount?: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L709)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L717)
 
 ##### :gear: mergeMaturity
 
@@ -433,7 +433,7 @@ Merge Maturity of a neuron
 | --------------- | ------------------------------------------------------------------------------------------------------- |
 | `mergeMaturity` | `({ neuronId, percentageToMerge, }: { neuronId: bigint; percentageToMerge: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L748)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L756)
 
 ##### :gear: stakeMaturity
 
@@ -448,7 +448,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to stake the maturity
 - `percentageToStake`: Optional. Percentage of the current maturity to stake. If not provided, all of the neuron's current maturity will be staked.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L781)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L789)
 
 ##### :gear: spawnNeuron
 
@@ -458,7 +458,7 @@ Merge Maturity of a neuron
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `spawnNeuron` | `({ neuronId, percentageToSpawn, newController, nonce, }: { neuronId: bigint; percentageToSpawn?: number; newController?: Principal; nonce?: bigint; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L803)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L811)
 
 ##### :gear: addHotkey
 
@@ -468,7 +468,7 @@ Add hotkey to neuron
 | ----------- | ------------------------------------------------------------------------------------------ |
 | `addHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L857)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L865)
 
 ##### :gear: removeHotkey
 
@@ -478,7 +478,7 @@ Remove hotkey to neuron
 | -------------- | ------------------------------------------------------------------------------------------ |
 | `removeHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L881)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L889)
 
 ##### :gear: claimOrRefreshNeuronFromAccount
 
@@ -488,7 +488,7 @@ Gets the NeuronID of a newly created neuron.
 | --------------------------------- | --------------------------------------------------------------------------------------- |
 | `claimOrRefreshNeuronFromAccount` | `({ memo, controller, }: { memo: bigint; controller?: Principal; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L902)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L910)
 
 ##### :gear: claimOrRefreshNeuron
 
@@ -499,7 +499,7 @@ Uses query call only.
 | ---------------------- | ----------------------------------------------------------- |
 | `claimOrRefreshNeuron` | `(request: ClaimOrRefreshNeuronRequest) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L933)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L941)
 
 ##### :gear: getNeuron
 
@@ -509,7 +509,7 @@ Return the data of the neuron provided as id.
 | ----------- | ---------------------------------------------------------------------------------------------- |
 | `getNeuron` | `({ certified, neuronId, }: { certified: boolean; neuronId: bigint; }) => Promise<NeuronInfo>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L984)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L992)
 
 ### :factory: SnsWasmCanister
 

--- a/packages/nns/src/canisters/governance/services.ts
+++ b/packages/nns/src/canisters/governance/services.ts
@@ -38,10 +38,10 @@ export const manageNeuron = async ({
 }: {
   request: ManageNeuron;
   service: GovernanceService;
-}): Promise<void> => {
+}): Promise<Command_1> => {
   const response = await service.manage_neuron(request);
   // We use it only to assert that there are no errors
-  getSuccessfulCommandFromResponse(response);
+  return getSuccessfulCommandFromResponse(response);
 };
 
 /**

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -1822,8 +1822,10 @@ describe("GovernanceCanister", () => {
       },
     };
     it("successfully creates a proposal", async () => {
+      const proposalId = 10n;
+
       const serviceResponse: ManageNeuronResponse = {
-        command: [{ MakeProposal: { proposal_id: [{ id: BigInt(10) }] } }],
+        command: [{ MakeProposal: { proposal_id: [{ id: proposalId }] } }],
       };
       const service = mock<ActorSubclass<GovernanceService>>();
       service.manage_neuron.mockResolvedValue(serviceResponse);
@@ -1833,6 +1835,22 @@ describe("GovernanceCanister", () => {
       });
       const response = await governance.makeProposal(makeProposalRequest);
       expect(service.manage_neuron).toBeCalled();
+      expect(response).toEqual(proposalId);
+    });
+
+    it("successfully creates a proposal but return undefined", async () => {
+      const serviceResponse: ManageNeuronResponse = {
+        command: [{ RegisterVote: {} }],
+      };
+      const service = mock<ActorSubclass<GovernanceService>>();
+      service.manage_neuron.mockResolvedValue(serviceResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+      });
+      const response = await governance.makeProposal(makeProposalRequest);
+      expect(service.manage_neuron).toBeCalled();
+      expect(response).toEqual(undefined);
     });
 
     it("throws error if response is error", async () => {

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -391,7 +391,7 @@ export class GovernanceCanister {
       additionalDissolveDelaySeconds,
     });
 
-    return manageNeuron({
+    await manageNeuron({
       request,
       service: this.certifiedService,
     });
@@ -417,7 +417,7 @@ export class GovernanceCanister {
       dissolveDelaySeconds,
     });
 
-    return manageNeuron({
+    await manageNeuron({
       request,
       service: this.certifiedService,
     });
@@ -434,7 +434,7 @@ export class GovernanceCanister {
     }
     const request = toStartDissolvingRequest(neuronId);
 
-    return manageNeuron({
+    await manageNeuron({
       request,
       service: this.certifiedService,
     });
@@ -451,7 +451,7 @@ export class GovernanceCanister {
     }
     const request = toStopDissolvingRequest(neuronId);
 
-    return manageNeuron({
+    await manageNeuron({
       request,
       service: this.certifiedService,
     });
@@ -469,7 +469,7 @@ export class GovernanceCanister {
 
     const request = toJoinCommunityFundRequest(neuronId);
 
-    return manageNeuron({
+    await manageNeuron({
       request,
       service: this.certifiedService,
     });
@@ -484,14 +484,15 @@ export class GovernanceCanister {
    *
    * @throws {@link GovernanceError}
    */
-  public autoStakeMaturity = (params: {
+  public autoStakeMaturity = async (params: {
     neuronId: NeuronId;
     autoStake: boolean;
-  }): Promise<void> =>
-    manageNeuron({
+  }): Promise<void> => {
+    await manageNeuron({
       request: toAutoStakeMaturityRequest(params),
       service: this.certifiedService,
     });
+  };
 
   /**
    * Neuron leaves the community fund
@@ -501,7 +502,7 @@ export class GovernanceCanister {
   public leaveCommunityFund = async (neuronId: NeuronId): Promise<void> => {
     const request = toLeaveCommunityFundRequest(neuronId);
 
-    return manageNeuron({
+    await manageNeuron({
       request,
       service: this.certifiedService,
     });
@@ -541,7 +542,7 @@ export class GovernanceCanister {
   }): Promise<void> => {
     const rawRequest = toMergeRequest(request);
 
-    return manageNeuron({
+    await manageNeuron({
       request: rawRequest,
       service: this.certifiedService,
     });
@@ -652,15 +653,22 @@ export class GovernanceCanister {
   /**
    * Create new proposal
    *
+   * @returns The newly created proposal ID or undefined if the success response returned by the Governance canister does not provide such information.
    * @throws {@link GovernanceError}
    */
-  public makeProposal = async (request: MakeProposalRequest): Promise<void> => {
+  public makeProposal = async (
+    request: MakeProposalRequest,
+  ): Promise<NeuronId | undefined> => {
     const rawRequest = toMakeProposalRawRequest(request);
 
-    return manageNeuron({
+    const cmd = await manageNeuron({
       request: rawRequest,
       service: this.certifiedService,
     });
+
+    return "MakeProposal" in cmd
+      ? fromNullable(cmd.MakeProposal.proposal_id)?.id
+      : undefined;
   };
 
   /**
@@ -680,7 +688,7 @@ export class GovernanceCanister {
   }): Promise<void> => {
     const request = toRegisterVoteRequest({ neuronId, vote, proposalId });
 
-    return manageNeuron({
+    await manageNeuron({
       request,
       service: this.certifiedService,
     });
@@ -694,7 +702,7 @@ export class GovernanceCanister {
   public setFollowees = async (followRequest: FollowRequest): Promise<void> => {
     const request = toManageNeuronsFollowRequest(followRequest);
 
-    return manageNeuron({
+    await manageNeuron({
       request,
       service: this.certifiedService,
     });
@@ -732,7 +740,7 @@ export class GovernanceCanister {
       amount,
     });
 
-    return manageNeuron({
+    await manageNeuron({
       request,
       service: this.certifiedService,
     });
@@ -761,7 +769,7 @@ export class GovernanceCanister {
 
     const request = toMergeMaturityRequest({ neuronId, percentageToMerge });
 
-    return manageNeuron({
+    await manageNeuron({
       request,
       service: this.certifiedService,
     });
@@ -867,7 +875,7 @@ export class GovernanceCanister {
 
     const request = toAddHotkeyRequest({ neuronId, principal });
 
-    return manageNeuron({
+    await manageNeuron({
       request,
       service: this.certifiedService,
     });
@@ -890,7 +898,7 @@ export class GovernanceCanister {
     }
     const request = toRemoveHotkeyRequest({ neuronId, principal });
 
-    return manageNeuron({
+    await manageNeuron({
       request,
       service: this.certifiedService,
     });


### PR DESCRIPTION
# Motivation

`makeProposal` returns currently void which is a bit inconvenient if the caller needs to know which proposal was created which happens to be the case in the small proof of concept I was developing.

Therefore this PR extends the function to return the potential ID of the proposal that was created.

# Notes

Given the fact that the answer of the Governance canister is a variant I hesitated between returning `Promise<bigint | undefined>` or `{success: boolean; proposalId?: bigint}`. Given the fact that there was no use cases where `success: false^ would be set, I opted for the first simple solution.

# Changes

- return `Command_1` for `manageNeuron`
- return the proposal ID for `makeProposal`
- make other functions that uses `manageNeuron` continue returning `void`

