### PR TITLE
Chore: Upgrade candid IC-Managment canister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # XXXX.XX
 
-## Added
+## Features
 
 - Upgrade candid files for ic-managmenet canister and support new field `reserved_cycles_limit`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# XXXX.XX
+
+## Added
+
+- Upgrade candid files for ic-managmenet canister and support new field `reserved_cycles_limit`.
+
 # 2024.01.09-1115Z
 
 ## Overview

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -143,8 +143,8 @@ Stop a canister
 Get canister details (memory size, status, etc.)
 
 | Method           | Type                                                                                    |
-| ---------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| `canisterStatus` | `(canisterId: Principal) => Promise<{ status: { stopped: null; } or { stopping: null; } | { running: null; }; memory_size: bigint; cycles: bigint; settings: definite_canister_settings; idle_cycles_burned_per_day: bigint; module_hash: [] | [...]; }>` |
+| ---------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `canisterStatus` | `(canisterId: Principal) => Promise<{ status: { stopped: null; } or { stopping: null; } | { running: null; }; memory_size: bigint; cycles: bigint; settings: definite_canister_settings; idle_cycles_burned_per_day: bigint; module_hash: [] | [...]; reserved_cycles: bigint; }>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L169)
 

--- a/packages/ic-management/candid/ic-management.did
+++ b/packages/ic-management/candid/ic-management.did
@@ -6,6 +6,7 @@ type canister_settings = record {
   compute_allocation : opt nat;
   memory_allocation : opt nat;
   freezing_threshold : opt nat;
+  reserved_cycles_limit : opt nat;
 };
 
 type definite_canister_settings = record {
@@ -13,6 +14,7 @@ type definite_canister_settings = record {
   compute_allocation : nat;
   memory_allocation : nat;
   freezing_threshold : nat;
+  reserved_cycles_limit : nat;
 };
 
 type change_origin = variant {
@@ -45,6 +47,8 @@ type change = record {
   origin : change_origin;
   details : change_details;
 };
+
+type chunk_hash = blob;
 
 type http_header = record { name: text; value: text };
 
@@ -111,6 +115,12 @@ type send_transaction_request = record {
 
 type millisatoshi_per_byte = nat64;
 
+type node_metrics = record {
+    node_id : principal;
+    num_blocks_total : nat64;
+    num_block_failures_total : nat64;
+};
+
 service ic : {
   create_canister : (record {
     settings : opt canister_settings;
@@ -121,10 +131,37 @@ service ic : {
     settings : canister_settings;
     sender_canister_version : opt nat64;
   }) -> ();
+  upload_chunk : (record {
+    canister_id : principal;
+    chunk : blob;
+  }) -> (chunk_hash);
+  clear_chunk_store: (record {canister_id : canister_id}) -> ();
+  stored_chunks: (record {canister_id : canister_id}) -> (vec chunk_hash);
   install_code : (record {
-    mode : variant {install; reinstall; upgrade};
+    mode : variant {
+      install;
+      reinstall;
+      upgrade : opt record {
+        skip_pre_upgrade: opt bool;
+      }
+    };
     canister_id : canister_id;
     wasm_module : wasm_module;
+    arg : blob;
+    sender_canister_version : opt nat64;
+  }) -> ();
+  install_chunked_code: (record {
+    mode : variant {
+      install;
+      reinstall;
+      upgrade : opt record {
+        skip_pre_upgrade: opt bool;
+      };
+    };
+    target_canister: canister_id;
+    storage_canister: opt canister_id;
+    chunk_hashes_list: vec chunk_hash;
+    wasm_module_hash: blob;
     arg : blob;
     sender_canister_version : opt nat64;
   }) -> ();
@@ -140,6 +177,7 @@ service ic : {
       module_hash: opt blob;
       memory_size: nat;
       cycles: nat;
+      reserved_cycles: nat;
       idle_cycles_burned_per_day: nat;
   });
   canister_info : (record {
@@ -180,9 +218,20 @@ service ic : {
 
   // bitcoin interface
   bitcoin_get_balance: (get_balance_request) -> (satoshi);
+  bitcoin_get_balance_query: (get_balance_request) -> (satoshi) query;
   bitcoin_get_utxos: (get_utxos_request) -> (get_utxos_response);
+  bitcoin_get_utxos_query: (get_utxos_request) -> (get_utxos_response) query;
   bitcoin_send_transaction: (send_transaction_request) -> ();
   bitcoin_get_current_fee_percentiles: (get_current_fee_percentiles_request) -> (vec millisatoshi_per_byte);
+
+  // metrics interface
+  node_metrics_history : (record {
+    subnet_id : principal;
+    start_at_timestamp_nanos: nat64;
+  }) -> (vec record {
+    timestamp_nanos : nat64;
+    node_metrics : vec node_metrics;
+  });
 
   // provisional interfaces for the pre-ledger world
   provisional_create_canister_with_cycles : (record {

--- a/packages/ic-management/candid/ic-management.idl.js
+++ b/packages/ic-management/candid/ic-management.idl.js
@@ -77,12 +77,14 @@ export const idlFactory = ({ IDL }) => {
   const definite_canister_settings = IDL.Record({
     'freezing_threshold' : IDL.Nat,
     'controllers' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Nat,
     'memory_allocation' : IDL.Nat,
     'compute_allocation' : IDL.Nat,
   });
   const canister_settings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat),
     'controllers' : IDL.Opt(IDL.Vec(IDL.Principal)),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat),
     'memory_allocation' : IDL.Opt(IDL.Nat),
     'compute_allocation' : IDL.Opt(IDL.Nat),
   });
@@ -93,9 +95,20 @@ export const idlFactory = ({ IDL }) => {
     'body' : IDL.Vec(IDL.Nat8),
     'headers' : IDL.Vec(http_header),
   });
+  const chunk_hash = IDL.Vec(IDL.Nat8);
   const wasm_module = IDL.Vec(IDL.Nat8);
+  const node_metrics = IDL.Record({
+    'num_block_failures_total' : IDL.Nat64,
+    'node_id' : IDL.Principal,
+    'num_blocks_total' : IDL.Nat64,
+  });
   return IDL.Service({
     'bitcoin_get_balance' : IDL.Func([get_balance_request], [satoshi], []),
+    'bitcoin_get_balance_query' : IDL.Func(
+        [get_balance_request],
+        [satoshi],
+        ['query'],
+      ),
     'bitcoin_get_current_fee_percentiles' : IDL.Func(
         [get_current_fee_percentiles_request],
         [IDL.Vec(millisatoshi_per_byte)],
@@ -105,6 +118,11 @@ export const idlFactory = ({ IDL }) => {
         [get_utxos_request],
         [get_utxos_response],
         [],
+      ),
+    'bitcoin_get_utxos_query' : IDL.Func(
+        [get_utxos_request],
+        [get_utxos_response],
+        ['query'],
       ),
     'bitcoin_send_transaction' : IDL.Func([send_transaction_request], [], []),
     'canister_info' : IDL.Func(
@@ -138,8 +156,14 @@ export const idlFactory = ({ IDL }) => {
             'settings' : definite_canister_settings,
             'idle_cycles_burned_per_day' : IDL.Nat,
             'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+            'reserved_cycles' : IDL.Nat,
           }),
         ],
+        [],
+      ),
+    'clear_chunk_store' : IDL.Func(
+        [IDL.Record({ 'canister_id' : canister_id })],
+        [],
         [],
       ),
     'create_canister' : IDL.Func(
@@ -210,6 +234,27 @@ export const idlFactory = ({ IDL }) => {
         [http_response],
         [],
       ),
+    'install_chunked_code' : IDL.Func(
+        [
+          IDL.Record({
+            'arg' : IDL.Vec(IDL.Nat8),
+            'wasm_module_hash' : IDL.Vec(IDL.Nat8),
+            'mode' : IDL.Variant({
+              'reinstall' : IDL.Null,
+              'upgrade' : IDL.Opt(
+                IDL.Record({ 'skip_pre_upgrade' : IDL.Opt(IDL.Bool) })
+              ),
+              'install' : IDL.Null,
+            }),
+            'chunk_hashes_list' : IDL.Vec(chunk_hash),
+            'target_canister' : canister_id,
+            'sender_canister_version' : IDL.Opt(IDL.Nat64),
+            'storage_canister' : IDL.Opt(canister_id),
+          }),
+        ],
+        [],
+        [],
+      ),
     'install_code' : IDL.Func(
         [
           IDL.Record({
@@ -217,7 +262,9 @@ export const idlFactory = ({ IDL }) => {
             'wasm_module' : wasm_module,
             'mode' : IDL.Variant({
               'reinstall' : IDL.Null,
-              'upgrade' : IDL.Null,
+              'upgrade' : IDL.Opt(
+                IDL.Record({ 'skip_pre_upgrade' : IDL.Opt(IDL.Bool) })
+              ),
               'install' : IDL.Null,
             }),
             'canister_id' : canister_id,
@@ -225,6 +272,23 @@ export const idlFactory = ({ IDL }) => {
           }),
         ],
         [],
+        [],
+      ),
+    'node_metrics_history' : IDL.Func(
+        [
+          IDL.Record({
+            'start_at_timestamp_nanos' : IDL.Nat64,
+            'subnet_id' : IDL.Principal,
+          }),
+        ],
+        [
+          IDL.Vec(
+            IDL.Record({
+              'timestamp_nanos' : IDL.Nat64,
+              'node_metrics' : IDL.Vec(node_metrics),
+            })
+          ),
+        ],
         [],
       ),
     'provisional_create_canister_with_cycles' : IDL.Func(
@@ -266,6 +330,11 @@ export const idlFactory = ({ IDL }) => {
         [],
         [],
       ),
+    'stored_chunks' : IDL.Func(
+        [IDL.Record({ 'canister_id' : canister_id })],
+        [IDL.Vec(chunk_hash)],
+        [],
+      ),
     'uninstall_code' : IDL.Func(
         [
           IDL.Record({
@@ -285,6 +354,16 @@ export const idlFactory = ({ IDL }) => {
           }),
         ],
         [],
+        [],
+      ),
+    'upload_chunk' : IDL.Func(
+        [
+          IDL.Record({
+            'chunk' : IDL.Vec(IDL.Nat8),
+            'canister_id' : IDL.Principal,
+          }),
+        ],
+        [chunk_hash],
         [],
       ),
   });

--- a/packages/ic-management/src/ic-management.canister.spec.ts
+++ b/packages/ic-management/src/ic-management.canister.spec.ts
@@ -106,6 +106,7 @@ describe("ICManagementCanister", () => {
           controllers: [[mockPrincipal]],
           freezing_threshold: [],
           memory_allocation: [],
+          reserved_cycles_limit: [],
         },
       });
     });
@@ -263,6 +264,7 @@ describe("ICManagementCanister", () => {
         controllers: [mockPrincipal],
         memory_allocation: BigInt(4),
         compute_allocation: BigInt(10),
+        reserved_cycles_limit: BigInt(11),
       };
       const response: CanisterStatusResponse = {
         status: { running: null },
@@ -271,6 +273,7 @@ describe("ICManagementCanister", () => {
         settings,
         idle_cycles_burned_per_day: BigInt(0),
         module_hash: [],
+        reserved_cycles: BigInt(11),
       };
       const service = mock<IcManagementService>();
       service.canister_status.mockResolvedValue(response);

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -10,6 +10,7 @@ export interface CanisterSettings {
   freezingThreshold?: bigint;
   memoryAllocation?: bigint;
   computeAllocation?: bigint;
+  reservedCyclesLimit?: bigint;
 }
 
 export const toCanisterSettings = ({
@@ -17,12 +18,14 @@ export const toCanisterSettings = ({
   freezingThreshold,
   memoryAllocation,
   computeAllocation,
+  reservedCyclesLimit,
 }: CanisterSettings = {}): canister_settings => {
   return {
     controllers: toNullable(controllers?.map((c) => Principal.fromText(c))),
     freezing_threshold: toNullable(freezingThreshold),
     memory_allocation: toNullable(memoryAllocation),
     compute_allocation: toNullable(computeAllocation),
+    reserved_cycles_limit: toNullable(reservedCyclesLimit),
   };
 };
 
@@ -55,7 +58,9 @@ export const toInstallMode = (installMode: InstallMode): InstallModeParam => {
     case InstallMode.Reinstall:
       return { reinstall: null };
     case InstallMode.Upgrade:
-      return { upgrade: null };
+      // TODO: Support Upgrade mode skipping pre-upgrade
+      // `upgrade` can also have `[{ skip_pre_upgrade: [] | [boolean] }]`
+      return { upgrade: [] };
   }
 };
 


### PR DESCRIPTION
# Motivation

Upgrade ic-management candid files that have some changes that break the pipeline even though they are backwards compatible.

This breaking of the pipeline prevents the bot from making PRs that can be merged without manual changes.

# Changes

## Automatic Changes

* "ic-management.did" file with `./scripts/import-candid ../ic`. In this step, I removed the changes in all the other candid files.
* "ic-managment.certified.idl.js", "ic-management.d.ts", "ic-management.idl.js" files with "./scripts/compile-idl-js"
* "README.md" the documentation bot.

## Manual Changes

* Changelog
* Add new optional field to `toCanisterSettings`.
* Change the return of `toInstallMode` for the `InstallMode.Upgrade`. In another PR, we might want to add a new field to InstallMode enum to support new functionality.

# Tests

* Fix tests expecting new optional field.

# Todos

- [x] Add entry to changelog (if necessary).
