### PR TITLE
feat: support for install_chunked_code in ic-mgmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Support for the installation of large canisters with chunked code of the Wasm module in `@dfinity/ic-management`.
 - Update most recent did files for ledgers (new optional field for initialization) and ckETH (new optional field in event).
 
 # 2024.03.05-1100Z

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -54,7 +54,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 
 ### :factory: ICManagementCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L30)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L36)
 
 #### Methods
 
@@ -62,6 +62,10 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 - [createCanister](#gear-createcanister)
 - [updateSettings](#gear-updatesettings)
 - [installCode](#gear-installcode)
+- [uploadChunk](#gear-uploadchunk)
+- [clearChunkStore](#gear-clearchunkstore)
+- [storedChunks](#gear-storedchunks)
+- [installChunkedCode](#gear-installchunkedcode)
 - [uninstallCode](#gear-uninstallcode)
 - [startCanister](#gear-startcanister)
 - [stopCanister](#gear-stopcanister)
@@ -78,7 +82,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 | -------- | ---------------------------------------------------------------- |
 | `create` | `(options: ICManagementCanisterOptions) => ICManagementCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L35)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L41)
 
 ##### :gear: createCanister
 
@@ -88,7 +92,7 @@ Create a new canister
 | ---------------- | ------------------------------------------------------------------------------------- |
 | `createCanister` | `({ settings, senderCanisterVersion, }?: CreateCanisterParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L75)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L81)
 
 ##### :gear: updateSettings
 
@@ -98,7 +102,7 @@ Update canister settings
 | ---------------- | ------------------------------------------------------------------------------------------- |
 | `updateSettings` | `({ canisterId, senderCanisterVersion, settings, }: UpdateSettingsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L96)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L102)
 
 ##### :gear: installCode
 
@@ -108,7 +112,70 @@ Install code to a canister
 | ------------- | ----------------------------------------------------------------------------------------------------- |
 | `installCode` | `({ mode, canisterId, wasmModule, arg, senderCanisterVersion, }: InstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L118)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L124)
+
+##### :gear: uploadChunk
+
+Upload chunks of Wasm modules that are too large to fit in a single message for installation purposes.
+
+| Method        | Type                                                                  |
+| ------------- | --------------------------------------------------------------------- |
+| `uploadChunk` | `({ canisterId, ...rest }: UploadChunkParams) => Promise<chunk_hash>` |
+
+Parameters:
+
+- `params.canisterId`: The canister in which the chunks will be stored.
+- `params.chunk`: A chunk of Wasm module.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L149)
+
+##### :gear: clearChunkStore
+
+Clear the entire chunk storage of a canister.
+
+| Method            | Type                                                        |
+| ----------------- | ----------------------------------------------------------- |
+| `clearChunkStore` | `({ canisterId, }: ClearChunkStoreParams) => Promise<void>` |
+
+Parameters:
+
+- `params.canisterId`: The canister in which the chunks are stored.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L169)
+
+##### :gear: storedChunks
+
+List the hashes of chunks in the chunk storage of a canister.
+
+| Method         | Type                                                             |
+| -------------- | ---------------------------------------------------------------- |
+| `storedChunks` | `({ canisterId, }: StoredChunksParams) => Promise<chunk_hash[]>` |
+
+Parameters:
+
+- `params.canisterId`: The canister in which the chunks are stored.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L188)
+
+##### :gear: installChunkedCode
+
+Installs code that had previously been uploaded in chunks.
+
+| Method               | Type                                                                                                                                                     |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `installChunkedCode` | `({ mode, arg, senderCanisterVersion, chunkHashesList, targetCanisterId, storeCanisterId, wasmModuleHash, }: InstallChunkedCodeParams) => Promise<void>` |
+
+Parameters:
+
+- `params.mode`: Installation, re-installation or upgrade.
+- `params.arg`: The arguments of the canister.
+- `params.senderCanisterVersion`: The optional sender_canister_version parameter can contain the caller's canister version.
+- `params.chunkHashesList`: The list of chunks of the Wasm module to install.
+- `params.targetCanisterId`: Specifies the canister where the code should be installed.
+- `params.storeCanisterId`: Specifies the canister in whose chunk storage the chunks are stored (this parameter defaults to target_canister if not specified).
+- `params.wasmModuleHash`: The Wasm module hash as hex string. Used to check that the SHA-256 hash of wasm_module is equal to the wasm_module_hash parameter and can calls install_code with parameters.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L213)
 
 ##### :gear: uninstallCode
 
@@ -118,7 +185,7 @@ Uninstall code from a canister
 | --------------- | -------------------------------------------------------------------------------- |
 | `uninstallCode` | `({ canisterId, senderCanisterVersion, }: UninstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L141)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L243)
 
 ##### :gear: startCanister
 
@@ -128,7 +195,7 @@ Start a canister
 | --------------- | ------------------------------------------ |
 | `startCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L156)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L258)
 
 ##### :gear: stopCanister
 
@@ -138,7 +205,7 @@ Stop a canister
 | -------------- | ------------------------------------------ |
 | `stopCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L165)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L267)
 
 ##### :gear: canisterStatus
 
@@ -148,7 +215,7 @@ Get canister details (memory size, status, etc.)
 | ---------------- | ------------------------------------------------------------ |
 | `canisterStatus` | `(canisterId: Principal) => Promise<canister_status_result>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L174)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L276)
 
 ##### :gear: canisterInfo
 
