### PR TITLE
fix: typo in ic-management interfaces (senderCanisterVerion -> senderCanisterVersion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2024.XX.YY-hhmmZ
+
+## Breaking Changes
+
+- Fix typo in `ic-management` interfaces (`senderCanisterVerion` -> `senderCanisterVersion`).
+
 # 2024.02.21-0835Z
 
 ## Overview

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -82,9 +82,9 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 
 Create a new canister
 
-| Method           | Type                                                                                 |
-| ---------------- | ------------------------------------------------------------------------------------ |
-| `createCanister` | `({ settings, senderCanisterVerion, }?: CreateCanisterParams) => Promise<Principal>` |
+| Method           | Type                                                                                  |
+| ---------------- | ------------------------------------------------------------------------------------- |
+| `createCanister` | `({ settings, senderCanisterVersion, }?: CreateCanisterParams) => Promise<Principal>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L70)
 
@@ -92,9 +92,9 @@ Create a new canister
 
 Update canister settings
 
-| Method           | Type                                                                                       |
-| ---------------- | ------------------------------------------------------------------------------------------ |
-| `updateSettings` | `({ canisterId, senderCanisterVerion, settings, }: UpdateSettingsParams) => Promise<void>` |
+| Method           | Type                                                                                        |
+| ---------------- | ------------------------------------------------------------------------------------------- |
+| `updateSettings` | `({ canisterId, senderCanisterVersion, settings, }: UpdateSettingsParams) => Promise<void>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L91)
 
@@ -102,9 +102,9 @@ Update canister settings
 
 Install code to a canister
 
-| Method        | Type                                                                                                 |
-| ------------- | ---------------------------------------------------------------------------------------------------- |
-| `installCode` | `({ mode, canisterId, wasmModule, arg, senderCanisterVerion, }: InstallCodeParams) => Promise<void>` |
+| Method        | Type                                                                                                  |
+| ------------- | ----------------------------------------------------------------------------------------------------- |
+| `installCode` | `({ mode, canisterId, wasmModule, arg, senderCanisterVersion, }: InstallCodeParams) => Promise<void>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L113)
 
@@ -112,9 +112,9 @@ Install code to a canister
 
 Uninstall code from a canister
 
-| Method          | Type                                                                            |
-| --------------- | ------------------------------------------------------------------------------- |
-| `uninstallCode` | `({ canisterId, senderCanisterVerion, }: UninstallCodeParams) => Promise<void>` |
+| Method          | Type                                                                             |
+| --------------- | -------------------------------------------------------------------------------- |
+| `uninstallCode` | `({ canisterId, senderCanisterVersion, }: UninstallCodeParams) => Promise<void>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L136)
 

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -69,11 +69,11 @@ export class ICManagementCanister {
    */
   createCanister = async ({
     settings,
-    senderCanisterVerion,
+    senderCanisterVersion,
   }: CreateCanisterParams = {}): Promise<Principal> => {
     const { canister_id } = await this.service.create_canister({
       settings: toNullable(toCanisterSettings(settings)),
-      sender_canister_version: toNullable(senderCanisterVerion),
+      sender_canister_version: toNullable(senderCanisterVersion),
     });
 
     return canister_id;
@@ -84,18 +84,18 @@ export class ICManagementCanister {
    *
    * @param {Object} params
    * @param {Principal} params.canisterId
-   * @param {BigInt} params.sender_canister_version
+   * @param {BigInt} params.senderCanisterVersion
    * @param {CanisterSettings} params.settings
    * @returns {Promise<void>}
    */
   updateSettings = ({
     canisterId,
-    senderCanisterVerion,
+    senderCanisterVersion,
     settings,
   }: UpdateSettingsParams): Promise<void> =>
     this.service.update_settings({
       canister_id: canisterId,
-      sender_canister_version: toNullable(senderCanisterVerion),
+      sender_canister_version: toNullable(senderCanisterVersion),
       settings: toCanisterSettings(settings),
     });
 
@@ -115,14 +115,14 @@ export class ICManagementCanister {
     canisterId,
     wasmModule,
     arg,
-    senderCanisterVerion,
+    senderCanisterVersion,
   }: InstallCodeParams): Promise<void> =>
     this.service.install_code({
       mode: toInstallMode(mode),
       canister_id: canisterId,
       wasm_module: wasmModule,
       arg,
-      sender_canister_version: toNullable(senderCanisterVerion),
+      sender_canister_version: toNullable(senderCanisterVersion),
     });
 
   /**
@@ -135,11 +135,11 @@ export class ICManagementCanister {
    */
   uninstallCode = ({
     canisterId,
-    senderCanisterVerion,
+    senderCanisterVersion,
   }: UninstallCodeParams): Promise<void> =>
     this.service.uninstall_code({
       canister_id: canisterId,
-      sender_canister_version: toNullable(senderCanisterVerion),
+      sender_canister_version: toNullable(senderCanisterVersion),
     });
 
   /**

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -31,12 +31,12 @@ export const toCanisterSettings = ({
 
 export interface CreateCanisterParams {
   settings?: CanisterSettings;
-  senderCanisterVerion?: bigint;
+  senderCanisterVersion?: bigint;
 }
 
 export interface UpdateSettingsParams {
   canisterId: Principal;
-  senderCanisterVerion?: bigint;
+  senderCanisterVersion?: bigint;
   settings: CanisterSettings;
 }
 
@@ -69,12 +69,12 @@ export interface InstallCodeParams {
   canisterId: Principal;
   wasmModule: Uint8Array;
   arg: Uint8Array;
-  senderCanisterVerion?: bigint;
+  senderCanisterVersion?: bigint;
 }
 
 export interface UninstallCodeParams {
   canisterId: Principal;
-  senderCanisterVerion?: bigint;
+  senderCanisterVersion?: bigint;
 }
 
 export interface CanisterInfoParams {


### PR DESCRIPTION
# Motivation

Fix typo.

# Changes

- search and replace `senderCanisterVerion` -> `senderCanisterVersion`