### PR TITLE
feat: support for withdraw_eth

### DIFF
--- a/packages/cketh/README.md
+++ b/packages/cketh/README.md
@@ -53,12 +53,13 @@ const address = await getSmartContractAddress({});
 
 ### :factory: CkETHMinterCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L8)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L12)
 
 #### Methods
 
 - [create](#gear-create)
 - [getSmartContractAddress](#gear-getsmartcontractaddress)
+- [withdrawEth](#gear-withdraweth)
 
 ##### :gear: create
 
@@ -66,7 +67,7 @@ const address = await getSmartContractAddress({});
 | -------- | ------------------------------------------------------------------------ |
 | `create` | `(options: CkETHMinterCanisterOptions<_SERVICE>) => CkETHMinterCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L9)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L13)
 
 ##### :gear: getSmartContractAddress
 
@@ -81,7 +82,26 @@ Parameters:
 - `params`: The parameters to resolve the ckETH smart contract address.
 - `params.certified`: query or update call
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L27)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L31)
+
+##### :gear: withdrawEth
+
+Submits a request to convert ckETH to ETH after making an ICRC-2 approval.
+
+Preconditions:
+
+The caller allowed the minter's principal to spend its funds using
+[icrc2_approve] on the ckETH ledger.
+
+| Method        | Type                                                                                          |
+| ------------- | --------------------------------------------------------------------------------------------- |
+| `withdrawEth` | `({ address, ...rest }: { address: string; amount: bigint; }) => Promise<RetrieveEthRequest>` |
+
+Parameters:
+
+- `params`: The parameters to withdrawal ckETH to ETH.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L51)
 
 <!-- TSDOC_END -->
 

--- a/packages/cketh/src/errors/minter.errors.ts
+++ b/packages/cketh/src/errors/minter.errors.ts
@@ -1,0 +1,46 @@
+import type { WithdrawalError } from "../../candid/minter";
+
+export class MinterGenericError extends Error {}
+
+export class MinterWithdrawalError extends MinterGenericError {}
+
+export class MinterTemporaryUnavailableError extends MinterWithdrawalError {}
+export class MinterInsufficientFundsError extends MinterWithdrawalError {}
+export class MinterInsufficientAllowanceError extends MinterWithdrawalError {}
+export class MinterAmountTooLowError extends MinterWithdrawalError {}
+export class MinterRecipientAddressBlockedError extends MinterWithdrawalError {}
+
+export const createWithdrawEthError = (
+  Err: WithdrawalError,
+): MinterWithdrawalError => {
+  if ("TemporarilyUnavailable" in Err) {
+    return new MinterTemporaryUnavailableError(Err.TemporarilyUnavailable);
+  }
+
+  if ("InsufficientAllowance" in Err) {
+    return new MinterInsufficientAllowanceError(
+      `${Err.InsufficientAllowance.allowance}`,
+    );
+  }
+
+  if ("AmountTooLow" in Err) {
+    return new MinterAmountTooLowError(
+      `${Err.AmountTooLow.min_withdrawal_amount}`,
+    );
+  }
+
+  if ("RecipientAddressBlocked" in Err) {
+    return new MinterRecipientAddressBlockedError(
+      `${Err.RecipientAddressBlocked.address}`,
+    );
+  }
+
+  if ("InsufficientFunds" in Err) {
+    return new MinterInsufficientFundsError(`${Err.InsufficientFunds.balance}`);
+  }
+
+  // Handle types added in the backend but not yet added in the frontend
+  return new MinterWithdrawalError(
+    `Unsupported response type in minter.withdrawEth ${JSON.stringify(Err)}`,
+  );
+};

--- a/packages/cketh/src/index.ts
+++ b/packages/cketh/src/index.ts
@@ -1,1 +1,3 @@
+export type { RetrieveEthRequest } from "../candid/minter";
+export * from "./errors/minter.errors";
 export { CkETHMinterCanister } from "./minter.canister";

--- a/packages/cketh/src/minter.canister.spec.ts
+++ b/packages/cketh/src/minter.canister.spec.ts
@@ -1,10 +1,22 @@
 import { ActorSubclass } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { mock } from "jest-mock-extended";
-import type { _SERVICE as CkETHMinterService } from "../candid/minter";
+import {
+  _SERVICE as CkETHMinterService,
+  RetrieveEthRequest,
+} from "../candid/minter";
+import {
+  MinterAmountTooLowError,
+  MinterInsufficientAllowanceError,
+  MinterInsufficientFundsError,
+  MinterRecipientAddressBlockedError,
+  MinterTemporaryUnavailableError,
+  MinterWithdrawalError,
+} from "./errors/minter.errors";
 import { CkETHMinterCanister } from "./minter.canister";
 import {
   ckETHSmartContractAddressMock,
+  ethAddressMock,
   minterCanisterIdMock,
 } from "./mocks/minter.mock";
 
@@ -49,6 +61,142 @@ describe("ckETH minter canister", () => {
       const canister = minter(service);
 
       expect(() => canister.getSmartContractAddress()).toThrowError();
+    });
+  });
+
+  describe("Withdraw ETH", () => {
+    const success: RetrieveEthRequest = {
+      block_index: 1n,
+    };
+    const ok = { Ok: success };
+
+    const params = {
+      address: ethAddressMock,
+      amount: 123_000n,
+    };
+
+    it("should return Ok", async () => {
+      const service = mock<ActorSubclass<CkETHMinterService>>();
+      service.withdraw_eth.mockResolvedValue(ok);
+
+      const canister = minter(service);
+
+      const res = await canister.withdrawEth(params);
+
+      expect(service.withdraw_eth).toBeCalledTimes(1);
+
+      const { address, ...rest } = params;
+      expect(service.withdraw_eth).toBeCalledWith({
+        recipient: address,
+        ...rest,
+      });
+
+      expect(res).toEqual(success);
+    });
+
+    it("should throw MinterTemporarilyUnavailable", async () => {
+      const service = mock<ActorSubclass<CkETHMinterService>>();
+
+      const error = { Err: { TemporarilyUnavailable: "unavailable" } };
+      service.withdraw_eth.mockResolvedValue(error);
+
+      const canister = minter(service);
+
+      const call = () => canister.withdrawEth(params);
+
+      await expect(call).rejects.toThrowError(
+        new MinterTemporaryUnavailableError(error.Err.TemporarilyUnavailable),
+      );
+    });
+
+    it("should throw MinterAmountTooLowError", async () => {
+      const service = mock<ActorSubclass<CkETHMinterService>>();
+
+      const error = { Err: { AmountTooLow: { min_withdrawal_amount: 123n } } };
+      service.withdraw_eth.mockResolvedValue(error);
+
+      const canister = minter(service);
+
+      const call = () => canister.withdrawEth(params);
+
+      await expect(call).rejects.toThrowError(
+        new MinterAmountTooLowError(
+          `${error.Err.AmountTooLow.min_withdrawal_amount}`,
+        ),
+      );
+    });
+
+    it("should throw MinterRecipientAddressBlockedError", async () => {
+      const service = mock<ActorSubclass<CkETHMinterService>>();
+
+      const error = {
+        Err: { RecipientAddressBlocked: { address: ethAddressMock } },
+      };
+      service.withdraw_eth.mockResolvedValue(error);
+
+      const canister = minter(service);
+
+      const call = () => canister.withdrawEth(params);
+
+      await expect(call).rejects.toThrowError(
+        new MinterRecipientAddressBlockedError(
+          `${error.Err.RecipientAddressBlocked.address}`,
+        ),
+      );
+    });
+
+    it("should throw MinterInsufficientFundsError", async () => {
+      const service = mock<ActorSubclass<CkETHMinterService>>();
+
+      const error = { Err: { InsufficientFunds: { balance: 123n } } };
+      service.withdraw_eth.mockResolvedValue(error);
+
+      const canister = minter(service);
+
+      const call = () => canister.withdrawEth(params);
+
+      await expect(call).rejects.toThrowError(
+        new MinterInsufficientFundsError(
+          `${error.Err.InsufficientFunds.balance}`,
+        ),
+      );
+    });
+
+    it("should throw MinterInsufficientAllowanceError", async () => {
+      const service = mock<ActorSubclass<CkETHMinterService>>();
+
+      const error = { Err: { InsufficientAllowance: { allowance: 123n } } };
+      service.withdraw_eth.mockResolvedValue(error);
+
+      const canister = minter(service);
+
+      const call = () => canister.withdrawEth(params);
+
+      await expect(call).rejects.toThrowError(
+        new MinterInsufficientAllowanceError(
+          `${error.Err.InsufficientAllowance.allowance}`,
+        ),
+      );
+    });
+
+    it("should throw unsupported response", async () => {
+      const service = mock<ActorSubclass<CkETHMinterService>>();
+
+      const error = { Err: { Test: null } as unknown };
+      // @ts-ignore we explicity want the results to throw some error type
+      service.withdraw_eth.mockResolvedValue(error);
+
+      const canister = minter(service);
+
+      const call = () => canister.withdrawEth(params);
+
+      await expect(call).rejects.toThrowError(
+        new MinterWithdrawalError(
+          `Unsupported response type in minter.withdrawEth ${JSON.stringify(
+            error.Err,
+          )}`,
+        ),
+      );
     });
   });
 });

--- a/packages/cketh/src/mocks/minter.mock.ts
+++ b/packages/cketh/src/mocks/minter.mock.ts
@@ -6,3 +6,5 @@ export const minterCanisterIdMock: Principal = Principal.fromText(
 
 export const ckETHSmartContractAddressMock =
   "0x7574eB42cA208A4f6960ECCAfDF186D627dCC175";
+
+export const ethAddressMock = "0x6D1b7ceAd24FBaf153a3a18f09395Fd2f9C64912";


### PR DESCRIPTION
# Motivation

Add support for `withdraw_eth` in `@dfinity/cketh` library.

# Notes

Pattern is really similar to ckBTC `retrieveBtcWithApproval`, kind of copy/paste + search and replace.

# Changes

- Implement `withdrawEth` and related result errors
- Expose errors and success types in `index.ts`