@@ -158,7 +225,7 @@ Get canister info (controllers, module hash, changes, etc.)
 | -------------- | ------------------------------------------------------------------------------------------- |
 | `canisterInfo` | `({ canisterId, numRequestChanges, }: CanisterInfoParams) => Promise<canister_info_result>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L187)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L289)
 
 ##### :gear: deleteCanister
 
@@ -168,7 +235,7 @@ Deletes a canister
 | ---------------- | ------------------------------------------ |
 | `deleteCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L202)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L304)
 
 ##### :gear: provisionalCreateCanisterWithCycles
 
@@ -178,7 +245,7 @@ Creates a canister. Only available on development instances.
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `provisionalCreateCanisterWithCycles` | `({ settings, amount, canisterId, }?: ProvisionalCreateCanisterWithCyclesParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L214)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L316)
 
 ##### :gear: bitcoinGetUtxos
 
@@ -188,7 +255,7 @@ Given a `get_utxos_request`, which must specify a Bitcoin address and a Bitcoin 
 | ----------------- | ---------------------------------------------------------------------- |
 | `bitcoinGetUtxos` | `(params: BitcoinGetUtxosParams) => Promise<bitcoin_get_utxos_result>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L241)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L343)
 
 ##### :gear: bitcoinGetUtxosQuery
 
