### PR TITLE
fix: utilize ICP Index `accountBalance` and `getTransactions` with account identifier hex directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ## Fix
 
-- Utilize ICP Index `accountBalance` and `getTransactions` with account identifier hex directly, eliminating the need for conversion with Buffer and resolving usage in non-polyfilled environments. 
+- Utilize ICP Index `accountBalance` and `getTransactions` with account identifier hex directly, eliminating the need for conversion with Buffer and resolving usage in non-polyfilled environments.
 
 ## Operations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Add a new type TokenAmountV2 which supports `decimals !== 8`.
 - Fix issue when converting token amount from small numbers with `TokenAmountV2`.
 
+## Fix
+
+- Utilize ICP Index `accountBalance` and `getTransactions` with account identifier hex directly, eliminating the need for conversion with Buffer and resolving usage in non-polyfilled environments. 
+
 ## Operations
 
 - Add a cron job to periodically update IC candid files and typescript bindings.

--- a/packages/ledger-icp/src/index.canister.ts
+++ b/packages/ledger-icp/src/index.canister.ts
@@ -14,7 +14,7 @@ import { MAINNET_INDEX_CANISTER_ID } from "./constants/canister_ids";
 import { IndexError } from "./errors/index.errors";
 import type { GetTransactionsParams } from "./types/index.params";
 import type { AccountBalanceParams } from "./types/ledger.params";
-import { paramToAccountIdentifier } from "./utils/params.utils";
+import { paramToAccountIdentifierHex } from "./utils/params.utils";
 
 export class IndexCanister extends Canister<IndexService> {
   static create({
@@ -47,7 +47,7 @@ export class IndexCanister extends Canister<IndexService> {
     accountIdentifier,
   }: AccountBalanceParams): Promise<bigint> =>
     this.caller({ certified }).get_account_identifier_balance(
-      paramToAccountIdentifier(accountIdentifier).toHex(),
+      paramToAccountIdentifierHex(accountIdentifier),
     );
 
   /**
@@ -70,7 +70,7 @@ export class IndexCanister extends Canister<IndexService> {
     const response = await this.caller({
       certified,
     }).get_account_identifier_transactions({
-      account_identifier: paramToAccountIdentifier(accountIdentifier).toHex(),
+      account_identifier: paramToAccountIdentifierHex(accountIdentifier),
       start: toNullable(start),
       max_results,
     });

--- a/packages/ledger-icp/src/utils/params.utils.ts
+++ b/packages/ledger-icp/src/utils/params.utils.ts
@@ -1,7 +1,13 @@
 import { AccountIdentifier } from "../account_identifier";
+import type { AccountIdentifierHex } from "../types/common";
 import type { AccountIdentifierParam } from "../types/ledger.params";
 
 export const paramToAccountIdentifier = (
   param: AccountIdentifierParam,
 ): AccountIdentifier =>
   param instanceof AccountIdentifier ? param : AccountIdentifier.fromHex(param);
+
+export const paramToAccountIdentifierHex = (
+  param: AccountIdentifierParam,
+): AccountIdentifierHex =>
+  param instanceof AccountIdentifier ? param.toHex() : param;


### PR DESCRIPTION
# Motivation

Utilize ICP Index `accountBalance` and `getTransactions` with account identifier hex directly, eliminating the need for conversion with Buffer and resolving usage in non-polyfilled environments.

# Changes

- if hex, use hex directly without converting first to an account identifier

# Issue

Oisy Wallet PR https://github.com/dfinity/oisy-wallet/pull/497 and potentially a bug we will face in NNS dapp as well in the future.

![image](https://github.com/dfinity/ic-js/assets/16886711/f40565a3-7cb3-49e1-a21e-c87efc614286)
