### PR TITLE
build: update ic-mgmt candid files

### DIFF
--- a/packages/ic-management/candid/ic-management.certified.idl.js
+++ b/packages/ic-management/candid/ic-management.certified.idl.js
@@ -188,7 +188,7 @@ export const idlFactory = ({ IDL }) => {
     ),
     'headers' : IDL.Vec(http_header),
   });
-  const chunk_hash = IDL.Vec(IDL.Nat8);
+  const chunk_hash = IDL.Record({ 'hash' : IDL.Vec(IDL.Nat8) });
   const install_chunked_code_args = IDL.Record({
     'arg' : IDL.Vec(IDL.Nat8),
     'wasm_module_hash' : IDL.Vec(IDL.Nat8),
@@ -201,8 +201,8 @@ export const idlFactory = ({ IDL }) => {
     }),
     'chunk_hashes_list' : IDL.Vec(chunk_hash),
     'target_canister' : canister_id,
+    'store_canister' : IDL.Opt(canister_id),
     'sender_canister_version' : IDL.Opt(IDL.Nat64),
-    'storage_canister' : IDL.Opt(canister_id),
   });
   const wasm_module = IDL.Vec(IDL.Nat8);
   const install_code_args = IDL.Record({

--- a/packages/ic-management/candid/ic-management.d.ts
+++ b/packages/ic-management/candid/ic-management.d.ts
@@ -108,7 +108,9 @@ export type change_origin =
         canister_id: Principal;
       };
     };
-export type chunk_hash = Uint8Array | number[];
+export interface chunk_hash {
+  hash: Uint8Array | number[];
+}
 export interface clear_chunk_store_args {
   canister_id: canister_id;
 }
@@ -170,8 +172,8 @@ export interface install_chunked_code_args {
     | { install: null };
   chunk_hashes_list: Array<chunk_hash>;
   target_canister: canister_id;
+  store_canister: [] | [canister_id];
   sender_canister_version: [] | [bigint];
-  storage_canister: [] | [canister_id];
 }
 export interface install_code_args {
   arg: Uint8Array | number[];

--- a/packages/ic-management/candid/ic-management.did
+++ b/packages/ic-management/candid/ic-management.did
@@ -48,7 +48,9 @@ type change = record {
     details : change_details;
 };
 
-type chunk_hash = blob;
+type chunk_hash = record {
+  hash : blob;
+};
 
 type http_header = record {
     name : text;
@@ -199,7 +201,7 @@ type install_chunked_code_args = record {
         };
     };
     target_canister : canister_id;
-    storage_canister : opt canister_id;
+    store_canister : opt canister_id;
     chunk_hashes_list : vec chunk_hash;
     wasm_module_hash : blob;
     arg : blob;

--- a/packages/ic-management/candid/ic-management.idl.js
+++ b/packages/ic-management/candid/ic-management.idl.js
@@ -188,7 +188,7 @@ export const idlFactory = ({ IDL }) => {
     ),
     'headers' : IDL.Vec(http_header),
   });
-  const chunk_hash = IDL.Vec(IDL.Nat8);
+  const chunk_hash = IDL.Record({ 'hash' : IDL.Vec(IDL.Nat8) });
   const install_chunked_code_args = IDL.Record({
     'arg' : IDL.Vec(IDL.Nat8),
     'wasm_module_hash' : IDL.Vec(IDL.Nat8),
@@ -201,8 +201,8 @@ export const idlFactory = ({ IDL }) => {
     }),
     'chunk_hashes_list' : IDL.Vec(chunk_hash),
     'target_canister' : canister_id,
+    'store_canister' : IDL.Opt(canister_id),
     'sender_canister_version' : IDL.Opt(IDL.Nat64),
-    'storage_canister' : IDL.Opt(canister_id),
   });
   const wasm_module = IDL.Vec(IDL.Nat8);
   const install_code_args = IDL.Record({


### PR DESCRIPTION
# Motivation

This PR updates the did files of `@dfinity/ic-management` as provided in #574. The changes come from the specification [#272](https://github.com/dfinity/interface-spec/pull/272). Given that the library does not expose installing chunked code yet (I opened a TODO #575) we can I think update the types without further notice.
