### PR TITLE
Handle forked PRs differently

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,8 +15,8 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/checkout@v2
         with:
-            # Must be used in order to allow Commit Formatting changes to create a new PR
-            token: ${{ secrets.GIX_CREATE_PR_PAT }}
+          # Must be used in order to allow Commit Formatting changes to create a new PR
+          token: ${{ secrets.GIX_CREATE_PR_PAT }}
       - name: Checkout Fork
         # in forks the token is not available
         if: github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/checkout@v2
         with:
-          # Must be used in order to allow Commit Formatting changes trigger the CLA when it creates a new commit
+          # Must be used in order to allow Commit Formatting changes to trigger the CLA when it creates a new commit
           token: ${{ secrets.GIX_CREATE_PR_PAT }}
       - name: Checkout Fork
         # in forks the token is not available

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,16 +16,11 @@ jobs:
         uses: actions/checkout@v2
         with:
             # Must be used in order to allow Commit Formatting changes to create a new PR
-            token: ${{ secrets.ACCESS_TOKEN }}
+            token: ${{ secrets.GIX_CREATE_PR_PAT }}
       - name: Checkout Fork
         # in forks the token is not available
         if: github.event.pull_request.head.repo.full_name != github.repository
         uses: actions/checkout@v2
-    
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.GIX_CREATE_PR_PAT }}
 
       - name: Install shfmt
         run: sudo snap install --classic shfmt

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,6 +12,17 @@ jobs:
 
     steps:
       - name: Checkout
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/checkout@v2
+        with:
+            # Must be used in order to allow Commit Formatting changes to create a new PR
+            token: ${{ secrets.ACCESS_TOKEN }}
+      - name: Checkout Fork
+        # in forks the token is not available
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/checkout@v2
+    
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.GIX_CREATE_PR_PAT }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/checkout@v2
         with:
-          # Must be used in order to allow Commit Formatting changes to create a new PR
+          # Must be used in order to allow Commit Formatting changes trigger the CLA when it creates a new commit
           token: ${{ secrets.GIX_CREATE_PR_PAT }}
       - name: Checkout Fork
         # in forks the token is not available


### PR DESCRIPTION
# Motivation

For forked PRs the github token is not passed in, so it causes the workflow to get stuck.

# Changes

For PRs made from within the org it will continue to work as-is. For PRs from external contributors we won't pass in the secret. It's possible the CLA could get stuck (what we were originally trying to prevent) and they will need to push an empty commit.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
