### PR TITLE
docs: bump tsdoc-markdown to parse optional results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "text-encoding": "^0.7.0",
         "ts-jest": "^29.1.2",
         "ts-protoc-gen": "^0.15.0",
-        "tsdoc-markdown": "^0.1.0",
+        "tsdoc-markdown": "^0.4.0",
         "typescript": "^5.2.2"
       }
     },
@@ -7486,9 +7486,9 @@
       }
     },
     "node_modules/tsdoc-markdown": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-0.1.0.tgz",
-      "integrity": "sha512-V2zayxM+QPukAoTs0WZhkL2SxX2he9l0PXlmkkB5rQN7mpwuk02zTnOAtKOZiU069QzBK51Jy7lBwQPfZvwglw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-0.4.0.tgz",
+      "integrity": "sha512-9w+5JPP7FUgDD2vzH761pUiSjoynVkN17TFGi1Q7AUCzhckrURCkbEeeD63Q/JcNRLljWdCkh2ZBR0YbCrNIdw==",
       "dev": true,
       "bin": {
         "tsdoc": "bin/index.js"
@@ -13162,9 +13162,9 @@
       }
     },
     "tsdoc-markdown": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-0.1.0.tgz",
-      "integrity": "sha512-V2zayxM+QPukAoTs0WZhkL2SxX2he9l0PXlmkkB5rQN7mpwuk02zTnOAtKOZiU069QzBK51Jy7lBwQPfZvwglw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-0.4.0.tgz",
+      "integrity": "sha512-9w+5JPP7FUgDD2vzH761pUiSjoynVkN17TFGi1Q7AUCzhckrURCkbEeeD63Q/JcNRLljWdCkh2ZBR0YbCrNIdw==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "text-encoding": "^0.7.0",
     "ts-jest": "^29.1.2",
     "ts-protoc-gen": "^0.15.0",
-    "tsdoc-markdown": "^0.1.0",
+    "tsdoc-markdown": "^0.4.0",
     "typescript": "^5.2.2"
   },
   "size-limit": [

--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -183,9 +183,9 @@ The BTC retrieval process is slow. Instead of synchronously waiting for a BTC tr
 The caller allowed the minter's principal to spend its funds using
 [icrc2_approve] on the ckBTC ledger.
 
-| Method                    | Type                                                                                                                                  |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `retrieveBtcWithApproval` | `({ address, amount, fromSubaccount, }: { address: string; amount: bigint; fromSubaccount?: Uint8Array; }) => Promise<RetrieveBtcOk>` |
+| Method                    | Type                                                                                                                                               |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `retrieveBtcWithApproval` | `({ address, amount, fromSubaccount, }: { address: string; amount: bigint; fromSubaccount?: Uint8Array or undefined; }) => Promise<RetrieveBtcOk>` |
 
 Parameters:
 

--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -80,9 +80,9 @@ const data = await metadata();
 
 ##### :gear: fromPrincipal
 
-| Method          | Type                                                                                                    |
-| --------------- | ------------------------------------------------------------------------------------------------------- |
-| `fromPrincipal` | `({ principal, subAccount, }: { principal: Principal; subAccount?: SubAccount; }) => AccountIdentifier` |
+| Method          | Type                                                                                                                 |
+| --------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `fromPrincipal` | `({ principal, subAccount, }: { principal: Principal; subAccount?: SubAccount or undefined; }) => AccountIdentifier` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L19)
 

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -111,9 +111,9 @@ param         = [ amountparam ]
 amountparam   = "amount=" *digit [ "." *digit ]
 ```
 
-| Function        | Type                                                                        |
-| --------------- | --------------------------------------------------------------------------- |
-| `decodePayment` | `(code: string) => { token: string; identifier: string; amount?: number; }` |
+| Function        | Type                                                                                                  |
+| --------------- | ----------------------------------------------------------------------------------------------------- |
+| `decodePayment` | `(code: string) => { token: string; identifier: string; amount?: number or undefined; } or undefined` |
 
 Parameters:
 

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -208,9 +208,9 @@ If an array of neuron IDs is provided, precisely those neurons will be fetched.
 If `certified` is true, the request is fetched as an update call, otherwise
 it is fetched using a query call.
 
-| Method        | Type                                                                                                  |
-| ------------- | ----------------------------------------------------------------------------------------------------- |
-| `listNeurons` | `({ certified, neuronIds, }: { certified: boolean; neuronIds?: bigint[]; }) => Promise<NeuronInfo[]>` |
+| Method        | Type                                                                                                               |
+| ------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `listNeurons` | `({ certified, neuronIds, }: { certified: boolean; neuronIds?: bigint[] or undefined; }) => Promise<NeuronInfo[]>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L157)
 
