### PR TITLE
fix: certified IDL factory using keyword "query"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
 
 - Upgrade candid files for cmc canister with new fields `subnet_selection` and `settings`.
 
+## Fix
+
+- Various certified Candid IDL functions had their names trimmed of the keyword "query". 
+
+## Build
+
+- Fixed script to generate certified IDL factory files to respect the keyword "query" when used in functions' names.
+
 # 2024.01.09-1115Z
 
 ## Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ## Fix
 
-- Various certified Candid IDL functions had their names trimmed of the keyword "query". 
+- Various certified Candid IDL functions had their names trimmed of the keyword "query".
 
 ## Build
 

--- a/packages/ckbtc/candid/minter.certified.idl.js
+++ b/packages/ckbtc/candid/minter.certified.idl.js
@@ -39,24 +39,24 @@ export const idlFactory = ({ IDL }) => {
     'stopping' : IDL.Null,
     'running' : IDL.Null,
   });
-  const QueryStats = IDL.Record({
-    'response_payload_bytes_total' : IDL.Nat,
-    'num_instructions_total' : IDL.Nat,
-    'num_calls_total' : IDL.Nat,
-    'request_payload_bytes_total' : IDL.Nat,
-  });
   const DefiniteCanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Nat,
     'controllers' : IDL.Vec(IDL.Principal),
     'memory_allocation' : IDL.Nat,
     'compute_allocation' : IDL.Nat,
   });
+  const QueryStats = IDL.Record({
+    'response_payload_bytes_total' : IDL.Nat,
+    'num_instructions_total' : IDL.Nat,
+    'num_calls_total' : IDL.Nat,
+    'request_payload_bytes_total' : IDL.Nat,
+  });
   const CanisterStatusResponse = IDL.Record({
     'status' : CanisterStatusType,
     'memory_size' : IDL.Nat,
-    '_stats' : QueryStats,
     'cycles' : IDL.Nat,
     'settings' : DefiniteCanisterSettings,
+    'query_stats' : QueryStats,
     'idle_cycles_burned_per_day' : IDL.Nat,
     'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });

--- a/packages/cketh/candid/minter.certified.idl.js
+++ b/packages/cketh/candid/minter.certified.idl.js
@@ -40,24 +40,24 @@ export const idlFactory = ({ IDL }) => {
     'stopping' : IDL.Null,
     'running' : IDL.Null,
   });
-  const QueryStats = IDL.Record({
-    'response_payload_bytes_total' : IDL.Nat,
-    'num_instructions_total' : IDL.Nat,
-    'num_calls_total' : IDL.Nat,
-    'request_payload_bytes_total' : IDL.Nat,
-  });
   const DefiniteCanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Nat,
     'controllers' : IDL.Vec(IDL.Principal),
     'memory_allocation' : IDL.Nat,
     'compute_allocation' : IDL.Nat,
   });
