### PR TITLE
build: bump agent-js v1.0.1 - security patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -717,9 +717,9 @@
       "dev": true
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.20.2.tgz",
-      "integrity": "sha512-xy90wXH4jn3KOi1vyeZ5ji8gnUUY4Iy8k8Juk8/P/IftTDUPmgWL5uLpL3wVV1qnna418Pms1kXSFtbf8OFM0Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-1.0.1.tgz",
+      "integrity": "sha512-QoCiKIWEgsXoaiHpb76M2qLXYDS9IdfvC81dLJYvX9KVXRq8Ojo4S82tBqBFGtM0j0EKEC6mIAJV/bqhOJTtjQ==",
       "peer": true,
       "dependencies": {
         "@noble/curves": "^1.2.0",
@@ -730,17 +730,17 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.20.2",
-        "@dfinity/principal": "^0.20.2"
+        "@dfinity/candid": "^1.0.1",
+        "@dfinity/principal": "^1.0.1"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.20.2.tgz",
-      "integrity": "sha512-pBKk7J+IzX6mnyU8T35751DjDxU2c+roMyrN5UU6fhems1ciITcOm29bPhGzQEe3f8hz/K4arlVMqWTYwOrdEg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-1.0.1.tgz",
+      "integrity": "sha512-PfZNV1fTOWtl+NhLOw71ACLYGugKF9HdEJKtkyBJqbj+6pqshvK6rllCUkGwMsmXfP8YopLzmoNVdy1rp/eOgg==",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "^0.20.2"
+        "@dfinity/principal": "^1.0.1"
       }
     },
     "node_modules/@dfinity/ckbtc": {
@@ -776,9 +776,9 @@
       "link": true
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.20.2.tgz",
-      "integrity": "sha512-xNysODrIxepNjo0ytBrpdCZOkoFCeD5zATyPDXT8tshpBeeQQlgSekDvfHqq7+DeGq9NkGfwTr8IPOmLpltKcg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.0.1.tgz",
+      "integrity": "sha512-pCAuTLcvZEZ8fYgVzTVhfUfFGadxeWN4v2z8Q0rizeiqcHKhbJVfWUiXXjzPGG5lNz2DxKyUHQ/WS4UTbTaxvg==",
       "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.3.1"
@@ -1653,21 +1653,21 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
       "peer": true,
       "dependencies": {
-        "@noble/hashes": "1.3.2"
+        "@noble/hashes": "1.3.3"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
       "engines": {
         "node": ">= 16"
       },
@@ -7864,9 +7864,9 @@
         "bech32": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.20.2",
-        "@dfinity/candid": "^0.20.2",
-        "@dfinity/principal": "^0.20.2",
+        "@dfinity/agent": "^1.0.1",
+        "@dfinity/candid": "^1.0.1",
+        "@dfinity/principal": "^1.0.1",
         "@dfinity/utils": "^2.1.1"
       }
     },
@@ -7875,9 +7875,9 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^0.20.2",
-        "@dfinity/candid": "^0.20.2",
-        "@dfinity/principal": "^0.20.2",
+        "@dfinity/agent": "^1.0.1",
+        "@dfinity/candid": "^1.0.1",
+        "@dfinity/principal": "^1.0.1",
         "@dfinity/utils": "^2.1.1"
       }
     },
@@ -7886,9 +7886,9 @@
       "version": "3.0.1",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^0.20.2",
-        "@dfinity/candid": "^0.20.2",
-        "@dfinity/principal": "^0.20.2",
+        "@dfinity/agent": "^1.0.1",
+        "@dfinity/candid": "^1.0.1",
+        "@dfinity/principal": "^1.0.1",
         "@dfinity/utils": "^2.1.1"
       }
     },
@@ -7897,9 +7897,9 @@
       "version": "2.2.1",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^0.20.2",
-        "@dfinity/candid": "^0.20.2",
-        "@dfinity/principal": "^0.20.2",
+        "@dfinity/agent": "^1.0.1",
+        "@dfinity/candid": "^1.0.1",
+        "@dfinity/principal": "^1.0.1",
         "@dfinity/utils": "^2.1.1"
       }
     },
@@ -7908,10 +7908,10 @@
       "version": "2.2.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^0.20.2",
-        "@dfinity/candid": "^0.20.2",
+        "@dfinity/agent": "^1.0.1",
+        "@dfinity/candid": "^1.0.1",
         "@dfinity/nns-proto": "^1.0.1",
