### PR TITLE
Add retrieveBtcStatusV2ByAccount to ckbtc canister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Substitute `?` fields with `Option` fields in the converters related to NNS proposals.
 - Add retrieveBtcStatus to ckbtc minter canister.
+- Add retrieveBtcStatusV2ByAccount to ckbtc minter canister.
 - Make uint8ArrayToHexString also accept `number[]` as input.
 - Add a new type TokenAmountV2 which supports `decimals !== 8`.
 - Fix issue when converting token amount from small numbers with `TokenAmountV2`.

--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -78,7 +78,7 @@ Parameters:
 
 ### :factory: CkBTCMinterCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L36)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L38)
 
 #### Methods
 
@@ -89,6 +89,7 @@ Parameters:
 - [retrieveBtc](#gear-retrievebtc)
 - [retrieveBtcWithApproval](#gear-retrievebtcwithapproval)
 - [retrieveBtcStatus](#gear-retrievebtcstatus)
+- [retrieveBtcStatusV2ByAccount](#gear-retrievebtcstatusv2byaccount)
 - [estimateWithdrawalFee](#gear-estimatewithdrawalfee)
 - [getMinterInfo](#gear-getminterinfo)
 
@@ -98,7 +99,7 @@ Parameters:
 | -------- | ------------------------------------------------------------------------ |
 | `create` | `(options: CkBTCMinterCanisterOptions<_SERVICE>) => CkBTCMinterCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L37)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L39)
 
 ##### :gear: getBtcAddress
 
@@ -116,7 +117,7 @@ Parameters:
 - `params.owner`: The owner for which the BTC address should be generated. If not provided, the `caller` will be use instead.
 - `params.subaccount`: An optional subaccount to compute the address.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L58)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L60)
 
 ##### :gear: updateBalance
 
@@ -134,7 +135,7 @@ Parameters:
 - `params.owner`: The owner of the address. If not provided, the `caller` will be use instead.
 - `params.subaccount`: An optional subaccount of the address.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L77)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L79)
 
 ##### :gear: getWithdrawalAccount
 
@@ -144,7 +145,7 @@ Returns the account to which the caller should deposit ckBTC before withdrawing 
 | ---------------------- | ------------------------ |
 | `getWithdrawalAccount` | `() => Promise<Account>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L100)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L102)
 
 ##### :gear: retrieveBtc
 
@@ -168,7 +169,7 @@ Parameters:
 - `params.address`: The bitcoin address.
 - `params.amount`: The ckBTC amount.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L119)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L121)
 
 ##### :gear: retrieveBtcWithApproval
 
@@ -194,7 +195,7 @@ Parameters:
 - `params.fromSubaccount`: An optional subaccount from which
   the ckBTC should be transferred.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L149)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L151)
 
 ##### :gear: retrieveBtcStatus
 
@@ -210,7 +211,22 @@ Parameters:
 - `transactionId`: The ID of the corresponding burn transaction.
 - `certified`: query or update call
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L180)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L182)
+
+##### :gear: retrieveBtcStatusV2ByAccount
+
+Returns the status of all BTC withdrawals for the user's main account.
+
+| Method                         | Type                                                                                |
+| ------------------------------ | ----------------------------------------------------------------------------------- |
+| `retrieveBtcStatusV2ByAccount` | `({ certified, }: { certified: boolean; }) => Promise<RetrieveBtcStatusV2WithId[]>` |
+
+Parameters:
+
+- `transactionId`: The ID of the corresponding burn transaction.
+- `certified`: query or update call
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L199)
 
 ##### :gear: estimateWithdrawalFee
 
@@ -226,7 +242,7 @@ Parameters:
 - `params.certified`: query or update call
 - `params.amount`: The optional amount for which the fee should be estimated.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L198)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L220)
 
 ##### :gear: getMinterInfo
 
@@ -241,7 +257,7 @@ Parameters:
 - `params`: The parameters to get the deposit fee.
 - `params.certified`: query or update call
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L212)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L234)
 
 <!-- TSDOC_END -->
 

--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -211,7 +211,7 @@ Parameters:
 - `transactionId`: The ID of the corresponding burn transaction.
 - `certified`: query or update call
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L182)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L183)
 
 ##### :gear: retrieveBtcStatusV2ByAccount
 
@@ -223,10 +223,9 @@ Returns the status of all BTC withdrawals for the user's main account.
 
 Parameters:
 