@@ -249,9 +249,9 @@ paginated and filtered by the request.
 If `certified` is true (default), the request is fetched as an update call, otherwise
 it is fetched using a query call.
 
-| Method          | Type                                                                                                                   |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `listProposals` | `({ request, certified, }: { request: ListProposalsRequest; certified?: boolean; }) => Promise<ListProposalsResponse>` |
+| Method          | Type                                                                                                                                |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `listProposals` | `({ request, certified, }: { request: ListProposalsRequest; certified?: boolean or undefined; }) => Promise<ListProposalsResponse>` |
 
 Parameters:
 
@@ -262,17 +262,17 @@ Parameters:
 
 ##### :gear: stakeNeuron
 
-| Method        | Type                                                                                                                                                                                                                                |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `stakeNeuron` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, fee, }: { stake: bigint; principal: Principal; fromSubAccount?: number[]; ledgerCanister: LedgerCanister; createdAt?: bigint; fee?: bigint; }) => Promise<bigint>` |
+| Method        | Type                                                                                                                                                                                                                                                                    |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stakeNeuron` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, fee, }: { stake: bigint; principal: Principal; fromSubAccount?: number[] or undefined; ledgerCanister: LedgerCanister; createdAt?: bigint or undefined; fee?: bigint or undefined; }) => Promise<...>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L245)
 
 ##### :gear: stakeNeuronIcrc1
 
-| Method             | Type                                                                                                                                                                                                                               |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `stakeNeuronIcrc1` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, fee, }: { stake: bigint; principal: Principal; fromSubAccount?: Uint8Array; ledgerCanister: LedgerCanister; createdAt?: bigint; fee?: bigint; }) => Promise<...>` |
+| Method             | Type                                                                                                                                                                                                                                                                      |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stakeNeuronIcrc1` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, fee, }: { stake: bigint; principal: Principal; fromSubAccount?: Uint8Array or undefined; ledgerCanister: LedgerCanister; createdAt?: bigint or undefined; fee?: bigint or undefined; }) => Promise<...>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L311)
 
@@ -400,9 +400,9 @@ Returns single proposal info
 If `certified` is true (default), the request is fetched as an update call, otherwise
 it is fetched using a query call.
 
-| Method        | Type                                                                                                  |
-| ------------- | ----------------------------------------------------------------------------------------------------- |
-| `getProposal` | `({ proposalId, certified, }: { proposalId: bigint; certified?: boolean; }) => Promise<ProposalInfo>` |
+| Method        | Type                                                                                                                            |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `getProposal` | `({ proposalId, certified, }: { proposalId: bigint; certified?: boolean or undefined; }) => Promise<ProposalInfo or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L641)
 
@@ -410,9 +410,9 @@ it is fetched using a query call.
 
 Create new proposal
 
-| Method         | Type                                                |
-| -------------- | --------------------------------------------------- |
-| `makeProposal` | `(request: MakeProposalRequest) => Promise<bigint>` |
+| Method         | Type                                                             |
+| -------------- | ---------------------------------------------------------------- |
+| `makeProposal` | `(request: MakeProposalRequest) => Promise<bigint or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L659)
 
@@ -440,9 +440,9 @@ Edit neuron followees per topic
 
 Disburse neuron on Account
 
