### PR TITLE
feat: defaultAgent host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Make uint8ArrayToHexString also accept `number[]` as input.
 - Add a new type TokenAmountV2 which supports `decimals !== 8`.
 - Fix issue when converting token amount from small numbers with `TokenAmountV2`.
+- Replace `https://ic0.app` by `https://icp-api.io` as the default host for the default anonymous agent provided by `defaultAgent`. 
 
 ## Operations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Make uint8ArrayToHexString also accept `number[]` as input.
 - Add a new type TokenAmountV2 which supports `decimals !== 8`.
 - Fix issue when converting token amount from small numbers with `TokenAmountV2`.
-- Replace `https://ic0.app` by `https://icp-api.io` as the default host for the default anonymous agent provided by `defaultAgent`. 
+- Replace `https://ic0.app` by `https://icp-api.io` as the default host for the default anonymous agent provided by `defaultAgent`.
 
 ## Operations
 

--- a/packages/utils/src/utils/agent.utils.ts
+++ b/packages/utils/src/utils/agent.utils.ts
@@ -7,7 +7,7 @@ import { AnonymousIdentity, HttpAgent } from "@dfinity/agent";
  */
 export const defaultAgent = (): Agent =>
   new HttpAgent({
-    host: "https://ic0.app",
+    host: "https://icp-api.io",
     identity: new AnonymousIdentity(),
   });
 


### PR DESCRIPTION
# Motivation

`https://icp-api.io` is recommended over `https://ic0.app` as host given that all canisters are accessible on the first.