-- `transactionId`: The ID of the corresponding burn transaction.
 - `certified`: query or update call
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L199)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L200)
 
 ##### :gear: estimateWithdrawalFee
 
@@ -242,7 +241,7 @@ Parameters:
 - `params.certified`: query or update call
 - `params.amount`: The optional amount for which the fee should be estimated.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L220)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L221)
 
 ##### :gear: getMinterInfo
 
@@ -257,7 +256,7 @@ Parameters:
 - `params`: The parameters to get the deposit fee.
 - `params.certified`: query or update call
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L234)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L235)
 
 <!-- TSDOC_END -->
 

--- a/packages/ckbtc/src/minter.canister.ts
+++ b/packages/ckbtc/src/minter.canister.ts
@@ -1,6 +1,7 @@
 import {
   Canister,
   createServices,
+  fromNullable,
   toNullable,
   type QueryParams,
 } from "@dfinity/utils";
@@ -28,6 +29,7 @@ import type {
 import type {
   EstimateWithdrawalFee,
   RetrieveBtcResponse,
+  RetrieveBtcStatusV2WithId,
   RetrieveBtcWithApprovalResponse,
   UpdateBalanceOk,
   UpdateBalanceResponse,
@@ -187,6 +189,26 @@ export class CkBTCMinterCanister extends Canister<CkBTCMinterService> {
     this.caller({
       certified,
     }).retrieve_btc_status({ block_index: transactionId });
+
+  /**
+   * Returns the status of all BTC withdrawals for the user's main account.
+   *
+   * @param {bigint} transactionId The ID of the corresponding burn transaction.
+   * @param {boolean} certified query or update call
+   */
+  retrieveBtcStatusV2ByAccount = async ({
+    certified,
+  }: {
+    certified: boolean;
+  }): Promise<RetrieveBtcStatusV2WithId[]> => {
+    const statuses = await this.caller({
+      certified,
+    }).retrieve_btc_status_v2_by_account([]);
+    return statuses.map(({ block_index, status_v2 }) => ({
+      id: block_index,
+      status: fromNullable(status_v2),
+    }));
+  };
 
   /**
    * Returns an estimation of the user's fee (in Satoshi) for a retrieve_btc request based on the current status of the Bitcoin network and the fee related to the minter.

--- a/packages/ckbtc/src/minter.canister.ts
+++ b/packages/ckbtc/src/minter.canister.ts
@@ -178,6 +178,7 @@ export class CkBTCMinterCanister extends Canister<CkBTCMinterService> {
    *
    * @param {bigint} transactionId The ID of the corresponding burn transaction.
    * @param {boolean} certified query or update call
+   * @returns {Promise<RetrieveBtcStatus>} The status of the BTC retrieval request.
    */
   retrieveBtcStatus = async ({
     transactionId,
@@ -193,8 +194,8 @@ export class CkBTCMinterCanister extends Canister<CkBTCMinterService> {
   /**
    * Returns the status of all BTC withdrawals for the user's main account.
    *
-   * @param {bigint} transactionId The ID of the corresponding burn transaction.
    * @param {boolean} certified query or update call
+   * @returns {Promise<RetrieveBtcStatusV2WithId[]>} The statuses of the BTC retrieval requests.
    */
   retrieveBtcStatusV2ByAccount = async ({
     certified,

--- a/packages/ckbtc/src/types/minter.responses.ts
+++ b/packages/ckbtc/src/types/minter.responses.ts
@@ -1,6 +1,7 @@
 import type {
   RetrieveBtcError,
   RetrieveBtcOk,
+  RetrieveBtcStatusV2,
   RetrieveBtcWithApprovalError,
   UpdateBalanceError,
   UtxoStatus,
@@ -21,3 +22,8 @@ export type RetrieveBtcWithApprovalResponse =
   | { Err: RetrieveBtcWithApprovalError };
 
 export type EstimateWithdrawalFee = { minter_fee: bigint; bitcoin_fee: bigint };
+
+export type RetrieveBtcStatusV2WithId = {
+  id: bigint;
+  status: RetrieveBtcStatusV2 | undefined;
+};


### PR DESCRIPTION
# Motivation

<!-- Describe the motivation that lead to the PR -->

# Changes

I want to use this to display BTC withdrawal transactions in nns-dapp as pending or failed when appropriate.

# Tests

Unit tests added.
Tested manually in an nns-dapp branch.

# Todos

- [x] Add entry to changelog (if necessary).
