### PR TITLE
GIX-2154: Add support for token decimals in TokenAmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## Overview
 
+## Breaking changes
+
+- `decimals` mandatory field in `Token`.
+- `TokenAmount` rejects tokens with `decimals !== 8`.
+
 ## Features
 
 - Substitute `?` fields with `Option` fields in the converters related to NNS proposals.
 - Add retrieveBtcStatus to ckbtc minter canister.
 - Make uint8ArrayToHexString also accept `number[]` as input.
+- Add a new type TokenAmountV2 which supports `decimals !== 8`.
 
 ## Operations
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -376,13 +376,15 @@ Tags after patch version are ignored, e.g. 1.0.0-beta.1 is considered equal to 1
 | ---------- | ------- |
 | `ICPToken` | `Token` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L62)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L113)
 
 ### :factory: TokenAmount
 
+Deprecated. Use TokenAmountV2 instead which supports decimals !== 8.
+
 Represents an amount of tokens.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L73)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L127)
 
 #### Methods
 
@@ -404,7 +406,7 @@ Parameters:
 - `params.amount`: The amount in bigint format.
 - `params.token`: The token type.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L86)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L144)
 
 ##### :gear: fromString
 
@@ -423,7 +425,7 @@ Parameters:
 - `params.amount`: The amount in string format.
 - `params.token`: The token type.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L107)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L165)
 
 ##### :gear: fromNumber
 
@@ -440,7 +442,7 @@ Parameters:
 - `params.amount`: The amount in number format.
 - `params.token`: The token type.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L131)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L195)
 
 ##### :gear: toE8s
 
@@ -448,7 +450,79 @@ Parameters:
 | ------- | -------------- |
 | `toE8s` | `() => bigint` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L157)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L221)
+
+### :factory: TokenAmountV2
+
+Represents an amount of tokens.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L233)
+
+#### Methods
+
+- [fromE8s](#gear-frome8s)
+- [fromString](#gear-fromstring)
+- [fromNumber](#gear-fromnumber)
+- [toUlps](#gear-toulps)
+
+##### :gear: fromE8s
+
+Initialize from a bigint. Bigint are considered ulps.
+
+| Method    | Type                                                                       |
+| --------- | -------------------------------------------------------------------------- |
+| `fromE8s` | `({ amount, token, }: { amount: bigint; token: Token; }) => TokenAmountV2` |
+
+Parameters:
+
+- `params.amount`: The amount in bigint format.
+- `params.token`: The token type.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L246)
+
+##### :gear: fromString
+
+Initialize from a string. Accepted formats:
+
+1234567.8901
+1'234'567.8901
+1,234,567.8901
+
+| Method       | Type                                                                                                 |
+| ------------ | ---------------------------------------------------------------------------------------------------- |
+| `fromString` | `({ amount, token, }: { amount: string; token: Token; }) => FromStringToTokenError or TokenAmountV2` |
+
+Parameters:
+
+- `params.amount`: The amount in string format.
+- `params.token`: The token type.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L267)
+
+##### :gear: fromNumber
+
+Initialize from a number.
+
+1 integer is considered 10^{token.decimals} ulps
+
+| Method       | Type                                                                       |
+| ------------ | -------------------------------------------------------------------------- |
+| `fromNumber` | `({ amount, token, }: { amount: number; token: Token; }) => TokenAmountV2` |
+
+Parameters:
+
+- `params.amount`: The amount in number format.
+- `params.token`: The token type.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L291)
+
+##### :gear: toUlps
+
+| Method   | Type           |
+| -------- | -------------- |
+| `toUlps` | `() => bigint` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L319)
 
 ### :factory: Canister
 

--- a/packages/utils/src/enums/token.enums.ts
+++ b/packages/utils/src/enums/token.enums.ts
@@ -1,4 +1,5 @@
 export enum FromStringToTokenError {
   FractionalMoreThan8Decimals,
   InvalidFormat,
+  FractionalTooManyDecimals,
 }

--- a/packages/utils/src/parser/token.spec.ts
+++ b/packages/utils/src/parser/token.spec.ts
@@ -129,3 +129,131 @@ describe("ICP", () => {
     );
   });
 });
