### PR TITLE
Chore: Upgrade candid files for sns-js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Upgrade candid files for ic-managmenet canister and support new field `reserved_cycles_limit`.
 - Add "API Boundary Node Management" topic support.
 - Add optional field `logo` to `Token` type.
+- Update `sns-js` candid files with new fields in sns canisters.
 
 ## Breaking changes
 

--- a/packages/sns/candid/sns_governance.certified.idl.js
+++ b/packages/sns/candid/sns_governance.certified.idl.js
@@ -94,7 +94,6 @@ export const idlFactory = ({ IDL }) => {
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
     'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
-    'total_available_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'distributed_e8s_equivalent' : IDL.Nat64,
     'round' : IDL.Nat64,
     'settled_proposals' : IDL.Vec(ProposalId),
@@ -142,6 +141,12 @@ export const idlFactory = ({ IDL }) => {
     'canister_ids' : IDL.Vec(IDL.Principal),
     'new_controllers' : IDL.Vec(IDL.Principal),
   });
+  const MintSnsTokens = IDL.Record({
+    'to_principal' : IDL.Opt(IDL.Principal),
+    'to_subaccount' : IDL.Opt(Subaccount),
+    'memo' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const ManageSnsMetadata = IDL.Record({
     'url' : IDL.Opt(IDL.Text),
     'logo' : IDL.Opt(IDL.Text),
@@ -151,6 +156,9 @@ export const idlFactory = ({ IDL }) => {
   const ExecuteGenericNervousSystemFunction = IDL.Record({
     'function_id' : IDL.Nat64,
     'payload' : IDL.Vec(IDL.Nat8),
+  });
+  const ManageLedgerParameters = IDL.Record({
+    'transfer_fee' : IDL.Opt(IDL.Nat64),
   });
   const Motion = IDL.Record({ 'motion_text' : IDL.Text });
   const Action = IDL.Variant({
@@ -162,9 +170,11 @@ export const idlFactory = ({ IDL }) => {
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
     'UpgradeSnsControlledCanister' : UpgradeSnsControlledCanister,
     'DeregisterDappCanisters' : DeregisterDappCanisters,
+    'MintSnsTokens' : MintSnsTokens,
     'Unspecified' : IDL.Record({}),
     'ManageSnsMetadata' : ManageSnsMetadata,
     'ExecuteGenericNervousSystemFunction' : ExecuteGenericNervousSystemFunction,
+    'ManageLedgerParameters' : ManageLedgerParameters,
     'Motion' : Motion,
   });
   const Proposal = IDL.Record({
@@ -291,6 +301,7 @@ export const idlFactory = ({ IDL }) => {
     'timestamp_of_disbursement_seconds' : IDL.Nat64,
     'amount_e8s' : IDL.Nat64,
     'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
   const Neuron = IDL.Record({
     'id' : IDL.Opt(NeuronId),
@@ -625,7 +636,6 @@ export const init = ({ IDL }) => {
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
     'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
-    'total_available_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'distributed_e8s_equivalent' : IDL.Nat64,
     'round' : IDL.Nat64,
     'settled_proposals' : IDL.Vec(ProposalId),
@@ -673,6 +683,12 @@ export const init = ({ IDL }) => {
     'canister_ids' : IDL.Vec(IDL.Principal),
     'new_controllers' : IDL.Vec(IDL.Principal),
   });
+  const MintSnsTokens = IDL.Record({
+    'to_principal' : IDL.Opt(IDL.Principal),
+    'to_subaccount' : IDL.Opt(Subaccount),
+    'memo' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const ManageSnsMetadata = IDL.Record({
     'url' : IDL.Opt(IDL.Text),
     'logo' : IDL.Opt(IDL.Text),
@@ -682,6 +698,9 @@ export const init = ({ IDL }) => {
   const ExecuteGenericNervousSystemFunction = IDL.Record({
     'function_id' : IDL.Nat64,
     'payload' : IDL.Vec(IDL.Nat8),
+  });
+  const ManageLedgerParameters = IDL.Record({
+    'transfer_fee' : IDL.Opt(IDL.Nat64),
   });
   const Motion = IDL.Record({ 'motion_text' : IDL.Text });
   const Action = IDL.Variant({
@@ -693,9 +712,11 @@ export const init = ({ IDL }) => {
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
     'UpgradeSnsControlledCanister' : UpgradeSnsControlledCanister,
     'DeregisterDappCanisters' : DeregisterDappCanisters,
+    'MintSnsTokens' : MintSnsTokens,
     'Unspecified' : IDL.Record({}),
     'ManageSnsMetadata' : ManageSnsMetadata,
     'ExecuteGenericNervousSystemFunction' : ExecuteGenericNervousSystemFunction,
+    'ManageLedgerParameters' : ManageLedgerParameters,
     'Motion' : Motion,
   });
   const Proposal = IDL.Record({
@@ -822,6 +843,7 @@ export const init = ({ IDL }) => {
     'timestamp_of_disbursement_seconds' : IDL.Nat64,
     'amount_e8s' : IDL.Nat64,
     'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
   const Neuron = IDL.Record({
     'id' : IDL.Opt(NeuronId),

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -16,11 +16,13 @@ export type Action =
   | { TransferSnsTreasuryFunds: TransferSnsTreasuryFunds }
   | { UpgradeSnsControlledCanister: UpgradeSnsControlledCanister }
   | { DeregisterDappCanisters: DeregisterDappCanisters }
+  | { MintSnsTokens: MintSnsTokens }
   | { Unspecified: {} }
   | { ManageSnsMetadata: ManageSnsMetadata }
   | {
       ExecuteGenericNervousSystemFunction: ExecuteGenericNervousSystemFunction;
     }
+  | { ManageLedgerParameters: ManageLedgerParameters }
   | { Motion: Motion };
 export interface AddNeuronPermissions {
   permissions_to_add: [] | [NeuronPermissionList];
@@ -137,6 +139,7 @@ export interface DisburseMaturityInProgress {
   timestamp_of_disbursement_seconds: bigint;
   amount_e8s: bigint;
   account_to_disburse_to: [] | [Account];
+  finalize_disbursement_timestamp_seconds: [] | [bigint];
 }
 export interface DisburseMaturityResponse {
   amount_disbursed_e8s: bigint;
@@ -269,6 +272,9 @@ export interface ListProposals {
 export interface ListProposalsResponse {
   proposals: Array<ProposalData>;
 }
+export interface ManageLedgerParameters {
+  transfer_fee: [] | [bigint];
+}
 export interface ManageNeuron {
   subaccount: Uint8Array | number[];
   command: [] | [Command];
@@ -296,6 +302,12 @@ export interface MergeMaturity {
 export interface MergeMaturityResponse {
   merged_maturity_e8s: bigint;
   new_stake_e8s: bigint;
+}
+export interface MintSnsTokens {
+  to_principal: [] | [Principal];
+  to_subaccount: [] | [Subaccount];
+  memo: [] | [bigint];
+  amount_e8s: [] | [bigint];
 }
 export interface Motion {
   motion_text: string;
@@ -428,7 +440,6 @@ export interface RewardEvent {
   rounds_since_last_distribution: [] | [bigint];
   actual_timestamp_seconds: bigint;
   end_timestamp_seconds: [] | [bigint];
-  total_available_e8s_equivalent: [] | [bigint];
   distributed_e8s_equivalent: bigint;
   round: bigint;
   settled_proposals: Array<ProposalId>;

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 57f0e39e3 (2023-11-22) 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 826f954658 (2024-01-22) 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
@@ -9,9 +9,11 @@ type Action = variant {
   TransferSnsTreasuryFunds : TransferSnsTreasuryFunds;
   UpgradeSnsControlledCanister : UpgradeSnsControlledCanister;
   DeregisterDappCanisters : DeregisterDappCanisters;
+  MintSnsTokens : MintSnsTokens;
   Unspecified : record {};
   ManageSnsMetadata : ManageSnsMetadata;
   ExecuteGenericNervousSystemFunction : ExecuteGenericNervousSystemFunction;
+  ManageLedgerParameters : ManageLedgerParameters;
   Motion : Motion;
 };
 type AddNeuronPermissions = record {
@@ -115,6 +117,7 @@ type DisburseMaturityInProgress = record {
   timestamp_of_disbursement_seconds : nat64;
   amount_e8s : nat64;
   account_to_disburse_to : opt Account;
+  finalize_disbursement_timestamp_seconds : opt nat64;
 };
 type DisburseMaturityResponse = record {
   amount_disbursed_e8s : nat64;
@@ -225,6 +228,7 @@ type ListProposals = record {
   include_status : vec int32;
 };
 type ListProposalsResponse = record { proposals : vec ProposalData };
+type ManageLedgerParameters = record { transfer_fee : opt nat64 };
 type ManageNeuron = record { subaccount : vec nat8; command : opt Command };
 type ManageNeuronResponse = record { command : opt Command_1 };
 type ManageSnsMetadata = record {
@@ -242,6 +246,12 @@ type MergeMaturity = record { percentage_to_merge : nat32 };
 type MergeMaturityResponse = record {
   merged_maturity_e8s : nat64;
   new_stake_e8s : nat64;
+};
+type MintSnsTokens = record {
+  to_principal : opt principal;
+  to_subaccount : opt Subaccount;
+  memo : opt nat64;
+  amount_e8s : opt nat64;
 };
 type Motion = record { motion_text : text };
 type NervousSystemFunction = record {
@@ -358,7 +368,6 @@ type RewardEvent = record {
   rounds_since_last_distribution : opt nat64;
   actual_timestamp_seconds : nat64;
   end_timestamp_seconds : opt nat64;
-  total_available_e8s_equivalent : opt nat64;
   distributed_e8s_equivalent : nat64;
   round : nat64;
   settled_proposals : vec ProposalId;

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -94,7 +94,6 @@ export const idlFactory = ({ IDL }) => {
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
     'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
-    'total_available_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'distributed_e8s_equivalent' : IDL.Nat64,
     'round' : IDL.Nat64,
     'settled_proposals' : IDL.Vec(ProposalId),
@@ -142,6 +141,12 @@ export const idlFactory = ({ IDL }) => {
     'canister_ids' : IDL.Vec(IDL.Principal),
     'new_controllers' : IDL.Vec(IDL.Principal),
   });
+  const MintSnsTokens = IDL.Record({
+    'to_principal' : IDL.Opt(IDL.Principal),
+    'to_subaccount' : IDL.Opt(Subaccount),
+    'memo' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const ManageSnsMetadata = IDL.Record({
     'url' : IDL.Opt(IDL.Text),
     'logo' : IDL.Opt(IDL.Text),
@@ -151,6 +156,9 @@ export const idlFactory = ({ IDL }) => {
   const ExecuteGenericNervousSystemFunction = IDL.Record({
     'function_id' : IDL.Nat64,
     'payload' : IDL.Vec(IDL.Nat8),
+  });
+  const ManageLedgerParameters = IDL.Record({
+    'transfer_fee' : IDL.Opt(IDL.Nat64),
   });
   const Motion = IDL.Record({ 'motion_text' : IDL.Text });
   const Action = IDL.Variant({
@@ -162,9 +170,11 @@ export const idlFactory = ({ IDL }) => {
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
     'UpgradeSnsControlledCanister' : UpgradeSnsControlledCanister,
     'DeregisterDappCanisters' : DeregisterDappCanisters,
+    'MintSnsTokens' : MintSnsTokens,
     'Unspecified' : IDL.Record({}),
     'ManageSnsMetadata' : ManageSnsMetadata,
     'ExecuteGenericNervousSystemFunction' : ExecuteGenericNervousSystemFunction,
+    'ManageLedgerParameters' : ManageLedgerParameters,
     'Motion' : Motion,
   });
   const Proposal = IDL.Record({
@@ -291,6 +301,7 @@ export const idlFactory = ({ IDL }) => {
     'timestamp_of_disbursement_seconds' : IDL.Nat64,
     'amount_e8s' : IDL.Nat64,
     'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
   const Neuron = IDL.Record({
     'id' : IDL.Opt(NeuronId),
@@ -633,7 +644,6 @@ export const init = ({ IDL }) => {
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
     'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
-    'total_available_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'distributed_e8s_equivalent' : IDL.Nat64,
     'round' : IDL.Nat64,
     'settled_proposals' : IDL.Vec(ProposalId),
@@ -681,6 +691,12 @@ export const init = ({ IDL }) => {
     'canister_ids' : IDL.Vec(IDL.Principal),
     'new_controllers' : IDL.Vec(IDL.Principal),
   });
+  const MintSnsTokens = IDL.Record({
+    'to_principal' : IDL.Opt(IDL.Principal),
+    'to_subaccount' : IDL.Opt(Subaccount),
+    'memo' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const ManageSnsMetadata = IDL.Record({
     'url' : IDL.Opt(IDL.Text),
     'logo' : IDL.Opt(IDL.Text),
@@ -690,6 +706,9 @@ export const init = ({ IDL }) => {
   const ExecuteGenericNervousSystemFunction = IDL.Record({
     'function_id' : IDL.Nat64,
     'payload' : IDL.Vec(IDL.Nat8),
+  });
+  const ManageLedgerParameters = IDL.Record({
+    'transfer_fee' : IDL.Opt(IDL.Nat64),
   });
   const Motion = IDL.Record({ 'motion_text' : IDL.Text });
   const Action = IDL.Variant({
@@ -701,9 +720,11 @@ export const init = ({ IDL }) => {
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
     'UpgradeSnsControlledCanister' : UpgradeSnsControlledCanister,
     'DeregisterDappCanisters' : DeregisterDappCanisters,
+    'MintSnsTokens' : MintSnsTokens,
     'Unspecified' : IDL.Record({}),
     'ManageSnsMetadata' : ManageSnsMetadata,
     'ExecuteGenericNervousSystemFunction' : ExecuteGenericNervousSystemFunction,
+    'ManageLedgerParameters' : ManageLedgerParameters,
     'Motion' : Motion,
   });
   const Proposal = IDL.Record({
@@ -830,6 +851,7 @@ export const init = ({ IDL }) => {
     'timestamp_of_disbursement_seconds' : IDL.Nat64,
     'amount_e8s' : IDL.Nat64,
     'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
   const Neuron = IDL.Record({
     'id' : IDL.Opt(NeuronId),

--- a/packages/sns/candid/sns_governance_test.certified.idl.js
+++ b/packages/sns/candid/sns_governance_test.certified.idl.js
@@ -94,7 +94,6 @@ export const idlFactory = ({ IDL }) => {
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
     'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
-    'total_available_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'distributed_e8s_equivalent' : IDL.Nat64,
     'round' : IDL.Nat64,
     'settled_proposals' : IDL.Vec(ProposalId),
@@ -142,6 +141,12 @@ export const idlFactory = ({ IDL }) => {
     'canister_ids' : IDL.Vec(IDL.Principal),
     'new_controllers' : IDL.Vec(IDL.Principal),
   });
+  const MintSnsTokens = IDL.Record({
+    'to_principal' : IDL.Opt(IDL.Principal),
+    'to_subaccount' : IDL.Opt(Subaccount),
+    'memo' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const ManageSnsMetadata = IDL.Record({
     'url' : IDL.Opt(IDL.Text),
     'logo' : IDL.Opt(IDL.Text),
@@ -151,6 +156,9 @@ export const idlFactory = ({ IDL }) => {
   const ExecuteGenericNervousSystemFunction = IDL.Record({
     'function_id' : IDL.Nat64,
     'payload' : IDL.Vec(IDL.Nat8),
+  });
+  const ManageLedgerParameters = IDL.Record({
+    'transfer_fee' : IDL.Opt(IDL.Nat64),
   });
   const Motion = IDL.Record({ 'motion_text' : IDL.Text });
   const Action = IDL.Variant({
@@ -162,9 +170,11 @@ export const idlFactory = ({ IDL }) => {
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
     'UpgradeSnsControlledCanister' : UpgradeSnsControlledCanister,
     'DeregisterDappCanisters' : DeregisterDappCanisters,
+    'MintSnsTokens' : MintSnsTokens,
     'Unspecified' : IDL.Record({}),
     'ManageSnsMetadata' : ManageSnsMetadata,
     'ExecuteGenericNervousSystemFunction' : ExecuteGenericNervousSystemFunction,
+    'ManageLedgerParameters' : ManageLedgerParameters,
     'Motion' : Motion,
   });
   const Proposal = IDL.Record({
@@ -291,6 +301,7 @@ export const idlFactory = ({ IDL }) => {
     'timestamp_of_disbursement_seconds' : IDL.Nat64,
     'amount_e8s' : IDL.Nat64,
     'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
   const Neuron = IDL.Record({
     'id' : IDL.Opt(NeuronId),
@@ -639,7 +650,6 @@ export const init = ({ IDL }) => {
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
     'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
-    'total_available_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'distributed_e8s_equivalent' : IDL.Nat64,
     'round' : IDL.Nat64,
     'settled_proposals' : IDL.Vec(ProposalId),
@@ -687,6 +697,12 @@ export const init = ({ IDL }) => {
     'canister_ids' : IDL.Vec(IDL.Principal),
     'new_controllers' : IDL.Vec(IDL.Principal),
   });
+  const MintSnsTokens = IDL.Record({
+    'to_principal' : IDL.Opt(IDL.Principal),
+    'to_subaccount' : IDL.Opt(Subaccount),
+    'memo' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const ManageSnsMetadata = IDL.Record({
     'url' : IDL.Opt(IDL.Text),
     'logo' : IDL.Opt(IDL.Text),
@@ -696,6 +712,9 @@ export const init = ({ IDL }) => {
   const ExecuteGenericNervousSystemFunction = IDL.Record({
     'function_id' : IDL.Nat64,
     'payload' : IDL.Vec(IDL.Nat8),
+  });
+  const ManageLedgerParameters = IDL.Record({
+    'transfer_fee' : IDL.Opt(IDL.Nat64),
   });
   const Motion = IDL.Record({ 'motion_text' : IDL.Text });
   const Action = IDL.Variant({
@@ -707,9 +726,11 @@ export const init = ({ IDL }) => {
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
     'UpgradeSnsControlledCanister' : UpgradeSnsControlledCanister,
     'DeregisterDappCanisters' : DeregisterDappCanisters,
+    'MintSnsTokens' : MintSnsTokens,
     'Unspecified' : IDL.Record({}),
     'ManageSnsMetadata' : ManageSnsMetadata,
     'ExecuteGenericNervousSystemFunction' : ExecuteGenericNervousSystemFunction,
+    'ManageLedgerParameters' : ManageLedgerParameters,
     'Motion' : Motion,
   });
   const Proposal = IDL.Record({
@@ -836,6 +857,7 @@ export const init = ({ IDL }) => {
     'timestamp_of_disbursement_seconds' : IDL.Nat64,
     'amount_e8s' : IDL.Nat64,
     'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
   const Neuron = IDL.Record({
     'id' : IDL.Opt(NeuronId),

--- a/packages/sns/candid/sns_governance_test.d.ts
+++ b/packages/sns/candid/sns_governance_test.d.ts
@@ -16,11 +16,13 @@ export type Action =
   | { TransferSnsTreasuryFunds: TransferSnsTreasuryFunds }
   | { UpgradeSnsControlledCanister: UpgradeSnsControlledCanister }
   | { DeregisterDappCanisters: DeregisterDappCanisters }
+  | { MintSnsTokens: MintSnsTokens }
   | { Unspecified: {} }
   | { ManageSnsMetadata: ManageSnsMetadata }
   | {
       ExecuteGenericNervousSystemFunction: ExecuteGenericNervousSystemFunction;
     }
+  | { ManageLedgerParameters: ManageLedgerParameters }
   | { Motion: Motion };
 export interface AddMaturityRequest {
   id: [] | [NeuronId];
@@ -144,6 +146,7 @@ export interface DisburseMaturityInProgress {
   timestamp_of_disbursement_seconds: bigint;
   amount_e8s: bigint;
   account_to_disburse_to: [] | [Account];
+  finalize_disbursement_timestamp_seconds: [] | [bigint];
 }
 export interface DisburseMaturityResponse {
   amount_disbursed_e8s: bigint;
@@ -276,6 +279,9 @@ export interface ListProposals {
 export interface ListProposalsResponse {
   proposals: Array<ProposalData>;
 }
+export interface ManageLedgerParameters {
+  transfer_fee: [] | [bigint];
+}
 export interface ManageNeuron {
   subaccount: Uint8Array | number[];
   command: [] | [Command];
@@ -303,6 +309,12 @@ export interface MergeMaturity {
 export interface MergeMaturityResponse {
   merged_maturity_e8s: bigint;
   new_stake_e8s: bigint;
+}
+export interface MintSnsTokens {
+  to_principal: [] | [Principal];
+  to_subaccount: [] | [Subaccount];
+  memo: [] | [bigint];
+  amount_e8s: [] | [bigint];
 }
 export interface MintTokensRequest {
   recipient: [] | [Account];
@@ -439,7 +451,6 @@ export interface RewardEvent {
   rounds_since_last_distribution: [] | [bigint];
   actual_timestamp_seconds: bigint;
   end_timestamp_seconds: [] | [bigint];
-  total_available_e8s_equivalent: [] | [bigint];
   distributed_e8s_equivalent: bigint;
   round: bigint;
   settled_proposals: Array<ProposalId>;

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 57f0e39e3 (2023-11-22) 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 826f954658 (2024-01-22) 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
@@ -9,9 +9,11 @@ type Action = variant {
   TransferSnsTreasuryFunds : TransferSnsTreasuryFunds;
   UpgradeSnsControlledCanister : UpgradeSnsControlledCanister;
   DeregisterDappCanisters : DeregisterDappCanisters;
+  MintSnsTokens : MintSnsTokens;
   Unspecified : record {};
   ManageSnsMetadata : ManageSnsMetadata;
   ExecuteGenericNervousSystemFunction : ExecuteGenericNervousSystemFunction;
+  ManageLedgerParameters : ManageLedgerParameters;
   Motion : Motion;
 };
 type AddMaturityRequest = record { id : opt NeuronId; amount_e8s : opt nat64 };
@@ -117,6 +119,7 @@ type DisburseMaturityInProgress = record {
   timestamp_of_disbursement_seconds : nat64;
   amount_e8s : nat64;
   account_to_disburse_to : opt Account;
+  finalize_disbursement_timestamp_seconds : opt nat64;
 };
 type DisburseMaturityResponse = record {
   amount_disbursed_e8s : nat64;
@@ -227,6 +230,7 @@ type ListProposals = record {
   include_status : vec int32;
 };
 type ListProposalsResponse = record { proposals : vec ProposalData };
+type ManageLedgerParameters = record { transfer_fee : opt nat64 };
 type ManageNeuron = record { subaccount : vec nat8; command : opt Command };
 type ManageNeuronResponse = record { command : opt Command_1 };
 type ManageSnsMetadata = record {
@@ -244,6 +248,12 @@ type MergeMaturity = record { percentage_to_merge : nat32 };
 type MergeMaturityResponse = record {
   merged_maturity_e8s : nat64;
   new_stake_e8s : nat64;
+};
+type MintSnsTokens = record {
+  to_principal : opt principal;
+  to_subaccount : opt Subaccount;
+  memo : opt nat64;
+  amount_e8s : opt nat64;
 };
 type MintTokensRequest = record {
   recipient : opt Account;
@@ -364,7 +374,6 @@ type RewardEvent = record {
   rounds_since_last_distribution : opt nat64;
   actual_timestamp_seconds : nat64;
   end_timestamp_seconds : opt nat64;
-  total_available_e8s_equivalent : opt nat64;
   distributed_e8s_equivalent : nat64;
   round : nat64;
   settled_proposals : vec ProposalId;

--- a/packages/sns/candid/sns_governance_test.idl.js
+++ b/packages/sns/candid/sns_governance_test.idl.js
@@ -94,7 +94,6 @@ export const idlFactory = ({ IDL }) => {
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
     'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
-    'total_available_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'distributed_e8s_equivalent' : IDL.Nat64,
     'round' : IDL.Nat64,
     'settled_proposals' : IDL.Vec(ProposalId),
@@ -142,6 +141,12 @@ export const idlFactory = ({ IDL }) => {
     'canister_ids' : IDL.Vec(IDL.Principal),
     'new_controllers' : IDL.Vec(IDL.Principal),
   });
+  const MintSnsTokens = IDL.Record({
+    'to_principal' : IDL.Opt(IDL.Principal),
+    'to_subaccount' : IDL.Opt(Subaccount),
+    'memo' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const ManageSnsMetadata = IDL.Record({
     'url' : IDL.Opt(IDL.Text),
     'logo' : IDL.Opt(IDL.Text),
@@ -151,6 +156,9 @@ export const idlFactory = ({ IDL }) => {
   const ExecuteGenericNervousSystemFunction = IDL.Record({
     'function_id' : IDL.Nat64,
     'payload' : IDL.Vec(IDL.Nat8),
+  });
+  const ManageLedgerParameters = IDL.Record({
+    'transfer_fee' : IDL.Opt(IDL.Nat64),
   });
   const Motion = IDL.Record({ 'motion_text' : IDL.Text });
   const Action = IDL.Variant({
@@ -162,9 +170,11 @@ export const idlFactory = ({ IDL }) => {
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
     'UpgradeSnsControlledCanister' : UpgradeSnsControlledCanister,
     'DeregisterDappCanisters' : DeregisterDappCanisters,
+    'MintSnsTokens' : MintSnsTokens,
     'Unspecified' : IDL.Record({}),
     'ManageSnsMetadata' : ManageSnsMetadata,
     'ExecuteGenericNervousSystemFunction' : ExecuteGenericNervousSystemFunction,
+    'ManageLedgerParameters' : ManageLedgerParameters,
     'Motion' : Motion,
   });
   const Proposal = IDL.Record({
@@ -291,6 +301,7 @@ export const idlFactory = ({ IDL }) => {
     'timestamp_of_disbursement_seconds' : IDL.Nat64,
     'amount_e8s' : IDL.Nat64,
     'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
   const Neuron = IDL.Record({
     'id' : IDL.Opt(NeuronId),
@@ -647,7 +658,6 @@ export const init = ({ IDL }) => {
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
     'end_timestamp_seconds' : IDL.Opt(IDL.Nat64),
-    'total_available_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'distributed_e8s_equivalent' : IDL.Nat64,
     'round' : IDL.Nat64,
     'settled_proposals' : IDL.Vec(ProposalId),
@@ -695,6 +705,12 @@ export const init = ({ IDL }) => {
     'canister_ids' : IDL.Vec(IDL.Principal),
     'new_controllers' : IDL.Vec(IDL.Principal),
   });
+  const MintSnsTokens = IDL.Record({
+    'to_principal' : IDL.Opt(IDL.Principal),
+    'to_subaccount' : IDL.Opt(Subaccount),
+    'memo' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+  });
   const ManageSnsMetadata = IDL.Record({
     'url' : IDL.Opt(IDL.Text),
     'logo' : IDL.Opt(IDL.Text),
@@ -704,6 +720,9 @@ export const init = ({ IDL }) => {
   const ExecuteGenericNervousSystemFunction = IDL.Record({
     'function_id' : IDL.Nat64,
     'payload' : IDL.Vec(IDL.Nat8),
+  });
+  const ManageLedgerParameters = IDL.Record({
+    'transfer_fee' : IDL.Opt(IDL.Nat64),
   });
   const Motion = IDL.Record({ 'motion_text' : IDL.Text });
   const Action = IDL.Variant({
@@ -715,9 +734,11 @@ export const init = ({ IDL }) => {
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
     'UpgradeSnsControlledCanister' : UpgradeSnsControlledCanister,
     'DeregisterDappCanisters' : DeregisterDappCanisters,
+    'MintSnsTokens' : MintSnsTokens,
     'Unspecified' : IDL.Record({}),
     'ManageSnsMetadata' : ManageSnsMetadata,
     'ExecuteGenericNervousSystemFunction' : ExecuteGenericNervousSystemFunction,
+    'ManageLedgerParameters' : ManageLedgerParameters,
     'Motion' : Motion,
   });
   const Proposal = IDL.Record({
@@ -844,6 +865,7 @@ export const init = ({ IDL }) => {
     'timestamp_of_disbursement_seconds' : IDL.Nat64,
     'amount_e8s' : IDL.Nat64,
     'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
   const Neuron = IDL.Record({
     'id' : IDL.Opt(NeuronId),

--- a/packages/sns/candid/sns_root.certified.idl.js
+++ b/packages/sns/candid/sns_root.certified.idl.js
@@ -31,23 +31,12 @@ export const idlFactory = ({ IDL }) => {
     'upgrade' : IDL.Null,
     'install' : IDL.Null,
   });
-  const AuthzChangeOp = IDL.Variant({
-    'Authorize' : IDL.Record({ 'add_self' : IDL.Bool }),
-    'Deauthorize' : IDL.Null,
-  });
-  const MethodAuthzChange = IDL.Record({
-    'principal' : IDL.Opt(IDL.Principal),
-    'method_name' : IDL.Text,
-    'canister' : IDL.Principal,
-    'operation' : AuthzChangeOp,
-  });
-  const ChangeCanisterProposal = IDL.Record({
+  const ChangeCanisterRequest = IDL.Record({
     'arg' : IDL.Vec(IDL.Nat8),
     'wasm_module' : IDL.Vec(IDL.Nat8),
     'stop_before_installing' : IDL.Bool,
     'mode' : CanisterInstallMode,
     'canister_id' : IDL.Principal,
-    'authz_changes' : IDL.Vec(MethodAuthzChange),
     '_allocation' : IDL.Opt(IDL.Nat),
     'memory_allocation' : IDL.Opt(IDL.Nat),
     'compute_allocation' : IDL.Opt(IDL.Nat),
@@ -118,7 +107,7 @@ export const idlFactory = ({ IDL }) => {
         [CanisterStatusResult],
         [],
       ),
-    'change_canister' : IDL.Func([ChangeCanisterProposal], [], []),
+    'change_canister' : IDL.Func([ChangeCanisterRequest], [], []),
     'get_build_metadata' : IDL.Func([], [IDL.Text], []),
     'get_sns_canisters_summary' : IDL.Func(
         [GetSnsCanistersSummaryRequest],

--- a/packages/sns/candid/sns_root.d.ts
+++ b/packages/sns/candid/sns_root.d.ts
@@ -1,9 +1,6 @@
 import type { ActorMethod } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 
-export type AuthzChangeOp =
-  | { Authorize: { add_self: boolean } }
-  | { Deauthorize: null };
 export interface CanisterCallError {
   code: [] | [number];
   description: string;
@@ -38,14 +35,13 @@ export interface CanisterSummary {
   status: [] | [CanisterStatusResultV2];
   canister_id: [] | [Principal];
 }
-export interface ChangeCanisterProposal {
+export interface ChangeCanisterRequest {
   arg: Uint8Array | number[];
   wasm_module: Uint8Array | number[];
   stop_before_installing: boolean;
   mode: CanisterInstallMode;
   canister_id: Principal;
   query_allocation: [] | [bigint];
-  authz_changes: Array<MethodAuthzChange>;
   memory_allocation: [] | [bigint];
   compute_allocation: [] | [bigint];
 }
@@ -83,12 +79,6 @@ export interface ListSnsCanistersResponse {
   dapps: Array<Principal>;
   archives: Array<Principal>;
 }
-export interface MethodAuthzChange {
-  principal: [] | [Principal];
-  method_name: string;
-  canister: Principal;
-  operation: AuthzChangeOp;
-}
 export interface RegisterDappCanisterRequest {
   canister_id: [] | [Principal];
 }
@@ -114,7 +104,7 @@ export interface SnsRootCanister {
 }
 export interface _SERVICE {
   canister_status: ActorMethod<[CanisterIdRecord], CanisterStatusResult>;
-  change_canister: ActorMethod<[ChangeCanisterProposal], undefined>;
+  change_canister: ActorMethod<[ChangeCanisterRequest], undefined>;
   get_build_metadata: ActorMethod<[], string>;
   get_sns_canisters_summary: ActorMethod<
     [GetSnsCanistersSummaryRequest],

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,8 +1,4 @@
-// Generated from IC repo commit dd51544944987556c978e774aa7a1992e5c11542 'rs/sns/root/canister/root.did' by import-candid
-type AuthzChangeOp = variant {
-  Authorize : record { add_self : bool };
-  Deauthorize;
-};
+// Generated from IC repo commit 826f954658 (2024-01-22) 'rs/sns/root/canister/root.did' by import-candid
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterIdRecord = record { canister_id : principal };
 type CanisterInstallMode = variant { reinstall; upgrade; install };
@@ -26,14 +22,13 @@ type CanisterSummary = record {
   status : opt CanisterStatusResultV2;
   canister_id : opt principal;
 };
-type ChangeCanisterProposal = record {
+type ChangeCanisterRequest = record {
   arg : vec nat8;
   wasm_module : vec nat8;
   stop_before_installing : bool;
   mode : CanisterInstallMode;
   canister_id : principal;
   query_allocation : opt nat;
-  authz_changes : vec MethodAuthzChange;
   memory_allocation : opt nat;
   compute_allocation : opt nat;
 };
@@ -67,12 +62,6 @@ type ListSnsCanistersResponse = record {
   dapps : vec principal;
   archives : vec principal;
 };
-type MethodAuthzChange = record {
-  "principal" : opt principal;
-  method_name : text;
-  canister : principal;
-  operation : AuthzChangeOp;
-};
 type RegisterDappCanisterRequest = record { canister_id : opt principal };
 type RegisterDappCanistersRequest = record { canister_ids : vec principal };
 type SetDappControllersRequest = record {
@@ -92,7 +81,7 @@ type SnsRootCanister = record {
 };
 service : (SnsRootCanister) -> {
   canister_status : (CanisterIdRecord) -> (CanisterStatusResult);
-  change_canister : (ChangeCanisterProposal) -> ();
+  change_canister : (ChangeCanisterRequest) -> ();
   get_build_metadata : () -> (text) query;
   get_sns_canisters_summary : (GetSnsCanistersSummaryRequest) -> (
       GetSnsCanistersSummaryResponse,

--- a/packages/sns/candid/sns_root.idl.js
+++ b/packages/sns/candid/sns_root.idl.js
@@ -31,24 +31,13 @@ export const idlFactory = ({ IDL }) => {
     'upgrade' : IDL.Null,
     'install' : IDL.Null,
   });
-  const AuthzChangeOp = IDL.Variant({
-    'Authorize' : IDL.Record({ 'add_self' : IDL.Bool }),
-    'Deauthorize' : IDL.Null,
-  });
-  const MethodAuthzChange = IDL.Record({
-    'principal' : IDL.Opt(IDL.Principal),
-    'method_name' : IDL.Text,
-    'canister' : IDL.Principal,
-    'operation' : AuthzChangeOp,
-  });
-  const ChangeCanisterProposal = IDL.Record({
+  const ChangeCanisterRequest = IDL.Record({
     'arg' : IDL.Vec(IDL.Nat8),
     'wasm_module' : IDL.Vec(IDL.Nat8),
     'stop_before_installing' : IDL.Bool,
     'mode' : CanisterInstallMode,
     'canister_id' : IDL.Principal,
     'query_allocation' : IDL.Opt(IDL.Nat),
-    'authz_changes' : IDL.Vec(MethodAuthzChange),
     'memory_allocation' : IDL.Opt(IDL.Nat),
     'compute_allocation' : IDL.Opt(IDL.Nat),
   });
@@ -118,7 +107,7 @@ export const idlFactory = ({ IDL }) => {
         [CanisterStatusResult],
         [],
       ),
-    'change_canister' : IDL.Func([ChangeCanisterProposal], [], []),
+    'change_canister' : IDL.Func([ChangeCanisterRequest], [], []),
     'get_build_metadata' : IDL.Func([], [IDL.Text], ['query']),
     'get_sns_canisters_summary' : IDL.Func(
         [GetSnsCanistersSummaryRequest],

--- a/packages/sns/candid/sns_swap.certified.idl.js
+++ b/packages/sns/candid/sns_swap.certified.idl.js
@@ -11,10 +11,16 @@ export const idlFactory = ({ IDL }) => {
     'slope_denominator' : IDL.Opt(IDL.Nat64),
     'to_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
+  const IdealMatchedParticipationFunction = IDL.Record({
+    'serialized_representation' : IDL.Opt(IDL.Text),
+  });
   const NeuronsFundParticipationConstraints = IDL.Record({
     'coefficient_intervals' : IDL.Vec(LinearScalingCoefficient),
     'max_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'min_direct_participation_threshold_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'ideal_matched_participation_function' : IDL.Opt(
+      IdealMatchedParticipationFunction
+    ),
   });
   const CfNeuron = IDL.Record({
     'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
@@ -89,6 +95,13 @@ export const idlFactory = ({ IDL }) => {
   const SetDappControllersCallResult = IDL.Record({
     'possibility' : IDL.Opt(Possibility),
   });
+  const SweepResult = IDL.Record({
+    'failure' : IDL.Nat32,
+    'skipped' : IDL.Nat32,
+    'invalid' : IDL.Nat32,
+    'success' : IDL.Nat32,
+    'global_failures' : IDL.Nat32,
+  });
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
@@ -103,26 +116,32 @@ export const idlFactory = ({ IDL }) => {
   const SettleCommunityFundParticipationResult = IDL.Record({
     'possibility' : IDL.Opt(Possibility_1),
   });
-  const Possibility_2 = IDL.Variant({
+  const Ok_1 = IDL.Record({
+    'neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'neurons_fund_neurons_count' : IDL.Opt(IDL.Nat64),
+  });
+  const Error = IDL.Record({ 'message' : IDL.Opt(IDL.Text) });
+  const Possibility_2 = IDL.Variant({ 'Ok' : Ok_1, 'Err' : Error });
+  const SettleNeuronsFundParticipationResult = IDL.Record({
+    'possibility' : IDL.Opt(Possibility_2),
+  });
+  const Possibility_3 = IDL.Variant({
     'Ok' : IDL.Record({}),
     'Err' : CanisterCallError,
   });
   const SetModeCallResult = IDL.Record({
-    'possibility' : IDL.Opt(Possibility_2),
-  });
-  const SweepResult = IDL.Record({
-    'failure' : IDL.Nat32,
-    'skipped' : IDL.Nat32,
-    'invalid' : IDL.Nat32,
-    'success' : IDL.Nat32,
-    'global_failures' : IDL.Nat32,
+    'possibility' : IDL.Opt(Possibility_3),
   });
   const FinalizeSwapResponse = IDL.Record({
     'set_dapp_controllers_call_result' : IDL.Opt(SetDappControllersCallResult),
+    'create_sns_neuron_recipes_result' : IDL.Opt(SweepResult),
     'settle_community_fund_participation_result' : IDL.Opt(
       SettleCommunityFundParticipationResult
     ),
     'error_message' : IDL.Opt(IDL.Text),
+    'settle_neurons_fund_participation_result' : IDL.Opt(
+      SettleNeuronsFundParticipationResult
+    ),
     'set_mode_call_result' : IDL.Opt(SetModeCallResult),
     'sweep_icp_result' : IDL.Opt(SweepResult),
     'claim_neuron_result' : IDL.Opt(SweepResult),
@@ -183,6 +202,7 @@ export const idlFactory = ({ IDL }) => {
   const GetLifecycleResponse = IDL.Record({
     'decentralization_sale_open_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'lifecycle' : IDL.Opt(IDL.Int32),
+    'decentralization_swap_termination_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
   const Icrc1Account = IDL.Record({
     'owner' : IDL.Opt(IDL.Principal),
@@ -194,9 +214,9 @@ export const idlFactory = ({ IDL }) => {
     'account' : IDL.Opt(Icrc1Account),
     'amount_icp_e8s' : IDL.Nat64,
   });
-  const Ok_1 = IDL.Record({ 'ticket' : IDL.Opt(Ticket) });
+  const Ok_2 = IDL.Record({ 'ticket' : IDL.Opt(Ticket) });
   const Err_1 = IDL.Record({ 'error_type' : IDL.Opt(IDL.Int32) });
-  const Result_1 = IDL.Variant({ 'Ok' : Ok_1, 'Err' : Err_1 });
+  const Result_1 = IDL.Variant({ 'Ok' : Ok_2, 'Err' : Err_1 });
   const GetOpenTicketResponse = IDL.Record({ 'result' : IDL.Opt(Result_1) });
   const Params = IDL.Record({
     'min_participant_icp_e8s' : IDL.Nat64,
@@ -251,6 +271,7 @@ export const idlFactory = ({ IDL }) => {
     'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'lifecycle' : IDL.Int32,
     'purge_old_tickets_next_principal' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'decentralization_swap_termination_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'buyers' : IDL.Vec(IDL.Tuple(IDL.Text, BuyerState)),
     'params' : IDL.Opt(Params),
     'open_sns_token_swap_proposal_id' : IDL.Opt(IDL.Nat64),
@@ -303,7 +324,7 @@ export const idlFactory = ({ IDL }) => {
     'existing_ticket' : IDL.Opt(Ticket),
     'error_type' : IDL.Int32,
   });
-  const Result_2 = IDL.Variant({ 'Ok' : Ok_1, 'Err' : Err_2 });
+  const Result_2 = IDL.Variant({ 'Ok' : Ok_2, 'Err' : Err_2 });
   const NewSaleTicketResponse = IDL.Record({ 'result' : IDL.Opt(Result_2) });
   const OpenRequest = IDL.Record({
     'cf_participants' : IDL.Vec(CfParticipant),
@@ -379,7 +400,7 @@ export const idlFactory = ({ IDL }) => {
         [NewSaleTicketResponse],
         [],
       ),
-    'notify_payment_failure' : IDL.Func([IDL.Record({})], [Ok_1], []),
+    'notify_payment_failure' : IDL.Func([IDL.Record({})], [Ok_2], []),
     'open' : IDL.Func([OpenRequest], [IDL.Record({})], []),
     'refresh_buyer_tokens' : IDL.Func(
         [RefreshBuyerTokensRequest],
@@ -405,10 +426,16 @@ export const init = ({ IDL }) => {
     'slope_denominator' : IDL.Opt(IDL.Nat64),
     'to_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
+  const IdealMatchedParticipationFunction = IDL.Record({
+    'serialized_representation' : IDL.Opt(IDL.Text),
+  });
   const NeuronsFundParticipationConstraints = IDL.Record({
     'coefficient_intervals' : IDL.Vec(LinearScalingCoefficient),
     'max_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'min_direct_participation_threshold_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'ideal_matched_participation_function' : IDL.Opt(
+      IdealMatchedParticipationFunction
+    ),
   });
   const CfNeuron = IDL.Record({
     'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),

--- a/packages/sns/candid/sns_swap.d.ts
+++ b/packages/sns/candid/sns_swap.d.ts
@@ -67,6 +67,9 @@ export interface Err_2 {
   existing_ticket: [] | [Ticket];
   error_type: number;
 }
+export interface Error {
+  message: [] | [string];
+}
 export interface ErrorRefundIcpRequest {
   source_principal_id: [] | [Principal];
 }
@@ -79,10 +82,14 @@ export interface FailedUpdate {
 }
 export interface FinalizeSwapResponse {
   set_dapp_controllers_call_result: [] | [SetDappControllersCallResult];
+  create_sns_neuron_recipes_result: [] | [SweepResult];
   settle_community_fund_participation_result:
     | []
     | [SettleCommunityFundParticipationResult];
   error_message: [] | [string];
+  settle_neurons_fund_participation_result:
+    | []
+    | [SettleNeuronsFundParticipationResult];
   set_mode_call_result: [] | [SetModeCallResult];
   sweep_icp_result: [] | [SweepResult];
   claim_neuron_result: [] | [SweepResult];
@@ -117,6 +124,7 @@ export interface GetInitResponse {
 export interface GetLifecycleResponse {
   decentralization_sale_open_timestamp_seconds: [] | [bigint];
   lifecycle: [] | [number];
+  decentralization_swap_termination_timestamp_seconds: [] | [bigint];
 }
 export interface GetOpenTicketResponse {
   result: [] | [Result_1];
@@ -135,6 +143,9 @@ export interface GovernanceError {
 export interface Icrc1Account {
   owner: [] | [Principal];
   subaccount: [] | [Uint8Array | number[]];
+}
+export interface IdealMatchedParticipationFunction {
+  serialized_representation: [] | [string];
 }
 export interface Init {
   nns_proposal_id: [] | [bigint];
@@ -219,6 +230,9 @@ export interface NeuronsFundParticipationConstraints {
   coefficient_intervals: Array<LinearScalingCoefficient>;
   max_neurons_fund_participation_icp_e8s: [] | [bigint];
   min_direct_participation_threshold_icp_e8s: [] | [bigint];
+  ideal_matched_participation_function:
+    | []
+    | [IdealMatchedParticipationFunction];
 }
 export interface NewSaleTicketRequest {
   subaccount: [] | [Uint8Array | number[]];
@@ -231,6 +245,10 @@ export interface Ok {
   block_height: [] | [bigint];
 }
 export interface Ok_1 {
+  neurons_fund_participation_icp_e8s: [] | [bigint];
+  neurons_fund_neurons_count: [] | [bigint];
+}
+export interface Ok_2 {
   ticket: [] | [Ticket];
 }
 export interface OpenRequest {
@@ -261,7 +279,8 @@ export type Possibility =
   | { Ok: SetDappControllersResponse }
   | { Err: CanisterCallError };
 export type Possibility_1 = { Ok: Response } | { Err: CanisterCallError };
-export type Possibility_2 = { Ok: {} } | { Err: CanisterCallError };
+export type Possibility_2 = { Ok: Ok_1 } | { Err: Error };
+export type Possibility_3 = { Ok: {} } | { Err: CanisterCallError };
 export interface RefreshBuyerTokensRequest {
   confirmation_text: [] | [string];
   buyer: string;
@@ -274,8 +293,8 @@ export interface Response {
   governance_error: [] | [GovernanceError];
 }
 export type Result = { Ok: Ok } | { Err: Err };
-export type Result_1 = { Ok: Ok_1 } | { Err: Err_1 };
-export type Result_2 = { Ok: Ok_1 } | { Err: Err_2 };
+export type Result_1 = { Ok: Ok_2 } | { Err: Err_1 };
+export type Result_2 = { Ok: Ok_2 } | { Err: Err_2 };
 export interface SetDappControllersCallResult {
   possibility: [] | [Possibility];
 }
@@ -283,10 +302,13 @@ export interface SetDappControllersResponse {
   failed_updates: Array<FailedUpdate>;
 }
 export interface SetModeCallResult {
-  possibility: [] | [Possibility_2];
+  possibility: [] | [Possibility_3];
 }
 export interface SettleCommunityFundParticipationResult {
   possibility: [] | [Possibility_1];
+}
+export interface SettleNeuronsFundParticipationResult {
+  possibility: [] | [Possibility_2];
 }
 export interface SnsNeuronRecipe {
   sns: [] | [TransferableAmount];
@@ -308,6 +330,7 @@ export interface Swap {
   direct_participation_icp_e8s: [] | [bigint];
   lifecycle: number;
   purge_old_tickets_next_principal: [] | [Uint8Array | number[]];
+  decentralization_swap_termination_timestamp_seconds: [] | [bigint];
   buyers: Array<[string, BuyerState]>;
   params: [] | [Params];
   open_sns_token_swap_proposal_id: [] | [bigint];
@@ -364,7 +387,7 @@ export interface _SERVICE {
     ListSnsNeuronRecipesResponse
   >;
   new_sale_ticket: ActorMethod<[NewSaleTicketRequest], NewSaleTicketResponse>;
-  notify_payment_failure: ActorMethod<[{}], Ok_1>;
+  notify_payment_failure: ActorMethod<[{}], Ok_2>;
   open: ActorMethod<[OpenRequest], {}>;
   refresh_buyer_tokens: ActorMethod<
     [RefreshBuyerTokensRequest],

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit dd51544944987556c978e774aa7a1992e5c11542 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 826f954658 (2024-01-22) 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;
@@ -47,6 +47,7 @@ type Err_2 = record {
   existing_ticket : opt Ticket;
   error_type : int32;
 };
+type Error = record { message : opt text };
 type ErrorRefundIcpRequest = record { source_principal_id : opt principal };
 type ErrorRefundIcpResponse = record { result : opt Result };
 type FailedUpdate = record {
@@ -55,8 +56,10 @@ type FailedUpdate = record {
 };
 type FinalizeSwapResponse = record {
   set_dapp_controllers_call_result : opt SetDappControllersCallResult;
+  create_sns_neuron_recipes_result : opt SweepResult;
   settle_community_fund_participation_result : opt SettleCommunityFundParticipationResult;
   error_message : opt text;
+  settle_neurons_fund_participation_result : opt SettleNeuronsFundParticipationResult;
   set_mode_call_result : opt SetModeCallResult;
   sweep_icp_result : opt SweepResult;
   claim_neuron_result : opt SweepResult;
@@ -83,12 +86,16 @@ type GetInitResponse = record { init : opt Init };
 type GetLifecycleResponse = record {
   decentralization_sale_open_timestamp_seconds : opt nat64;
   lifecycle : opt int32;
+  decentralization_swap_termination_timestamp_seconds : opt nat64;
 };
 type GetOpenTicketResponse = record { result : opt Result_1 };
 type GetSaleParametersResponse = record { params : opt Params };
 type GetStateResponse = record { swap : opt Swap; derived : opt DerivedState };
 type GovernanceError = record { error_message : text; error_type : int32 };
 type Icrc1Account = record { owner : opt principal; subaccount : opt vec nat8 };
+type IdealMatchedParticipationFunction = record {
+  serialized_representation : opt text;
+};
 type Init = record {
   nns_proposal_id : opt nat64;
   sns_root_canister_id : text;
@@ -163,6 +170,7 @@ type NeuronsFundParticipationConstraints = record {
   coefficient_intervals : vec LinearScalingCoefficient;
   max_neurons_fund_participation_icp_e8s : opt nat64;
   min_direct_participation_threshold_icp_e8s : opt nat64;
+  ideal_matched_participation_function : opt IdealMatchedParticipationFunction;
 };
 type NewSaleTicketRequest = record {
   subaccount : opt vec nat8;
@@ -170,7 +178,11 @@ type NewSaleTicketRequest = record {
 };
 type NewSaleTicketResponse = record { result : opt Result_2 };
 type Ok = record { block_height : opt nat64 };
-type Ok_1 = record { ticket : opt Ticket };
+type Ok_1 = record {
+  neurons_fund_participation_icp_e8s : opt nat64;
+  neurons_fund_neurons_count : opt nat64;
+};
+type Ok_2 = record { ticket : opt Ticket };
 type OpenRequest = record {
   cf_participants : vec CfParticipant;
   params : opt Params;
@@ -198,7 +210,8 @@ type Possibility = variant {
   Err : CanisterCallError;
 };
 type Possibility_1 = variant { Ok : Response; Err : CanisterCallError };
-type Possibility_2 = variant { Ok : record {}; Err : CanisterCallError };
+type Possibility_2 = variant { Ok : Ok_1; Err : Error };
+type Possibility_3 = variant { Ok : record {}; Err : CanisterCallError };
 type RefreshBuyerTokensRequest = record {
   confirmation_text : opt text;
   buyer : text;
@@ -209,13 +222,16 @@ type RefreshBuyerTokensResponse = record {
 };
 type Response = record { governance_error : opt GovernanceError };
 type Result = variant { Ok : Ok; Err : Err };
-type Result_1 = variant { Ok : Ok_1; Err : Err_1 };
-type Result_2 = variant { Ok : Ok_1; Err : Err_2 };
+type Result_1 = variant { Ok : Ok_2; Err : Err_1 };
+type Result_2 = variant { Ok : Ok_2; Err : Err_2 };
 type SetDappControllersCallResult = record { possibility : opt Possibility };
 type SetDappControllersResponse = record { failed_updates : vec FailedUpdate };
-type SetModeCallResult = record { possibility : opt Possibility_2 };
+type SetModeCallResult = record { possibility : opt Possibility_3 };
 type SettleCommunityFundParticipationResult = record {
   possibility : opt Possibility_1;
+};
+type SettleNeuronsFundParticipationResult = record {
+  possibility : opt Possibility_2;
 };
 type SnsNeuronRecipe = record {
   sns : opt TransferableAmount;
@@ -237,6 +253,7 @@ type Swap = record {
   direct_participation_icp_e8s : opt nat64;
   lifecycle : int32;
   purge_old_tickets_next_principal : opt vec nat8;
+  decentralization_swap_termination_timestamp_seconds : opt nat64;
   buyers : vec record { text; BuyerState };
   params : opt Params;
   open_sns_token_swap_proposal_id : opt nat64;
@@ -286,7 +303,7 @@ service : (Init) -> {
       ListSnsNeuronRecipesResponse,
     ) query;
   new_sale_ticket : (NewSaleTicketRequest) -> (NewSaleTicketResponse);
-  notify_payment_failure : (record {}) -> (Ok_1);
+  notify_payment_failure : (record {}) -> (Ok_2);
   open : (OpenRequest) -> (record {});
   refresh_buyer_tokens : (RefreshBuyerTokensRequest) -> (
       RefreshBuyerTokensResponse,

--- a/packages/sns/candid/sns_swap.idl.js
+++ b/packages/sns/candid/sns_swap.idl.js
@@ -11,10 +11,16 @@ export const idlFactory = ({ IDL }) => {
     'slope_denominator' : IDL.Opt(IDL.Nat64),
     'to_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
+  const IdealMatchedParticipationFunction = IDL.Record({
+    'serialized_representation' : IDL.Opt(IDL.Text),
+  });
   const NeuronsFundParticipationConstraints = IDL.Record({
     'coefficient_intervals' : IDL.Vec(LinearScalingCoefficient),
     'max_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'min_direct_participation_threshold_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'ideal_matched_participation_function' : IDL.Opt(
+      IdealMatchedParticipationFunction
+    ),
   });
   const CfNeuron = IDL.Record({
     'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
@@ -89,6 +95,13 @@ export const idlFactory = ({ IDL }) => {
   const SetDappControllersCallResult = IDL.Record({
     'possibility' : IDL.Opt(Possibility),
   });
+  const SweepResult = IDL.Record({
+    'failure' : IDL.Nat32,
+    'skipped' : IDL.Nat32,
+    'invalid' : IDL.Nat32,
+    'success' : IDL.Nat32,
+    'global_failures' : IDL.Nat32,
+  });
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
@@ -103,26 +116,32 @@ export const idlFactory = ({ IDL }) => {
   const SettleCommunityFundParticipationResult = IDL.Record({
     'possibility' : IDL.Opt(Possibility_1),
   });
-  const Possibility_2 = IDL.Variant({
+  const Ok_1 = IDL.Record({
+    'neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'neurons_fund_neurons_count' : IDL.Opt(IDL.Nat64),
+  });
+  const Error = IDL.Record({ 'message' : IDL.Opt(IDL.Text) });
+  const Possibility_2 = IDL.Variant({ 'Ok' : Ok_1, 'Err' : Error });
+  const SettleNeuronsFundParticipationResult = IDL.Record({
+    'possibility' : IDL.Opt(Possibility_2),
+  });
+  const Possibility_3 = IDL.Variant({
     'Ok' : IDL.Record({}),
     'Err' : CanisterCallError,
   });
   const SetModeCallResult = IDL.Record({
-    'possibility' : IDL.Opt(Possibility_2),
-  });
-  const SweepResult = IDL.Record({
-    'failure' : IDL.Nat32,
-    'skipped' : IDL.Nat32,
-    'invalid' : IDL.Nat32,
-    'success' : IDL.Nat32,
-    'global_failures' : IDL.Nat32,
+    'possibility' : IDL.Opt(Possibility_3),
   });
   const FinalizeSwapResponse = IDL.Record({
     'set_dapp_controllers_call_result' : IDL.Opt(SetDappControllersCallResult),
+    'create_sns_neuron_recipes_result' : IDL.Opt(SweepResult),
     'settle_community_fund_participation_result' : IDL.Opt(
       SettleCommunityFundParticipationResult
     ),
     'error_message' : IDL.Opt(IDL.Text),
+    'settle_neurons_fund_participation_result' : IDL.Opt(
+      SettleNeuronsFundParticipationResult
+    ),
     'set_mode_call_result' : IDL.Opt(SetModeCallResult),
     'sweep_icp_result' : IDL.Opt(SweepResult),
     'claim_neuron_result' : IDL.Opt(SweepResult),
@@ -183,6 +202,7 @@ export const idlFactory = ({ IDL }) => {
   const GetLifecycleResponse = IDL.Record({
     'decentralization_sale_open_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'lifecycle' : IDL.Opt(IDL.Int32),
+    'decentralization_swap_termination_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
   const Icrc1Account = IDL.Record({
     'owner' : IDL.Opt(IDL.Principal),
@@ -194,9 +214,9 @@ export const idlFactory = ({ IDL }) => {
     'account' : IDL.Opt(Icrc1Account),
     'amount_icp_e8s' : IDL.Nat64,
   });
-  const Ok_1 = IDL.Record({ 'ticket' : IDL.Opt(Ticket) });
+  const Ok_2 = IDL.Record({ 'ticket' : IDL.Opt(Ticket) });
   const Err_1 = IDL.Record({ 'error_type' : IDL.Opt(IDL.Int32) });
-  const Result_1 = IDL.Variant({ 'Ok' : Ok_1, 'Err' : Err_1 });
+  const Result_1 = IDL.Variant({ 'Ok' : Ok_2, 'Err' : Err_1 });
   const GetOpenTicketResponse = IDL.Record({ 'result' : IDL.Opt(Result_1) });
   const Params = IDL.Record({
     'min_participant_icp_e8s' : IDL.Nat64,
@@ -251,6 +271,7 @@ export const idlFactory = ({ IDL }) => {
     'direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'lifecycle' : IDL.Int32,
     'purge_old_tickets_next_principal' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'decentralization_swap_termination_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'buyers' : IDL.Vec(IDL.Tuple(IDL.Text, BuyerState)),
     'params' : IDL.Opt(Params),
     'open_sns_token_swap_proposal_id' : IDL.Opt(IDL.Nat64),
@@ -303,7 +324,7 @@ export const idlFactory = ({ IDL }) => {
     'existing_ticket' : IDL.Opt(Ticket),
     'error_type' : IDL.Int32,
   });
-  const Result_2 = IDL.Variant({ 'Ok' : Ok_1, 'Err' : Err_2 });
+  const Result_2 = IDL.Variant({ 'Ok' : Ok_2, 'Err' : Err_2 });
   const NewSaleTicketResponse = IDL.Record({ 'result' : IDL.Opt(Result_2) });
   const OpenRequest = IDL.Record({
     'cf_participants' : IDL.Vec(CfParticipant),
@@ -387,7 +408,7 @@ export const idlFactory = ({ IDL }) => {
         [NewSaleTicketResponse],
         [],
       ),
-    'notify_payment_failure' : IDL.Func([IDL.Record({})], [Ok_1], []),
+    'notify_payment_failure' : IDL.Func([IDL.Record({})], [Ok_2], []),
     'open' : IDL.Func([OpenRequest], [IDL.Record({})], []),
     'refresh_buyer_tokens' : IDL.Func(
         [RefreshBuyerTokensRequest],
@@ -413,10 +434,16 @@ export const init = ({ IDL }) => {
     'slope_denominator' : IDL.Opt(IDL.Nat64),
     'to_direct_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
   });
+  const IdealMatchedParticipationFunction = IDL.Record({
+    'serialized_representation' : IDL.Opt(IDL.Text),
+  });
   const NeuronsFundParticipationConstraints = IDL.Record({
     'coefficient_intervals' : IDL.Vec(LinearScalingCoefficient),
     'max_neurons_fund_participation_icp_e8s' : IDL.Opt(IDL.Nat64),
     'min_direct_participation_threshold_icp_e8s' : IDL.Opt(IDL.Nat64),
+    'ideal_matched_participation_function' : IDL.Opt(
+      IdealMatchedParticipationFunction
+    ),
   });
   const CfNeuron = IDL.Record({
     'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),

--- a/packages/sns/src/swap.canister.spec.ts
+++ b/packages/sns/src/swap.canister.spec.ts
@@ -231,6 +231,7 @@ describe("Swap canister", () => {
     const mockResponse: GetLifecycleResponse = {
       decentralization_sale_open_timestamp_seconds: [BigInt(2)],
       lifecycle: [SnsSwapLifecycle.Adopted],
+      decentralization_swap_termination_timestamp_seconds: [],
     };
 
     const service = mock<ActorSubclass<SnsSwapService>>();


### PR DESCRIPTION
# Motivation

Update sns-js candid files so that the bot can update the files without manual intervention.

# Changes

## Automatic Changes

* [First commit](https://github.com/dfinity/ic-js/pull/528/commits/dc20f3445b8ea70c43724a656429c702f33b1f8d): Changes after running "./scripts/import-candid ../ic" and reverting the changes outside the "packages/sns".
* [Second commit](https://github.com/dfinity/ic-js/pull/528/commits/b518b51b2e582b36c3a2e3336f22137c4aa6e869): Changes after running "./scripts/compile-idl-js".

# Tests

## Manual Changes

There was a test failure after the automatic changes in swap.canister.spec: `"should return the lifecycle state of the swap canister"`.

* [Third commit](https://github.com/dfinity/ic-js/pull/528/commits/3f25e9701f7bbe0d6a1b0c4fdb63f0f779e11c1a): Add new field in response of `get_lifecycle`.

# Todos

- [x] Add entry to changelog (if necessary).
