### PR TITLE
feat: expose utxo types

### DIFF
--- a/packages/ckbtc/src/index.ts
+++ b/packages/ckbtc/src/index.ts
@@ -5,6 +5,8 @@ export type {
   RetrieveBtcOk,
   RetrieveBtcStatus,
   RetrieveBtcStatusV2,
+  Utxo,
+  UtxoStatus,
   Account as WithdrawalAccount,
 } from "../candid/minter";
 export * from "./enums/btc.enums";


### PR DESCRIPTION
# Motivation

`UpdateBalanceOk` which wraps `Utxo` is exposed in ckBTC-js but, the latest, `Utxo`, isn't. Therefore this PR exposes thoses types.
