### PR TITLE
Chore: Upgrade candid files for cmc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Add "API Boundary Node Management" topic support.
 - Add optional field `logo` to `Token` type.
 
+## Breaking changes
+
+- Upgrade candid files for cmc canister with new fields `subnet_selection` and `settings`.
+
 # 2024.01.09-1115Z
 
 ## Overview

--- a/packages/cmc/candid/cmc.certified.idl.js
+++ b/packages/cmc/candid/cmc.certified.idl.js
@@ -4,13 +4,46 @@ export const idlFactory = ({ IDL }) => {
     'Set' : IDL.Principal,
     'Unset' : IDL.Null,
   });
-  const AccountIdentifier = IDL.Record({ 'bytes' : IDL.Vec(IDL.Nat8) });
+  const AccountIdentifier = IDL.Text;
   const CyclesCanisterInitPayload = IDL.Record({
     'exchange_rate_canister' : IDL.Opt(ExchangeRateCanister),
+    'cycles_ledger_canister_id' : IDL.Opt(IDL.Principal),
     'last_purged_notification' : IDL.Opt(IDL.Nat64),
     'governance_canister_id' : IDL.Opt(IDL.Principal),
     'minting_account_id' : IDL.Opt(AccountIdentifier),
     'ledger_canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const SubnetFilter = IDL.Record({ 'subnet_type' : IDL.Opt(IDL.Text) });
+  const SubnetSelection = IDL.Variant({
+    'Filter' : SubnetFilter,
+    'Subnet' : IDL.Record({ 'subnet' : IDL.Principal }),
+  });
+  const CanisterSettings = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
+    'freezing_threshold' : IDL.Opt(IDL.Nat),
+    'controllers' : IDL.Opt(IDL.Vec(IDL.Principal)),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat),
+    'memory_allocation' : IDL.Opt(IDL.Nat),
+    'compute_allocation' : IDL.Opt(IDL.Nat),
+  });
+  const CreateCanisterArg = IDL.Record({
+    'subnet_selection' : IDL.Opt(SubnetSelection),
+    'settings' : IDL.Opt(CanisterSettings),
+    'subnet_type' : IDL.Opt(IDL.Text),
+  });
+  const CreateCanisterError = IDL.Variant({
+    'Refunded' : IDL.Record({
+      'create_error' : IDL.Text,
+      'refund_amount' : IDL.Nat,
+    }),
+    'RefundFailed' : IDL.Record({
+      'create_error' : IDL.Text,
+      'refund_error' : IDL.Text,
+    }),
+  });
+  const CreateCanisterResult = IDL.Variant({
+    'Ok' : IDL.Principal,
+    'Err' : CreateCanisterError,
   });
   const IcpXdrConversionRate = IDL.Record({
     'xdr_permyriad_per_icp' : IDL.Nat64,
@@ -31,6 +64,8 @@ export const idlFactory = ({ IDL }) => {
   const NotifyCreateCanisterArg = IDL.Record({
     'controller' : IDL.Principal,
     'block_index' : BlockIndex,
+    'subnet_selection' : IDL.Opt(SubnetSelection),
+    'settings' : IDL.Opt(CanisterSettings),
     'subnet_type' : IDL.Opt(IDL.Text),
   });
   const NotifyError = IDL.Variant({
@@ -50,6 +85,22 @@ export const idlFactory = ({ IDL }) => {
     'Ok' : IDL.Principal,
     'Err' : NotifyError,
   });
+  const Memo = IDL.Opt(IDL.Vec(IDL.Nat8));
+  const Subaccount = IDL.Opt(IDL.Vec(IDL.Nat8));
+  const NotifyMintCyclesArg = IDL.Record({
+    'block_index' : BlockIndex,
+    'deposit_memo' : Memo,
+    'to_subaccount' : Subaccount,
+  });
+  const NotifyMintCyclesSuccess = IDL.Record({
+    'balance' : IDL.Nat,
+    'block_index' : IDL.Nat,
+    'minted' : IDL.Nat,
+  });
+  const NotifyMintCyclesResult = IDL.Variant({
+    'Ok' : NotifyMintCyclesSuccess,
+    'Err' : NotifyError,
+  });
   const NotifyTopUpArg = IDL.Record({
     'block_index' : BlockIndex,
     'canister_id' : IDL.Principal,
@@ -57,6 +108,12 @@ export const idlFactory = ({ IDL }) => {
   const Cycles = IDL.Nat;
   const NotifyTopUpResult = IDL.Variant({ 'Ok' : Cycles, 'Err' : NotifyError });
   return IDL.Service({
+    'create_canister' : IDL.Func(
+        [CreateCanisterArg],
+        [CreateCanisterResult],
+        [],
+      ),
+    'get_build_metadata' : IDL.Func([], [IDL.Text], []),
     'get_icp_xdr_conversion_rate' : IDL.Func(
         [],
         [IcpXdrConversionRateResponse],
@@ -77,6 +134,11 @@ export const idlFactory = ({ IDL }) => {
         [NotifyCreateCanisterResult],
         [],
       ),
+    'notify_mint_cycles' : IDL.Func(
+        [NotifyMintCyclesArg],
+        [NotifyMintCyclesResult],
+        [],
+      ),
     'notify_top_up' : IDL.Func([NotifyTopUpArg], [NotifyTopUpResult], []),
   });
 };
@@ -85,9 +147,10 @@ export const init = ({ IDL }) => {
     'Set' : IDL.Principal,
     'Unset' : IDL.Null,
   });
-  const AccountIdentifier = IDL.Record({ 'bytes' : IDL.Vec(IDL.Nat8) });
+  const AccountIdentifier = IDL.Text;
   const CyclesCanisterInitPayload = IDL.Record({
     'exchange_rate_canister' : IDL.Opt(ExchangeRateCanister),
+    'cycles_ledger_canister_id' : IDL.Opt(IDL.Principal),
     'last_purged_notification' : IDL.Opt(IDL.Nat64),
     'governance_canister_id' : IDL.Opt(IDL.Principal),
     'minting_account_id' : IDL.Opt(AccountIdentifier),

--- a/packages/cmc/candid/cmc.d.ts
+++ b/packages/cmc/candid/cmc.d.ts
@@ -1,13 +1,33 @@
 import type { ActorMethod } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 
-export interface AccountIdentifier {
-  bytes: Uint8Array | number[];
-}
+export type AccountIdentifier = string;
 export type BlockIndex = bigint;
+export interface CanisterSettings {
+  controller: [] | [Principal];
+  freezing_threshold: [] | [bigint];
+  controllers: [] | [Array<Principal>];
+  reserved_cycles_limit: [] | [bigint];
+  memory_allocation: [] | [bigint];
+  compute_allocation: [] | [bigint];
+}
+export interface CreateCanisterArg {
+  subnet_selection: [] | [SubnetSelection];
+  settings: [] | [CanisterSettings];
+  subnet_type: [] | [string];
+}
+export type CreateCanisterError =
+  | {
+      Refunded: { create_error: string; refund_amount: bigint };
+    }
+  | { RefundFailed: { create_error: string; refund_error: string } };
+export type CreateCanisterResult =
+  | { Ok: Principal }
+  | { Err: CreateCanisterError };
 export type Cycles = bigint;
 export interface CyclesCanisterInitPayload {
   exchange_rate_canister: [] | [ExchangeRateCanister];
+  cycles_ledger_canister_id: [] | [Principal];
   last_purged_notification: [] | [bigint];
   governance_canister_id: [] | [Principal];
   minting_account_id: [] | [AccountIdentifier];
@@ -23,9 +43,12 @@ export interface IcpXdrConversionRateResponse {
   data: IcpXdrConversionRate;
   hash_tree: Uint8Array | number[];
 }
+export type Memo = [] | [Uint8Array | number[]];
 export interface NotifyCreateCanisterArg {
   controller: Principal;
   block_index: BlockIndex;
+  subnet_selection: [] | [SubnetSelection];
+  settings: [] | [CanisterSettings];
   subnet_type: [] | [string];
 }
 export type NotifyCreateCanisterResult =
@@ -39,6 +62,19 @@ export type NotifyError =
   | { Other: { error_message: string; error_code: bigint } }
   | { Processing: null }
   | { TransactionTooOld: BlockIndex };
+export interface NotifyMintCyclesArg {
+  block_index: BlockIndex;
+  deposit_memo: Memo;
+  to_subaccount: Subaccount;
+}
+export type NotifyMintCyclesResult =
+  | { Ok: NotifyMintCyclesSuccess }
+  | { Err: NotifyError };
+export interface NotifyMintCyclesSuccess {
+  balance: bigint;
+  block_index: bigint;
+  minted: bigint;
+}
 export interface NotifyTopUpArg {
   block_index: BlockIndex;
   canister_id: Principal;
@@ -47,10 +83,19 @@ export type NotifyTopUpResult = { Ok: Cycles } | { Err: NotifyError };
 export interface PrincipalsAuthorizedToCreateCanistersToSubnetsResponse {
   data: Array<[Principal, Array<Principal>]>;
 }
+export type Subaccount = [] | [Uint8Array | number[]];
+export interface SubnetFilter {
+  subnet_type: [] | [string];
+}
+export type SubnetSelection =
+  | { Filter: SubnetFilter }
+  | { Subnet: { subnet: Principal } };
 export interface SubnetTypesToSubnetsResponse {
   data: Array<[string, Array<Principal>]>;
 }
 export interface _SERVICE {
+  create_canister: ActorMethod<[CreateCanisterArg], CreateCanisterResult>;
+  get_build_metadata: ActorMethod<[], string>;
   get_icp_xdr_conversion_rate: ActorMethod<[], IcpXdrConversionRateResponse>;
   get_principals_authorized_to_create_canisters_to_subnets: ActorMethod<
     [],
@@ -60,6 +105,10 @@ export interface _SERVICE {
   notify_create_canister: ActorMethod<
     [NotifyCreateCanisterArg],
     NotifyCreateCanisterResult
+  >;
+  notify_mint_cycles: ActorMethod<
+    [NotifyMintCyclesArg],
+    NotifyMintCyclesResult
   >;
   notify_top_up: ActorMethod<[NotifyTopUpArg], NotifyTopUpResult>;
 }

--- a/packages/cmc/candid/cmc.did
+++ b/packages/cmc/candid/cmc.did
@@ -1,6 +1,16 @@
-// Generated from IC repo commit d2331ec4b3c60f408b876427d7238ec15fb16ad5 'rs/nns/cmc/cmc.did' by import-candid
+// Generated from IC repo commit d970aa69a9 (2024-01-17) 'rs/nns/cmc/cmc.did' by import-candid
 type Cycles = nat;
 type BlockIndex = nat64;
+type CanisterSettings = record {
+  controller : opt principal;
+  controllers : opt vec principal;
+  compute_allocation : opt nat;
+  memory_allocation : opt nat;
+  freezing_threshold : opt nat;
+  reserved_cycles_limit: opt nat;
+};
+type Subaccount = opt blob;
+type Memo = opt blob;
 
 // The argument of the [notify_top_up] method.
 type NotifyTopUpArg = record {
@@ -9,6 +19,35 @@ type NotifyTopUpArg = record {
 
   // The canister to top up.
   canister_id : principal;
+};
+
+
+type SubnetSelection = variant {
+    /// Choose a specific subnet
+    Subnet : record {
+      subnet: principal;
+    };
+    /// Choose a random subnet that fulfills the specified properties
+    Filter : SubnetFilter;
+};
+
+type SubnetFilter = record {
+  subnet_type: opt text;
+};
+
+// The argument of the [create_canister] method.
+type CreateCanisterArg = record {
+  // Optional canister settings that, if set, are applied to the newly created canister.
+  // If not specified, the caller is the controller of the canister and the other settings are set to default values.
+  settings : opt CanisterSettings;
+
+  // An optional subnet type that, if set, determines what type of subnet
+  // the new canister will be created on.
+  // Deprecated. Use subnet_selection instead.
+  subnet_type: opt text;
+
+  // Optional instructions to select on which subnet the new canister will be created on.
+  subnet_selection: opt SubnetSelection;
 };
 
 // The argument of the [notify_create_canister] method.
@@ -21,7 +60,35 @@ type NotifyCreateCanisterArg = record {
 
   // An optional subnet type that, if set, determines what type of subnet
   // the new canister will be created on.
+  // Deprecated. Use subnet_selection instead.
   subnet_type: opt text;
+
+  // Optional instructions to select on which subnet the new canister will be created on.
+  // vec may contain no more than one element.
+  subnet_selection: opt SubnetSelection;
+
+  // Optional canister settings that, if set, are applied to the newly created canister.
+  // If not specified, the caller is the controller of the canister and the other settings are set to default values.
+  settings : opt CanisterSettings;
+};
+
+// Canister creation failed and the cycles attached to the call were returned to the calling canister.
+// A small fee may be charged.
+type CreateCanisterError = variant {
+  Refunded : record {
+    // The amount of cycles returned to the calling canister
+    refund_amount: nat;
+
+    // The reason why creating a canister failed.
+    create_error: text;
+  };
+  RefundFailed : record {
+    // The reason why creating a canister failed.
+    create_error: text;
+
+    // The reason why refunding cycles failed.
+    refund_error: text;
+  };
 };
 
 type NotifyError = variant {
@@ -56,6 +123,12 @@ type NotifyTopUpResult = variant {
   // The amount of cycles sent to the specified canister.
   Ok : Cycles;
   Err : NotifyError;
+};
+
+type CreateCanisterResult = variant {
+  // The principal of the newly created canister.
+  Ok : principal;
+  Err : CreateCanisterError;
 };
 
 type NotifyCreateCanisterResult = variant {
@@ -104,9 +177,7 @@ type PrincipalsAuthorizedToCreateCanistersToSubnetsResponse = record {
   data: vec record { principal; vec principal };
 };
 
-type AccountIdentifier = record {
-  bytes: blob;
-};
+type AccountIdentifier = text;
 
 type ExchangeRateCanister = variant {
     /// Enables the exchange rate canister with the given canister ID.
@@ -121,15 +192,42 @@ type CyclesCanisterInitPayload = record {
     minting_account_id: opt AccountIdentifier;
     last_purged_notification: opt nat64;
     exchange_rate_canister: opt ExchangeRateCanister;
+    cycles_ledger_canister_id: opt principal;
+};
+
+type NotifyMintCyclesArg = record {
+  block_index: BlockIndex;
+  to_subaccount: Subaccount;
+  deposit_memo: Memo;
+};
+
+type NotifyMintCyclesResult = variant {
+  Ok: NotifyMintCyclesSuccess;
+  Err: NotifyError;
+};
+
+type NotifyMintCyclesSuccess = record {
+    // Cycles ledger block index of deposit
+    block_index: nat;
+    // Amount of cycles that were minted and deposited to the cycles ledger
+    minted: nat;
+    // New balance of the cycles ledger account
+    balance: nat;
 };
 
 service : (opt CyclesCanisterInitPayload) -> {
-  // Propmts the cycles minting canister to process a payment by converting ICP
+  // Prompts the cycles minting canister to process a payment by converting ICP
   // into cycles and sending the cycles the specified canister.
   notify_top_up : (NotifyTopUpArg) -> (NotifyTopUpResult);
 
+  // Creates a canister using the cycles attached to the function call.
+  create_canister : (CreateCanisterArg) -> (CreateCanisterResult);
+
   // Prompts the cycles minting canister to process a payment for canister creation.
   notify_create_canister : (NotifyCreateCanisterArg) -> (NotifyCreateCanisterResult);
+
+  // Mints cycles and deposits them to the cycles ledger
+  notify_mint_cycles : (NotifyMintCyclesArg) -> (NotifyMintCyclesResult);
 
   // Returns the ICP/XDR conversion rate.
   get_icp_xdr_conversion_rate : () -> (IcpXdrConversionRateResponse) query;
@@ -140,4 +238,6 @@ service : (opt CyclesCanisterInitPayload) -> {
   // Returns the mapping from principals to subnets in which they are authorized
   // to create canisters.
   get_principals_authorized_to_create_canisters_to_subnets : () -> (PrincipalsAuthorizedToCreateCanistersToSubnetsResponse) query;
+
+  get_build_metadata : () -> (text) query;
 }

--- a/packages/cmc/src/cmc.canister.spec.ts
+++ b/packages/cmc/src/cmc.canister.spec.ts
@@ -70,6 +70,8 @@ describe("CyclesMintingCanister", () => {
         controller: Principal.fromText("aaaaa-aa"),
         block_index: BigInt(10),
         subnet_type: [],
+        subnet_selection: [],
+        settings: [],
       });
 
       expect(res).toEqual(canisterId);
@@ -89,6 +91,8 @@ describe("CyclesMintingCanister", () => {
           controller: Principal.fromText("aaaaa-aa"),
           block_index: BigInt(10),
           subnet_type: [],
+          subnet_selection: [],
+          settings: [],
         });
 
       expect(call).rejects.toThrowError(RefundedError);
@@ -108,6 +112,8 @@ describe("CyclesMintingCanister", () => {
           controller: Principal.fromText("aaaaa-aa"),
           block_index: BigInt(10),
           subnet_type: [],
+          subnet_selection: [],
+          settings: [],
         });
 
       expect(call).rejects.toThrowError(InvalidaTransactionError);
@@ -127,6 +133,8 @@ describe("CyclesMintingCanister", () => {
           controller: Principal.fromText("aaaaa-aa"),
           block_index: BigInt(10),
           subnet_type: [],
+          subnet_selection: [],
+          settings: [],
         });
 
       expect(call).rejects.toThrowError(ProcessingError);
@@ -146,6 +154,8 @@ describe("CyclesMintingCanister", () => {
           controller: Principal.fromText("aaaaa-aa"),
           block_index: BigInt(10),
           subnet_type: [],
+          subnet_selection: [],
+          settings: [],
         });
 
       expect(call).rejects.toThrowError(TransactionTooOldError);
@@ -165,6 +175,8 @@ describe("CyclesMintingCanister", () => {
           controller: Principal.fromText("aaaaa-aa"),
           block_index: BigInt(10),
           subnet_type: [],
+          subnet_selection: [],
+          settings: [],
         });
 
       expect(call).rejects.toThrowError(CMCError);


### PR DESCRIPTION
# Motivation

Update candid files for CMC and fix the test failure with the new cmc candid files.

This way the bot can make PRs that can be fixed without further intervention.

The new candid types are a breaking change for the `notifyCreateCanister` method.

# Changes

## Automatic changes

* Changes in "*/cmc/candid/*.did" from running script `/scripts/import-candid`.
* Changes in "/cmc/candid/*" from running script `/scripts/compile-idl-js`.

# Tests

* The test in cmc.canister.spec `"CMCCanister.notifyCreateCanister"` was failing because the new parameters were not being passed.

# Todos

- [x] Add entry to changelog (if necessary).
