### PR TITLE
Upgrade nns governance candid 2024 02 19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Breaking changes
+
+- Update `listProposals` return type in sns governance canister.
+
+## Features
+
+## Build
+
 # 2024.02.14-1600Z
 
 ## Overview

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -83,7 +83,7 @@ Lookup for the canister ids of a Sns and initialize the wrapper to access its fe
 
 ### :factory: SnsGovernanceCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L62)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L63)
 
 #### Methods
 
@@ -125,7 +125,7 @@ Parameters:
 
 - `options`: Miscellaneous options to initialize the canister. Its ID being the only mandatory parammeter.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L68)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L69)
 
 ##### :gear: listNeurons
 
@@ -135,17 +135,17 @@ List the neurons of the Sns
 | ------------- | ----------------------------------------------------- |
 | `listNeurons` | `(params: SnsListNeuronsParams) => Promise<Neuron[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L82)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L83)
 
 ##### :gear: listProposals
 
 List the proposals of the Sns
 
-| Method          | Type                                                          |
-| --------------- | ------------------------------------------------------------- |
-| `listProposals` | `(params: SnsListProposalsParams) => Promise<ProposalData[]>` |
+| Method          | Type                                                                 |
+| --------------- | -------------------------------------------------------------------- |
+| `listProposals` | `(params: SnsListProposalsParams) => Promise<ListProposalsResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L96)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L97)
 
 ##### :gear: getProposal
 
@@ -155,7 +155,7 @@ Get the proposal of the Sns
 | ------------- | --------------------------------------------------------- |
 | `getProposal` | `(params: SnsGetProposalParams) => Promise<ProposalData>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L110)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L111)
 
 ##### :gear: listNervousSystemFunctions
 
@@ -166,7 +166,7 @@ Neurons can follow other neurons in specific Nervous System Functions.
 | ---------------------------- | ---------------------------------------------------------------------- |
 | `listNervousSystemFunctions` | `(params: QueryParams) => Promise<ListNervousSystemFunctionsResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L129)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L130)
 
 ##### :gear: metadata
 
@@ -176,7 +176,7 @@ Get the Sns metadata (title, description, etc.)
 | ---------- | ------------------------------------------------------- |
 | `metadata` | `(params: QueryParams) => Promise<GetMetadataResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L137)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L138)
 
 ##### :gear: nervousSystemParameters
 
@@ -186,7 +186,7 @@ Get the Sns nervous system parameters (default followees, max dissolve delay, ma
 | ------------------------- | ----------------------------------------------------------- |
 | `nervousSystemParameters` | `(params: QueryParams) => Promise<NervousSystemParameters>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L143)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L144)
 
 ##### :gear: getNeuron
 
@@ -196,7 +196,7 @@ Get the neuron of the Sns
 | ----------- | ------------------------------------------------- |
 | `getNeuron` | `(params: SnsGetNeuronParams) => Promise<Neuron>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L151)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L152)
 
 ##### :gear: queryNeuron
 
@@ -206,7 +206,7 @@ Same as `getNeuron` but returns undefined instead of raising error when not foun
 | ------------- | ------------------------------------------------- |
 | `queryNeuron` | `(params: SnsGetNeuronParams) => Promise<Neuron>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L169)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L170)
 
 ##### :gear: manageNeuron
 
@@ -216,7 +216,7 @@ Manage neuron. For advanced users.
 | -------------- | ---------------------------------------------------------- |
 | `manageNeuron` | `(request: ManageNeuron) => Promise<ManageNeuronResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L189)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L190)
 
 ##### :gear: addNeuronPermissions
 
@@ -226,7 +226,7 @@ Add permissions to a neuron for a specific principal
 | ---------------------- | ------------------------------------------------------- |
 | `addNeuronPermissions` | `(params: SnsNeuronPermissionsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L202)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L203)
 
 ##### :gear: removeNeuronPermissions
 