@@ -198,7 +265,7 @@ This method is identical to `bitcoinGetUtxos`, but exposed as a query.
 | ---------------------- | --------------------------------------------------------------------------------- |
 | `bitcoinGetUtxosQuery` | `(params: BitcoinGetUtxosQueryParams) => Promise<bitcoin_get_utxos_query_result>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L259)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L361)
 
 <!-- TSDOC_END -->
 

--- a/packages/ic-management/src/ic-management.canister.spec.ts
+++ b/packages/ic-management/src/ic-management.canister.spec.ts
@@ -24,6 +24,7 @@ import {
   toInstallMode,
   type BitcoinGetUtxosParams,
   type ClearChunkStoreParams,
+  type StoredChunksParams,
   type UploadChunkParams,
 } from "./types/ic-management.params";
 import {
@@ -600,6 +601,44 @@ describe("ICManagementCanister", () => {
       const icManagement = await createICManagement(service);
 
       const call = () => icManagement.clearChunkStore(params);
+
+      expect(call).rejects.toThrowError(Error);
+    });
+  });
+
+  describe("storedChunks", () => {
+    const params: StoredChunksParams = {
+      canisterId: mockCanisterId,
+    };
+
+    it("returns list of hash when success", async () => {
+      const response: chunk_hash[] = [
+        { hash: [1, 2, 3, 4] },
+        { hash: [5, 6, 7] },
+        { hash: [8, 9, 10] },
+      ];
+
+      const service = mock<IcManagementService>();
+      service.stored_chunks.mockResolvedValue(response);
+
+      const icManagement = await createICManagement(service);
+
+      const res = await icManagement.storedChunks(params);
+
+      expect(res).toEqual(response);
+      expect(service.stored_chunks).toHaveBeenCalledWith({
+        canister_id: params.canisterId,
+      });
+    });
+
+    it("throws Error", async () => {
+      const error = new Error("Test");
+      const service = mock<IcManagementService>();
+      service.stored_chunks.mockRejectedValue(error);
+
+      const icManagement = await createICManagement(service);
+
+      const call = () => icManagement.storedChunks(params);
 
       expect(call).rejects.toThrowError(Error);
     });

--- a/packages/ic-management/src/ic-management.canister.spec.ts
+++ b/packages/ic-management/src/ic-management.canister.spec.ts
@@ -23,6 +23,7 @@ import {
   InstallMode,
   toInstallMode,
   type BitcoinGetUtxosParams,
+  type ClearChunkStoreParams,
   type UploadChunkParams,
 } from "./types/ic-management.params";
 import {
@@ -568,6 +569,37 @@ describe("ICManagementCanister", () => {
       const icManagement = await createICManagement(service);
 
       const call = () => icManagement.uploadChunk(params);
+
+      expect(call).rejects.toThrowError(Error);
+    });
+  });
+
+  describe("clearChunkStore", () => {
+    const params: ClearChunkStoreParams = {
+      canisterId: mockCanisterId,
+    };
+
+    it("returns void when success", async () => {
+      const service = mock<IcManagementService>();
+      service.clear_chunk_store.mockResolvedValue(undefined);
+
+      const icManagement = await createICManagement(service);
+
+      const res = await icManagement.clearChunkStore(params);
+
+      expect(service.clear_chunk_store).toHaveBeenCalledWith({
+        canister_id: params.canisterId,
+      });
+    });
+
+    it("throws Error", async () => {
+      const error = new Error("Test");
+      const service = mock<IcManagementService>();
+      service.clear_chunk_store.mockRejectedValue(error);
+
+      const icManagement = await createICManagement(service);
+
+      const call = () => icManagement.clearChunkStore(params);
 
       expect(call).rejects.toThrowError(Error);
     });

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -228,7 +228,10 @@ export class ICManagementCanister {
       arg,
       sender_canister_version: toNullable(senderCanisterVersion),
       chunk_hashes_list: chunkHashesList,
-      wasm_module_hash: hexStringToUint8Array(wasmModuleHash),
+      wasm_module_hash:
+        typeof wasmModuleHash === "string"
+          ? hexStringToUint8Array(wasmModuleHash)
+          : wasmModuleHash,
     });
   };
 

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -2,7 +2,7 @@ import type { CallConfig } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { createServices, toNullable } from "@dfinity/utils";
 import { hexStringToUint8Array } from "@dfinity/utils/src";
-import {
+import type {
   _SERVICE as IcManagementService,
   bitcoin_get_utxos_query_result,
   bitcoin_get_utxos_result,
@@ -12,21 +12,21 @@ import { idlFactory as certifiedIdlFactory } from "../candid/ic-management.certi
 import { idlFactory } from "../candid/ic-management.idl";
 import type { ICManagementCanisterOptions } from "./types/canister.options";
 import {
-  ClearChunkStoreParams,
-  InstallChunkedCodeParams,
-  StoredChunksParams,
-  UploadChunkParams,
   toBitcoinGetUtxosParams,
   toCanisterSettings,
   toInstallMode,
   type BitcoinGetUtxosParams,
   type BitcoinGetUtxosQueryParams,
   type CanisterInfoParams,
+  type ClearChunkStoreParams,
   type CreateCanisterParams,
+  type InstallChunkedCodeParams,
   type InstallCodeParams,
   type ProvisionalCreateCanisterWithCyclesParams,
+  type StoredChunksParams,
   type UninstallCodeParams,
   type UpdateSettingsParams,
+  type UploadChunkParams,
 } from "./types/ic-management.params";
 import type {
   CanisterInfoResponse,

--- a/packages/ic-management/src/index.ts
+++ b/packages/ic-management/src/index.ts
@@ -3,6 +3,7 @@ export type {
   bitcoin_get_utxos_result,
   bitcoin_network,
   block_hash,
+  chunk_hash,
   outpoint,
   satoshi,
   utxo,

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -1,6 +1,6 @@
 import { Principal } from "@dfinity/principal";
 import { toNullable, type ServiceParam } from "@dfinity/utils";
-import {
+import type {
   _SERVICE as IcManagementService,
   bitcoin_get_utxos_args,
   bitcoin_get_utxos_query_args,

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -93,7 +93,7 @@ export interface InstallChunkedCodeParams
   chunkHashesList: Array<chunk_hash>;
   targetCanisterId: Principal;
   storeCanisterId?: Principal;
-  wasmModuleHash: string;
+  wasmModuleHash: string | Uint8Array | number[];
 }
 
 export interface UninstallCodeParams {

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -1,10 +1,12 @@
 import { Principal } from "@dfinity/principal";
 import { toNullable, type ServiceParam } from "@dfinity/utils";
-import type {
+import {
   _SERVICE as IcManagementService,
   bitcoin_get_utxos_args,
   bitcoin_get_utxos_query_args,
   canister_settings,
+  chunk_hash,
+  upload_chunk_args,
 } from "../../candid/ic-management";
 
 export interface CanisterSettings {
@@ -72,6 +74,26 @@ export interface InstallCodeParams {
   wasmModule: Uint8Array;
   arg: Uint8Array;
   senderCanisterVersion?: bigint;
+}
+
+export interface UploadChunkParams extends Pick<upload_chunk_args, "chunk"> {
+  canisterId: Principal;
+}
+
+export interface ClearChunkStoreParams {
+  canisterId: Principal;
+}
+
+export interface StoredChunksParams {
+  canisterId: Principal;
+}
+
+export interface InstallChunkedCodeParams
+  extends Omit<InstallCodeParams, "canisterId" | "wasmModule"> {
+  chunkHashesList: Array<chunk_hash>;
+  targetCanisterId: Principal;
+  storeCanisterId?: Principal;
+  wasmModuleHash: string;
 }
 
 export interface UninstallCodeParams {


### PR DESCRIPTION
# Motivation

Add support for installation of large Wasm modules to `@dfinity/ic-management`. The feature has been rolled out in dfx few weeks ago and was often requested by Azle developers. Not sure there are that much devs that need this with our library but that way the tooling is up-to-date everywhere given. that we already support `installCode`.

# Notes

Nothing that particular in the implementation, it follows the existing code base. Only particularity is probably `installChunkedCode` which accepts a hash as `Uint8array or number[]` as defined by did but als as `string` hex because most probably it is the type of hash that will effectivelly be used by a consumer - i.e. a human readable hash.

# Changes

- add support for IC mgmt `upload_chunk`, `clear_chunk_store`, `stored_chunks` and `install_chunked_code`
