### PR TITLE
Fix async ckETH test

### DIFF
--- a/packages/cketh/src/minter.canister.spec.ts
+++ b/packages/cketh/src/minter.canister.spec.ts
@@ -226,15 +226,26 @@ describe("ckETH minter canister", () => {
       expect(res).toEqual(result);
     });
 
-    it("should bubble errors", () => {
+    it("should bubble errors", async () => {
       const service = mock<ActorSubclass<CkETHMinterService>>();
       service.eip_1559_transaction_price.mockRejectedValue(new Error());
 
       const canister = minter(service);
 
+      const call = () => canister.eip1559TransactionPrice({ certified: true });
+
+      await expect(call).rejects.toThrowError();
+    });
+
+    it("should bubble errors non-certified", async () => {
+      const service = mock<ActorSubclass<CkETHMinterService>>();
+      service.eip_1559_transaction_price.mockRejectedValue(new Error());
+
+      const canister = nonCertifiedMinter(service);
+
       const call = () => canister.eip1559TransactionPrice({ certified: false });
 
-      expect(call).rejects.toThrowError();
+      await expect(call).rejects.toThrowError();
     });
   });
 


### PR DESCRIPTION
# Motivation

When running tests in `ic-js`, I noticed this error:
```
Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        0.911 s, estimated 1 s
Ran all test suites.
/Users/dskloet/dev/ic-js/tree2/node_modules/expect/build/index.js:113
  const err = new JestAssertionError();
              ^

JestAssertionError: expect(received).rejects.toThrowError()

Received promise resolved instead of rejected
Resolved to value: {"gas_limit": 21000n, "max_fee_per_gas": 122272445514n, "max_priority_fee_per_gas": 1500000000n, "max_transaction_fee": 2567721355794000n, "timestamp": [1709707209241181133n]}
    at expect (/Users/dskloet/dev/ic-js/tree2/node_modules/expect/build/index.js:113:15)
    at Object.<anonymous> (/Users/dskloet/dev/ic-js/tree2/packages/cketh/src/minter.canister.spec.ts:237:7)
    at Promise.then.completed (/Users/dskloet/dev/ic-js/tree2/node_modules/jest-circus/build/utils.js:298:28)
    at new Promise (<anonymous>)
    at callAsyncCircusFn (/Users/dskloet/dev/ic-js/tree2/node_modules/jest-circus/build/utils.js:231:10)
    at _callCircusTest (/Users/dskloet/dev/ic-js/tree2/node_modules/jest-circus/build/run.js:316:40)
    at _runTest (/Users/dskloet/dev/ic-js/tree2/node_modules/jest-circus/build/run.js:252:3)
    at _runTestsForDescribeBlock (/Users/dskloet/dev/ic-js/tree2/node_modules/jest-circus/build/run.js:126:9)
    at _runTestsForDescribeBlock (/Users/dskloet/dev/ic-js/tree2/node_modules/jest-circus/build/run.js:121:9)
    at _runTestsForDescribeBlock (/Users/dskloet/dev/ic-js/tree2/node_modules/jest-circus/build/run.js:121:9)
    at run (/Users/dskloet/dev/ic-js/tree2/node_modules/jest-circus/build/run.js:71:3)
    at runAndTransformResultsToJestFormat (/Users/dskloet/dev/ic-js/tree2/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
    at jestAdapter (/Users/dskloet/dev/ic-js/tree2/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
    at runTestInternal (/Users/dskloet/dev/ic-js/tree2/node_modules/jest-runner/build/runTest.js:367:16)
    at runTest (/Users/dskloet/dev/ic-js/tree2/node_modules/jest-runner/build/runTest.js:444:34) {
  matcherResult: undefined
}

Node.js v18.14.0
npm ERR! Lifecycle script `test` failed with error: 
npm ERR! Error: command failed 
npm ERR!   in workspace: @dfinity/cketh@2.0.0 
npm ERR!   at location: /Users/dskloet/dev/ic-js/tree2/packages/cketh
```

I also found it on IC: https://github.com/dfinity/ic-js/actions/runs/8154742878/job/22288791566
The error happens only after all the tests pass, which is why it didn't cause IC to fail.
This started happening since https://github.com/dfinity/ic-js/pull/554 .
The issue is that a test expects an async result but the test itself is not async so it completes before the expectation happens.

The reason the test fails is because it sets mock behavior on the certified service but then calls the non-certified service.

# Changes

1. Make `"should bubble errors"` async.
2. Add a certified version of the test in addition to the non-certified version.
3. Make sure the non-certified version uses the non-certified service.

# Tests

After making the test `async` it consistently failed. After fixing it, it consistently passes.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary