### PR TITLE
feat: deprecate ICRC IndexCanister module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ## Features
 
 - Add support for `bitcoin_get_utxos` and `bitcoin_get_utxos_query` features to `@dfinity/ic-management` library.
+- New `IndexNgCanister` in `@dfinity/ledger-icrc`, which can be used to interact with the newer version of the ICRC Index canister, notably exposing `getTransactions` as a `query` function.
+- Deprecate `IndexCanister` usage in `@dfinity/ledger-icrc`.
 
 # 2024.02.21-0835Z
 

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -275,7 +275,7 @@ Parameters:
 
 ### :factory: IcrcIndexCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L13)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L16)
 
 #### Methods
 
@@ -288,7 +288,7 @@ Parameters:
 | -------- | --------------------------------------------------------------------- |
 | `create` | `(options: IcrcLedgerCanisterOptions<_SERVICE>) => IcrcIndexCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L14)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L17)
 
 ##### :gear: getTransactions
 
@@ -303,7 +303,7 @@ Index Canister only holds the transactions ids in state, not the whole transacti
 | ----------------- | -------------------------------------------------------------------- |
 | `getTransactions` | `(params: GetAccountTransactionsParams) => Promise<GetTransactions>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L33)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L38)
 
 ### :factory: IcrcIndexNgCanister
 

--- a/packages/ledger-icrc/src/index.canister.ts
+++ b/packages/ledger-icrc/src/index.canister.ts
@@ -10,6 +10,9 @@ import { IndexError } from "./errors/index.errors";
 import type { IcrcLedgerCanisterOptions } from "./types/canister.options";
 import type { GetAccountTransactionsParams } from "./types/index.params";
 
+/**
+ * @deprecated Replaced by `IcrcIndexNgCanister`, which requires interacting with an Index canister that has been upgraded to the so-called `index-ng` WASM.
+ */
 export class IcrcIndexCanister extends Canister<IcrcIndexService> {
   static create(options: IcrcLedgerCanisterOptions<IcrcIndexService>) {
     const { service, certifiedService, canisterId } =
@@ -29,6 +32,8 @@ export class IcrcIndexCanister extends Canister<IcrcIndexService> {
    * `get_account_transactions` needs to be called with an update
    * because the index canisters makes a call to the ledger canister to get the transaction data.
    * Index Canister only holds the transactions ids in state, not the whole transaction data.
+   *
+   * @deprecated Replaced by `IcrcIndexNgCanister.getTransactions`.
    */
   getTransactions = async (
     params: GetAccountTransactionsParams,


### PR DESCRIPTION
# Motivation

Late yesterday evening, I realized that we should actually mark the ICRC `IndexCanister` as deprecated, given that the general goal is to migrate any Index to `index-ng`.

# Changes

- Mark canister and function as deprecated
- Update CHANGELOG and also add a note about `IndexNgCanister`
