### PR TITLE
docs: replace ckbtc code doc title per for note

### DIFF
--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -149,11 +149,11 @@ Returns the account to which the caller should deposit ckBTC before withdrawing 
 
 Submits a request to convert ckBTC to BTC.
 
-# Note
+Note:
 
 The BTC retrieval process is slow. Instead of synchronously waiting for a BTC transaction to settle, this method returns a request ([block_index]) that the caller can use to query the request status.
 
-# Preconditions
+Preconditions:
 
 The caller deposited the requested amount in ckBTC to the account that the [getWithdrawalAccount] endpoint returns.
 

--- a/packages/ckbtc/src/minter.canister.ts
+++ b/packages/ckbtc/src/minter.canister.ts
@@ -105,11 +105,11 @@ export class CkBTCMinterCanister extends Canister<CkBTCMinterService> {
   /**
    * Submits a request to convert ckBTC to BTC.
    *
-   * # Note
+   * Note:
    *
    * The BTC retrieval process is slow. Instead of synchronously waiting for a BTC transaction to settle, this method returns a request ([block_index]) that the caller can use to query the request status.
    *
-   * # Preconditions
+   * Preconditions:
    *
    * The caller deposited the requested amount in ckBTC to the account that the [getWithdrawalAccount] endpoint returns.
    *


### PR DESCRIPTION
# Motivation

My documentation lib [tsdoc-markdown](https://github.com/peterpeterparker/tsdoc-markdown) does not manipulate the documentation to prefix potentital markdown title with the actual parent title. So using `#` in a doc comment ends up in a main title. Long story short, this PR just modify a doc comment to remove two `#`.