-| Method     | Type                                                                                                                  |
-| ---------- | --------------------------------------------------------------------------------------------------------------------- |
-| `disburse` | `({ neuronId, toAccountId, amount, }: { neuronId: bigint; toAccountId?: string; amount?: bigint; }) => Promise<void>` |
+| Method     | Type                                                                                                                                            |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `disburse` | `({ neuronId, toAccountId, amount, }: { neuronId: bigint; toAccountId?: string or undefined; amount?: bigint or undefined; }) => Promise<void>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L717)
 
@@ -460,9 +460,9 @@ Merge Maturity of a neuron
 
 Stake the maturity of a neuron.
 
-| Method          | Type                                                                                                     |
-| --------------- | -------------------------------------------------------------------------------------------------------- |
-| `stakeMaturity` | `({ neuronId, percentageToStake, }: { neuronId: bigint; percentageToStake?: number; }) => Promise<void>` |
+| Method          | Type                                                                                                                  |
+| --------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `stakeMaturity` | `({ neuronId, percentageToStake, }: { neuronId: bigint; percentageToStake?: number or undefined; }) => Promise<void>` |
 
 Parameters:
 
@@ -475,9 +475,9 @@ Parameters:
 
 Merge Maturity of a neuron
 
-| Method        | Type                                                                                                                                                                        |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `spawnNeuron` | `({ neuronId, percentageToSpawn, newController, nonce, }: { neuronId: bigint; percentageToSpawn?: number; newController?: Principal; nonce?: bigint; }) => Promise<bigint>` |
+| Method        | Type                                                                                                                                                                                                               |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `spawnNeuron` | `({ neuronId, percentageToSpawn, newController, nonce, }: { neuronId: bigint; percentageToSpawn?: number or undefined; newController?: Principal or undefined; nonce?: bigint or undefined; }) => Promise<bigint>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L811)
 
@@ -505,9 +505,9 @@ Remove hotkey to neuron
 
 Gets the NeuronID of a newly created neuron.
 
-| Method                            | Type                                                                                    |
-| --------------------------------- | --------------------------------------------------------------------------------------- |
-| `claimOrRefreshNeuronFromAccount` | `({ memo, controller, }: { memo: bigint; controller?: Principal; }) => Promise<bigint>` |
+| Method                            | Type                                                                                                              |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `claimOrRefreshNeuronFromAccount` | `({ memo, controller, }: { memo: bigint; controller?: Principal or undefined; }) => Promise<bigint or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L910)
 
@@ -516,9 +516,9 @@ Gets the NeuronID of a newly created neuron.
 Refreshes neuron and returns neuronId when successful
 Uses query call only.
 
-| Method                 | Type                                                        |
-| ---------------------- | ----------------------------------------------------------- |
-| `claimOrRefreshNeuron` | `(request: ClaimOrRefreshNeuronRequest) => Promise<bigint>` |
+| Method                 | Type                                                                     |
+| ---------------------- | ------------------------------------------------------------------------ |
+| `claimOrRefreshNeuron` | `(request: ClaimOrRefreshNeuronRequest) => Promise<bigint or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L941)
 
@@ -526,9 +526,9 @@ Uses query call only.
 
 Return the data of the neuron provided as id.
 
-| Method      | Type                                                                                           |
-| ----------- | ---------------------------------------------------------------------------------------------- |
-| `getNeuron` | `({ certified, neuronId, }: { certified: boolean; neuronId: bigint; }) => Promise<NeuronInfo>` |
+| Method      | Type                                                                                                        |
+| ----------- | ----------------------------------------------------------------------------------------------------------- |
+| `getNeuron` | `({ certified, neuronId, }: { certified: boolean; neuronId: bigint; }) => Promise<NeuronInfo or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L992)
 
@@ -551,9 +551,9 @@ Return the data of the neuron provided as id.
 
 ##### :gear: listSnses
 
-| Method      | Type                                                                   |
-| ----------- | ---------------------------------------------------------------------- |
-| `listSnses` | `({ certified, }: { certified?: boolean; }) => Promise<DeployedSns[]>` |
+| Method      | Type                                                                                |
+| ----------- | ----------------------------------------------------------------------------------- |
+| `listSnses` | `({ certified, }: { certified?: boolean or undefined; }) => Promise<DeployedSns[]>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/sns_wasm.canister.ts#L29)
 

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -219,9 +219,9 @@ Get the neuron of the Sns
 
 Same as `getNeuron` but returns undefined instead of raising error when not found.
 
-| Method        | Type                                              |
-| ------------- | ------------------------------------------------- |
-| `queryNeuron` | `(params: SnsGetNeuronParams) => Promise<Neuron>` |
+| Method        | Type                                                           |
+| ------------- | -------------------------------------------------------------- |
+| `queryNeuron` | `(params: SnsGetNeuronParams) => Promise<Neuron or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L170)
 
@@ -259,9 +259,9 @@ Remove permissions to a neuron for a specific principal
 
 Split neuron
 
-| Method        | Type                                                  |
-| ------------- | ----------------------------------------------------- |
-| `splitNeuron` | `(params: SnsSplitNeuronParams) => Promise<NeuronId>` |
+| Method        | Type                                                               |
+| ------------- | ------------------------------------------------------------------ |
+| `splitNeuron` | `(params: SnsSplitNeuronParams) => Promise<NeuronId or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L223)
 
