### PR TITLE
build: remove whatwg-fetch dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,8 +44,7 @@
         "ts-jest": "^29.1.1",
         "ts-protoc-gen": "^0.15.0",
         "tsdoc-markdown": "^0.1.0",
-        "typescript": "^5.2.2",
-        "whatwg-fetch": "^3.6.19"
+        "typescript": "^5.2.2"
       }
     },
     "../../opensource/tsdoc-markdown": {
@@ -6991,12 +6990,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.19",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.19.tgz",
-      "integrity": "sha512-d67JP4dHSbm2TrpFj8AbO8DnL1JXL5J9u0Kq2xW6d0TFDbCA3Muhdt8orXC22utleTVj7Prqt82baN6RBvnEgw==",
-      "dev": true
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7183,7 +7176,7 @@
         "@dfinity/agent": "^0.20.2",
         "@dfinity/candid": "^0.20.2",
         "@dfinity/principal": "^0.20.2",
-        "@dfinity/utils": "^2.0.0"
+        "@dfinity/utils": "^2.1.0"
       }
     },
     "packages/ledger-icp": {
@@ -12187,12 +12180,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "dev": true
-    },
-    "whatwg-fetch": {
-      "version": "3.6.19",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.19.tgz",
-      "integrity": "sha512-d67JP4dHSbm2TrpFj8AbO8DnL1JXL5J9u0Kq2xW6d0TFDbCA3Muhdt8orXC22utleTVj7Prqt82baN6RBvnEgw==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "ts-jest": "^29.1.1",
     "ts-protoc-gen": "^0.15.0",
     "tsdoc-markdown": "^0.1.0",
-    "typescript": "^5.2.2",
-    "whatwg-fetch": "^3.6.19"
+    "typescript": "^5.2.2"
   },
   "size-limit": [
     {

--- a/test-setup.ts
+++ b/test-setup.ts
@@ -1,9 +1,4 @@
 import textEncoding = require("text-encoding");
-const { Response, Request, Headers, fetch } = require("whatwg-fetch");
 
 global.TextEncoder = textEncoding.TextEncoder;
 global.TextDecoder = textEncoding.TextDecoder;
-global.Response = Response;
-global.Request = Request;
-global.Headers = Headers;
-global.fetch = fetch;


### PR DESCRIPTION
# Motivation

`whatwg-fetch` was historically added and used as a dev dependency and to mock some properties for test but we, gix team, never used it. Therefore this PR removes it.
