### PR TITLE
feat: ICP index canister block timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 2024.xx.yy-hhmmZ
 
+## Breaking Changes
+
+- ICP transactions, as provided by the Index canister, have been extended to include their block timestamp information.
+
 ## Features
 
 - Update most recent did files for ledgers (new optional field for initialization) and ckETH (new optional field in event).

--- a/packages/ledger-icp/candid/index.certified.idl.js
+++ b/packages/ledger-icp/candid/index.certified.idl.js
@@ -31,19 +31,20 @@ export const idlFactory = ({ IDL }) => {
       'spender' : IDL.Opt(IDL.Text),
     }),
   });
-  const Transaction = IDL.Record({
+  const SettledTransaction = IDL.Record({
     'memo' : IDL.Nat64,
     'icrc1_memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'operation' : Operation,
+    'timestamp' : TimeStamp,
     'created_at_time' : IDL.Opt(TimeStamp),
   });
-  const TransactionWithId = IDL.Record({
+  const SettledTransactionWithId = IDL.Record({
     'id' : IDL.Nat64,
-    'transaction' : Transaction,
+    'transaction' : SettledTransaction,
   });
   const GetAccountIdentifierTransactionsResponse = IDL.Record({
     'balance' : IDL.Nat64,
-    'transactions' : IDL.Vec(TransactionWithId),
+    'transactions' : IDL.Vec(SettledTransactionWithId),
     'oldest_tx_id' : IDL.Opt(IDL.Nat64),
   });
   const GetAccountIdentifierTransactionsError = IDL.Record({

--- a/packages/ledger-icp/candid/index.d.ts
+++ b/packages/ledger-icp/candid/index.d.ts
@@ -15,7 +15,7 @@ export interface GetAccountIdentifierTransactionsError {
 }
 export interface GetAccountIdentifierTransactionsResponse {
   balance: bigint;
-  transactions: Array<TransactionWithId>;
+  transactions: Array<SettledTransactionWithId>;
   oldest_tx_id: [] | [bigint];
 }
 export type GetAccountIdentifierTransactionsResult =
@@ -74,6 +74,17 @@ export type Operation =
         spender: [] | [string];
       };
     };
+export interface SettledTransaction {
+  memo: bigint;
+  icrc1_memo: [] | [Uint8Array | number[]];
+  operation: Operation;
+  timestamp: TimeStamp;
+  created_at_time: [] | [TimeStamp];
+}
+export interface SettledTransactionWithId {
+  id: bigint;
+  transaction: SettledTransaction;
+}
 export interface Status {
   num_blocks_synced: bigint;
 }
@@ -82,16 +93,6 @@ export interface TimeStamp {
 }
 export interface Tokens {
   e8s: bigint;
-}
-export interface Transaction {
-  memo: bigint;
-  icrc1_memo: [] | [Uint8Array | number[]];
-  operation: Operation;
-  created_at_time: [] | [TimeStamp];
-}
-export interface TransactionWithId {
-  id: bigint;
-  transaction: Transaction;
 }
 export interface _SERVICE {
   get_account_identifier_balance: ActorMethod<[string], bigint>;

--- a/packages/ledger-icp/candid/index.did
+++ b/packages/ledger-icp/candid/index.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit fff2052 (2024-03-07 tags: release-2024-03-06_23-01+p2p) 'rs/rosetta-api/icp_ledger/index/index.did' by import-candid
+// Generated from IC repo commit c3c5dc8 (2024-03-15 tags: release-2024-03-14_23-01-p2p) 'rs/rosetta-api/icp_ledger/index/index.did' by import-candid
 type Account = record { owner : principal; subaccount : opt vec nat8 };
 type GetAccountIdentifierTransactionsArgs = record {
   max_results : nat64;
@@ -17,7 +17,7 @@ type GetAccountTransactionsArgs = record {
 type GetAccountIdentifierTransactionsError = record { message : text };
 type GetAccountIdentifierTransactionsResponse = record {
   balance : nat64;
-  transactions : vec TransactionWithId;
+  transactions : vec SettledTransactionWithId;
   oldest_tx_id : opt nat64;
 };
 type GetBlocksRequest = record { start : nat; length : nat };
@@ -54,13 +54,14 @@ type GetAccountIdentifierTransactionsResult = variant {
 type Status = record { num_blocks_synced : nat64 };
 type TimeStamp = record { timestamp_nanos : nat64 };
 type Tokens = record { e8s : nat64 };
-type Transaction = record {
+type SettledTransaction = record {
   memo : nat64;
   icrc1_memo : opt vec nat8;
   operation : Operation;
   created_at_time : opt TimeStamp;
+  timestamp : TimeStamp;
 };
-type TransactionWithId = record { id : nat64; transaction : Transaction };
+type SettledTransactionWithId = record { id : nat64; transaction : SettledTransaction };
 service : (InitArg) -> {
   get_account_identifier_balance : (text) -> (nat64) query;
   get_account_identifier_transactions : (

--- a/packages/ledger-icp/candid/index.idl.js
+++ b/packages/ledger-icp/candid/index.idl.js
@@ -31,19 +31,20 @@ export const idlFactory = ({ IDL }) => {
       'spender' : IDL.Opt(IDL.Text),
     }),
   });
-  const Transaction = IDL.Record({
+  const SettledTransaction = IDL.Record({
     'memo' : IDL.Nat64,
     'icrc1_memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'operation' : Operation,
+    'timestamp' : TimeStamp,
     'created_at_time' : IDL.Opt(TimeStamp),
   });
-  const TransactionWithId = IDL.Record({
+  const SettledTransactionWithId = IDL.Record({
     'id' : IDL.Nat64,
-    'transaction' : Transaction,
+    'transaction' : SettledTransaction,
   });
   const GetAccountIdentifierTransactionsResponse = IDL.Record({
     'balance' : IDL.Nat64,
-    'transactions' : IDL.Vec(TransactionWithId),
+    'transactions' : IDL.Vec(SettledTransactionWithId),
     'oldest_tx_id' : IDL.Opt(IDL.Nat64),
   });
   const GetAccountIdentifierTransactionsError = IDL.Record({

--- a/packages/ledger-icp/candid/ledger.did
+++ b/packages/ledger-icp/candid/ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit fff2052 (2024-03-07 tags: release-2024-03-06_23-01+p2p) 'rs/rosetta-api/icp_ledger/ledger.did' by import-candid
+// Generated from IC repo commit c3c5dc8 (2024-03-15 tags: release-2024-03-14_23-01-p2p) 'rs/rosetta-api/icp_ledger/ledger.did' by import-candid
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.


### PR DESCRIPTION
# Motivation

ICP transactions, as provided by the Index canister, have been extended to include their block timestamp information.

# Notes

I labelled this as a breaking changes because the did type was renamed.

# Changes

- Update did files as provided by #574