@@ -236,7 +236,7 @@ Remove permissions to a neuron for a specific principal
 | ------------------------- | ------------------------------------------------------- |
 | `removeNeuronPermissions` | `(params: SnsNeuronPermissionsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L212)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L213)
 
 ##### :gear: splitNeuron
 
@@ -246,7 +246,7 @@ Split neuron
 | ------------- | ----------------------------------------------------- |
 | `splitNeuron` | `(params: SnsSplitNeuronParams) => Promise<NeuronId>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L222)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L223)
 
 ##### :gear: disburse
 
@@ -256,7 +256,7 @@ Disburse neuron on Account
 | ---------- | ---------------------------------------------------- |
 | `disburse` | `(params: SnsDisburseNeuronParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L253)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L254)
 
 ##### :gear: startDissolving
 
@@ -266,7 +266,7 @@ Start dissolving process of a neuron
 | ----------------- | --------------------------------------- |
 | `startDissolving` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L261)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L262)
 
 ##### :gear: stopDissolving
 
@@ -276,7 +276,7 @@ Stop dissolving process of a neuron
 | ---------------- | --------------------------------------- |
 | `stopDissolving` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L269)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L270)
 
 ##### :gear: stakeMaturity
 
@@ -291,7 +291,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to stake the maturity
 - `percentageToStake`: Optional. Percentage of the current maturity to stake. If not provided, all of the neuron's current maturity will be staked.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L281)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L282)
 
 ##### :gear: disburseMaturity
 
@@ -307,7 +307,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to disburse the maturity
 - `percentageToDisburse`: What percentage of the available maturity to disburse.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L302)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L303)
 
 ##### :gear: autoStakeMaturity
 
@@ -322,7 +322,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to request a change of the auto stake feature
 - `autoStake`: `true` to enable the auto-stake maturity for this neuron, `false` to turn it off
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L318)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L319)
 
 ##### :gear: setDissolveTimestamp
 
@@ -332,7 +332,7 @@ Increase dissolve delay of a neuron
 | ---------------------- | ---------------------------------------------------------- |
 | `setDissolveTimestamp` | `(params: SnsSetDissolveTimestampParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L328)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L329)
 
 ##### :gear: increaseDissolveDelay
 
@@ -342,7 +342,7 @@ Increase dissolve delay of a neuron
 | ----------------------- | ----------------------------------------------------------- |
 | `increaseDissolveDelay` | `(params: SnsIncreaseDissolveDelayParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L338)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L339)
 
 ##### :gear: setTopicFollowees
 
@@ -352,7 +352,7 @@ Sets followees of a neuron for a specific Nervous System Function (topic)
 | ------------------- | ------------------------------------------------- |
 | `setTopicFollowees` | `(params: SnsSetTopicFollowees) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L348)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L349)
 
 ##### :gear: registerVote
 
@@ -362,7 +362,7 @@ Registers vote for a proposal from the neuron passed.
 | -------------- | -------------------------------------------------- |
 | `registerVote` | `(params: SnsRegisterVoteParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L356)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L357)
 
 ##### :gear: refreshNeuron
 
@@ -372,7 +372,7 @@ Refresh neuron
 | --------------- | --------------------------------------- |
 | `refreshNeuron` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L364)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L365)
 
 ##### :gear: claimNeuron
 
@@ -382,7 +382,7 @@ Claim neuron
 | ------------- | -------------------------------------------------------------------------------- |
 | `claimNeuron` | `({ memo, controller, subaccount, }: SnsClaimNeuronParams) => Promise<NeuronId>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L374)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L375)
 
 ### :factory: SnsRootCanister
 
@@ -545,7 +545,7 @@ Sns wrapper - notably used by NNS-dapp - ease the access to a particular Sns.
 It knows all the Sns' canisters, wrap and enhance their available features.
 A wrapper either performs query or update calls.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L84)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L85)
 
 #### Constructors
 
@@ -607,15 +607,15 @@ Parameters:
 | ------------- | ------------------------------------------------------------------------ |
 | `listNeurons` | `(params: Omit<SnsListNeuronsParams, "certified">) => Promise<Neuron[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L130)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L131)
 
 ##### :gear: listProposals
 
-| Method          | Type                                                                             |
-| --------------- | -------------------------------------------------------------------------------- |
-| `listProposals` | `(params: Omit<SnsListProposalsParams, "certified">) => Promise<ProposalData[]>` |
+| Method          | Type                                                                                    |
+| --------------- | --------------------------------------------------------------------------------------- |
+| `listProposals` | `(params: Omit<SnsListProposalsParams, "certified">) => Promise<ListProposalsResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L134)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L135)
 
 ##### :gear: getProposal
 