+
+describe("ICP", () => {
+  it("can be initialized from a whole number string", () => {
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "1" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000) }),
+    );
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "1234" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(123400000000) }),
+    );
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "000001234" }),
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(123400000000) }),
+    );
+    expect(TokenAmount.fromString({ token: ICPToken, amount: " 1" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000) }),
+    );
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "1,000" }),
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000000) }),
+    );
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "1'000" }),
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000000) }),
+    );
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "1'000'000" }),
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000000000) }),
+    );
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "1'000'000" }),
+    ).toEqual(TokenAmount.fromNumber({ token: ICPToken, amount: 1_000_000 }));
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "1'000'000" }),
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000000000) }),
+    );
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "1'000" }),
+    ).toEqual(TokenAmount.fromNumber({ token: ICPToken, amount: 1_000 }));
+  });
+
+  it("can be initialized from a fractional number string", () => {
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "0.1" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(10000000) }),
+    );
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "0.1" })).toEqual(
+      TokenAmount.fromNumber({ token: ICPToken, amount: 0.1 }),
+    );
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "45.1231" }),
+    ).toEqual(TokenAmount.fromNumber({ token: ICPToken, amount: 45.1231 }));
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "0.3319" }),
+    ).toEqual(TokenAmount.fromNumber({ token: ICPToken, amount: 0.3319 }));
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "0.0001" }),
+    ).toEqual(TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(10000) }));
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "0.00000001" }),
+    ).toEqual(TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1) }));
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "0.0000000001" }),
+    ).toEqual(FromStringToTokenError.FractionalMoreThan8Decimals);
+    expect(TokenAmount.fromString({ token: ICPToken, amount: ".01" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1000000) }),
+    );
+  });
+
+  it("can be initialized from a mixed string", () => {
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "1.1" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(110000000) }),
+    );
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "1.1" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(110000000) }),
+    );
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "12,345.00000001" }),
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1234500000001) }),
+    );
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "12'345.00000001" }),
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1234500000001) }),
+    );
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "12345.00000001" }),
+    ).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1234500000001) }),
+    );
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "1e-8" })).toEqual(
+      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1) }),
+    );
+  });
+
+  it("returns an error on invalid formats", () => {
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "1.1.1" })).toBe(
+      FromStringToTokenError.InvalidFormat,
+    );
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "a" })).toBe(
+      FromStringToTokenError.InvalidFormat,
+    );
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "3.a" })).toBe(
+      FromStringToTokenError.InvalidFormat,
+    );
+    expect(
+      TokenAmount.fromString({ token: ICPToken, amount: "123asdf$#@~!" }),
+    ).toBe(FromStringToTokenError.InvalidFormat);
+
+    const callToNumber = () =>
+      TokenAmount.fromNumber({ token: ICPToken, amount: 1e-9 });
+    expect(callToNumber).toThrow(
+      expect.objectContaining({
+        message: "Number 1e-9 has more than 8 decimals",
+      }),
+    );
+  });
+
+  it("rejects negative numbers", () => {
+    expect(TokenAmount.fromString({ token: ICPToken, amount: "-1" })).toBe(
+      FromStringToTokenError.InvalidFormat,
+    );
+  });
+});

--- a/packages/utils/src/parser/token.spec.ts
+++ b/packages/utils/src/parser/token.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "@jest/globals";
 import { FromStringToTokenError } from "../enums/token.enums";
-import { ICPToken, TokenAmount } from "./token";
+import { ICPToken, TokenAmount, TokenAmountV2 } from "./token";
 
