### PR TITLE
feat: extend retrieveBtcStatusV2ByAccount with optional account param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# XXXX.XX
+
+## Features
+
+- Extend ckBTC `retrieveBtcStatusV2ByAccount` with optional `account` parameter.
+
 # 2024.01.30-1600Z
 
 ## Overview

--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -76,7 +76,7 @@ Parameters:
 
 ### :factory: CkBTCMinterCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L38)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L40)
 
 #### Methods
 
@@ -97,7 +97,7 @@ Parameters:
 | -------- | ------------------------------------------------------------------------ |
 | `create` | `(options: CkBTCMinterCanisterOptions<_SERVICE>) => CkBTCMinterCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L39)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L41)
 
 ##### :gear: getBtcAddress
 
@@ -115,7 +115,7 @@ Parameters:
 - `params.owner`: The owner for which the BTC address should be generated. If not provided, the `caller` will be use instead.
 - `params.subaccount`: An optional subaccount to compute the address.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L60)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L62)
 
 ##### :gear: updateBalance
 
@@ -133,7 +133,7 @@ Parameters:
 - `params.owner`: The owner of the address. If not provided, the `caller` will be use instead.
 - `params.subaccount`: An optional subaccount of the address.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L79)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L81)
 
 ##### :gear: getWithdrawalAccount
 
@@ -143,7 +143,7 @@ Returns the account to which the caller should deposit ckBTC before withdrawing 
 | ---------------------- | ------------------------ |
 | `getWithdrawalAccount` | `() => Promise<Account>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L102)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L104)
 
 ##### :gear: retrieveBtc
 
@@ -167,7 +167,7 @@ Parameters:
 - `params.address`: The bitcoin address.
 - `params.amount`: The ckBTC amount.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L121)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L123)
 
 ##### :gear: retrieveBtcWithApproval
 
@@ -193,7 +193,7 @@ Parameters:
 - `params.fromSubaccount`: An optional subaccount from which
   the ckBTC should be transferred.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L151)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L153)
 
 ##### :gear: retrieveBtcStatus
 
@@ -209,21 +209,22 @@ Parameters:
 - `transactionId`: The ID of the corresponding burn transaction.
 - `certified`: query or update call
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L183)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L185)
 
 ##### :gear: retrieveBtcStatusV2ByAccount
 
-Returns the status of all BTC withdrawals for the user's main account.
+Returns the status of all BTC withdrawals for an account.
 
-| Method                         | Type                                                                                |
-| ------------------------------ | ----------------------------------------------------------------------------------- |
-| `retrieveBtcStatusV2ByAccount` | `({ certified, }: { certified: boolean; }) => Promise<RetrieveBtcStatusV2WithId[]>` |
+| Method                         | Type                                                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `retrieveBtcStatusV2ByAccount` | `({ account, certified, }: RetrieveBtcStatusV2ByAccountParams) => Promise<RetrieveBtcStatusV2WithId[]>` |
 
 Parameters:
 
 - `certified`: query or update call
+- `account`: an optional account to retrieve the statuses. If not provided, statuses for the caller are retrieved.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L200)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L203)
 
 ##### :gear: estimateWithdrawalFee
 
@@ -239,7 +240,7 @@ Parameters:
 - `params.certified`: query or update call
 - `params.amount`: The optional amount for which the fee should be estimated.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L221)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L237)
 
 ##### :gear: getMinterInfo
 
@@ -254,7 +255,7 @@ Parameters:
 - `params`: The parameters to get the deposit fee.
 - `params.certified`: query or update call
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L235)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L251)
 
 <!-- TSDOC_END -->
 

--- a/packages/ckbtc/src/index.ts
+++ b/packages/ckbtc/src/index.ts
@@ -1,4 +1,5 @@
 export type {
+  Account,
   MinterInfo,
   PendingUtxo,
   RetrieveBtcOk,

--- a/packages/ckbtc/src/minter.canister.spec.ts
+++ b/packages/ckbtc/src/minter.canister.spec.ts
@@ -748,6 +748,62 @@ describe("ckBTC minter canister", () => {
       expect(res).toEqual(expectedResponse);
     });
 
+    it("should return statuses for account owner", async () => {
+      const service = mock<ActorSubclass<CkBTCMinterService>>();
+      service.retrieve_btc_status_v2_by_account.mockResolvedValue(response);
+
+      const canister = minter(service);
+
+      const owner = Principal.fromText("aaaaa-aa");
+
+      const account = {
+        owner,
+      };
+
+      const res = await canister.retrieveBtcStatusV2ByAccount({
+        certified: true,
+        account,
+      });
+
+      expect(service.retrieve_btc_status_v2_by_account).toBeCalledTimes(1);
+      expect(service.retrieve_btc_status_v2_by_account).toBeCalledWith([
+        {
+          owner,
+          subaccount: [],
+        },
+      ]);
+      expect(res).toEqual(expectedResponse);
+    });
+
+    it("should return statuses for account with subaccount", async () => {
+      const service = mock<ActorSubclass<CkBTCMinterService>>();
+      service.retrieve_btc_status_v2_by_account.mockResolvedValue(response);
+
+      const canister = minter(service);
+
+      const owner = Principal.fromText("aaaaa-aa");
+      const subaccount = arrayOfNumberToUint8Array([0, 0, 1]);
+
+      const account = {
+        owner,
+        subaccount,
+      };
+
+      const res = await canister.retrieveBtcStatusV2ByAccount({
+        certified: true,
+        account,
+      });
+
+      expect(service.retrieve_btc_status_v2_by_account).toBeCalledTimes(1);
+      expect(service.retrieve_btc_status_v2_by_account).toBeCalledWith([
+        {
+          owner,
+          subaccount: [subaccount],
+        },
+      ]);
+      expect(res).toEqual(expectedResponse);
+    });
+
     it("should use non-certified service", async () => {
       const service = mock<ActorSubclass<CkBTCMinterService>>();
       service.retrieve_btc_status_v2_by_account.mockResolvedValue(response);

--- a/packages/ckbtc/src/types/minter.params.ts
+++ b/packages/ckbtc/src/types/minter.params.ts
@@ -2,10 +2,13 @@ import type { Principal } from "@dfinity/principal";
 import type { QueryParams } from "@dfinity/utils";
 import type { RetrieveBtcArgs } from "../../candid/minter";
 
-export interface MinterParams extends Omit<QueryParams, "certified"> {
-  owner?: Principal;
+export interface MinterAccount {
+  owner: Principal;
   subaccount?: Uint8Array;
 }
+
+export type MinterParams = Omit<QueryParams, "certified"> &
+  Partial<MinterAccount>;
 
 /**
  * Params to get a BTC address.
@@ -28,4 +31,11 @@ export type RetrieveBtcParams = RetrieveBtcArgs &
  */
 export type EstimateWithdrawalFeeParams = QueryParams & {
   amount: bigint | undefined;
+};
+
+/**
+ * Params to retrieve the status of all BTC withdrawals for an account.
+ */
+export type RetrieveBtcStatusV2ByAccountParams = QueryParams & {
+  account?: MinterAccount;
 };


### PR DESCRIPTION
# Motivation

Extend ckBTC `retrieveBtcStatusV2ByAccount` with optional account param for consistency reason (other functions expose an optional account) and also because it can be useful to some devs.

# Changes

- add optional `account` parameter to `retrieveBtcStatusV2ByAccount`
