### PR TITLE
docs: add IndexNgCanister to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,9 @@
 ## Features
 
 - Support for new ckETH endpoint `get_minter_info` which returns internal minter parameters such as the minimal withdrawal amount, the last observed block number, etc.
-
-## Features
-
 - Add support for `bitcoin_get_utxos` and `bitcoin_get_utxos_query` features to `@dfinity/ic-management` library.
 - Support for new ckBTC endpoint `get_known_utxos` which returns UTXOs of the given account known by the minter.
+- New `IndexNgCanister` in `@dfinity/ledger-icrc`, which can be used to interact with the newer version of the ICRC Index canister, notably exposing `getTransactions` as a `query` function.
 
 # 2024.02.21-0835Z
 


### PR DESCRIPTION
# Motivation

Mentionning the `IndexNgCanister` as a new feature is missing in the CHANGELOG.