-describe("ICP", () => {
+describe("ICP with 8 decimals", () => {
   it("can be initialized from a whole number string", () => {
     expect(TokenAmount.fromString({ token: ICPToken, amount: "1" })).toEqual(
       TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000) }),
@@ -130,130 +130,304 @@ describe("ICP", () => {
   });
 });
 
-describe("ICP", () => {
+describe("TokenAmount v1", () => {
+  const token = {
+    symbol: "token",
+    name: "token",
+    decimals: 6,
+  };
+
+  it("Fails when decimals !== 8", () => {
+    const call = () => {
+      TokenAmount.fromE8s({ token, amount: BigInt(1) });
+    };
+    expect(call).toThrow(
+      new Error("Use TokenAmountV2 for number of decimals other than 8"),
+    );
+  });
+});
+
+describe("TokenAmountV2 with 18 decimals", () => {
+  const token = {
+    symbol: "ckETH",
+    name: "ckETH",
+    decimals: 18,
+  };
+
   it("can be initialized from a whole number string", () => {
-    expect(TokenAmount.fromString({ token: ICPToken, amount: "1" })).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000) }),
+    expect(TokenAmountV2.fromString({ token: token, amount: "1" })).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 1000000000000000000n,
+      }),
     );
-    expect(TokenAmount.fromString({ token: ICPToken, amount: "1234" })).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(123400000000) }),
+    expect(TokenAmountV2.fromString({ token: token, amount: "1234" })).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 1234000000000000000000n,
+      }),
     );
     expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "000001234" }),
+      TokenAmountV2.fromString({ token: token, amount: "000001234" }),
     ).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(123400000000) }),
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 1234000000000000000000n,
+      }),
     );
-    expect(TokenAmount.fromString({ token: ICPToken, amount: " 1" })).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000) }),
+    expect(TokenAmountV2.fromString({ token: token, amount: " 1" })).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 1000000000000000000n,
+      }),
+    );
+    expect(TokenAmountV2.fromString({ token: token, amount: "1,000" })).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 1000000000000000000000n,
+      }),
+    );
+    expect(TokenAmountV2.fromString({ token: token, amount: "1'000" })).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 1000000000000000000000n,
+      }),
     );
     expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "1,000" }),
+      TokenAmountV2.fromString({ token: token, amount: "1'000'000" }),
     ).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000000) }),
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 1000000000000000000000000n,
+      }),
     );
     expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "1'000" }),
+      TokenAmountV2.fromString({ token: token, amount: "1'000'000" }),
     ).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000000) }),
+      TokenAmountV2.fromNumber({
+        token: token,
+        amount: 1_000_000,
+      }),
     );
     expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "1'000'000" }),
+      TokenAmountV2.fromString({ token: token, amount: "1'000'000" }),
     ).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000000000) }),
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 1000000000000000000000000n,
+      }),
     );
-    expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "1'000'000" }),
-    ).toEqual(TokenAmount.fromNumber({ token: ICPToken, amount: 1_000_000 }));
-    expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "1'000'000" }),
-    ).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(100000000000000) }),
+    expect(TokenAmountV2.fromString({ token: token, amount: "1'000" })).toEqual(
+      TokenAmountV2.fromNumber({ token: token, amount: 1_000 }),
     );
-    expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "1'000" }),
-    ).toEqual(TokenAmount.fromNumber({ token: ICPToken, amount: 1_000 }));
   });
 
   it("can be initialized from a fractional number string", () => {
-    expect(TokenAmount.fromString({ token: ICPToken, amount: "0.1" })).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(10000000) }),
+    expect(TokenAmountV2.fromString({ token: token, amount: "0.1" })).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 100000000000000000n,
+      }),
     );
-    expect(TokenAmount.fromString({ token: ICPToken, amount: "0.1" })).toEqual(
-      TokenAmount.fromNumber({ token: ICPToken, amount: 0.1 }),
+    expect(TokenAmountV2.fromString({ token: token, amount: "0.1" })).toEqual(
+      TokenAmountV2.fromNumber({ token: token, amount: 0.1 }),
     );
     expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "45.1231" }),
-    ).toEqual(TokenAmount.fromNumber({ token: ICPToken, amount: 45.1231 }));
+      TokenAmountV2.fromString({ token: token, amount: "45.1231" }),
+    ).toEqual(TokenAmountV2.fromNumber({ token: token, amount: 45.1231 }));
     expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "0.3319" }),
-    ).toEqual(TokenAmount.fromNumber({ token: ICPToken, amount: 0.3319 }));
+      TokenAmountV2.fromString({ token: token, amount: "0.3319" }),
+    ).toEqual(TokenAmountV2.fromNumber({ token: token, amount: 0.3319 }));
     expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "0.0001" }),