@@ -424,9 +424,9 @@ List the canisters that are part of the Sns.
 
 Source code: https://github.com/dfinity/ic/blob/master/rs/sns/root/src/lib.rs
 
-| Method             | Type                                                                              |
-| ------------------ | --------------------------------------------------------------------------------- |
-| `listSnsCanisters` | `({ certified, }: { certified?: boolean; }) => Promise<ListSnsCanistersResponse>` |
+| Method             | Type                                                                                           |
+| ------------------ | ---------------------------------------------------------------------------------------------- |
+| `listSnsCanisters` | `({ certified, }: { certified?: boolean or undefined; }) => Promise<ListSnsCanistersResponse>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/root.canister.ts#L32)
 
@@ -470,9 +470,9 @@ Get the state of the swap
 
 Notify of the payment failure to remove the ticket
 
-| Method                 | Type                    |
-| ---------------------- | ----------------------- |
-| `notifyPaymentFailure` | `() => Promise<Ticket>` |
+| Method                 | Type                                 |
+| ---------------------- | ------------------------------------ |
+| `notifyPaymentFailure` | `() => Promise<Ticket or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L54)
 
@@ -490,9 +490,9 @@ Notify of the user participating in the swap
 
 Get user commitment
 
-| Method              | Type                                                                    |
-| ------------------- | ----------------------------------------------------------------------- |
-| `getUserCommitment` | `(params: GetBuyerStateRequest and QueryParams) => Promise<BuyerState>` |
+| Method              | Type                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------ |
+| `getUserCommitment` | `(params: GetBuyerStateRequest and QueryParams) => Promise<BuyerState or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L72)
 
@@ -520,9 +520,9 @@ Get sale parameters
 
 Return a sale ticket if created and not yet removed (payment flow)
 
-| Method          | Type                                       |
-| --------------- | ------------------------------------------ |
-| `getOpenTicket` | `(params: QueryParams) => Promise<Ticket>` |
+| Method          | Type                                                    |
+| --------------- | ------------------------------------------------------- |
+| `getOpenTicket` | `(params: QueryParams) => Promise<Ticket or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L102)
 
@@ -716,9 +716,9 @@ Parameters:
 
 ##### :gear: queryNeuron
 
-| Method        | Type                                                                 |
-| ------------- | -------------------------------------------------------------------- |
-| `queryNeuron` | `(params: Omit<SnsGetNeuronParams, "certified">) => Promise<Neuron>` |
+| Method        | Type                                                                              |
+| ------------- | --------------------------------------------------------------------------------- |
+| `queryNeuron` | `(params: Omit<SnsGetNeuronParams, "certified">) => Promise<Neuron or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L189)
 
@@ -812,9 +812,9 @@ This is a convenient method that transfers the stake to the neuron subaccount an
 
 ##### :gear: splitNeuron
 
-| Method        | Type                                                  |
-| ------------- | ----------------------------------------------------- |
-| `splitNeuron` | `(params: SnsSplitNeuronParams) => Promise<NeuronId>` |
+| Method        | Type                                                               |
+| ------------- | ------------------------------------------------------------------ |
+| `splitNeuron` | `(params: SnsSplitNeuronParams) => Promise<NeuronId or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L349)
 
@@ -890,9 +890,9 @@ Only the owner of a ticket can remove it.
 
 Always certified
 
-| Method                 | Type                    |
-| ---------------------- | ----------------------- |
-| `notifyPaymentFailure` | `() => Promise<Ticket>` |
+| Method                 | Type                                 |
+| ---------------------- | ------------------------------------ |
+| `notifyPaymentFailure` | `() => Promise<Ticket or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L395)
 
@@ -906,17 +906,17 @@ Always certified
 
 ##### :gear: getUserCommitment
 
-| Method              | Type                                                    |
-| ------------------- | ------------------------------------------------------- |
-| `getUserCommitment` | `(params: GetBuyerStateRequest) => Promise<BuyerState>` |
+| Method              | Type                                                                 |
+| ------------------- | -------------------------------------------------------------------- |
+| `getUserCommitment` | `(params: GetBuyerStateRequest) => Promise<BuyerState or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L404)
 
 ##### :gear: getOpenTicket
 