-        "@dfinity/principal": "^0.20.2",
+        "@dfinity/principal": "^1.0.1",
         "@dfinity/utils": "^2.1.1"
       }
     },
@@ -7920,9 +7920,9 @@
       "version": "2.1.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^0.20.2",
-        "@dfinity/candid": "^0.20.2",
-        "@dfinity/principal": "^0.20.2",
+        "@dfinity/agent": "^1.0.1",
+        "@dfinity/candid": "^1.0.1",
+        "@dfinity/principal": "^1.0.1",
         "@dfinity/utils": "^2.1.1"
       }
     },
@@ -7938,11 +7938,11 @@
         "@types/randombytes": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.20.2",
-        "@dfinity/candid": "^0.20.2",
+        "@dfinity/agent": "^1.0.1",
+        "@dfinity/candid": "^1.0.1",
         "@dfinity/ledger-icp": "^2.2.0",
         "@dfinity/nns-proto": "^1.0.1",
-        "@dfinity/principal": "^0.20.2",
+        "@dfinity/principal": "^1.0.1",
         "@dfinity/utils": "^2.1.1"
       }
     },
@@ -7965,10 +7965,10 @@
         "@noble/hashes": "^1.3.2"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.20.2",
-        "@dfinity/candid": "^0.20.2",
+        "@dfinity/agent": "^1.0.1",
+        "@dfinity/candid": "^1.0.1",
         "@dfinity/ledger-icrc": "^2.1.2",
-        "@dfinity/principal": "^0.20.2",
+        "@dfinity/principal": "^1.0.1",
         "@dfinity/utils": "^2.1.1"
       }
     },
@@ -7977,9 +7977,9 @@
       "version": "2.1.1",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^0.20.2",
-        "@dfinity/candid": "^0.20.2",
-        "@dfinity/principal": "^0.20.2"
+        "@dfinity/agent": "^1.0.1",
+        "@dfinity/candid": "^1.0.1",
+        "@dfinity/principal": "^1.0.1"
       }
     }
   },
@@ -8493,9 +8493,9 @@
       "dev": true
     },
     "@dfinity/agent": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.20.2.tgz",
-      "integrity": "sha512-xy90wXH4jn3KOi1vyeZ5ji8gnUUY4Iy8k8Juk8/P/IftTDUPmgWL5uLpL3wVV1qnna418Pms1kXSFtbf8OFM0Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-1.0.1.tgz",
+      "integrity": "sha512-QoCiKIWEgsXoaiHpb76M2qLXYDS9IdfvC81dLJYvX9KVXRq8Ojo4S82tBqBFGtM0j0EKEC6mIAJV/bqhOJTtjQ==",
       "peer": true,
       "requires": {
         "@noble/curves": "^1.2.0",
@@ -8507,9 +8507,9 @@
       }
     },
     "@dfinity/candid": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.20.2.tgz",
-      "integrity": "sha512-pBKk7J+IzX6mnyU8T35751DjDxU2c+roMyrN5UU6fhems1ciITcOm29bPhGzQEe3f8hz/K4arlVMqWTYwOrdEg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-1.0.1.tgz",
+      "integrity": "sha512-PfZNV1fTOWtl+NhLOw71ACLYGugKF9HdEJKtkyBJqbj+6pqshvK6rllCUkGwMsmXfP8YopLzmoNVdy1rp/eOgg==",
       "peer": true,
       "requires": {}
     },
@@ -8557,9 +8557,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.20.2.tgz",
-      "integrity": "sha512-xNysODrIxepNjo0ytBrpdCZOkoFCeD5zATyPDXT8tshpBeeQQlgSekDvfHqq7+DeGq9NkGfwTr8IPOmLpltKcg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.0.1.tgz",
+      "integrity": "sha512-pCAuTLcvZEZ8fYgVzTVhfUfFGadxeWN4v2z8Q0rizeiqcHKhbJVfWUiXXjzPGG5lNz2DxKyUHQ/WS4UTbTaxvg==",
       "peer": true,
       "requires": {
         "@noble/hashes": "^1.3.1"
@@ -9125,18 +9125,18 @@
       }
     },
     "@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
       "peer": true,
       "requires": {
-        "@noble/hashes": "1.3.2"
+        "@noble/hashes": "1.3.3"
       }
     },
     "@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.20.2",
