### PR TITLE
build: clean package-lock of unused local dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,33 +47,6 @@
         "typescript": "^5.2.2"
       }
     },
-    "../../opensource/tsdoc-markdown": {
-      "version": "0.1.0",
-      "extraneous": true,
-      "license": "MIT",
-      "bin": {
-        "tsdoc": "bin/index.js"
-      },
-      "devDependencies": {
-        "@types/jest": "^29.5.5",
-        "@types/node": "^20.6.3",
-        "@typescript-eslint/eslint-plugin": "^6.7.2",
-        "all-contributors-cli": "^6.26.1",
-        "esbuild": "^0.19.3",
-        "eslint": "^8.49.0",
-        "eslint-config-standard": "^17.1.0",
-        "eslint-plugin-import": "^2.28.1",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^6.1.1",
-        "jest": "^29.7.0",
-        "prettier": "^3.0.3",
-        "prettier-plugin-organize-imports": "^3.2.3",
-        "ts-jest": "^29.1.1"
-      },
-      "peerDependencies": {
-        "typescript": "^5"
-      }
-    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",


### PR DESCRIPTION
# Motivation

Looks like there was a local dependency leftover in `package-lock` of some `tsdoc-markdown` debugging.

# Changes

- remove unused local path to `tsdoc-markdown` (we used the lib fetched from npm)