@@ -623,7 +623,7 @@ Parameters:
 | ------------- | ---------------------------------------------------------------------------- |
 | `getProposal` | `(params: Omit<SnsGetProposalParams, "certified">) => Promise<ProposalData>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L139)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L140)
 
 ##### :gear: listNervousSystemFunctions
 
@@ -631,7 +631,7 @@ Parameters:
 | ---------------------------- | ----------------------------------------------------------------------------------------- |
 | `listNervousSystemFunctions` | `(params: Omit<QueryParams, "certified">) => Promise<ListNervousSystemFunctionsResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L144)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L145)
 
 ##### :gear: metadata
 
@@ -639,7 +639,7 @@ Parameters:
 | ---------- | ------------------------------------------------------------------------------------------------------- |
 | `metadata` | `(params: Omit<QueryParams, "certified">) => Promise<[GetMetadataResponse, IcrcTokenMetadataResponse]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L149)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L150)
 
 ##### :gear: nervousSystemParameters
 
@@ -647,7 +647,7 @@ Parameters:
 | ------------------------- | ------------------------------------------------------------------------------ |
 | `nervousSystemParameters` | `(params: Omit<QueryParams, "certified">) => Promise<NervousSystemParameters>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L157)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L158)
 
 ##### :gear: ledgerMetadata
 
@@ -655,7 +655,7 @@ Parameters:
 | ---------------- | -------------------------------------------------------------------------------- |
 | `ledgerMetadata` | `(params: Omit<QueryParams, "certified">) => Promise<IcrcTokenMetadataResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L162)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L163)
 
 ##### :gear: transactionFee
 
@@ -663,7 +663,7 @@ Parameters:
 | ---------------- | ------------------------------------------------------------- |
 | `transactionFee` | `(params: Omit<QueryParams, "certified">) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L167)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L168)
 
 ##### :gear: totalTokensSupply
 
@@ -671,7 +671,7 @@ Parameters:
 | ------------------- | ------------------------------------------------------------- |
 | `totalTokensSupply` | `(params: Omit<QueryParams, "certified">) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L172)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L173)
 
 ##### :gear: balance
 
@@ -679,7 +679,7 @@ Parameters:
 | --------- | --------------------------------------------------------------- |
 | `balance` | `(params: Omit<BalanceParams, "certified">) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L177)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L178)
 
 ##### :gear: transfer
 
@@ -687,7 +687,7 @@ Parameters:
 | ---------- | --------------------------------------------- |
 | `transfer` | `(params: TransferParams) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L181)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L182)
 
 ##### :gear: getNeuron
 
@@ -695,7 +695,7 @@ Parameters:
 | ----------- | -------------------------------------------------------------------- |
 | `getNeuron` | `(params: Omit<SnsGetNeuronParams, "certified">) => Promise<Neuron>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L184)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L185)
 
 ##### :gear: queryNeuron
 
@@ -703,7 +703,7 @@ Parameters:
 | ------------- | -------------------------------------------------------------------- |
 | `queryNeuron` | `(params: Omit<SnsGetNeuronParams, "certified">) => Promise<Neuron>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L188)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L189)
 
 ##### :gear: nextNeuronAccount
 
@@ -723,7 +723,7 @@ This is how the backend can identify which neuron is being claimed.
 | ------------------- | ------------------------------------------------------------------------------ |
 | `nextNeuronAccount` | `(controller: Principal) => Promise<{ account: IcrcAccount; index: bigint; }>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L209)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L210)
 
 ##### :gear: stakeNeuron
 
@@ -737,7 +737,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ------------- | ------------------------------------------------------------------------------------------------ |
 | `stakeNeuron` | `({ stakeE8s, source, controller, createdAt, fee, }: SnsStakeNeuronParams) => Promise<NeuronId>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L256)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L257)
 
 ##### :gear: increaseStakeNeuron
 
@@ -751,7 +751,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | --------------------- | ---------------------------------------------------------------------------------- |
 | `increaseStakeNeuron` | `({ stakeE8s, source, neuronId, }: SnsIncreaseStakeNeuronParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L303)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L304)
 
 ##### :gear: getNeuronBalance
 
