### PR TITLE
Upgrade sns governance candids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# 2024.02.16-1100Z
+
+## Overview
+
+The current status of the libraries at the time of the release is as follows:
+
+| Library                  | Version | Status        |
+| ------------------------ | ------- | ------------- |
+| `@dfinity/ckbtc`         | v2.2.0  | Unchanged️    |
+| `@dfinity/cketh`         | v1.0.1  | Unchanged️️   |
+| `@dfinity/cmc`           | v3.0.1  | Unchanged️️   |
+| `@dfinity/ic-management` | v2.2.1  | Unchanged️️   |
+| `@dfinity/ledger-icp`    | v2.2.0  | Unchanged️    |
+| `@dfinity/ledger-icrc`   | v2.1.2  | Unchanged️️   |
+| `@dfinity/nns`           | v4.0.0  | Unchanged️️   |
+| `@dfinity/nns-proto`     | v1.0.1  | Unchanged️    |
+| `@dfinity/sns`           | v2.1.2  | Maintained ⚙️ |
+| `@dfinity/utils`         | v2.1.1  | Unchanged️    |
+
+## Breaking changes
+
+## Features
+
+- Extend sns governance canister with a `listCallerProposals` for `include_ballots_by_caller` flag.
+
+## Build
+
 # 2024.02.14-1600Z
 
 ## Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,3 @@
-# 2024.02.16-1100Z
-
-## Overview
-
-The current status of the libraries at the time of the release is as follows:
-
-| Library                  | Version | Status        |
-| ------------------------ | ------- | ------------- |
-| `@dfinity/ckbtc`         | v2.2.0  | Unchanged️    |
-| `@dfinity/cketh`         | v1.0.1  | Unchanged️️   |
-| `@dfinity/cmc`           | v3.0.1  | Unchanged️️   |
-| `@dfinity/ic-management` | v2.2.1  | Unchanged️️   |
-| `@dfinity/ledger-icp`    | v2.2.0  | Unchanged️    |
-| `@dfinity/ledger-icrc`   | v2.1.2  | Unchanged️️   |
-| `@dfinity/nns`           | v4.0.0  | Unchanged️️   |
-| `@dfinity/nns-proto`     | v1.0.1  | Unchanged️    |
-| `@dfinity/sns`           | v2.1.3  | Maintained ⚙️ |
-| `@dfinity/utils`         | v2.1.1  | Unchanged️    |
-
 ## Breaking changes
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The current status of the libraries at the time of the release is as follows:
 | `@dfinity/ledger-icrc`   | v2.1.2  | Unchanged️️   |
 | `@dfinity/nns`           | v4.0.0  | Unchanged️️   |
 | `@dfinity/nns-proto`     | v1.0.1  | Unchanged️    |