-    ).toEqual(TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(10000) }));
+      TokenAmountV2.fromString({ token: token, amount: "0.0001" }),
+    ).toEqual(
+      TokenAmountV2.fromE8s({ token: token, amount: 100000000000000n }),
+    );
     expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "0.00000001" }),
-    ).toEqual(TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1) }));
+      TokenAmountV2.fromString({ token: token, amount: "0.00000001" }),
+    ).toEqual(TokenAmountV2.fromE8s({ token: token, amount: 10000000000n }));
     expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "0.0000000001" }),
-    ).toEqual(FromStringToTokenError.FractionalMoreThan8Decimals);
-    expect(TokenAmount.fromString({ token: ICPToken, amount: ".01" })).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1000000) }),
+      TokenAmountV2.fromString({
+        token: token,
+        amount: "0.00000000000000000001",
+      }),
+    ).toEqual(FromStringToTokenError.FractionalTooManyDecimals);
+    expect(TokenAmountV2.fromString({ token: token, amount: ".01" })).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 10000000000000000n,
+      }),
     );
   });
 
   it("can be initialized from a mixed string", () => {
-    expect(TokenAmount.fromString({ token: ICPToken, amount: "1.1" })).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(110000000) }),
+    expect(TokenAmountV2.fromString({ token: token, amount: "1.1" })).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 1100000000000000000n,
+      }),
     );
-    expect(TokenAmount.fromString({ token: ICPToken, amount: "1.1" })).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(110000000) }),
-    );
-    expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "12,345.00000001" }),
-    ).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1234500000001) }),
-    );
-    expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "12'345.00000001" }),
-    ).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1234500000001) }),
+    expect(TokenAmountV2.fromString({ token: token, amount: "1.1" })).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 1100000000000000000n,
+      }),
     );
     expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "12345.00000001" }),
+      TokenAmountV2.fromString({ token: token, amount: "12,345.00000001" }),
     ).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1234500000001) }),
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 12345000000010000000000n,
+      }),
     );
