### PR TITLE
Fix: Support converting small number to AmountTokenV2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add retrieveBtcStatus to ckbtc minter canister.
 - Make uint8ArrayToHexString also accept `number[]` as input.
 - Add a new type TokenAmountV2 which supports `decimals !== 8`.
+- Fix issue when converting token amount from small numbers with `TokenAmountV2`.
 
 ## Operations
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     {
       "name": "@dfinity/ledger-icp",
       "path": "./packages/ledger-icp/dist/index.js",
-      "limit": "15 kB",
+      "limit": "16 kB",
       "ignore": [
         "@dfinity/agent",
         "@dfinity/candid",

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -74,7 +74,7 @@ Parameters:
 
 - `amount`: - in string format
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L10)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L12)
 
 #### :gear: defaultAgent
 
@@ -376,7 +376,7 @@ Tags after patch version are ignored, e.g. 1.0.0-beta.1 is considered equal to 1
 | ---------- | ------- |
 | `ICPToken` | `Token` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L113)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L115)
 
 ### :factory: TokenAmount
 
@@ -384,7 +384,7 @@ Deprecated. Use TokenAmountV2 instead which supports decimals !== 8.
 
 Represents an amount of tokens.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L127)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L129)
 
 #### Methods
 
@@ -406,7 +406,7 @@ Parameters:
 - `params.amount`: The amount in bigint format.
 - `params.token`: The token type.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L144)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L146)
 
 ##### :gear: fromString
 
@@ -425,7 +425,7 @@ Parameters:
 - `params.amount`: The amount in string format.
 - `params.token`: The token type.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L165)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L167)
 
 ##### :gear: fromNumber
 
@@ -442,7 +442,7 @@ Parameters:
 - `params.amount`: The amount in number format.
 - `params.token`: The token type.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L195)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L197)
 
 ##### :gear: toE8s
 
@@ -450,13 +450,13 @@ Parameters:
 | ------- | -------------- |
 | `toE8s` | `() => bigint` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L221)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L223)
 
 ### :factory: TokenAmountV2
 
 Represents an amount of tokens.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L233)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L235)
 
 #### Methods
 
@@ -478,7 +478,7 @@ Parameters:
 - `params.amount`: The amount in bigint format.
 - `params.token`: The token type.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L246)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L248)
 
 ##### :gear: fromString
 
@@ -497,7 +497,7 @@ Parameters:
 - `params.amount`: The amount in string format.
 - `params.token`: The token type.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L267)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L269)
 
 ##### :gear: fromNumber
 
@@ -514,7 +514,7 @@ Parameters:
 - `params.amount`: The amount in number format.
 - `params.token`: The token type.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L291)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L293)
 
 ##### :gear: toUlps
 
@@ -522,7 +522,7 @@ Parameters:
 | -------- | -------------- |
 | `toUlps` | `() => bigint` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L319)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L321)
 
 ### :factory: Canister
 

--- a/packages/utils/src/parser/token.spec.ts
+++ b/packages/utils/src/parser/token.spec.ts
@@ -433,3 +433,33 @@ describe("TokenAmountV2 with 0 decimals", () => {
     ).toEqual(FromStringToTokenError.FractionalTooManyDecimals);
   });
 });
+
+describe("TokenAmountV2 with 8 decimals", () => {
+  const token = {
+    symbol: "ICP",
+    name: "ICP",
+    decimals: 8,
+  };
+  it("can be initialized from a number", () => {
+    expect(TokenAmountV2.fromNumber({ token: token, amount: 1 })).toEqual(
+      TokenAmountV2.fromUlps({
+        token: token,
+        amount: 100000000n,
+      }),
+    );
+    expect(TokenAmountV2.fromNumber({ token: token, amount: 1234 })).toEqual(
+      TokenAmountV2.fromUlps({
+        token: token,
+        amount: 123400000000n,
+      }),
+    );
+    expect(
+      TokenAmountV2.fromNumber({ token: token, amount: 0.00000002 }),
+    ).toEqual(
+      TokenAmountV2.fromUlps({
+        token: token,
+        amount: 2n,
+      }),
+    );
+  });
+});