-| `@dfinity/sns`           | v2.1.2  | Maintained ⚙️ |
+| `@dfinity/sns`           | v2.1.3  | Maintained ⚙️ |
 | `@dfinity/utils`         | v2.1.1  | Unchanged️    |
 
 ## Breaking changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -7959,7 +7959,7 @@
     },
     "packages/sns": {
       "name": "@dfinity/sns",
-      "version": "2.1.3",
+      "version": "2.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7959,7 +7959,7 @@
     },
     "packages/sns": {
       "name": "@dfinity/sns",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2"

--- a/packages/sns/candid/sns_governance.certified.idl.js
+++ b/packages/sns/candid/sns_governance.certified.idl.js
@@ -120,6 +120,14 @@ export const idlFactory = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -164,6 +172,7 @@ export const idlFactory = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
@@ -431,6 +440,7 @@ export const idlFactory = ({ IDL }) => {
     'include_status' : IDL.Vec(IDL.Int32),
   });
   const ListProposalsResponse = IDL.Record({
+    'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
   });
   const StakeMaturity = IDL.Record({
@@ -662,6 +672,14 @@ export const init = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -706,6 +724,7 @@ export const init = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -10,6 +10,7 @@ export type Action =
       ManageNervousSystemParameters: NervousSystemParameters;
     }
   | { AddGenericNervousSystemFunction: NervousSystemFunction }
+  | { ManageDappCanisterSettings: ManageDappCanisterSettings }
   | { RemoveGenericNervousSystemFunction: bigint }
   | { UpgradeSnsToNextVersion: {} }
   | { RegisterDappCanisters: RegisterDappCanisters }
@@ -270,7 +271,16 @@ export interface ListProposals {
   include_status: Int32Array | number[];
 }
 export interface ListProposalsResponse {
+  include_ballots_by_caller: [] | [boolean];
   proposals: Array<ProposalData>;
+}
+export interface ManageDappCanisterSettings {
+  freezing_threshold: [] | [bigint];
+  canister_ids: Array<Principal>;
+  reserved_cycles_limit: [] | [bigint];
+  log_visibility: [] | [number];
+  memory_allocation: [] | [bigint];
+  compute_allocation: [] | [bigint];
 }
 export interface ManageLedgerParameters {
   transfer_fee: [] | [bigint];

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,8 +1,9 @@
-// Generated from IC repo commit 044cfd5 (2024-01-25 tags: release-2024-01-25_14-09+p2p-con) 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 757c4947d (2024-02-16) 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
   AddGenericNervousSystemFunction : NervousSystemFunction;
+  ManageDappCanisterSettings : ManageDappCanisterSettings;
   RemoveGenericNervousSystemFunction : nat64;
   UpgradeSnsToNextVersion : record {};
   RegisterDappCanisters : RegisterDappCanisters;
@@ -227,7 +228,18 @@ type ListProposals = record {
   exclude_type : vec nat64;
   include_status : vec int32;
 };
-type ListProposalsResponse = record { proposals : vec ProposalData };
+type ListProposalsResponse = record {
+  include_ballots_by_caller : opt bool;
+  proposals : vec ProposalData;
+};
+type ManageDappCanisterSettings = record {
+  freezing_threshold : opt nat64;
+  canister_ids : vec principal;
+  reserved_cycles_limit : opt nat64;
+  log_visibility : opt int32;
+  memory_allocation : opt nat64;
+  compute_allocation : opt nat64;
+};
 type ManageLedgerParameters = record { transfer_fee : opt nat64 };
 type ManageNeuron = record { subaccount : vec nat8; command : opt Command };
 type ManageNeuronResponse = record { command : opt Command_1 };

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -120,6 +120,14 @@ export const idlFactory = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -164,6 +172,7 @@ export const idlFactory = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
@@ -431,6 +440,7 @@ export const idlFactory = ({ IDL }) => {
     'include_status' : IDL.Vec(IDL.Int32),
   });
   const ListProposalsResponse = IDL.Record({
+    'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
   });
   const StakeMaturity = IDL.Record({
@@ -670,6 +680,14 @@ export const init = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -714,6 +732,7 @@ export const init = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,

--- a/packages/sns/candid/sns_governance_test.certified.idl.js
+++ b/packages/sns/candid/sns_governance_test.certified.idl.js
@@ -120,6 +120,14 @@ export const idlFactory = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -164,6 +172,7 @@ export const idlFactory = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
@@ -438,6 +447,7 @@ export const idlFactory = ({ IDL }) => {
     'include_status' : IDL.Vec(IDL.Int32),
   });
   const ListProposalsResponse = IDL.Record({
+    'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
   });
   const StakeMaturity = IDL.Record({
@@ -676,6 +686,14 @@ export const init = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -720,6 +738,7 @@ export const init = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,

--- a/packages/sns/candid/sns_governance_test.d.ts
+++ b/packages/sns/candid/sns_governance_test.d.ts
@@ -10,6 +10,7 @@ export type Action =
       ManageNervousSystemParameters: NervousSystemParameters;
     }
   | { AddGenericNervousSystemFunction: NervousSystemFunction }
+  | { ManageDappCanisterSettings: ManageDappCanisterSettings }
   | { RemoveGenericNervousSystemFunction: bigint }
   | { UpgradeSnsToNextVersion: {} }
   | { RegisterDappCanisters: RegisterDappCanisters }
@@ -277,7 +278,16 @@ export interface ListProposals {
   include_status: Int32Array | number[];
 }
 export interface ListProposalsResponse {
+  include_ballots_by_caller: [] | [boolean];
   proposals: Array<ProposalData>;
+}
+export interface ManageDappCanisterSettings {
+  freezing_threshold: [] | [bigint];
+  canister_ids: Array<Principal>;
+  reserved_cycles_limit: [] | [bigint];
+  log_visibility: [] | [number];
+  memory_allocation: [] | [bigint];
+  compute_allocation: [] | [bigint];
 }
 export interface ManageLedgerParameters {
   transfer_fee: [] | [bigint];

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,8 +1,9 @@
-// Generated from IC repo commit 044cfd5 (2024-01-25 tags: release-2024-01-25_14-09+p2p-con) 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 757c4947d (2024-02-16) 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
   AddGenericNervousSystemFunction : NervousSystemFunction;
+  ManageDappCanisterSettings : ManageDappCanisterSettings;
   RemoveGenericNervousSystemFunction : nat64;
   UpgradeSnsToNextVersion : record {};
   RegisterDappCanisters : RegisterDappCanisters;
@@ -229,7 +230,18 @@ type ListProposals = record {
   exclude_type : vec nat64;
   include_status : vec int32;
 };
-type ListProposalsResponse = record { proposals : vec ProposalData };
+type ListProposalsResponse = record {
+  include_ballots_by_caller : opt bool;
+  proposals : vec ProposalData;
+};
+type ManageDappCanisterSettings = record {
+  freezing_threshold : opt nat64;
+  canister_ids : vec principal;
+  reserved_cycles_limit : opt nat64;
+  log_visibility : opt int32;
+  memory_allocation : opt nat64;
+  compute_allocation : opt nat64;
+};
 type ManageLedgerParameters = record { transfer_fee : opt nat64 };
 type ManageNeuron = record { subaccount : vec nat8; command : opt Command };
 type ManageNeuronResponse = record { command : opt Command_1 };

--- a/packages/sns/candid/sns_governance_test.idl.js
+++ b/packages/sns/candid/sns_governance_test.idl.js
@@ -120,6 +120,14 @@ export const idlFactory = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -164,6 +172,7 @@ export const idlFactory = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
@@ -438,6 +447,7 @@ export const idlFactory = ({ IDL }) => {
     'include_status' : IDL.Vec(IDL.Int32),
   });
   const ListProposalsResponse = IDL.Record({
+    'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
   });
   const StakeMaturity = IDL.Record({
@@ -684,6 +694,14 @@ export const init = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -728,6 +746,7 @@ export const init = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,

--- a/packages/sns/candid/sns_root.certified.idl.js
+++ b/packages/sns/candid/sns_root.certified.idl.js
@@ -80,6 +80,17 @@ export const idlFactory = ({ IDL }) => {
     'dapps' : IDL.Vec(IDL.Principal),
     'archives' : IDL.Vec(IDL.Principal),
   });
+  const ManageDappCanisterSettingsRequest = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
+  const ManageDappCanisterSettingsResponse = IDL.Record({
+    'failure_reason' : IDL.Opt(IDL.Text),
+  });
   const RegisterDappCanisterRequest = IDL.Record({
     'canister_id' : IDL.Opt(IDL.Principal),
   });
@@ -117,6 +128,11 @@ export const idlFactory = ({ IDL }) => {
     'list_sns_canisters' : IDL.Func(
         [IDL.Record({})],
         [ListSnsCanistersResponse],
+        [],
+      ),
+    'manage_dapp_canister_settings' : IDL.Func(
+        [ManageDappCanisterSettingsRequest],
+        [ManageDappCanisterSettingsResponse],
         [],
       ),
     'register_dapp_canister' : IDL.Func(

--- a/packages/sns/candid/sns_root.d.ts
+++ b/packages/sns/candid/sns_root.d.ts
@@ -79,6 +79,17 @@ export interface ListSnsCanistersResponse {
   dapps: Array<Principal>;
   archives: Array<Principal>;
 }
+export interface ManageDappCanisterSettingsRequest {
+  freezing_threshold: [] | [bigint];
+  canister_ids: Array<Principal>;
+  reserved_cycles_limit: [] | [bigint];
+  log_visibility: [] | [number];
+  memory_allocation: [] | [bigint];
+  compute_allocation: [] | [bigint];
+}
+export interface ManageDappCanisterSettingsResponse {
+  failure_reason: [] | [string];
+}
 export interface RegisterDappCanisterRequest {
   canister_id: [] | [Principal];
 }
@@ -111,6 +122,10 @@ export interface _SERVICE {
     GetSnsCanistersSummaryResponse
   >;
   list_sns_canisters: ActorMethod<[{}], ListSnsCanistersResponse>;
+  manage_dapp_canister_settings: ActorMethod<
+    [ManageDappCanisterSettingsRequest],
+    ManageDappCanisterSettingsResponse
+  >;
   register_dapp_canister: ActorMethod<[RegisterDappCanisterRequest], {}>;
   register_dapp_canisters: ActorMethod<[RegisterDappCanistersRequest], {}>;
   set_dapp_controllers: ActorMethod<

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 044cfd5 (2024-01-25 tags: release-2024-01-25_14-09+p2p-con) 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit 757c4947d (2024-02-16) 'rs/sns/root/canister/root.did' by import-candid
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterIdRecord = record { canister_id : principal };
 type CanisterInstallMode = variant { reinstall; upgrade; install };
@@ -62,6 +62,15 @@ type ListSnsCanistersResponse = record {
   dapps : vec principal;
   archives : vec principal;
 };
+type ManageDappCanisterSettingsRequest = record {
+  freezing_threshold : opt nat64;
+  canister_ids : vec principal;
+  reserved_cycles_limit : opt nat64;
+  log_visibility : opt int32;
+  memory_allocation : opt nat64;
+  compute_allocation : opt nat64;
+};
+type ManageDappCanisterSettingsResponse = record { failure_reason : opt text };
 type RegisterDappCanisterRequest = record { canister_id : opt principal };
 type RegisterDappCanistersRequest = record { canister_ids : vec principal };
 type SetDappControllersRequest = record {
@@ -87,6 +96,9 @@ service : (SnsRootCanister) -> {
       GetSnsCanistersSummaryResponse,
     );
   list_sns_canisters : (record {}) -> (ListSnsCanistersResponse) query;
+  manage_dapp_canister_settings : (ManageDappCanisterSettingsRequest) -> (
+      ManageDappCanisterSettingsResponse,
+    );
   register_dapp_canister : (RegisterDappCanisterRequest) -> (record {});
   register_dapp_canisters : (RegisterDappCanistersRequest) -> (record {});
   set_dapp_controllers : (SetDappControllersRequest) -> (

--- a/packages/sns/candid/sns_root.idl.js
+++ b/packages/sns/candid/sns_root.idl.js
@@ -80,6 +80,17 @@ export const idlFactory = ({ IDL }) => {
     'dapps' : IDL.Vec(IDL.Principal),
     'archives' : IDL.Vec(IDL.Principal),
   });
+  const ManageDappCanisterSettingsRequest = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
+  const ManageDappCanisterSettingsResponse = IDL.Record({
+    'failure_reason' : IDL.Opt(IDL.Text),
+  });
   const RegisterDappCanisterRequest = IDL.Record({
     'canister_id' : IDL.Opt(IDL.Principal),
   });
@@ -118,6 +129,11 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Record({})],
         [ListSnsCanistersResponse],
         ['query'],
+      ),
+    'manage_dapp_canister_settings' : IDL.Func(
+        [ManageDappCanisterSettingsRequest],
+        [ManageDappCanisterSettingsResponse],
+        [],
       ),
     'register_dapp_canister' : IDL.Func(
         [RegisterDappCanisterRequest],

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 044cfd5 (2024-01-25 tags: release-2024-01-25_14-09+p2p-con) 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 757c4947d (2024-02-16) 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/sns",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "A library for interfacing with a Service Nervous System (SNS) project.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/sns",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A library for interfacing with a Service Nervous System (SNS) project.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -229,7 +229,8 @@ describe("Governance canister", () => {
         certifiedServiceOverride: service,
       });
 
-      const {proposals, include_ballots_by_caller} = await canister.listCallerProposals({});
+      const { proposals, include_ballots_by_caller } =
+        await canister.listCallerProposals({});
       expect(mockListProposals).toBeCalled();
       expect(proposals).toEqual(proposalsMock);
       expect(include_ballots_by_caller).toEqual([true]);

--- a/packages/sns/src/governance.canister.ts
+++ b/packages/sns/src/governance.canister.ts
@@ -58,6 +58,7 @@ import type {
   SnsSetTopicFollowees,
   SnsSplitNeuronParams,
 } from "./types/governance.params";
+import {ListProposalsResponse} from "../candid/sns_governance";
 
 export class SnsGovernanceCanister extends Canister<SnsGovernanceService> {
   /**
@@ -102,6 +103,22 @@ export class SnsGovernanceCanister extends Canister<SnsGovernanceService> {
       toListProposalRequest(params),
     );
     return proposals;
+  };
+
+  /**
+   * List the proposals of the Sns including `include_ballots_by_caller` flag.
+   * When the flag is true, we know that the sns governance canister returns real ballots information.
+   * When the flag is false, there is always an empty list of ballots.
+   */
+  listCallerProposals = async (
+    params: SnsListProposalsParams,
+  ): Promise<ListProposalsResponse> => {
+    const { certified } = params;
+
+    const response = await this.caller({ certified }).list_proposals(
+      toListProposalRequest(params),
+    );
+    return response;
   };
 
   /**

--- a/packages/sns/src/governance.canister.ts
+++ b/packages/sns/src/governance.canister.ts
@@ -20,7 +20,6 @@ import type {
   _SERVICE as SnsGovernanceService,
   SplitResponse,
 } from "../candid/sns_governance";
-import { ListProposalsResponse } from "../candid/sns_governance";
 import { idlFactory as certifiedIdlFactory } from "../candid/sns_governance.certified.idl";
 import { idlFactory } from "../candid/sns_governance.idl";
 import { MAX_LIST_NEURONS_RESULTS } from "./constants/governance.constants";

--- a/packages/sns/src/governance.canister.ts
+++ b/packages/sns/src/governance.canister.ts
@@ -10,6 +10,7 @@ import {
 import type {
   GetMetadataResponse,
   ListNervousSystemFunctionsResponse,
+  ListProposalsResponse,
   ManageNeuron,
   ManageNeuronResponse,
   NervousSystemParameters,
@@ -58,7 +59,6 @@ import type {
   SnsSetTopicFollowees,
   SnsSplitNeuronParams,
 } from "./types/governance.params";
-import {ListProposalsResponse} from "../candid/sns_governance";
 
 export class SnsGovernanceCanister extends Canister<SnsGovernanceService> {
   /**


### PR DESCRIPTION
# Motivation

Add `listCallerProposals` function to make available `include_ballots_by_caller` flag w/o breaking the current interface of `listProposals`. The flag is needed to differentiate between upgraded canisters that fully supports ballots and w/o support.

# Changes

- upgrade sns candids and types
- add `listCallerProposals` to in

# Tests

- tests for `listCallerProposals` (same as for `listProposals`)

# Todos

- [x] Add entry to changelog (if necessary).