-    expect(TokenAmount.fromString({ token: ICPToken, amount: "1e-8" })).toEqual(
-      TokenAmount.fromE8s({ token: ICPToken, amount: BigInt(1) }),
+    expect(
+      TokenAmountV2.fromString({ token: token, amount: "12'345.00000001" }),
+    ).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 12345000000010000000000n,
+      }),
+    );
+    expect(
+      TokenAmountV2.fromString({ token: token, amount: "12345.00000001" }),
+    ).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 12345000000010000000000n,
+      }),
+    );
+    expect(
+      TokenAmountV2.fromString({
+        token: token,
+        amount: "100000000.000000000000000001",
+      }),
+    ).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 100000000000000000000000001n,
+      }),
+    );
+    expect(
+      TokenAmountV2.fromString({
+        token: token,
+        amount: "199999999.999999999999999991",
+      }),
+    ).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 199999999999999999999999991n,
+      }),
     );
   });
 
   it("returns an error on invalid formats", () => {
-    expect(TokenAmount.fromString({ token: ICPToken, amount: "1.1.1" })).toBe(
+    expect(TokenAmountV2.fromString({ token: token, amount: "1.1.1" })).toBe(
       FromStringToTokenError.InvalidFormat,
     );
-    expect(TokenAmount.fromString({ token: ICPToken, amount: "a" })).toBe(
+    expect(TokenAmountV2.fromString({ token: token, amount: "a" })).toBe(
       FromStringToTokenError.InvalidFormat,
     );
-    expect(TokenAmount.fromString({ token: ICPToken, amount: "3.a" })).toBe(
+    expect(TokenAmountV2.fromString({ token: token, amount: "3.a" })).toBe(
       FromStringToTokenError.InvalidFormat,
     );
     expect(
-      TokenAmount.fromString({ token: ICPToken, amount: "123asdf$#@~!" }),
+      TokenAmountV2.fromString({ token: token, amount: "123asdf$#@~!" }),
     ).toBe(FromStringToTokenError.InvalidFormat);
 
     const callToNumber = () =>
-      TokenAmount.fromNumber({ token: ICPToken, amount: 1e-9 });
+      TokenAmountV2.fromNumber({ token: token, amount: 1e-9 });
     expect(callToNumber).toThrow(
       expect.objectContaining({
-        message: "Number 1e-9 has more than 8 decimals",
+        message: "Invalid number 1e-9",
       }),
     );
   });
 
   it("rejects negative numbers", () => {
-    expect(TokenAmount.fromString({ token: ICPToken, amount: "-1" })).toBe(
+    expect(TokenAmountV2.fromString({ token: token, amount: "-1" })).toBe(
       FromStringToTokenError.InvalidFormat,
     );
+  });
+});
+
+describe("TokenAmountV2 with 2 decimals", () => {
+  const token = {
+    symbol: "USD",
+    name: "US Dollar",
+    decimals: 2,
+  };
+
+  it("can be initialized from a whole number string", () => {
+    expect(TokenAmountV2.fromString({ token: token, amount: "123" })).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 12300n,
+      }),
+    );
+  });
+
+  it("can be initialized from a fractional number string", () => {
+    expect(TokenAmountV2.fromString({ token: token, amount: "0.99" })).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 99n,
+      }),
+    );
+    expect(
+      TokenAmountV2.fromString({
+        token: token,
+        amount: "0.001",
+      }),
+    ).toEqual(FromStringToTokenError.FractionalTooManyDecimals);
+  });
+
+  it("can be initialized from a mixed string", () => {
+    expect(
+      TokenAmountV2.fromString({
+        token: token,
+        amount: "100000000.91",
+      }),
+    ).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 10000000091n,
+      }),
+    );
+  });
+});
+
+describe("TokenAmountV2 with 0 decimals", () => {
+  const token = {
+    symbol: "CENT",
+    name: "Cents",
+    decimals: 0,
+  };
+
+  it("can be initialized from a whole number string", () => {
+    expect(TokenAmountV2.fromString({ token: token, amount: "123" })).toEqual(
+      TokenAmountV2.fromE8s({
+        token: token,
+        amount: 123n,
+      }),
+    );
+  });
+
+  it("can not be initialized from a fractional number string", () => {
+    expect(
+      TokenAmountV2.fromString({
+        token: token,
+        amount: "0.5",
+      }),
+    ).toEqual(FromStringToTokenError.FractionalTooManyDecimals);
+  });
+
+  it("can not be initialized from a mixed string", () => {
+    expect(
+      TokenAmountV2.fromString({
+        token: token,
+        amount: "1.5",
+      }),
+    ).toEqual(FromStringToTokenError.FractionalTooManyDecimals);
   });
 });

--- a/packages/utils/src/parser/token.spec.ts
+++ b/packages/utils/src/parser/token.spec.ts
@@ -334,7 +334,9 @@ describe("TokenAmountV2 with 18 decimals", () => {
     expect(
       TokenAmountV2.fromString({ token: token, amount: "123asdf$#@~!" }),
     ).toBe(FromStringToTokenError.InvalidFormat);
+  });
 
