### PR TITLE
docs: typo in query params description for ckBTC getMinterInfo

### DIFF
--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -252,7 +252,7 @@ Returns internal minter parameters such as the minimal amount to retrieve BTC, m
 
 Parameters:
 
-- `params`: The parameters to get the deposit fee.
+- `params`: The parameters to get the minter info.
 - `params.certified`: query or update call
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L251)

--- a/packages/ckbtc/src/minter.canister.ts
+++ b/packages/ckbtc/src/minter.canister.ts
@@ -245,7 +245,7 @@ export class CkBTCMinterCanister extends Canister<CkBTCMinterService> {
   /**
    * Returns internal minter parameters such as the minimal amount to retrieve BTC, minimal number of confirmations or KYT fee.
    *
-   * @param {QueryParams} params The parameters to get the deposit fee.
+   * @param {QueryParams} params The parameters to get the minter info.
    * @param {boolean} params.certified query or update call
    */
   getMinterInfo = async ({ certified }: QueryParams): Promise<MinterInfo> =>


### PR DESCRIPTION
# Motivation

Spotted a typo in the description of ckBTC `getMinterInfo`. Probably due to a copy paste originaly.