### PR TITLE
feat: estimate ckETH to eth fee

### DIFF
--- a/packages/cketh/README.md
+++ b/packages/cketh/README.md
@@ -53,13 +53,14 @@ const address = await getSmartContractAddress({});
 
 ### :factory: CkETHMinterCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L12)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L13)
 
 #### Methods
 
 - [create](#gear-create)
 - [getSmartContractAddress](#gear-getsmartcontractaddress)
 - [withdrawEth](#gear-withdraweth)
+- [eip1559TransactionPrice](#gear-eip1559transactionprice)
 
 ##### :gear: create
 
@@ -67,7 +68,7 @@ const address = await getSmartContractAddress({});
 | -------- | ------------------------------------------------------------------------ |
 | `create` | `(options: CkETHMinterCanisterOptions<_SERVICE>) => CkETHMinterCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L13)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L14)
 
 ##### :gear: getSmartContractAddress
 
@@ -82,7 +83,7 @@ Parameters:
 - `params`: The parameters to resolve the ckETH smart contract address.
 - `params.certified`: query or update call
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L31)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L32)
 
 ##### :gear: withdrawEth
 
@@ -101,7 +102,17 @@ Parameters:
 
 - `params`: The parameters to withdrawal ckETH to ETH.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L51)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L52)
+
+##### :gear: eip1559TransactionPrice
+
+Estimate the price of a transaction issued by the minter when converting ckETH to ETH.
+
+| Method                    | Type                                     |
+| ------------------------- | ---------------------------------------- |
+| `eip1559TransactionPrice` | `() => Promise<Eip1559TransactionPrice>` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L80)
 
 <!-- TSDOC_END -->
 

--- a/packages/cketh/src/index.ts
+++ b/packages/cketh/src/index.ts
@@ -1,3 +1,6 @@
-export type { RetrieveEthRequest } from "../candid/minter";
+export type {
+  Eip1559TransactionPrice,
+  RetrieveEthRequest,
+} from "../candid/minter";
 export * from "./errors/minter.errors";
 export { CkETHMinterCanister } from "./minter.canister";

--- a/packages/cketh/src/minter.canister.spec.ts
+++ b/packages/cketh/src/minter.canister.spec.ts
@@ -199,4 +199,36 @@ describe("ckETH minter canister", () => {
       );
     });
   });
+
+  describe("Estimate withdrawal fee", () => {
+    it("should return estimated fee", async () => {
+      const result = {
+        max_priority_fee_per_gas: 123n,
+        max_fee_per_gas: 456n,
+        max_transaction_fee: 7n,
+        gas_limit: 89n,
+      };
+
+      const service = mock<ActorSubclass<CkETHMinterService>>();
+      service.eip_1559_transaction_price.mockResolvedValue(result);
+
+      const canister = minter(service);
+
+      const res = await canister.eip1559TransactionPrice();
+
+      expect(service.eip_1559_transaction_price).toBeCalled();
+      expect(res).toEqual(result);
+    });
+
+    it("should bubble errors", () => {
+      const service = mock<ActorSubclass<CkETHMinterService>>();
+      service.eip_1559_transaction_price.mockRejectedValue(new Error());
+
+      const canister = minter(service);
+
+      const call = () => canister.eip1559TransactionPrice();
+
+      expect(call).rejects.toThrowError();
+    });
+  });
 });

--- a/packages/cketh/src/minter.canister.ts
+++ b/packages/cketh/src/minter.canister.ts
@@ -1,9 +1,10 @@
-import { idlFactory as certifiedIdlFactory } from "@dfinity/ckbtc/candid/minter.certified.idl";
 import { idlFactory } from "@dfinity/ckbtc/candid/minter.idl";
+import { idlFactory as certifiedIdlFactory } from "@dfinity/cketh/candid/minter.certified.idl";
 import type { QueryParams } from "@dfinity/utils";
 import { Canister, createServices } from "@dfinity/utils";
 import type {
   _SERVICE as CkETHMinterService,
+  Eip1559TransactionPrice,
   RetrieveEthRequest,
 } from "../candid/minter";
 import { createWithdrawEthError } from "./errors/minter.errors";
@@ -69,5 +70,17 @@ export class CkETHMinterCanister extends Canister<CkETHMinterService> {
     }
 
     return response.Ok;
+  };
+
+  /**
+   * Estimate the price of a transaction issued by the minter when converting ckETH to ETH.
+   *
+   * @returns {Promise<Eip1559TransactionPrice>} The estimated gas fee and limit
+   */
+  eip1559TransactionPrice = (): Promise<Eip1559TransactionPrice> => {
+    const { eip_1559_transaction_price } = this.caller({
+      certified: true,
+    });
+    return eip_1559_transaction_price();
   };
 }


### PR DESCRIPTION
# Motivation

Add support for `eip_1559_transaction_price`.

# Note

Basically the exact same pattern as ckBTC `estimate_withdrawal_fee` so close to copy/paste.

# Changes

- Use and expose new function `eip1559TransactionPrice`
