### PR TITLE
feat: add wasm_memory_limit to Cmc canister settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Support for the installation of large canisters with chunked code of the Wasm module in `@dfinity/ic-management`.
 - Update most recent did files for ledgers (new optional field for initialization) and ckETH (new optional field in event).
+- Add `wasm_memory_limit` field to Cmc canister settings
 
 # 2024.03.05-1100Z
 

--- a/packages/cmc/candid/cmc.certified.idl.js
+++ b/packages/cmc/candid/cmc.certified.idl.js
@@ -28,6 +28,7 @@ export const idlFactory = ({ IDL }) => {
     'controllers' : IDL.Opt(IDL.Vec(IDL.Principal)),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat),
     'log_visibility' : IDL.Opt(log_visibility),
+    'wasm_memory_limit' : IDL.Opt(IDL.Nat),
     'memory_allocation' : IDL.Opt(IDL.Nat),
     'compute_allocation' : IDL.Opt(IDL.Nat),
   });

--- a/packages/cmc/candid/cmc.d.ts
+++ b/packages/cmc/candid/cmc.d.ts
@@ -9,6 +9,7 @@ export interface CanisterSettings {
   controllers: [] | [Array<Principal>];
   reserved_cycles_limit: [] | [bigint];
   log_visibility: [] | [log_visibility];
+  wasm_memory_limit: [] | [bigint];
   memory_allocation: [] | [bigint];
   compute_allocation: [] | [bigint];
 }

--- a/packages/cmc/candid/cmc.did
+++ b/packages/cmc/candid/cmc.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit c3c5dc8 (2024-03-15 tags: release-2024-03-14_23-01-p2p) 'rs/nns/cmc/cmc.did' by import-candid
+// Generated from IC repo commit 04775a0 (2024-03-21 tags: release-2024-03-20_23-01-p2p) 'rs/nns/cmc/cmc.did' by import-candid
 type Cycles = nat;
 type BlockIndex = nat64;
 type log_visibility = variant {
@@ -13,6 +13,7 @@ type CanisterSettings = record {
   freezing_threshold : opt nat;
   reserved_cycles_limit: opt nat;
   log_visibility : opt log_visibility;
+  wasm_memory_limit: opt nat;
 };
 type Subaccount = opt blob;
 type Memo = opt blob;

--- a/packages/cmc/candid/cmc.idl.js
+++ b/packages/cmc/candid/cmc.idl.js
@@ -28,6 +28,7 @@ export const idlFactory = ({ IDL }) => {
     'controllers' : IDL.Opt(IDL.Vec(IDL.Principal)),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat),
     'log_visibility' : IDL.Opt(log_visibility),
+    'wasm_memory_limit' : IDL.Opt(IDL.Nat),
     'memory_allocation' : IDL.Opt(IDL.Nat),
     'compute_allocation' : IDL.Opt(IDL.Nat),
   });


### PR DESCRIPTION
# Motivation

Field `wasm_memory_limit` was added to the Cmc canister settings.

# Related PRs

- Detected in [#581]
- Commit in ic repo [f2f03f803970e5cb30f20f2cfa8eacc5ccf9be5a](https://github.com/dfinity/ic/commit/f2f03f803970e5cb30f20f2cfa8eacc5ccf9be5a)

