### PR TITLE
refactor: type canister_install_mode replaces InstallModeParam

### DIFF
--- a/packages/ic-management/candid/ic-management.certified.idl.js
+++ b/packages/ic-management/candid/ic-management.certified.idl.js
@@ -188,17 +188,16 @@ export const idlFactory = ({ IDL }) => {
     ),
     'headers' : IDL.Vec(http_header),
   });
+  const canister_install_mode = IDL.Variant({
+    'reinstall' : IDL.Null,
+    'upgrade' : IDL.Opt(IDL.Record({ 'skip_pre_upgrade' : IDL.Opt(IDL.Bool) })),
+    'install' : IDL.Null,
+  });
   const chunk_hash = IDL.Record({ 'hash' : IDL.Vec(IDL.Nat8) });
   const install_chunked_code_args = IDL.Record({
     'arg' : IDL.Vec(IDL.Nat8),
     'wasm_module_hash' : IDL.Vec(IDL.Nat8),
-    'mode' : IDL.Variant({
-      'reinstall' : IDL.Null,
-      'upgrade' : IDL.Opt(
-        IDL.Record({ 'skip_pre_upgrade' : IDL.Opt(IDL.Bool) })
-      ),
-      'install' : IDL.Null,
-    }),
+    'mode' : canister_install_mode,
     'chunk_hashes_list' : IDL.Vec(chunk_hash),
     'target_canister' : canister_id,
     'store_canister' : IDL.Opt(canister_id),
@@ -208,13 +207,7 @@ export const idlFactory = ({ IDL }) => {
   const install_code_args = IDL.Record({
     'arg' : IDL.Vec(IDL.Nat8),
     'wasm_module' : wasm_module,
-    'mode' : IDL.Variant({
-      'reinstall' : IDL.Null,
-      'upgrade' : IDL.Opt(
-        IDL.Record({ 'skip_pre_upgrade' : IDL.Opt(IDL.Bool) })
-      ),
-      'install' : IDL.Null,
-    }),
+    'mode' : canister_install_mode,
     'canister_id' : canister_id,
     'sender_canister_version' : IDL.Opt(IDL.Nat64),
   });

--- a/packages/ic-management/candid/ic-management.d.ts
+++ b/packages/ic-management/candid/ic-management.d.ts
@@ -63,6 +63,10 @@ export interface canister_info_result {
   recent_changes: Array<change>;
   total_num_changes: bigint;
 }
+export type canister_install_mode =
+  | { reinstall: null }
+  | { upgrade: [] | [{ skip_pre_upgrade: [] | [boolean] }] }
+  | { install: null };
 export interface canister_settings {
   freezing_threshold: [] | [bigint];
   controllers: [] | [Array<Principal>];
@@ -166,10 +170,7 @@ export interface http_request_result {
 export interface install_chunked_code_args {
   arg: Uint8Array | number[];
   wasm_module_hash: Uint8Array | number[];
-  mode:
-    | { reinstall: null }
-    | { upgrade: [] | [{ skip_pre_upgrade: [] | [boolean] }] }
-    | { install: null };
+  mode: canister_install_mode;
   chunk_hashes_list: Array<chunk_hash>;
   target_canister: canister_id;
   store_canister: [] | [canister_id];
@@ -178,10 +179,7 @@ export interface install_chunked_code_args {
 export interface install_code_args {
   arg: Uint8Array | number[];
   wasm_module: wasm_module;
-  mode:
-    | { reinstall: null }
-    | { upgrade: [] | [{ skip_pre_upgrade: [] | [boolean] }] }
-    | { install: null };
+  mode: canister_install_mode;
   canister_id: canister_id;
   sender_canister_version: [] | [bigint];
 }

--- a/packages/ic-management/candid/ic-management.did
+++ b/packages/ic-management/candid/ic-management.did
@@ -178,14 +178,16 @@ type stored_chunks_args = record {
     canister_id : canister_id;
 };
 
-type install_code_args = record {
-    mode : variant {
-        install;
-        reinstall;
-        upgrade : opt record {
-            skip_pre_upgrade : opt bool;
-        };
+type canister_install_mode = variant {
+    install;
+    reinstall;
+    upgrade : opt record {
+        skip_pre_upgrade : opt bool;
     };
+};
+
+type install_code_args = record {
+    mode : canister_install_mode;
     canister_id : canister_id;
     wasm_module : wasm_module;
     arg : blob;
@@ -193,13 +195,7 @@ type install_code_args = record {
 };
 
 type install_chunked_code_args = record {
-    mode : variant {
-        install;
-        reinstall;
-        upgrade : opt record {
-            skip_pre_upgrade : opt bool;
-        };
-    };
+    mode : canister_install_mode;
     target_canister : canister_id;
     store_canister : opt canister_id;
     chunk_hashes_list : vec chunk_hash;

--- a/packages/ic-management/candid/ic-management.idl.js
+++ b/packages/ic-management/candid/ic-management.idl.js
@@ -188,17 +188,16 @@ export const idlFactory = ({ IDL }) => {
     ),
     'headers' : IDL.Vec(http_header),
   });
+  const canister_install_mode = IDL.Variant({
+    'reinstall' : IDL.Null,
+    'upgrade' : IDL.Opt(IDL.Record({ 'skip_pre_upgrade' : IDL.Opt(IDL.Bool) })),
+    'install' : IDL.Null,
+  });
   const chunk_hash = IDL.Record({ 'hash' : IDL.Vec(IDL.Nat8) });
   const install_chunked_code_args = IDL.Record({
     'arg' : IDL.Vec(IDL.Nat8),
     'wasm_module_hash' : IDL.Vec(IDL.Nat8),
-    'mode' : IDL.Variant({
-      'reinstall' : IDL.Null,
-      'upgrade' : IDL.Opt(
-        IDL.Record({ 'skip_pre_upgrade' : IDL.Opt(IDL.Bool) })
-      ),
-      'install' : IDL.Null,
-    }),
+    'mode' : canister_install_mode,
     'chunk_hashes_list' : IDL.Vec(chunk_hash),
     'target_canister' : canister_id,
     'store_canister' : IDL.Opt(canister_id),
@@ -208,13 +207,7 @@ export const idlFactory = ({ IDL }) => {
   const install_code_args = IDL.Record({
     'arg' : IDL.Vec(IDL.Nat8),
     'wasm_module' : wasm_module,
-    'mode' : IDL.Variant({
-      'reinstall' : IDL.Null,
-      'upgrade' : IDL.Opt(
-        IDL.Record({ 'skip_pre_upgrade' : IDL.Opt(IDL.Bool) })
-      ),
-      'install' : IDL.Null,
-    }),
+    'mode' : canister_install_mode,
     'canister_id' : canister_id,
     'sender_canister_version' : IDL.Opt(IDL.Nat64),
   });

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -1,9 +1,9 @@
 import { Principal } from "@dfinity/principal";
-import { toNullable, type ServiceParam } from "@dfinity/utils";
-import type {
-  _SERVICE as IcManagementService,
+import { toNullable } from "@dfinity/utils";
+import {
   bitcoin_get_utxos_args,
   bitcoin_get_utxos_query_args,
+  canister_install_mode,
   canister_settings,
   chunk_hash,
   upload_chunk_args,
@@ -50,12 +50,9 @@ export enum InstallMode {
   Upgrade,
 }
 
-export type InstallModeParam = ServiceParam<
-  IcManagementService,
-  "install_code"
->[0]["mode"];
-
-export const toInstallMode = (installMode: InstallMode): InstallModeParam => {
+export const toInstallMode = (
+  installMode: InstallMode,
+): canister_install_mode => {
   switch (installMode) {
     case InstallMode.Install:
       return { install: null };

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -1,6 +1,6 @@
 import { Principal } from "@dfinity/principal";
 import { toNullable } from "@dfinity/utils";
-import {
+import type {
   bitcoin_get_utxos_args,
   bitcoin_get_utxos_query_args,
   canister_install_mode,


### PR DESCRIPTION
# Motivation

A type `canister_install_mode` was added in the ic-mgmt did file which can replace the type declared within the library `InstallModeParam`.

# Changes

- update did and replace type (which is not exposed)