@@ -759,7 +759,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ------------------ | ----------------------------------------- |
 | `getNeuronBalance` | `(neuronId: NeuronId) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L322)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L323)
 
 ##### :gear: addNeuronPermissions
 
@@ -767,7 +767,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ---------------------- | ------------------------------------------------------- |
 | `addNeuronPermissions` | `(params: SnsNeuronPermissionsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L331)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L332)
 
 ##### :gear: refreshNeuron
 
@@ -775,7 +775,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | --------------- | --------------------------------------- |
 | `refreshNeuron` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L335)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L336)
 
 ##### :gear: claimNeuron
 
@@ -783,7 +783,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ------------- | ----------------------------------------------------- |
 | `claimNeuron` | `(params: SnsClaimNeuronParams) => Promise<NeuronId>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L339)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L340)
 
 ##### :gear: removeNeuronPermissions
 
@@ -791,7 +791,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ------------------------- | ------------------------------------------------------- |
 | `removeNeuronPermissions` | `(params: SnsNeuronPermissionsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L343)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L344)
 
 ##### :gear: splitNeuron
 
@@ -799,7 +799,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ------------- | ----------------------------------------------------- |
 | `splitNeuron` | `(params: SnsSplitNeuronParams) => Promise<NeuronId>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L348)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L349)
 
 ##### :gear: disburse
 
@@ -807,7 +807,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ---------- | ---------------------------------------------------- |
 | `disburse` | `(params: SnsDisburseNeuronParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L352)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L353)
 
 ##### :gear: startDissolving
 
@@ -815,7 +815,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ----------------- | --------------------------------------- |
 | `startDissolving` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L356)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L357)
 
 ##### :gear: stopDissolving
 
@@ -823,7 +823,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ---------------- | --------------------------------------- |
 | `stopDissolving` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L360)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L361)
 
 ##### :gear: setDissolveTimestamp
 
@@ -831,7 +831,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ---------------------- | ---------------------------------------------------------- |
 | `setDissolveTimestamp` | `(params: SnsSetDissolveTimestampParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L364)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L365)
 
 ##### :gear: increaseDissolveDelay
 
@@ -839,7 +839,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ----------------------- | ----------------------------------------------------------- |
 | `increaseDissolveDelay` | `(params: SnsIncreaseDissolveDelayParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L369)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L370)
 
 ##### :gear: setTopicFollowees
 
@@ -847,7 +847,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ------------------- | ------------------------------------------------- |
 | `setTopicFollowees` | `(params: SnsSetTopicFollowees) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L374)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L375)
 
 ##### :gear: registerVote
 
@@ -855,7 +855,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | -------------- | -------------------------------------------------- |
 | `registerVote` | `(params: SnsRegisterVoteParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L378)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L379)
 
 ##### :gear: swapState
 
@@ -863,7 +863,7 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 | ----------- | ----------------------------------------------------------------------- |
 | `swapState` | `(params: Omit<QueryParams, "certified">) => Promise<GetStateResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L381)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L382)
 
 ##### :gear: notifyPaymentFailure
 
@@ -877,7 +877,7 @@ Always certified
 | ---------------------- | ----------------------- |
 | `notifyPaymentFailure` | `() => Promise<Ticket>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L394)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L395)
 
 ##### :gear: notifyParticipation
 
@@ -885,7 +885,7 @@ Always certified
 | --------------------- | ---------------------------------------------------------------------------- |
 | `notifyParticipation` | `(params: RefreshBuyerTokensRequest) => Promise<RefreshBuyerTokensResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L398)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L399)
 
 ##### :gear: getUserCommitment
 
@@ -893,7 +893,7 @@ Always certified
 | ------------------- | ------------------------------------------------------- |
 | `getUserCommitment` | `(params: GetBuyerStateRequest) => Promise<BuyerState>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L403)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L404)
 
 ##### :gear: getOpenTicket
 