--- a/packages/utils/src/parser/token.spec.ts
+++ b/packages/utils/src/parser/token.spec.ts
@@ -457,6 +457,14 @@ describe("TokenAmountV2 with 8 decimals", () => {
         amount: 2n,
       }),
     );
+    expect(
+      TokenAmountV2.fromNumber({ token: token, amount: 0.00000001 }),
+    ).toEqual(
+      TokenAmountV2.fromUlps({
+        token: token,
+        amount: 1n,
+      }),
+    );
   });
 
   it("truncates small numbers to 8 decimals", () => {

--- a/packages/utils/src/parser/token.spec.ts
+++ b/packages/utils/src/parser/token.spec.ts
@@ -336,9 +336,9 @@ describe("TokenAmountV2 with 18 decimals", () => {
     ).toBe(FromStringToTokenError.InvalidFormat);
   });
 
-  it("truncates scientific notation to 8 decimals", () => {
-    expect(TokenAmountV2.fromNumber({ token: token, amount: 1e-9 })).toEqual(
-      TokenAmountV2.fromUlps({ token: token, amount: 0n }),
+  it("does not support scientific notation as string", () => {
+    expect(TokenAmountV2.fromString({ token: token, amount: "1e-9" })).toEqual(
+      FromStringToTokenError.InvalidFormat,
     );
   });
 
@@ -456,6 +456,12 @@ describe("TokenAmountV2 with 8 decimals", () => {
         token: token,
         amount: 2n,
       }),
+    );
+  });
+
+  it("truncates small numbers to 8 decimals", () => {
+    expect(TokenAmountV2.fromNumber({ token: token, amount: 1e-9 })).toEqual(
+      TokenAmountV2.fromUlps({ token: token, amount: 0n }),
     );
   });
 });

--- a/packages/utils/src/parser/token.spec.ts
+++ b/packages/utils/src/parser/token.spec.ts
@@ -336,13 +336,9 @@ describe("TokenAmountV2 with 18 decimals", () => {
     ).toBe(FromStringToTokenError.InvalidFormat);
   });
 
-  it("does not support scientific notation", () => {
-    const callToNumber = () =>
-      TokenAmountV2.fromNumber({ token: token, amount: 1e-9 });
-    expect(callToNumber).toThrow(
-      expect.objectContaining({
-        message: "Invalid number 1e-9",
-      }),
+  it("truncates scientific notation to 8 decimals", () => {
+    expect(TokenAmountV2.fromNumber({ token: token, amount: 1e-9 })).toEqual(
+      TokenAmountV2.fromUlps({ token: token, amount: 0n }),
     );
   });
 

--- a/packages/utils/src/parser/token.ts
+++ b/packages/utils/src/parser/token.ts
@@ -1,6 +1,8 @@
 import { E8S_PER_TOKEN } from "../constants/constants";
 import { FromStringToTokenError } from "../enums/token.enums";
 
+const DECIMALS_CONVERSION_SUPPORTED = 8;
+
 /**
  * Receives a string representing a number and returns the big int or error.
  *
@@ -296,7 +298,7 @@ export class TokenAmountV2 {
     token: Token;
   }): TokenAmountV2 {
     const tokenAmount = TokenAmountV2.fromString({
-      amount: amount.toString(),
+      amount: amount.toFixed(DECIMALS_CONVERSION_SUPPORTED),
       token,
     });
     if (tokenAmount instanceof TokenAmountV2) {


### PR DESCRIPTION
# Motivation

TokenAmountV2 can't convert small numbers such as `0.00000002` which is 2 e8s of ICP.

The problem was that `fromNumber` was using `toString` and `toString` was converting `0.00000002` to the scientific notation. Which we specifically don't want to support when converting from a string.

Solution, use `toFixed(8)` instead of `toString`. We already support only a precision of 8 decimals.

# Changes

* Use `toFixed(8)` instead of `toString` in `fromNumber` of TokenAmountV2.

# Tests

* Change test `"does not support scientific notation"` to do it `fromString`.
* Add tests for 8 decimals.
* Add a test for `fromNumber` with very small numbers.
* Add test for `fromNumber` to check that precision is 8 decimals.

# Todos

- [x] Add entry to changelog (if necessary).
