### PR TITLE
Bug Fix: IDL paths to Index from Ledger

### DIFF
--- a/packages/ledger-icp/src/index.canister.ts
+++ b/packages/ledger-icp/src/index.canister.ts
@@ -8,8 +8,8 @@ import type {
   GetAccountIdentifierTransactionsResponse,
   _SERVICE as IndexService,
 } from "../candid/index";
-import { idlFactory as certifiedIdlFactory } from "../candid/ledger.certified.idl";
-import { idlFactory } from "../candid/ledger.idl";
+import { idlFactory as certifiedIdlFactory } from "../candid/index.certified.idl";
+import { idlFactory } from "../candid/index.idl";
 import { MAINNET_INDEX_CANISTER_ID } from "./constants/canister_ids";
 import { IndexError } from "./errors/index.errors";
 import type { GetTransactionsParams } from "./types/index.params";


### PR DESCRIPTION
IDL paths for IndexCanister are pointing to ledger canister idls instead of Index

# Motivation

Bug fix, regression, IDL paths in Index Cannister are pointing to Ledger instead of Index.

# Changes

<!-- List the changes that have been developed -->
Updated loading path info for IDLs

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