@@ -901,7 +901,7 @@ Always certified
 | --------------- | ------------------------------------------------------------- |
 | `getOpenTicket` | `(params: Omit<QueryParams, "certified">) => Promise<Ticket>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L408)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L409)
 
 ##### :gear: newSaleTicket
 
@@ -909,7 +909,7 @@ Always certified
 | --------------- | -------------------------------------------------- |
 | `newSaleTicket` | `(params: NewSaleTicketParams) => Promise<Ticket>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L414)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L415)
 
 ##### :gear: getLifecycle
 
@@ -917,7 +917,7 @@ Always certified
 | -------------- | --------------------------------------------------------------------------- |
 | `getLifecycle` | `(params: Omit<QueryParams, "certified">) => Promise<GetLifecycleResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L417)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L418)
 
 ##### :gear: getFinalizationStatus
 
@@ -925,7 +925,7 @@ Always certified
 | ----------------------- | ---------------------------------------------------------------------------------------- |
 | `getFinalizationStatus` | `(params: Omit<QueryParams, "certified">) => Promise<GetAutoFinalizationStatusResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L422)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L423)
 
 ##### :gear: getSaleParameters
 
@@ -933,7 +933,7 @@ Always certified
 | ------------------- | -------------------------------------------------------------------------------- |
 | `getSaleParameters` | `(params: Omit<QueryParams, "certified">) => Promise<GetSaleParametersResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L427)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L428)
 
 ##### :gear: getDerivedState
 
@@ -941,7 +941,7 @@ Always certified
 | ----------------- | ------------------------------------------------------------------------------ |
 | `getDerivedState` | `(params: Omit<QueryParams, "certified">) => Promise<GetDerivedStateResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L432)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L433)
 
 ##### :gear: getTransactions
 
@@ -949,7 +949,7 @@ Always certified
 | ----------------- | -------------------------------------------------------------------- |
 | `getTransactions` | `(params: GetAccountTransactionsParams) => Promise<GetTransactions>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L438)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L439)
 
 ##### :gear: stakeMaturity
 
@@ -957,7 +957,7 @@ Always certified
 | --------------- | --------------------------------------------------------- |
 | `stakeMaturity` | `(params: SnsNeuronStakeMaturityParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L443)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L444)
 
 ##### :gear: disburseMaturity
 
@@ -965,7 +965,7 @@ Always certified
 | ------------------ | ------------------------------------------------------------ |
 | `disburseMaturity` | `(params: SnsNeuronDisburseMaturityParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L447)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L448)
 
 ##### :gear: autoStakeMaturity
 
@@ -973,6 +973,6 @@ Always certified
 | ------------------- | ------------------------------------------------------------- |
 | `autoStakeMaturity` | `(params: SnsNeuronAutoStakeMaturityParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L451)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L452)
 
 <!-- TSDOC_END -->

