### PR TITLE
Feat: Add `toE8s` to TokenAmountV2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add "API Boundary Node Management" topic support.
 - Add optional field `logo` to `Token` type.
 - Update `sns-js` candid files with new fields in sns canisters.
+- Add public method `toE8s` to `TokenAmountV2`.
 
 ## Breaking changes
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -465,6 +465,7 @@ Represents an amount of tokens.
 - [fromString](#gear-fromstring)
 - [fromNumber](#gear-fromnumber)
 - [toUlps](#gear-toulps)
+- [toE8s](#gear-toe8s)
 
 ##### :gear: fromUlps
 
@@ -524,6 +525,14 @@ Parameters:
 | `toUlps` | `() => bigint` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L322)
+
+##### :gear: toE8s
+
+| Method  | Type           |
+| ------- | -------------- |
+| `toE8s` | `() => bigint` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L330)
 
 ### :factory: Canister
 

--- a/packages/utils/src/parser/token.spec.ts
+++ b/packages/utils/src/parser/token.spec.ts
@@ -347,6 +347,32 @@ describe("TokenAmountV2 with 18 decimals", () => {
       FromStringToTokenError.InvalidFormat,
     );
   });
+
+  it("returns the value in e8s", () => {
+    expect(
+      (
+        TokenAmountV2.fromString({ amount: "2", token }) as TokenAmountV2
+      ).toE8s(),
+    ).toEqual(200_000_000n);
+
+    expect(
+      (
+        TokenAmountV2.fromString({ amount: "0.21", token }) as TokenAmountV2
+      ).toE8s(),
+    ).toEqual(21_000_000n);
+
+    expect(
+      (
+        TokenAmountV2.fromString({ amount: "0.00021", token }) as TokenAmountV2
+      ).toE8s(),
+    ).toEqual(21_000n);
+
+    expect(
+      (
+        TokenAmountV2.fromString({ amount: "2000", token }) as TokenAmountV2
+      ).toE8s(),
+    ).toEqual(200_000_000_000n);
+  });
 });
 
 describe("TokenAmountV2 with 2 decimals", () => {
@@ -392,6 +418,26 @@ describe("TokenAmountV2 with 2 decimals", () => {
         amount: 10000000091n,
       }),
     );
+  });
+
+  it("returns the value in e8s", () => {
+    expect(
+      (
+        TokenAmountV2.fromString({ amount: "2", token }) as TokenAmountV2
+      ).toE8s(),
+    ).toEqual(200_000_000n);
+
+    expect(
+      (
+        TokenAmountV2.fromString({ amount: "0.21", token }) as TokenAmountV2
+      ).toE8s(),
+    ).toEqual(21_000_000n);
+
+    expect(
+      (
+        TokenAmountV2.fromString({ amount: "2000", token }) as TokenAmountV2
+      ).toE8s(),
+    ).toEqual(200_000_000_000n);
   });
 });
 
@@ -471,5 +517,31 @@ describe("TokenAmountV2 with 8 decimals", () => {
     expect(TokenAmountV2.fromNumber({ token: token, amount: 1e-9 })).toEqual(
       TokenAmountV2.fromUlps({ token: token, amount: 0n }),
     );
+  });
+
+  it("returns the value in e8s", () => {
+    expect(
+      (
+        TokenAmountV2.fromString({ amount: "2", token }) as TokenAmountV2
+      ).toE8s(),
+    ).toEqual(200_000_000n);
+
+    expect(
+      (
+        TokenAmountV2.fromString({ amount: "0.21", token }) as TokenAmountV2
+      ).toE8s(),
+    ).toEqual(21_000_000n);
+
+    expect(
+      (
+        TokenAmountV2.fromString({ amount: "0.00021", token }) as TokenAmountV2
+      ).toE8s(),
+    ).toEqual(21_000n);
+
+    expect(
+      (
+        TokenAmountV2.fromString({ amount: "2000", token }) as TokenAmountV2
+      ).toE8s(),
+    ).toEqual(200_000_000_000n);
   });
 });

--- a/packages/utils/src/parser/token.ts
+++ b/packages/utils/src/parser/token.ts
@@ -322,4 +322,18 @@ export class TokenAmountV2 {
   public toUlps(): bigint {
     return this.ulps;
   }
+
+  /**
+   *
+   * @returns The amount of ulps in e8s precision
+   */
+  public toE8s(): bigint {
+    if (this.token.decimals < 8) {
+      return this.ulps * 10n ** BigInt(8 - this.token.decimals);
+    } else if (this.token.decimals === 8) {
+      return this.ulps;
+    } else {
+      return this.ulps / 10n ** BigInt(this.token.decimals - 8);
+    }
+  }
 }


### PR DESCRIPTION
# Motivation

Support formatting e8s for tokens that have different decimals than 8.

# Changes

* Add method `toE8s` to `TokenAmountV2`.

# Tests

* Add tests for new method.

# Todos

- [x] Add entry to changelog (if necessary).