+  const QueryStats = IDL.Record({
+    'response_payload_bytes_total' : IDL.Nat,
+    'num_instructions_total' : IDL.Nat,
+    'num_calls_total' : IDL.Nat,
+    'request_payload_bytes_total' : IDL.Nat,
+  });
   const CanisterStatusResponse = IDL.Record({
     'status' : CanisterStatusType,
     'memory_size' : IDL.Nat,
-    '_stats' : QueryStats,
     'cycles' : IDL.Nat,
     'settings' : DefiniteCanisterSettings,
+    'query_stats' : QueryStats,
     'idle_cycles_burned_per_day' : IDL.Nat,
     'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });

--- a/packages/ic-management/candid/ic-management.certified.idl.js
+++ b/packages/ic-management/candid/ic-management.certified.idl.js
@@ -104,7 +104,11 @@ export const idlFactory = ({ IDL }) => {
   });
   return IDL.Service({
     'bitcoin_get_balance' : IDL.Func([get_balance_request], [satoshi], []),
-    'bitcoin_get_balance_' : IDL.Func([get_balance_request], [satoshi], []),
+    'bitcoin_get_balance_query' : IDL.Func(
+        [get_balance_request],
+        [satoshi],
+        [],
+      ),
     'bitcoin_get_current_fee_percentiles' : IDL.Func(
         [get_current_fee_percentiles_request],
         [IDL.Vec(millisatoshi_per_byte)],
@@ -115,7 +119,7 @@ export const idlFactory = ({ IDL }) => {
         [get_utxos_response],
         [],
       ),
-    'bitcoin_get_utxos_' : IDL.Func(
+    'bitcoin_get_utxos_query' : IDL.Func(
         [get_utxos_request],
         [get_utxos_response],
         [],

--- a/packages/ledger-icp/candid/ledger.certified.idl.js
+++ b/packages/ledger-icp/candid/ledger.certified.idl.js
@@ -42,98 +42,7 @@ export const idlFactory = ({ IDL }) => {
     'Upgrade' : IDL.Opt(UpgradeArgs),
     'Init' : InitArgs,
   });
-  const BlockIndex = IDL.Nat64;
-  const GetBlocksArgs = IDL.Record({
-    'start' : BlockIndex,
-    'length' : IDL.Nat64,
-  });
-  const Memo = IDL.Nat64;
   const AccountIdentifier = IDL.Vec(IDL.Nat8);
-  const TimeStamp = IDL.Record({ 'timestamp_nanos' : IDL.Nat64 });
-  const Operation = IDL.Variant({
-    'Approve' : IDL.Record({
-      'fee' : Tokens,
-      'from' : AccountIdentifier,
-      'allowance_e8s' : IDL.Int,
-      'allowance' : Tokens,
-      'expected_allowance' : IDL.Opt(Tokens),
-      'expires_at' : IDL.Opt(TimeStamp),
-      'spender' : AccountIdentifier,
-    }),
-    'Burn' : IDL.Record({
-      'from' : AccountIdentifier,
-      'amount' : Tokens,
-      'spender' : IDL.Opt(AccountIdentifier),
-    }),
-    'Mint' : IDL.Record({ 'to' : AccountIdentifier, 'amount' : Tokens }),
-    'Transfer' : IDL.Record({
-      'to' : AccountIdentifier,
-      'fee' : Tokens,
-      'from' : AccountIdentifier,
-      'amount' : Tokens,
-      'spender' : IDL.Opt(IDL.Vec(IDL.Nat8)),
-    }),
-  });
-  const Transaction = IDL.Record({
-    'memo' : Memo,
-    'icrc1_memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
-    'operation' : IDL.Opt(Operation),
-    'created_at_time' : TimeStamp,
-  });
-  const Block = IDL.Record({
-    'transaction' : Transaction,
-    'timestamp' : TimeStamp,
-    'parent_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
-  });
-  const BlockRange = IDL.Record({ 'blocks' : IDL.Vec(Block) });
-  const QueryArchiveError = IDL.Variant({
-    'BadFirstBlockIndex' : IDL.Record({
-      'requested_index' : BlockIndex,
-      'first_valid_index' : BlockIndex,
-    }),
-    'Other' : IDL.Record({
-      'error_message' : IDL.Text,
-      'error_code' : IDL.Nat64,
-    }),
-  });
-  const QueryArchiveResult = IDL.Variant({
-    'Ok' : BlockRange,
-    'Err' : QueryArchiveError,
-  });
-  const QueryArchiveFn = IDL.Func([GetBlocksArgs], [QueryArchiveResult], []);
-  const ArchivedBlocksRange = IDL.Record({
-    'callback' : QueryArchiveFn,
-    'start' : BlockIndex,
-    'length' : IDL.Nat64,
-  });
-  const QueryBlocksResponse = IDL.Record({
-    'certificate' : IDL.Opt(IDL.Vec(IDL.Nat8)),
-    'blocks' : IDL.Vec(Block),
-    'chain_length' : IDL.Nat64,
-    'first_block_index' : BlockIndex,
-    'archived_blocks' : IDL.Vec(ArchivedBlocksRange),
-  });
-  const ArchivedEncodedBlocksRange = IDL.Record({
-    'callback' : IDL.Func(
-        [GetBlocksArgs],
-        [
-          IDL.Variant({
-            'Ok' : IDL.Vec(IDL.Vec(IDL.Nat8)),
-            'Err' : QueryArchiveError,
-          }),
-        ],
-        [],
-      ),
-    'start' : IDL.Nat64,
-    'length' : IDL.Nat64,
-  });
-  const QueryEncodedBlocksResponse = IDL.Record({
-    'certificate' : IDL.Opt(IDL.Vec(IDL.Nat8)),
-    'blocks' : IDL.Vec(IDL.Vec(IDL.Nat8)),
-    'chain_length' : IDL.Nat64,
-    'first_block_index' : IDL.Nat64,
-    'archived_blocks' : IDL.Vec(ArchivedEncodedBlocksRange),
-  });
   const AccountBalanceArgs = IDL.Record({ 'account' : AccountIdentifier });
   const AccountBalanceArgsDfx = IDL.Record({
     'account' : TextAccountIdentifier,
@@ -237,6 +146,97 @@ export const idlFactory = ({ IDL }) => {
     'Ok' : Icrc1BlockIndex,
     'Err' : TransferFromError,
   });
+  const BlockIndex = IDL.Nat64;
+  const GetBlocksArgs = IDL.Record({
+    'start' : BlockIndex,
+    'length' : IDL.Nat64,
+  });
+  const Memo = IDL.Nat64;
+  const TimeStamp = IDL.Record({ 'timestamp_nanos' : IDL.Nat64 });
+  const Operation = IDL.Variant({
+    'Approve' : IDL.Record({
+      'fee' : Tokens,
+      'from' : AccountIdentifier,
+      'allowance_e8s' : IDL.Int,
+      'allowance' : Tokens,
+      'expected_allowance' : IDL.Opt(Tokens),
+      'expires_at' : IDL.Opt(TimeStamp),
+      'spender' : AccountIdentifier,
+    }),
+    'Burn' : IDL.Record({
+      'from' : AccountIdentifier,
+      'amount' : Tokens,
+      'spender' : IDL.Opt(AccountIdentifier),
+    }),
+    'Mint' : IDL.Record({ 'to' : AccountIdentifier, 'amount' : Tokens }),
+    'Transfer' : IDL.Record({
+      'to' : AccountIdentifier,
+      'fee' : Tokens,
+      'from' : AccountIdentifier,
+      'amount' : Tokens,
+      'spender' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    }),
+  });
+  const Transaction = IDL.Record({
+    'memo' : Memo,
+    'icrc1_memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'operation' : IDL.Opt(Operation),
+    'created_at_time' : TimeStamp,
+  });
+  const Block = IDL.Record({
+    'transaction' : Transaction,
+    'timestamp' : TimeStamp,
+    'parent_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
+  const BlockRange = IDL.Record({ 'blocks' : IDL.Vec(Block) });
+  const QueryArchiveError = IDL.Variant({
+    'BadFirstBlockIndex' : IDL.Record({
+      'requested_index' : BlockIndex,
+      'first_valid_index' : BlockIndex,
+    }),
+    'Other' : IDL.Record({
+      'error_message' : IDL.Text,
+      'error_code' : IDL.Nat64,
+    }),
+  });
+  const QueryArchiveResult = IDL.Variant({
+    'Ok' : BlockRange,
+    'Err' : QueryArchiveError,
+  });
+  const QueryArchiveFn = IDL.Func([GetBlocksArgs], [QueryArchiveResult], []);
+  const ArchivedBlocksRange = IDL.Record({
+    'callback' : QueryArchiveFn,
+    'start' : BlockIndex,
+    'length' : IDL.Nat64,
+  });
+  const QueryBlocksResponse = IDL.Record({
+    'certificate' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'blocks' : IDL.Vec(Block),
+    'chain_length' : IDL.Nat64,
+    'first_block_index' : BlockIndex,
+    'archived_blocks' : IDL.Vec(ArchivedBlocksRange),
+  });
+  const ArchivedEncodedBlocksRange = IDL.Record({
+    'callback' : IDL.Func(
+        [GetBlocksArgs],
+        [
+          IDL.Variant({
+            'Ok' : IDL.Vec(IDL.Vec(IDL.Nat8)),
+            'Err' : QueryArchiveError,
+          }),
+        ],
+        [],
+      ),
+    'start' : IDL.Nat64,
+    'length' : IDL.Nat64,
+  });
+  const QueryEncodedBlocksResponse = IDL.Record({
+    'certificate' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'blocks' : IDL.Vec(IDL.Vec(IDL.Nat8)),
+    'chain_length' : IDL.Nat64,
+    'first_block_index' : IDL.Nat64,
+    'archived_blocks' : IDL.Vec(ArchivedEncodedBlocksRange),
+  });
   const SendArgs = IDL.Record({
     'to' : TextAccountIdentifier,
     'fee' : Tokens,
@@ -267,12 +267,6 @@ export const idlFactory = ({ IDL }) => {
   const TransferFeeArg = IDL.Record({});
   const TransferFee = IDL.Record({ 'transfer_fee' : Tokens });
   return IDL.Service({
-    '_blocks' : IDL.Func([GetBlocksArgs], [QueryBlocksResponse], []),
-    '_encoded_blocks' : IDL.Func(
-        [GetBlocksArgs],
-        [QueryEncodedBlocksResponse],
-        [],
-      ),
     'account_balance' : IDL.Func([AccountBalanceArgs], [Tokens], []),
     'account_balance_dfx' : IDL.Func([AccountBalanceArgsDfx], [Tokens], []),
     'account_identifier' : IDL.Func([Account], [AccountIdentifier], []),
@@ -300,6 +294,12 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'name' : IDL.Func([], [IDL.Record({ 'name' : IDL.Text })], []),
+    'query_blocks' : IDL.Func([GetBlocksArgs], [QueryBlocksResponse], []),
+    'query_encoded_blocks' : IDL.Func(
+        [GetBlocksArgs],
+        [QueryEncodedBlocksResponse],
+        [],
+      ),
     'send_dfx' : IDL.Func([SendArgs], [BlockIndex], []),
     'symbol' : IDL.Func([], [IDL.Record({ 'symbol' : IDL.Text })], []),
     'transfer' : IDL.Func([TransferArgs], [TransferResult], []),

--- a/packages/sns/candid/sns_root.certified.idl.js
+++ b/packages/sns/candid/sns_root.certified.idl.js
@@ -37,7 +37,7 @@ export const idlFactory = ({ IDL }) => {
     'stop_before_installing' : IDL.Bool,
     'mode' : CanisterInstallMode,
     'canister_id' : IDL.Principal,
-    '_allocation' : IDL.Opt(IDL.Nat),
+    'query_allocation' : IDL.Opt(IDL.Nat),
     'memory_allocation' : IDL.Opt(IDL.Nat),
     'compute_allocation' : IDL.Opt(IDL.Nat),
   });

--- a/scripts/compile-idl-js
+++ b/scripts/compile-idl-js
@@ -58,8 +58,8 @@ compile_certified_did() {
   local jsFactoryFile="$(echo "$didfile" | sed 's/did$/certified.idl.js/g')"
   local tsFactoryFile="$(echo "$didfile" | sed 's/did$/certified.idl.d.ts/g')"
 
-  QUERY_ARG='query'
-  sed "s/$QUERY_ARG//g" "$didfile" >"$certified_didfile"
+  QUERY_ARG='query;'
+  sed "s/$QUERY_ARG/;/g" "$didfile" >"$certified_didfile"
 
   {
     echo "/* Do not edit.  Compiled with ./scripts/compile-idl-js from ${didfile} */"


### PR DESCRIPTION
# Motivation

Few canisters functions are using the keyword "query" in their name - e.g. `fn query_stats()`.

Given that our command line parser to generate the certified IDL JS/TS files optimistically removes the keyword `query`, such functions ended being delivered with trimmed names - e.g. `fn _stats()`.

# Changes

- instead of replacing `query`, replace `query;` given that we want to remove the query keyword of the service function in the did files which always ends with a `;`.