-| Method          | Type                                                          |
-| --------------- | ------------------------------------------------------------- |
-| `getOpenTicket` | `(params: Omit<QueryParams, "certified">) => Promise<Ticket>` |
+| Method          | Type                                                                       |
+| --------------- | -------------------------------------------------------------------------- |
+| `getOpenTicket` | `(params: Omit<QueryParams, "certified">) => Promise<Ticket or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L409)
 
@@ -930,33 +930,33 @@ Always certified
 
 ##### :gear: getLifecycle
 
-| Method         | Type                                                                        |
-| -------------- | --------------------------------------------------------------------------- |
-| `getLifecycle` | `(params: Omit<QueryParams, "certified">) => Promise<GetLifecycleResponse>` |
+| Method         | Type                                                                                     |
+| -------------- | ---------------------------------------------------------------------------------------- |
+| `getLifecycle` | `(params: Omit<QueryParams, "certified">) => Promise<GetLifecycleResponse or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L418)
 
 ##### :gear: getFinalizationStatus
 
-| Method                  | Type                                                                                     |
-| ----------------------- | ---------------------------------------------------------------------------------------- |
-| `getFinalizationStatus` | `(params: Omit<QueryParams, "certified">) => Promise<GetAutoFinalizationStatusResponse>` |
+| Method                  | Type                                                                                                  |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- |
+| `getFinalizationStatus` | `(params: Omit<QueryParams, "certified">) => Promise<GetAutoFinalizationStatusResponse or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L423)
 
 ##### :gear: getSaleParameters
 
-| Method              | Type                                                                             |
-| ------------------- | -------------------------------------------------------------------------------- |
-| `getSaleParameters` | `(params: Omit<QueryParams, "certified">) => Promise<GetSaleParametersResponse>` |
+| Method              | Type                                                                                          |
+| ------------------- | --------------------------------------------------------------------------------------------- |
+| `getSaleParameters` | `(params: Omit<QueryParams, "certified">) => Promise<GetSaleParametersResponse or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L428)
 
 ##### :gear: getDerivedState
 
-| Method            | Type                                                                           |
-| ----------------- | ------------------------------------------------------------------------------ |
-| `getDerivedState` | `(params: Omit<QueryParams, "certified">) => Promise<GetDerivedStateResponse>` |
+| Method            | Type                                                                                        |
+| ----------------- | ------------------------------------------------------------------------------------------- |
+| `getDerivedState` | `(params: Omit<QueryParams, "certified">) => Promise<GetDerivedStateResponse or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/sns.wrapper.ts#L433)
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -90,9 +90,9 @@ Get a default agent that connects to mainnet with the anonymous identity.
 
 Create an agent for a given identity
 
-| Function      | Type                                                                                                                                                                                |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `createAgent` | `({ identity, host, fetchRootKey, verifyQuerySignatures, }: { identity: Identity; host?: string; fetchRootKey?: boolean; verifyQuerySignatures?: boolean; }) => Promise<HttpAgent>` |
+| Function      | Type                                                                                                                                                                                                                       |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createAgent` | `({ identity, host, fetchRootKey, verifyQuerySignatures, }: { identity: Identity; host?: string or undefined; fetchRootKey?: boolean or undefined; verifyQuerySignatures?: boolean or undefined; }) => Promise<HttpAgent>` |
 
 Parameters:
 
@@ -105,17 +105,17 @@ Parameters:
 
 #### :gear: createServices
 
