### PR TITLE
Update ckbtc candid

### DIFF
--- a/packages/ckbtc/candid/minter.certified.idl.js
+++ b/packages/ckbtc/candid/minter.certified.idl.js
@@ -117,6 +117,7 @@ export const idlFactory = ({ IDL }) => {
       'received_at' : IDL.Nat64,
       'block_index' : IDL.Nat64,
       'address' : BitcoinAddress,
+      'reimbursement_account' : IDL.Opt(Account),
       'amount' : IDL.Nat64,
       'kyt_provider' : IDL.Opt(IDL.Principal),
     }),
@@ -169,6 +170,28 @@ export const idlFactory = ({ IDL }) => {
     'AmountTooLow' : IDL.Null,
     'Unknown' : IDL.Null,
     'Submitted' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8) }),
+    'Pending' : IDL.Null,
+  });
+  const ReimbursementRequest = IDL.Record({
+    'account' : Account,
+    'amount' : IDL.Nat64,
+    'reason' : ReimbursementReason,
+  });
+  const ReimbursedDeposit = IDL.Record({
+    'account' : Account,
+    'mint_block_index' : IDL.Nat64,
+    'amount' : IDL.Nat64,
+    'reason' : ReimbursementReason,
+  });
+  const RetrieveBtcStatusV2 = IDL.Variant({
+    'Signing' : IDL.Null,
+    'Confirmed' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8) }),
+    'Sending' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8) }),
+    'AmountTooLow' : IDL.Null,
+    'WillReimburse' : ReimbursementRequest,
+    'Unknown' : IDL.Null,
+    'Submitted' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8) }),
+    'Reimbursed' : ReimbursedDeposit,
     'Pending' : IDL.Null,
   });
   const RetrieveBtcWithApprovalArgs = IDL.Record({
@@ -249,6 +272,23 @@ export const idlFactory = ({ IDL }) => {
     'retrieve_btc_status' : IDL.Func(
         [IDL.Record({ 'block_index' : IDL.Nat64 })],
         [RetrieveBtcStatus],
+        [],
+      ),
+    'retrieve_btc_status_v2' : IDL.Func(
+        [IDL.Record({ 'block_index' : IDL.Nat64 })],
+        [RetrieveBtcStatusV2],
+        [],
+      ),
+    'retrieve_btc_status_v2_by_account' : IDL.Func(
+        [IDL.Opt(Account)],
+        [
+          IDL.Vec(
+            IDL.Record({
+              'block_index' : IDL.Nat64,
+              'status_v2' : IDL.Opt(RetrieveBtcStatusV2),
+            })
+          ),
+        ],
         [],
       ),
     'retrieve_btc_with_approval' : IDL.Func(

--- a/packages/ckbtc/candid/minter.d.ts
+++ b/packages/ckbtc/candid/minter.d.ts
@@ -83,6 +83,7 @@ export type Event =
         received_at: bigint;
         block_index: bigint;
         address: BitcoinAddress;
+        reimbursement_account: [] | [Account];
         amount: bigint;
         kyt_provider: [] | [Principal];
       };
@@ -140,9 +141,20 @@ export interface PendingUtxo {
   value: bigint;
   outpoint: { txid: Uint8Array | number[]; vout: number };
 }
+export interface ReimbursedDeposit {
+  account: Account;
+  mint_block_index: bigint;
+  amount: bigint;
+  reason: ReimbursementReason;
+}
 export type ReimbursementReason =
   | { CallFailed: null }
   | { TaintedDestination: { kyt_fee: bigint; kyt_provider: Principal } };
+export interface ReimbursementRequest {
+  account: Account;
+  amount: bigint;
+  reason: ReimbursementReason;
+}
 export interface RetrieveBtcArgs {
   address: string;
   amount: bigint;
@@ -164,6 +176,16 @@ export type RetrieveBtcStatus =
   | { AmountTooLow: null }
   | { Unknown: null }
   | { Submitted: { txid: Uint8Array | number[] } }
+  | { Pending: null };
+export type RetrieveBtcStatusV2 =
+  | { Signing: null }
+  | { Confirmed: { txid: Uint8Array | number[] } }
+  | { Sending: { txid: Uint8Array | number[] } }
+  | { AmountTooLow: null }
+  | { WillReimburse: ReimbursementRequest }
+  | { Unknown: null }
+  | { Submitted: { txid: Uint8Array | number[] } }
+  | { Reimbursed: ReimbursedDeposit }
   | { Pending: null };
 export interface RetrieveBtcWithApprovalArgs {
   from_subaccount: [] | [Uint8Array | number[]];
@@ -241,6 +263,14 @@ export interface _SERVICE {
   retrieve_btc_status: ActorMethod<
     [{ block_index: bigint }],
     RetrieveBtcStatus
+  >;
+  retrieve_btc_status_v2: ActorMethod<
+    [{ block_index: bigint }],
+    RetrieveBtcStatusV2
+  >;
+  retrieve_btc_status_v2_by_account: ActorMethod<
+    [[] | [Account]],
+    Array<{ block_index: bigint; status_v2: [] | [RetrieveBtcStatusV2] }>
   >;
   retrieve_btc_with_approval: ActorMethod<
     [RetrieveBtcWithApprovalArgs],

--- a/packages/ckbtc/candid/minter.did
+++ b/packages/ckbtc/candid/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 4de99bc27b (2023-11-20) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
+// Generated from IC repo commit a8e25a31a (2023-12-12) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
 // Represents an account on the ckBTC ledger.
 type Account = record { owner : principal; subaccount : opt blob };
 
@@ -233,6 +233,48 @@ type RetrieveBtcStatus = variant {
     Confirmed : record { txid : blob };
 };
 
+type ReimbursementRequest = record {
+  account : Account;
+  amount : nat64;
+  reason : ReimbursementReason;
+};
+
+type ReimbursedDeposit = record {
+  account : Account;
+  mint_block_index : nat64;
+  amount : nat64;
+  reason : ReimbursementReason;
+};
+
+type RetrieveBtcStatusV2 = variant {
+    // The minter does not have any information on the specified
+    // retrieval request.  It can be that nobody submitted the
+    // request or the minter pruned the relevant information from the
+    // history to save space.
+    Unknown;
+    // The minter did not send a Bitcoin transaction for this request yet.
+    Pending;
+    // The minter is obtaining all required ECDSA signatures on the
+    // Bitcoin transaction for this request.
+    Signing;
+    // The minter signed the transaction and is waiting for a reply
+    // from the Bitcoin canister.
+    Sending : record { txid : blob };
+    // The minter sent a transaction for the retrieve request.
+    // The payload contains the identifier of the transaction on the Bitcoin network.
+    Submitted : record { txid : blob };
+    // The amount was too low to cover the transaction fees.
+    AmountTooLow;
+    // The minter received enough confirmations for the Bitcoin
+    // transaction for this request.  The payload contains the
+    // identifier of the transaction on the Bitcoin network.
+    Confirmed : record { txid : blob };
+    /// The retrieve bitcoin request has been reimbursed.
+    Reimbursed : ReimbursedDeposit;
+    /// The minter will try to reimburse this transaction.
+    WillReimburse : ReimbursementRequest;
+};
+
 type Utxo = record {
     outpoint : record { txid : vec nat8; vout : nat32 };
     value : nat64;
@@ -271,6 +313,7 @@ type Event = variant {
         block_index : nat64;
         received_at : nat64;
         kyt_provider : opt principal;
+        reimbursement_account : opt Account;
     };
     distributed_kyt_fee : record {
         kyt_provider : principal;
@@ -389,8 +432,20 @@ service : (minter_arg : MinterArg) -> {
     //   using [icrc2_approve] on the ckBTC ledger.
     retrieve_btc_with_approval : (RetrieveBtcWithApprovalArgs) -> (variant { Ok : RetrieveBtcOk; Err : RetrieveBtcWithApprovalError });
 
-    /// Returns the status of a [retrieve_btc] request.
+    /// [deprecated] Returns the status of a withdrawal request.
+    /// You should use retrieve_btc_status_v2 to retrieve the status of your withdrawal request.
     retrieve_btc_status : (record { block_index : nat64 }) -> (RetrieveBtcStatus) query;
+
+    /// Returns the status of a withdrawal request request using the RetrieveBtcStatusV2 type.
+    retrieve_btc_status_v2 : (record { block_index : nat64 }) -> (RetrieveBtcStatusV2) query;
+    
+    // Returns the withdrawal statues by account.
+    //
+    // # Note
+    // The _v2_ part indicates that you get a response in line with the retrieve_btc_status_v2 endpoint,
+    // i.e., you get a vector of RetrieveBtcStatusV2 and not RetrieveBtcStatus.
+    //
+    retrieve_btc_status_v2_by_account : (opt Account) -> (vec record { block_index: nat64; status_v2: opt RetrieveBtcStatusV2; }) query;
 
     // }}} Section "Convert ckBTC to BTC"
 

--- a/packages/ckbtc/candid/minter.idl.js
+++ b/packages/ckbtc/candid/minter.idl.js
@@ -117,6 +117,7 @@ export const idlFactory = ({ IDL }) => {
       'received_at' : IDL.Nat64,
       'block_index' : IDL.Nat64,
       'address' : BitcoinAddress,
+      'reimbursement_account' : IDL.Opt(Account),
       'amount' : IDL.Nat64,
       'kyt_provider' : IDL.Opt(IDL.Principal),
     }),
@@ -169,6 +170,28 @@ export const idlFactory = ({ IDL }) => {
     'AmountTooLow' : IDL.Null,
     'Unknown' : IDL.Null,
     'Submitted' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8) }),
+    'Pending' : IDL.Null,
+  });
+  const ReimbursementRequest = IDL.Record({
+    'account' : Account,
+    'amount' : IDL.Nat64,
+    'reason' : ReimbursementReason,
+  });
+  const ReimbursedDeposit = IDL.Record({
+    'account' : Account,
+    'mint_block_index' : IDL.Nat64,
+    'amount' : IDL.Nat64,
+    'reason' : ReimbursementReason,
+  });
+  const RetrieveBtcStatusV2 = IDL.Variant({
+    'Signing' : IDL.Null,
+    'Confirmed' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8) }),
+    'Sending' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8) }),
+    'AmountTooLow' : IDL.Null,
+    'WillReimburse' : ReimbursementRequest,
+    'Unknown' : IDL.Null,
+    'Submitted' : IDL.Record({ 'txid' : IDL.Vec(IDL.Nat8) }),
+    'Reimbursed' : ReimbursedDeposit,
     'Pending' : IDL.Null,
   });
   const RetrieveBtcWithApprovalArgs = IDL.Record({
@@ -249,6 +272,23 @@ export const idlFactory = ({ IDL }) => {
     'retrieve_btc_status' : IDL.Func(
         [IDL.Record({ 'block_index' : IDL.Nat64 })],
         [RetrieveBtcStatus],
+        ['query'],
+      ),
+    'retrieve_btc_status_v2' : IDL.Func(
+        [IDL.Record({ 'block_index' : IDL.Nat64 })],
+        [RetrieveBtcStatusV2],
+        ['query'],
+      ),
+    'retrieve_btc_status_v2_by_account' : IDL.Func(
+        [IDL.Opt(Account)],
+        [
+          IDL.Vec(
+            IDL.Record({
+              'block_index' : IDL.Nat64,
+              'status_v2' : IDL.Opt(RetrieveBtcStatusV2),
+            })
+          ),
+        ],
         ['query'],
       ),
     'retrieve_btc_with_approval' : IDL.Func(


### PR DESCRIPTION
# Motivation

I want to use the new `retrieve_btc_status_v2_by_account` method on the ckbtc minter.

# Changes

Ran the following to update only the ckbtc candid:
```
scripts/import-candid ../../ic
scripts/compile-idl-js
git checkout packages/{cmc,ic-management,ledger-icp,ledger-icrc,nns,sns}
```

# Tests

Installed `utils` and `ckbtc` in `nns-dapp` and ran all the unit and e2e tests there.

# Todos

- [ ] Add entry to changelog (if necessary).
Will add when I implement the method in the `ckbtc` package.