### PR TITLE
docs: list TypeScript breaking change in ledger-icrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Breaking Changes
 
 - Fix typo in `ic-management` interfaces (`senderCanisterVerion` -> `senderCanisterVersion`).
+- The `GetTransactionsResponse` provided by the ICRC `IndexCanister` contains a new additional information `balance`. (1)
 
 ## Features
 


### PR DESCRIPTION
# Motivation

It isn't a JS breaking change but, there is an additional parameter in `GetTransactionsResponse` which can lead to a TypeScript issue if not assigned. So this PR documents it.

# Related

Discovered with NNS dapp CI: https://github.com/dfinity/nns-dapp/actions/runs/8140257404/job/22245101959?pr=4586