-    "@dfinity/candid": "^0.20.2",
-    "@dfinity/principal": "^0.20.2",
+    "@dfinity/agent": "^1.0.1",
+    "@dfinity/candid": "^1.0.1",
+    "@dfinity/principal": "^1.0.1",
     "@dfinity/utils": "^2.1.1"
   },
   "dependencies": {

--- a/packages/cketh/package.json
+++ b/packages/cketh/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.20.2",
-    "@dfinity/candid": "^0.20.2",
-    "@dfinity/principal": "^0.20.2",
+    "@dfinity/agent": "^1.0.1",
+    "@dfinity/candid": "^1.0.1",
+    "@dfinity/principal": "^1.0.1",
     "@dfinity/utils": "^2.1.1"
   }
 }

--- a/packages/cmc/package.json
+++ b/packages/cmc/package.json
@@ -36,9 +36,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.20.2",
-    "@dfinity/candid": "^0.20.2",
-    "@dfinity/principal": "^0.20.2",
+    "@dfinity/agent": "^1.0.1",
+    "@dfinity/candid": "^1.0.1",
+    "@dfinity/principal": "^1.0.1",
     "@dfinity/utils": "^2.1.1"
   }
 }

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -34,9 +34,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.20.2",
-    "@dfinity/candid": "^0.20.2",
-    "@dfinity/principal": "^0.20.2",
+    "@dfinity/agent": "^1.0.1",
+    "@dfinity/candid": "^1.0.1",
+    "@dfinity/principal": "^1.0.1",
     "@dfinity/utils": "^2.1.1"
   }
 }

--- a/packages/ledger-icp/package.json
+++ b/packages/ledger-icp/package.json
@@ -38,10 +38,10 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.20.2",
-    "@dfinity/candid": "^0.20.2",
+    "@dfinity/agent": "^1.0.1",
+    "@dfinity/candid": "^1.0.1",
     "@dfinity/nns-proto": "^1.0.1",
-    "@dfinity/principal": "^0.20.2",
+    "@dfinity/principal": "^1.0.1",
     "@dfinity/utils": "^2.1.1"
   }
 }

--- a/packages/ledger-icrc/package.json
+++ b/packages/ledger-icrc/package.json
@@ -37,9 +37,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^0.20.2",
-    "@dfinity/candid": "^0.20.2",
-    "@dfinity/principal": "^0.20.2",
+    "@dfinity/agent": "^1.0.1",
+    "@dfinity/candid": "^1.0.1",
+    "@dfinity/principal": "^1.0.1",
     "@dfinity/utils": "^2.1.1"
   }
 }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -51,11 +51,11 @@
     "network-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^0.20.2",
-    "@dfinity/candid": "^0.20.2",
+    "@dfinity/agent": "^1.0.1",
+    "@dfinity/candid": "^1.0.1",
     "@dfinity/ledger-icp": "^2.2.0",
     "@dfinity/nns-proto": "^1.0.1",
-    "@dfinity/principal": "^0.20.2",
+    "@dfinity/principal": "^1.0.1",
     "@dfinity/utils": "^2.1.1"
   }
 }

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -36,10 +36,10 @@
     "sns"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^0.20.2",
-    "@dfinity/candid": "^0.20.2",
+    "@dfinity/agent": "^1.0.1",
+    "@dfinity/candid": "^1.0.1",
     "@dfinity/ledger-icrc": "^2.1.2",
-    "@dfinity/principal": "^0.20.2",
+    "@dfinity/principal": "^1.0.1",
     "@dfinity/utils": "^2.1.1"
   },
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -47,8 +47,8 @@
     "service-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^0.20.2",
-    "@dfinity/candid": "^0.20.2",
-    "@dfinity/principal": "^0.20.2"
+    "@dfinity/agent": "^1.0.1",
+    "@dfinity/candid": "^1.0.1",
+    "@dfinity/principal": "^1.0.1"
   }
 }


### PR DESCRIPTION
# Motivation

A [critical security issue](https://github.com/dfinity/agent-js/security/advisories/GHSA-c9vv-fhgv-cjc3) was patched in agent-js v1.0.1.

Affected version of agent-js are v0.20.x, v0.21.x and v1.0.0. We are currently using v0.20.2.

While NNS dapp is **not** impacted, it is important that we bump and rollout a version of ic-js to help the community upgrade without the need to use the npm `--force` flag (it has already been requested on the [forum](https://forum.dfinity.org/t/agent-js-v1-0-0-is-released/27553/4?u=peterparker)).

# Changes

- bump agent-js v1.0.1