### PR TITLE
Proof of concept: provide empty optionals

### DIFF
--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -50,6 +50,7 @@ export * from "./errors/governance.errors";
 export * from "./errors/swap.errors";
 export { SnsGovernanceCanister } from "./governance.canister";
 export { SnsGovernanceTestCanister } from "./governance_test.canister";
+export * from "./optionals/optionals";
 export { SnsRootCanister } from "./root.canister";
 export * from "./sns";
 export * from "./sns.wrapper";

--- a/packages/sns/src/optionals/optionals.spec.ts
+++ b/packages/sns/src/optionals/optionals.spec.ts
@@ -1,0 +1,17 @@
+import type { NeuronsFundParticipationConstraints as SnsNeuronsFundParticipationConstraints } from "../../candid/sns_swap";
+import { emptyOptionalsForSnsNeuronsFundParticipationConstraints } from "./optionals";
+
+// If this file has a compilation error because new optional fields were added
+// to a Candid type, add the the empty optional field values to the
+// corresponding `emptyOptionalsFor...` value in `./optionals.ts`.
+
+const testValueForSnsNeuronsFundParticipationConstraints: SnsNeuronsFundParticipationConstraints =
+  {
+    ...emptyOptionalsForSnsNeuronsFundParticipationConstraints,
+    coefficient_intervals: [],
+  };
+
+// The real test is whether the types above are accepted by the compiler.
+it("should have at least one test", () => {
+  expect(true).toBe(true);
+});

--- a/packages/sns/src/optionals/optionals.ts
+++ b/packages/sns/src/optionals/optionals.ts
@@ -1,0 +1,14 @@
+import type { NeuronsFundParticipationConstraints as SnsNeuronsFundParticipationConstraints } from "../../candid/sns_swap";
+
+export interface NeuronsFundParticipationConstraints {}
+
+export const emptyOptionalsForSnsNeuronsFundParticipationConstraints: Pick<
+  SnsNeuronsFundParticipationConstraints,
+  | "max_neurons_fund_participation_icp_e8s"
+  | "min_direct_participation_threshold_icp_e8s"
+  | "ideal_matched_participation_function"
+> = {
+  max_neurons_fund_participation_icp_e8s: [],
+  min_direct_participation_threshold_icp_e8s: [],
+  ideal_matched_participation_function: [],
+};


### PR DESCRIPTION
# Proof of concept

## The problem

When Candid types are updated in ic-js, if new optional fields are added, updating the ic-js version in nns-dapp (or other depending repos) is a breaking change, even though the fields are optional.

Here is an [example of a PR](https://github.com/dfinity/nns-dapp/pull/4283) that updated the ic-js dependency in nns-dapp. In addition to updating the dependency, it had to add new empty field values in many places. I'd like updating the ic-js dependency to be automatic without manual changes.

## A solution?

The solution I propose is to provide default empty values for all Candid types. The client repo can then destructure these values in order to get all empty optional values. If a new optional field is added, it should be added to the default empty values such that the client repo will use it automatically.

This PR shows how this could be done for a single type.

It also adds a test which makes sure that any new optional fields are added.

Here is an example of how this would be used in NNS dapp: https://github.com/dfinity/nns-dapp/pull/4594