### PR TITLE
fix: iOS 15 usage and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next release
+
+## Fix
+
+- `@dfinity/ledger-icp` bundled with Rollup v4 leads to an incompatibility with iOS 15  
+
 # 2024.01.03-1115Z
 
 ## Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The current status of the libraries at the time of the release is as follows:
 
 ## Fix
 
-- `@dfinity/ledger-icp` bundled with Rollup v4 leads to an incompatibility with iOS 15  
+- `@dfinity/ledger-icp` bundled with Rollup v4 leads to an incompatibility with iOS 15
 
 # 2024.01.03-1115Z
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status     |
-| ------------------------ |---------|------------|
+| ------------------------ | ------- | ---------- |
 | `@dfinity/ckbtc`         | v2.1.0  | Unchanged  |
 | `@dfinity/cketh`         | v0.0.1  | Unchanged  |
 | `@dfinity/cmc`           | v2.1.0  | Unchanged  |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
-# Next release
+# 2024.01.09-1115Z
+
+## Overview
+
+The current status of the libraries at the time of the release is as follows:
+
+| Library                  | Version | Status     |
+| ------------------------ |---------|------------|
+| `@dfinity/ckbtc`         | v2.1.0  | Unchanged  |
+| `@dfinity/cketh`         | v0.0.1  | Unchanged  |
+| `@dfinity/cmc`           | v2.1.0  | Unchanged  |
+| `@dfinity/ic-management` | v2.1.0  | Unchanged  |
+| `@dfinity/ledger-icp`    | v2.1.1  | Patched 🤕 |
+| `@dfinity/ledger-icrc`   | v2.1.0  | Unchanged  |
+| `@dfinity/nns`           | v3.1.0  | Unchanged  |
+| `@dfinity/nns-proto`     | v1.0.0  | Unchanged  |
+| `@dfinity/sns`           | v2.1.0  | Unchanged  |
+| `@dfinity/utils`         | v2.0.0  | Unchanged️ |
 
 ## Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The current status of the libraries at the time of the release is as follows:
 
 ## Fix
 
-- `@dfinity/ledger-icp` bundled with Rollup v4 leads to an incompatibility with iOS 15
+- When `@dfinity/ledger-icp` is bundled with Rollup v4, it leads to an incompatibility issue with iOS 15.
 
 # 2024.01.03-1115Z
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "2024.01.03-1115Z",
+  "version": "2024.01.09-1115Z",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/ic-js",
-      "version": "2024.01.03-1115Z",
+      "version": "2024.01.09-1115Z",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/utils",
@@ -7188,7 +7188,7 @@
     },
     "packages/ledger-icp": {
       "name": "@dfinity/ledger-icp",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^0.20.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "2024.01.03-1115Z",
+  "version": "2024.01.09-1115Z",
   "description": "A collection of library for interfacing with the Internet Computer.",
   "license": "Apache-2.0",
   "workspaces": [

--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -166,7 +166,7 @@ const data = await metadata();
 | -------------- | ------------------ |
 | `toUint8Array` | `() => Uint8Array` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L111)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L109)
 
 ### :factory: LedgerCanister
 

--- a/packages/ledger-icp/package.json
+++ b/packages/ledger-icp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ledger-icp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A library for interfacing with the ICP ledger on the Internet Computer.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/ledger-icp/src/account_identifier.spec.ts
+++ b/packages/ledger-icp/src/account_identifier.spec.ts
@@ -11,7 +11,9 @@ describe("SubAccount", () => {
   });
 
   it("defines ZERO as a 32-byte zeroed array", () => {
-    expect(SubAccount.ZERO.toUint8Array()).toEqual(new Uint8Array(32).fill(0));
+    expect(SubAccount.fromID(0).toUint8Array()).toEqual(
+      new Uint8Array(32).fill(0),
+    );
   });
 
   it("can be initialized from a principal", () => {
@@ -96,7 +98,7 @@ describe("AccountIdentifier", () => {
         principal: Principal.fromText(
           "bwz3t-ercuj-owo6s-4adfr-sbu4o-l72hg-kfhc5-5sapm-tj6bn-3scho-uqe",
         ),
-        subAccount: SubAccount.ZERO,
+        subAccount: SubAccount.fromID(0),
       }).toHex(),
     ).toBe("df4ad42194201b15ecbbe66ff68559a126854d8141fd935c5bd53433c2fb28d4");
   });

--- a/packages/ledger-icp/src/account_identifier.ts
+++ b/packages/ledger-icp/src/account_identifier.ts
@@ -18,7 +18,7 @@ export class AccountIdentifier {
 
   public static fromPrincipal({
     principal,
-    subAccount = SubAccount.ZERO,
+    subAccount = SubAccount.fromID(0),
   }: {
     principal: Principal;
     subAccount?: SubAccount;
@@ -105,8 +105,6 @@ export class SubAccount {
     bytes[31] = id;
     return new SubAccount(bytes);
   }
-
-  public static ZERO: SubAccount = this.fromID(0);
 
   public toUint8Array(): Uint8Array {
     return this.bytes;


### PR DESCRIPTION
# Motivation

It was reported that the last version of NNS dapp shipped with SvelteKit v2 and per extension Rollup v4 was not usable on iOS 15 (iOS 17 was fine). Afternarrowing down the issue I figured out that the root cause of the issue was the usage of a static variable using within an object parameter.

# Error stacktrace on iOS v15

```
Unhandled Promise Rejection: SyntaxError: Unexpected token '{'
```

# Changes

- Replace static usage of `SubAccount.ZERO` with an object to fix the issue
- Add entry in CHANGELOG
- Bump version to release the patch to npm asap.

# Screenshot

![image](https://github.com/dfinity/ic-js/assets/16886711/f6581810-d0de-4f74-bcbf-3133fb31f112)

# Test

The fix was tested locally by bundling the library and including it in NNS dapp which was build and served `npx serve public` + `npx local-ssl-proxy --source 3001 --target 3000`. Finally the fix was validated by loading https://locahost:3001 in Xcode simulator with iOS 15.4.