-| Function         | Type                                                                                                                                                                                                                                                                                                                                 |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `createServices` | `<T>({ options: { canisterId, serviceOverride, certifiedServiceOverride, agent: agentOption, callTransform, queryTransform, }, idlFactory, certifiedIdlFactory, }: { options: Required<Pick<CanisterOptions<T>, "canisterId">> and Omit<CanisterOptions<T>, "canisterId"> & Pick<...>; idlFactory: InterfaceFactory; certifiedId...` |
+| Function         | Type                                                                                                                                                                                                                                                                                                                                   |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createServices` | `<T>({ options: { canisterId, serviceOverride, certifiedServiceOverride, agent: agentOption, callTransform, queryTransform, }, idlFactory, certifiedIdlFactory, }: { options: Required<Pick<CanisterOptions<T>, "canisterId">> and Omit<CanisterOptions<T>, "canisterId"> and Pick<...>; idlFactory: InterfaceFactory; certifiedId...` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/actor.utils.ts#L13)
 
 #### :gear: assertNonNullish
 
-| Function           | Type                                                                 |
-| ------------------ | -------------------------------------------------------------------- |
-| `assertNonNullish` | `<T>(value: T, message?: string) => asserts value is NonNullable<T>` |
+| Function           | Type                                                                              |
+| ------------------ | --------------------------------------------------------------------------------- |
+| `assertNonNullish` | `<T>(value: T, message?: string or undefined) => asserts value is NonNullable<T>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/asserts.utils.ts#L7)
 
@@ -240,9 +240,9 @@ Parameters:
 
 Convert seconds to a human-readable duration, such as "6 days, 10 hours."
 
-| Function            | Type                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------ |
-| `secondsToDuration` | `({ seconds, i18n, }: { seconds: bigint; i18n?: I18nSecondsToDuration; }) => string` |
+| Function            | Type                                                                                              |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| `secondsToDuration` | `({ seconds, i18n, }: { seconds: bigint; i18n?: I18nSecondsToDuration or undefined; }) => string` |
 
 Parameters:
 
@@ -252,9 +252,9 @@ Parameters:
 
 #### :gear: debounce
 
-| Function   | Type                                                                 |
-| ---------- | -------------------------------------------------------------------- |
-| `debounce` | `(func: Function, timeout?: number) => (...args: unknown[]) => void` |
+| Function   | Type                                                                              |
+| ---------- | --------------------------------------------------------------------------------- |
+| `debounce` | `(func: Function, timeout?: number or undefined) => (...args: unknown[]) => void` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/debounce.utils.ts#L2)
 
@@ -262,9 +262,9 @@ Parameters:
 
 Is null or undefined
 
-| Function    | Type                                   |
-| ----------- | -------------------------------------- |
-| `isNullish` | `<T>(argument: T) => argument is null` |
+| Function    | Type                                                                     |
+| ----------- | ------------------------------------------------------------------------ |
+| `isNullish` | `<T>(argument: T or null or undefined) => argument is null or undefined` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/nullish.utils.ts#L2)
 
@@ -272,9 +272,9 @@ Is null or undefined
 
 Not null and not undefined
 
-| Function     | Type                                             |
-| ------------ | ------------------------------------------------ |
-| `nonNullish` | `<T>(argument: T) => argument is NonNullable<T>` |
+| Function     | Type                                                                  |
+| ------------ | --------------------------------------------------------------------- |
+| `nonNullish` | `<T>(argument: T or null or undefined) => argument is NonNullable<T>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/nullish.utils.ts#L7)
 
@@ -282,25 +282,25 @@ Not null and not undefined
 
 Not null and not undefined and not empty
 
-| Function         | Type                         |
-| ---------------- | ---------------------------- |
-| `notEmptyString` | `(value: string) => boolean` |
+| Function         | Type                                              |
+| ---------------- | ------------------------------------------------- |
+| `notEmptyString` | `(value: string or null or undefined) => boolean` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/nullish.utils.ts#L12)
 
 #### :gear: toNullable
 
-| Function     | Type                          |
-| ------------ | ----------------------------- |
-| `toNullable` | `<T>(value?: T) => [] or [T]` |
+| Function     | Type                                               |
+| ------------ | -------------------------------------------------- |
+| `toNullable` | `<T>(value?: T or null or undefined) => [] or [T]` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/did.utils.ts#L4)
 
 #### :gear: fromNullable
 
-| Function       | Type                         |
-| -------------- | ---------------------------- |
-| `fromNullable` | `<T>(value: [] or [T]) => T` |
+| Function       | Type                                      |
+| -------------- | ----------------------------------------- |
+| `fromNullable` | `<T>(value: [] or [T]) => T or undefined` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/did.utils.ts#L8)
 


### PR DESCRIPTION
# Motivation

In previous version of `tsdoc-markdown` types that returned e.g. `T | undefined` were documented as `T`. The new version is set as `strictNullChecks` activated per default which should export those types correctly.

# Reference

- https://github.com/peterpeterparker/tsdoc-markdown/issues/24

# Changes

- bump `tsdoc-markdown`
- generate docs