--- a/packages/sns/candid/sns_governance.certified.idl.js
+++ b/packages/sns/candid/sns_governance.certified.idl.js
@@ -120,6 +120,14 @@ export const idlFactory = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -164,6 +172,7 @@ export const idlFactory = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
@@ -431,6 +440,7 @@ export const idlFactory = ({ IDL }) => {
     'include_status' : IDL.Vec(IDL.Int32),
   });
   const ListProposalsResponse = IDL.Record({
+    'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
   });
   const StakeMaturity = IDL.Record({
@@ -662,6 +672,14 @@ export const init = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -706,6 +724,7 @@ export const init = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -10,6 +10,7 @@ export type Action =
       ManageNervousSystemParameters: NervousSystemParameters;
     }
   | { AddGenericNervousSystemFunction: NervousSystemFunction }
+  | { ManageDappCanisterSettings: ManageDappCanisterSettings }
   | { RemoveGenericNervousSystemFunction: bigint }
   | { UpgradeSnsToNextVersion: {} }
   | { RegisterDappCanisters: RegisterDappCanisters }
@@ -270,7 +271,16 @@ export interface ListProposals {
   include_status: Int32Array | number[];
 }
 export interface ListProposalsResponse {
+  include_ballots_by_caller: [] | [boolean];
   proposals: Array<ProposalData>;
+}
+export interface ManageDappCanisterSettings {
+  freezing_threshold: [] | [bigint];
+  canister_ids: Array<Principal>;
+  reserved_cycles_limit: [] | [bigint];
+  log_visibility: [] | [number];
+  memory_allocation: [] | [bigint];
+  compute_allocation: [] | [bigint];
 }
 export interface ManageLedgerParameters {
   transfer_fee: [] | [bigint];

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,8 +1,9 @@
-// Generated from IC repo commit 044cfd5 (2024-01-25 tags: release-2024-01-25_14-09+p2p-con) 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 757c4947d (2024-02-16) 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
   AddGenericNervousSystemFunction : NervousSystemFunction;
+  ManageDappCanisterSettings : ManageDappCanisterSettings;
   RemoveGenericNervousSystemFunction : nat64;
   UpgradeSnsToNextVersion : record {};
   RegisterDappCanisters : RegisterDappCanisters;
@@ -227,7 +228,18 @@ type ListProposals = record {
   exclude_type : vec nat64;
   include_status : vec int32;
 };
-type ListProposalsResponse = record { proposals : vec ProposalData };
+type ListProposalsResponse = record {
+  include_ballots_by_caller : opt bool;
+  proposals : vec ProposalData;
+};
+type ManageDappCanisterSettings = record {
+  freezing_threshold : opt nat64;
+  canister_ids : vec principal;
+  reserved_cycles_limit : opt nat64;
+  log_visibility : opt int32;
+  memory_allocation : opt nat64;
+  compute_allocation : opt nat64;
+};
 type ManageLedgerParameters = record { transfer_fee : opt nat64 };
 type ManageNeuron = record { subaccount : vec nat8; command : opt Command };
 type ManageNeuronResponse = record { command : opt Command_1 };

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -120,6 +120,14 @@ export const idlFactory = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -164,6 +172,7 @@ export const idlFactory = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
@@ -431,6 +440,7 @@ export const idlFactory = ({ IDL }) => {
     'include_status' : IDL.Vec(IDL.Int32),
   });
   const ListProposalsResponse = IDL.Record({
+    'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
   });
   const StakeMaturity = IDL.Record({
@@ -670,6 +680,14 @@ export const init = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -714,6 +732,7 @@ export const init = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,

--- a/packages/sns/candid/sns_governance_test.certified.idl.js
+++ b/packages/sns/candid/sns_governance_test.certified.idl.js
@@ -120,6 +120,14 @@ export const idlFactory = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -164,6 +172,7 @@ export const idlFactory = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
@@ -438,6 +447,7 @@ export const idlFactory = ({ IDL }) => {
     'include_status' : IDL.Vec(IDL.Int32),
   });
   const ListProposalsResponse = IDL.Record({
+    'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
   });
   const StakeMaturity = IDL.Record({
@@ -676,6 +686,14 @@ export const init = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -720,6 +738,7 @@ export const init = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,

--- a/packages/sns/candid/sns_governance_test.d.ts
+++ b/packages/sns/candid/sns_governance_test.d.ts
@@ -10,6 +10,7 @@ export type Action =
       ManageNervousSystemParameters: NervousSystemParameters;
     }
   | { AddGenericNervousSystemFunction: NervousSystemFunction }
+  | { ManageDappCanisterSettings: ManageDappCanisterSettings }
   | { RemoveGenericNervousSystemFunction: bigint }
   | { UpgradeSnsToNextVersion: {} }
   | { RegisterDappCanisters: RegisterDappCanisters }
@@ -277,7 +278,16 @@ export interface ListProposals {
   include_status: Int32Array | number[];
 }
 export interface ListProposalsResponse {
+  include_ballots_by_caller: [] | [boolean];
   proposals: Array<ProposalData>;
+}
+export interface ManageDappCanisterSettings {
+  freezing_threshold: [] | [bigint];
+  canister_ids: Array<Principal>;
+  reserved_cycles_limit: [] | [bigint];
+  log_visibility: [] | [number];
+  memory_allocation: [] | [bigint];
+  compute_allocation: [] | [bigint];
 }
 export interface ManageLedgerParameters {
   transfer_fee: [] | [bigint];

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,8 +1,9 @@
-// Generated from IC repo commit 044cfd5 (2024-01-25 tags: release-2024-01-25_14-09+p2p-con) 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 757c4947d (2024-02-16) 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
   AddGenericNervousSystemFunction : NervousSystemFunction;
+  ManageDappCanisterSettings : ManageDappCanisterSettings;
   RemoveGenericNervousSystemFunction : nat64;
   UpgradeSnsToNextVersion : record {};
   RegisterDappCanisters : RegisterDappCanisters;
@@ -229,7 +230,18 @@ type ListProposals = record {
   exclude_type : vec nat64;
   include_status : vec int32;
 };
-type ListProposalsResponse = record { proposals : vec ProposalData };
+type ListProposalsResponse = record {
+  include_ballots_by_caller : opt bool;
+  proposals : vec ProposalData;
+};
+type ManageDappCanisterSettings = record {
+  freezing_threshold : opt nat64;
+  canister_ids : vec principal;
+  reserved_cycles_limit : opt nat64;
+  log_visibility : opt int32;
+  memory_allocation : opt nat64;
+  compute_allocation : opt nat64;
+};
 type ManageLedgerParameters = record { transfer_fee : opt nat64 };
 type ManageNeuron = record { subaccount : vec nat8; command : opt Command };
 type ManageNeuronResponse = record { command : opt Command_1 };

--- a/packages/sns/candid/sns_governance_test.idl.js
+++ b/packages/sns/candid/sns_governance_test.idl.js
@@ -120,6 +120,14 @@ export const idlFactory = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -164,6 +172,7 @@ export const idlFactory = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
@@ -438,6 +447,7 @@ export const idlFactory = ({ IDL }) => {
     'include_status' : IDL.Vec(IDL.Int32),
   });
   const ListProposalsResponse = IDL.Record({
+    'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
   });
   const StakeMaturity = IDL.Record({
@@ -684,6 +694,14 @@ export const init = ({ IDL }) => {
     'total' : IDL.Nat64,
     'timestamp_seconds' : IDL.Nat64,
   });
+  const ManageDappCanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'canister_ids' : IDL.Vec(IDL.Principal),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -728,6 +746,7 @@ export const init = ({ IDL }) => {
   const Action = IDL.Variant({
     'ManageNervousSystemParameters' : NervousSystemParameters,
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
+    'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -7,6 +7,7 @@ import {
 import { mock } from "jest-mock-extended";
 import type {
   ListNervousSystemFunctionsResponse,
+  ListProposalsResponse,
   ManageNeuron,
   ManageNeuronResponse,
   NervousSystemFunction,
@@ -108,6 +109,7 @@ describe("Governance canister", () => {
       const service = mock<ActorSubclass<SnsGovernanceService>>();
       const mockListProposals = service.list_proposals.mockResolvedValue({
         proposals: proposalsMock,
+        include_ballots_by_caller: [],
       });
 
       const canister = SnsGovernanceCanister.create({
@@ -115,7 +117,23 @@ describe("Governance canister", () => {
         certifiedServiceOverride: service,
       });
 
-      const expectedProposals = await canister.listProposals({});
+      const { proposals: expectedProposals } = await canister.listProposals({});
+      expect(mockListProposals).toBeCalled();
+      expect(expectedProposals).toEqual(proposalsMock);
+    });
+
+    it('should not break when no "include_ballots_by_caller" parameter provided', async () => {
+      const service = mock<ActorSubclass<SnsGovernanceService>>();
+      const mockListProposals = service.list_proposals.mockResolvedValue({
+        proposals: proposalsMock,
+      } as ListProposalsResponse);
+
+      const canister = SnsGovernanceCanister.create({
+        canisterId: rootCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+
+      const { proposals: expectedProposals } = await canister.listProposals({});
       expect(mockListProposals).toBeCalled();
       expect(expectedProposals).toEqual(proposalsMock);
     });
@@ -124,6 +142,7 @@ describe("Governance canister", () => {
       const service = mock<ActorSubclass<SnsGovernanceService>>();
       const mockListProposals = service.list_proposals.mockResolvedValue({
         proposals: proposalsMock,
+        include_ballots_by_caller: [],
       });
 
       const canister = SnsGovernanceCanister.create({
@@ -145,6 +164,7 @@ describe("Governance canister", () => {
       const service = mock<ActorSubclass<SnsGovernanceService>>();
       const mockListProposals = service.list_proposals.mockResolvedValue({
         proposals: proposalsMock,
+        include_ballots_by_caller: [],
       });
 
       const canister = SnsGovernanceCanister.create({
@@ -175,6 +195,7 @@ describe("Governance canister", () => {
       const service = mock<ActorSubclass<SnsGovernanceService>>();
       const mockListProposals = service.list_proposals.mockResolvedValue({
         proposals: proposalsMock,
+        include_ballots_by_caller: [],
       });
 
       const canister = SnsGovernanceCanister.create({

--- a/packages/sns/src/governance.canister.ts
+++ b/packages/sns/src/governance.canister.ts
@@ -10,6 +10,7 @@ import {
 import type {
   GetMetadataResponse,
   ListNervousSystemFunctionsResponse,
+  ListProposalsResponse,
   ManageNeuron,
   ManageNeuronResponse,
   NervousSystemParameters,
@@ -95,13 +96,13 @@ export class SnsGovernanceCanister extends Canister<SnsGovernanceService> {
    */
   listProposals = async (
     params: SnsListProposalsParams,
-  ): Promise<ProposalData[]> => {
+  ): Promise<ListProposalsResponse> => {
     const { certified } = params;
 
-    const { proposals } = await this.caller({ certified }).list_proposals(
+    const response = await this.caller({ certified }).list_proposals(
       toListProposalRequest(params),
     );
-    return proposals;
+    return response;
   };
 
   /**

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -21,6 +21,7 @@ import type {
   NeuronId,
   ProposalData,
 } from "../candid/sns_governance";
+import { ListProposalsResponse } from "../candid/sns_governance";
 import type {
   BuyerState,
   GetAutoFinalizationStatusResponse,
@@ -59,7 +60,6 @@ import type {
 } from "./types/governance.params";
 import type { NewSaleTicketParams } from "./types/swap.params";
 import { neuronSubaccount } from "./utils/governance.utils";
-import {ListProposalsResponse} from "../candid/sns_governance";
 
 interface SnsWrapperOptions {
   /** The wrapper for the "root" canister of the particular Sns */

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -16,12 +16,12 @@ import { bigIntToUint8Array, toNullable } from "@dfinity/utils";
 import type {
   GetMetadataResponse,
   ListNervousSystemFunctionsResponse,
+  ListProposalsResponse,
   NervousSystemParameters,
   Neuron,
   NeuronId,
   ProposalData,
 } from "../candid/sns_governance";
-import { ListProposalsResponse } from "../candid/sns_governance";
 import type {
   BuyerState,
   GetAutoFinalizationStatusResponse,

--- a/packages/sns/src/sns.wrapper.ts
+++ b/packages/sns/src/sns.wrapper.ts
@@ -59,6 +59,7 @@ import type {
 } from "./types/governance.params";
 import type { NewSaleTicketParams } from "./types/swap.params";
 import { neuronSubaccount } from "./utils/governance.utils";
+import {ListProposalsResponse} from "../candid/sns_governance";
 
 interface SnsWrapperOptions {
   /** The wrapper for the "root" canister of the particular Sns */
@@ -133,7 +134,7 @@ export class SnsWrapper {
 
   listProposals = (
     params: Omit<SnsListProposalsParams, "certified">,
-  ): Promise<ProposalData[]> =>
+  ): Promise<ListProposalsResponse> =>
     this.governance.listProposals(this.mergeParams(params));
 
   getProposal = (


### PR DESCRIPTION
# Motivation

Update `listProposals` return type to make available `include_ballots_by_caller` flag (**Breaking Change!**). The flag is needed to differentiate between upgraded canisters that fully supports ballots and w/o support.

# Changes

- upgrade sns candids and types
- adjust return type in the source

# Tests

- the `listProposals` should not break when there is no `include_ballots_by_caller` flag provided from the backend (not upgraded canisters don't deliver the flag)

# Todos

- [x] Add entry to changelog (if necessary).
