### PR TITLE
feat: update SubAccount.formID to handle bigger numbers

### DIFF
--- a/packages/ledger-icp/src/account_identifier.spec.ts
+++ b/packages/ledger-icp/src/account_identifier.spec.ts
@@ -60,6 +60,15 @@ describe("SubAccount", () => {
     expect(SubAccount.fromID(1)).toEqual(SubAccount.fromBytes(bytes));
     bytes[31] = 255;
     expect(SubAccount.fromID(255)).toEqual(SubAccount.fromBytes(bytes));
+
+    // Number 18791 in big endian 32 bytes
+    const numberInBytes = [
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 73, 103,
+    ];
+    expect(SubAccount.fromID(18791)).toEqual(
+      SubAccount.fromBytes(new Uint8Array(numberInBytes)),
+    );
   });
 
   it("throws an exception if initialized with an ID < 0", () => {
@@ -68,9 +77,9 @@ describe("SubAccount", () => {
     }).toThrow();
   });
 
-  it("throws an exception if initialized with an ID > 255", () => {
+  it("throws an exception if initialized with an ID > max int", () => {
     expect(() => {
-      SubAccount.fromID(256);
+      SubAccount.fromID(Number.MAX_SAFE_INTEGER + 1);
     }).toThrow();
   });
 });

--- a/packages/ledger-icp/src/account_identifier.ts
+++ b/packages/ledger-icp/src/account_identifier.ts
@@ -97,12 +97,18 @@ export class SubAccount {
   }
 
   public static fromID(id: number): SubAccount {
-    if (id < 0 || id > 255) {
-      throw "Subaccount ID must be >= 0 and <= 255";
+    if (id < 0) throw new Error("Number cannot be negative");
+
+    if (id > Number.MAX_SAFE_INTEGER) {
+      throw new Error("Number is too large to fit in 32 bytes.");
     }
 
-    const bytes: Uint8Array = new Uint8Array(32).fill(0);
-    bytes[31] = id;
+    const buffer = Buffer.alloc(32);
+
+    // Using 24 as the offset since BigInt64BE uses 8 bytes
+    buffer.writeBigInt64BE(BigInt(id), 24);
+
+    const bytes = new Uint8Array(buffer);
     return new SubAccount(bytes);
   }
 

--- a/packages/ledger-icp/src/account_identifier.ts
+++ b/packages/ledger-icp/src/account_identifier.ts
@@ -103,13 +103,12 @@ export class SubAccount {
       throw new Error("Number is too large to fit in 32 bytes.");
     }
 
-    const buffer = Buffer.alloc(32);
+    const view = new DataView(new ArrayBuffer(32));
 
-    // Using 24 as the offset since BigInt64BE uses 8 bytes
-    buffer.writeBigInt64BE(BigInt(id), 24);
+    view.setBigUint64(24, BigInt(id), false);
 
-    const bytes = new Uint8Array(buffer);
-    return new SubAccount(bytes);
+    const uint8Arary = new Uint8Array(view.buffer);
+    return new SubAccount(uint8Arary);
   }
 
   public toUint8Array(): Uint8Array {

--- a/packages/ledger-icp/src/account_identifier.ts
+++ b/packages/ledger-icp/src/account_identifier.ts
@@ -105,7 +105,14 @@ export class SubAccount {
 
     const view = new DataView(new ArrayBuffer(32));
 
-    view.setBigUint64(24, BigInt(id), false);
+    // Fix for IOS < 14.8 setBigUint64 absence
+    if (typeof view.setBigUint64 === "function") {
+      view.setBigUint64(24, BigInt(id));
+    } else {
+      const TWO_TO_THE_32 = BigInt(1) << BigInt(32);
+      view.setUint32(24, Number(BigInt(id) >> BigInt(32)));
+      view.setUint32(28, Number(BigInt(id) % TWO_TO_THE_32));
+    }
 
     const uint8Arary = new Uint8Array(view.buffer);
     return new SubAccount(uint8Arary);


### PR DESCRIPTION
# Motivation

I am having a scenario where I need to handle more than 256 subaccounts. This is my workaround for now:
```
const principal = identity.getPrincipal()

const generatedAccountId = AccountIdentifier.fromPrincipal({
    principal,
    subAccount: SubAccount.fromBytes(numberToUint8Array32(newIndexNumber)),
})
```
where `numberToUint8Array32` is the updated `fromID` method.


# Changes

Updates the `SubAccount.fromID` method to handle up to nine quadrillion subaccounts (which is the max safe int).

It creates a buffer of 32 bytes and uses `writeBigInt64BE` to write the `id` using a 24 offest.

# Tests

Added one more test for `fromID` method under `account_identifier.spec.ts`. All tests are passing.

# Todos

- Enjoy!