+  it("does not support scientific notation", () => {
     const callToNumber = () =>
       TokenAmountV2.fromNumber({ token: token, amount: 1e-9 });
     expect(callToNumber).toThrow(

--- a/packages/utils/src/parser/token.ts
+++ b/packages/utils/src/parser/token.ts
@@ -54,6 +54,59 @@ export const convertStringToE8s = (
   return e8s;
 };
 
+/**
+ * Receives a string representing a number and returns the big int or error.
+ *
+ * @param amount - in string format
+ * @returns bigint | FromStringToTokenError
+ */
+export const convertStringToE8s = (
+  value: string,
+): bigint | FromStringToTokenError => {
+  // replace exponential format (1e-4) with plain (0.0001)
+  // doesn't support decimals for values >= ~1e16
+  let amount = value.includes("e")
+    ? Number(value).toLocaleString("en", {
+        useGrouping: false,
+        maximumFractionDigits: 20,
+      })
+    : value;
+
+  // Remove all instances of "," and "'".
+  amount = amount.trim().replace(/[,']/g, "");
+
+  // Verify that the string is of the format 1234.5678
+  const regexMatch = amount.match(/\d*(\.\d*)?/);
+  if (!regexMatch || regexMatch[0] !== amount) {
+    return FromStringToTokenError.InvalidFormat;
+  }
+
+  const [integral, fractional] = amount.split(".");
+
+  let e8s = BigInt(0);
+
+  if (integral) {
+    try {
+      e8s += BigInt(integral) * E8S_PER_TOKEN;
+    } catch {
+      return FromStringToTokenError.InvalidFormat;
+    }
+  }
+
+  if (fractional) {
+    if (fractional.length > 8) {
+      return FromStringToTokenError.FractionalMoreThan8Decimals;
+    }
+    try {
+      e8s += BigInt(fractional.padEnd(8, "0"));
+    } catch {
+      return FromStringToTokenError.InvalidFormat;
+    }
+  }
+
+  return e8s;
+};
+
 export interface Token {
   symbol: string;
   name: string;
@@ -63,6 +116,101 @@ export const ICPToken: Token = {
   symbol: "ICP",
   name: "Internet Computer",
 };
+
+/**
+ * Represents an amount of tokens.
+ *
+ * @param e8s - The amount of tokens in bigint.
+ * @param token - The token type.
+ */
+export class TokenAmount {
+  private constructor(
+    protected e8s: bigint,
+    public token: Token,
+  ) {}
+
+  /**
+   * Initialize from a bigint. Bigint are considered e8s.
+   *
+   * @param {amount: bigint; token?: Token;} params
+   * @param {bigint} params.amount The amount in bigint format.
+   * @param {Token} params.token The token type.
+   */
+  public static fromE8s({
+    amount,
+    token,
+  }: {
+    amount: bigint;
+    token: Token;
+  }): TokenAmount {
+    return new TokenAmount(amount, token);
+  }
+
+  /**
+   * Initialize from a string. Accepted formats:
+   *
+   * 1234567.8901
+   * 1'234'567.8901
+   * 1,234,567.8901
+   *
+   * @param {amount: string; token?: Token;} params
+   * @param {string} params.amount The amount in string format.
+   * @param {Token} params.token The token type.
+   */
+  public static fromString({
+    amount,
+    token,
+  }: {
+    amount: string;
+    token: Token;
+  }): TokenAmount | FromStringToTokenError {
+    const e8s = convertStringToE8s(amount);
+
+    if (typeof e8s === "bigint") {
+      return new TokenAmount(e8s, token);
+    }
+    return e8s;
+  }
+
+  /**
+   * Initialize from a number.
+   *
+   * 1 integer is considered E8S_PER_TOKEN
+   *
+   * @param {amount: number; token?: Token;} params
+   * @param {string} params.amount The amount in number format.
+   * @param {Token} params.token The token type.
+   */
+  public static fromNumber({
+    amount,
+    token,
+  }: {
+    amount: number;
+    token: Token;
+  }): TokenAmount {
+    const tokenAmount = TokenAmount.fromString({
+      amount: amount.toString(),
+      token,
+    });
+    if (tokenAmount instanceof TokenAmount) {
+      return tokenAmount;
+    }
+    if (tokenAmount === FromStringToTokenError.FractionalMoreThan8Decimals) {
+      throw new Error(`Number ${amount} has more than 8 decimals`);
+    }
+
+    // This should never happen
+    throw new Error(`Invalid number ${amount}`);
+  }
+
+  /**
+   *
+   * @returns The amount of e8s.
+   */
+  public toE8s(): bigint {
+    return this.e8s;
+  }
+}
 
 /**
  * Represents an amount of tokens.


### PR DESCRIPTION
# Motivation

Some tokens (like ckETH) have a precision different than 8 decimals.

In this PR, support decimals precision in the new TokenAmountV2 class.

# Changes

* Add mandatory field `decimals` in `Token` type.
* Add `decimals` to ICPToken.
* `TokenAmount` rejects tokens with `decimals !== 8`
*  New type `TokenAmountV2` which supports `decimals !== 8`

# Tests

* Test that `TokenAmount` does not support different decimals.
* Test that TokenAmountV2 supports different decimals.

# Todos

- [x] Add entry to changelog (if necessary).
