### PR TITLE
feat: clean-up nns duplicate AccountIdentifier and Subaccount types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Features
 
 - Extend ckBTC `retrieveBtcStatusV2ByAccount` with optional `account` parameter.
+- Replace duplicate string type `AccountIdentifier` in `@dfinity/nns` with `AccountIdentifierHex` of `@dfinity/ledger-icp`.
+- Remove unused Uint8Array type `SubAccount` in `@dfinity/nns`.
 
 # 2024.01.30-1600Z
 

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -1,4 +1,7 @@
-import type { AccountIdentifier as AccountIdentifierClass } from "@dfinity/ledger-icp";
+import type {
+  AccountIdentifier as AccountIdentifierClass,
+  AccountIdentifierHex,
+} from "@dfinity/ledger-icp";
 import { accountIdentifierToBytes } from "@dfinity/ledger-icp";
 import { Principal } from "@dfinity/principal";
 import { arrayBufferToUint8Array, toNullable } from "@dfinity/utils";
@@ -37,7 +40,7 @@ import type {
 } from "../../../candid/governance";
 import type { Vote } from "../../enums/governance.enums";
 import { UnsupportedValueError } from "../../errors/governance.errors";
-import type { AccountIdentifier, E8s, NeuronId } from "../../types/common";
+import type { E8s, NeuronId } from "../../types/common";
 import type {
   Action,
   By,
@@ -845,7 +848,7 @@ const fromAmount = (amount: E8s): Amount => ({
 });
 
 const fromAccountIdentifier = (
-  accountIdentifier: AccountIdentifier,
+  accountIdentifier: AccountIdentifierHex,
 ): RawAccountIdentifier => ({
   hash: accountIdentifierToBytes(accountIdentifier),
 });

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -1,3 +1,4 @@
+import type { AccountIdentifierHex } from "@dfinity/ledger-icp";
 import {
   AccountIdentifier,
   accountIdentifierFromBytes,
@@ -64,12 +65,7 @@ import type {
 } from "../../../candid/governance";
 import { NeuronState, type NeuronType } from "../../enums/governance.enums";
 import { UnsupportedValueError } from "../../errors/governance.errors";
-import type {
-  AccountIdentifier as AccountIdentifierString,
-  CanisterIdString,
-  E8s,
-  NeuronId,
-} from "../../types/common";
+import type { CanisterIdString, E8s, NeuronId } from "../../types/common";
 import type {
   Action,
   Ballot,
@@ -760,7 +756,7 @@ const toAmount = (amount: RawAmount): E8s => {
 
 const toAccountIdentifier = (
   accountIdentifier: RawAccountIdentifier,
-): AccountIdentifierString =>
+): AccountIdentifierHex =>
   accountIdentifierFromBytes(new Uint8Array(accountIdentifier.hash));
 
 const toRewardMode = (rewardMode: RawRewardMode): RewardMode => {

--- a/packages/nns/src/types/common.ts
+++ b/packages/nns/src/types/common.ts
@@ -1,6 +1,5 @@
 export type CanisterIdString = string;
 export type NeuronId = bigint;
-export type AccountIdentifier = string;
 export type E8s = bigint;
 export type Memo = bigint;
 export type PrincipalString = string;

--- a/packages/nns/src/types/common.ts
+++ b/packages/nns/src/types/common.ts
@@ -3,6 +3,5 @@ export type NeuronId = bigint;
 export type E8s = bigint;
 export type Memo = bigint;
 export type PrincipalString = string;
-export type SubAccount = Uint8Array;
 
 export type Option<T> = T | undefined;

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -1,4 +1,5 @@
 import type { DerEncodedPublicKey } from "@dfinity/agent";
+import type { AccountIdentifierHex } from "@dfinity/ledger-icp";
 import type { Principal } from "@dfinity/principal";
 import type {
   NeuronState,
@@ -9,7 +10,6 @@ import type {
   Vote,
 } from "../enums/governance.enums";
 import type {
-  AccountIdentifier,
   CanisterIdString,
   E8s,
   NeuronId,
@@ -88,7 +88,7 @@ export interface Configure {
   operation: Option<Operation>;
 }
 export interface Disburse {
-  toAccountId: Option<AccountIdentifier>;
+  toAccountId: Option<AccountIdentifierHex>;
   amount: Option<E8s>;
 }
 export interface DisburseResponse {
@@ -273,7 +273,7 @@ export interface Neuron {
   spawnAtTimesSeconds: Option<bigint>;
   neuronFees: E8s;
   hotKeys: Array<PrincipalString>;
-  accountIdentifier: AccountIdentifier;
+  accountIdentifier: AccountIdentifierHex;
   joinedCommunityFundTimestampSeconds: Option<bigint>;
   dissolveState: Option<DissolveState>;
   followees: Array<Followees>;
@@ -297,7 +297,7 @@ export interface NeuronInfo {
 
 export interface NodeProvider {
   id: Option<PrincipalString>;
-  rewardAccount: Option<AccountIdentifier>;
+  rewardAccount: Option<AccountIdentifierHex>;
 }
 export type Operation =
   | { RemoveHotKey: RemoveHotKey }
@@ -350,7 +350,7 @@ export type RewardNodeProviders = {
   rewards: Array<RewardNodeProvider>;
 };
 export interface RewardToAccount {
-  toAccount: Option<AccountIdentifier>;
+  toAccount: Option<AccountIdentifierHex>;
 }
 export interface RewardToNeuron {
   dissolveDelaySeconds: bigint;
@@ -433,7 +433,7 @@ export interface SplitRequest {
 
 export interface DisburseRequest {
   neuronId: NeuronId;
-  toAccountId?: AccountIdentifier;
+  toAccountId?: AccountIdentifierHex;
   amount?: E8s;
 }
 


### PR DESCRIPTION
# Motivation

Saturday evening, a dev shared an issue on the [forum](https://forum.dfinity.org/t/calculating-subaccounts-from-principal-agent-js/18849/8?u=peterparker) hich was resolved by using the appropriate types. `@dfinity/nns` exposes two types, `AccountIdentifier` and `SubAccount`, that duplicate the effective classes in `@dfinity/ledger-icp`. So, the issue was solved by importing the types from the latest library. To avoid confusion in the future, let's remove those historical types.

# Changes

- Replace duplicate string type `AccountIdentifier` in `@dfinity/nns` with `AccountIdentifierHex` of `@dfinity/ledger-icp`.
- Remove unused Uint8Array type `SubAccount` in `@dfinity/nns`.

