### PR TITLE
chore: bump next version and prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2024.03.25-1330Z
+# 2024.03.25-1345Z
 
 ## Overview
 
@@ -8,20 +8,24 @@ The current status of the libraries at the time of the release is as follows:
 | ------------------------ | ------- | ------------- |
 | `@dfinity/ckbtc`         | v2.3.1  | Maintained ⚙️ |
 | `@dfinity/cketh`         | v2.0.1  | Maintained ⚙️ |
-| `@dfinity/cmc`           | v3.0.2  | Unchanged️    |
+| `@dfinity/cmc`           | v3.0.3  | Maintained ⚙️ |
 | `@dfinity/ic-management` | v3.1.0  | Enhanced 🔧   |
 | `@dfinity/ledger-icp`    | v2.2.2  | Maintained ⚙️ |
 | `@dfinity/ledger-icrc`   | v2.1.1  | Maintained ⚙️ |
 | `@dfinity/nns`           | v4.0.2  | Maintained ⚙️ |
-| `@dfinity/nns-proto`     | v1.0.1  | Unchanged️    |
-| `@dfinity/sns`           | v3.0.1  | Unchanged️    |
-| `@dfinity/utils`         | v2.1.2  | Unchanged️    |
+| `@dfinity/nns-proto`     | v1.0.2  | Maintained ⚙️ |
+| `@dfinity/sns`           | v3.0.2  | Maintained ⚙️ |
+| `@dfinity/utils`         | v2.1.3  | Maintained ⚙️ |
 
 ## Features
 
 - Support for the installation of large canisters with chunked code of the Wasm module in `@dfinity/ic-management`.
 - Update most recent did files for ledgers (new optional field for initialization) and ckETH (new optional field in event).
 - Expose Utxo types in `@dfinity/ckbtc`.
+
+## Build
+
+- Bump dev dependencies including esbuild and TypeScript.
 
 ## Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,31 @@
-# 2024.xx.yy-hhmmZ
+# 2024.03.25-1330Z
+
+## Overview
+
+The current status of the libraries at the time of the release is as follows:
+
+| Library                  | Version | Status        |
+| ------------------------ | ------- | ------------- |
+| `@dfinity/ckbtc`         | v2.3.1  | Maintained ⚙️ |
+| `@dfinity/cketh`         | v2.0.1  | Maintained ⚙️ |
+| `@dfinity/cmc`           | v3.0.2  | Unchanged️    |
+| `@dfinity/ic-management` | v3.1.0  | Enhanced 🔧   |
+| `@dfinity/ledger-icp`    | v2.2.2  | Maintained ⚙️ |
+| `@dfinity/ledger-icrc`   | v2.1.1  | Maintained ⚙️ |
+| `@dfinity/nns`           | v4.0.2  | Maintained ⚙️ |
+| `@dfinity/nns-proto`     | v1.0.1  | Unchanged️    |
+| `@dfinity/sns`           | v3.0.1  | Unchanged️    |
+| `@dfinity/utils`         | v2.1.2  | Unchanged️    |
 
 ## Features
 
 - Support for the installation of large canisters with chunked code of the Wasm module in `@dfinity/ic-management`.
 - Update most recent did files for ledgers (new optional field for initialization) and ckETH (new optional field in event).
+- Expose Utxo types in `@dfinity/ckbtc`.
+
+## Documentation
+
+- Bump `tsdoc-markdown` to parse optional result into READMEs.
 
 # 2024.03.05-1100Z
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "2024.03.05-1130Z",
+  "version": "2024.03.25-1330Z",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/ic-js",
-      "version": "2024.03.05-1130Z",
+      "version": "2024.03.25-1330Z",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/utils",
@@ -7256,7 +7256,7 @@
     },
     "packages/ckbtc": {
       "name": "@dfinity/ckbtc",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -7272,7 +7272,7 @@
     },
     "packages/cketh": {
       "name": "@dfinity/cketh",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^1.0.1",
@@ -7294,7 +7294,7 @@
     },
     "packages/ic-management": {
       "name": "@dfinity/ic-management",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^1.0.1",
@@ -7305,7 +7305,7 @@
     },
     "packages/ledger-icp": {
       "name": "@dfinity/ledger-icp",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^1.0.1",
@@ -7317,7 +7317,7 @@
     },
     "packages/ledger-icrc": {
       "name": "@dfinity/ledger-icrc",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^1.0.1",
@@ -7328,7 +7328,7 @@
     },
     "packages/nns": {
       "name": "@dfinity/nns",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -7340,7 +7340,7 @@
       "peerDependencies": {
         "@dfinity/agent": "^1.0.1",
         "@dfinity/candid": "^1.0.1",
-        "@dfinity/ledger-icp": "^2.2.1",
+        "@dfinity/ledger-icp": "^2.2.2",
         "@dfinity/nns-proto": "^1.0.1",
         "@dfinity/principal": "^1.0.1",
         "@dfinity/utils": "^2.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "2024.03.25-1330Z",
+  "version": "2024.03.25-1345Z",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/ic-js",
-      "version": "2024.03.25-1330Z",
+      "version": "2024.03.25-1345Z",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/utils",
@@ -7267,7 +7267,7 @@
         "@dfinity/agent": "^1.0.1",
         "@dfinity/candid": "^1.0.1",
         "@dfinity/principal": "^1.0.1",
-        "@dfinity/utils": "^2.1.2"
+        "@dfinity/utils": "^2.1.3"
       }
     },
     "packages/cketh": {
@@ -7278,18 +7278,18 @@
         "@dfinity/agent": "^1.0.1",
         "@dfinity/candid": "^1.0.1",
         "@dfinity/principal": "^1.0.1",
-        "@dfinity/utils": "^2.1.2"
+        "@dfinity/utils": "^2.1.3"
       }
     },
     "packages/cmc": {
       "name": "@dfinity/cmc",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^1.0.1",
         "@dfinity/candid": "^1.0.1",
         "@dfinity/principal": "^1.0.1",
-        "@dfinity/utils": "^2.1.2"
+        "@dfinity/utils": "^2.1.3"
       }
     },
     "packages/ic-management": {
@@ -7300,7 +7300,7 @@
         "@dfinity/agent": "^1.0.1",
         "@dfinity/candid": "^1.0.1",
         "@dfinity/principal": "^1.0.1",
-        "@dfinity/utils": "^2.1.2"
+        "@dfinity/utils": "^2.1.3"
       }
     },
     "packages/ledger-icp": {
@@ -7312,7 +7312,7 @@
         "@dfinity/candid": "^1.0.1",
         "@dfinity/nns-proto": "^1.0.1",
         "@dfinity/principal": "^1.0.1",
-        "@dfinity/utils": "^2.1.2"
+        "@dfinity/utils": "^2.1.3"
       }
     },
     "packages/ledger-icrc": {
@@ -7323,7 +7323,7 @@
         "@dfinity/agent": "^1.0.1",
         "@dfinity/candid": "^1.0.1",
         "@dfinity/principal": "^1.0.1",
-        "@dfinity/utils": "^2.1.2"
+        "@dfinity/utils": "^2.1.3"
       }
     },
     "packages/nns": {
@@ -7343,12 +7343,12 @@
         "@dfinity/ledger-icp": "^2.2.2",
         "@dfinity/nns-proto": "^1.0.1",
         "@dfinity/principal": "^1.0.1",
-        "@dfinity/utils": "^2.1.2"
+        "@dfinity/utils": "^2.1.3"
       }
     },
     "packages/nns-proto": {
       "name": "@dfinity/nns-proto",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "google-protobuf": "^3.21.2"
@@ -7359,7 +7359,7 @@
     },
     "packages/sns": {
       "name": "@dfinity/sns",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
@@ -7367,14 +7367,14 @@
       "peerDependencies": {
         "@dfinity/agent": "^1.0.1",
         "@dfinity/candid": "^1.0.1",
-        "@dfinity/ledger-icrc": "^2.2.0",
+        "@dfinity/ledger-icrc": "^2.2.1",
         "@dfinity/principal": "^1.0.1",
-        "@dfinity/utils": "^2.1.2"
+        "@dfinity/utils": "^2.1.3"
       }
     },
     "packages/utils": {
       "name": "@dfinity/utils",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "2024.03.25-1330Z",
+  "version": "2024.03.25-1345Z",
   "description": "A collection of library for interfacing with the Internet Computer.",
   "license": "Apache-2.0",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "2024.03.05-1130Z",
+  "version": "2024.03.25-1330Z",
   "description": "A collection of library for interfacing with the Internet Computer.",
   "license": "Apache-2.0",
   "workspaces": [

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ckbtc",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A library for interfacing with ckBTC.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -41,7 +41,7 @@
     "@dfinity/agent": "^1.0.1",
     "@dfinity/candid": "^1.0.1",
     "@dfinity/principal": "^1.0.1",
-    "@dfinity/utils": "^2.1.2"
+    "@dfinity/utils": "^2.1.3"
   },
   "dependencies": {
     "@noble/hashes": "^1.3.2",

--- a/packages/cketh/package.json
+++ b/packages/cketh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/cketh",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A library for interfacing with ckETH.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/cketh/package.json
+++ b/packages/cketh/package.json
@@ -41,6 +41,6 @@
     "@dfinity/agent": "^1.0.1",
     "@dfinity/candid": "^1.0.1",
     "@dfinity/principal": "^1.0.1",
-    "@dfinity/utils": "^2.1.2"
+    "@dfinity/utils": "^2.1.3"
   }
 }

--- a/packages/cmc/package.json
+++ b/packages/cmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/cmc",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A library for interfacing with the cycle minting canister.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -39,6 +39,6 @@
     "@dfinity/agent": "^1.0.1",
     "@dfinity/candid": "^1.0.1",
     "@dfinity/principal": "^1.0.1",
-    "@dfinity/utils": "^2.1.2"
+    "@dfinity/utils": "^2.1.3"
   }
 }

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-management",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A library for interfacing with the IC management canister.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -37,6 +37,6 @@
     "@dfinity/agent": "^1.0.1",
     "@dfinity/candid": "^1.0.1",
     "@dfinity/principal": "^1.0.1",
-    "@dfinity/utils": "^2.1.2"
+    "@dfinity/utils": "^2.1.3"
   }
 }

--- a/packages/ledger-icp/package.json
+++ b/packages/ledger-icp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ledger-icp",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A library for interfacing with the ICP ledger on the Internet Computer.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/ledger-icp/package.json
+++ b/packages/ledger-icp/package.json
@@ -40,8 +40,8 @@
   "peerDependencies": {
     "@dfinity/agent": "^1.0.1",
     "@dfinity/candid": "^1.0.1",
-    "@dfinity/nns-proto": "^1.0.1",
+    "@dfinity/nns-proto": "^1.0.2",
     "@dfinity/principal": "^1.0.1",
-    "@dfinity/utils": "^2.1.2"
+    "@dfinity/utils": "^2.1.3"
   }
 }

--- a/packages/ledger-icrc/package.json
+++ b/packages/ledger-icrc/package.json
@@ -40,6 +40,6 @@
     "@dfinity/agent": "^1.0.1",
     "@dfinity/candid": "^1.0.1",
     "@dfinity/principal": "^1.0.1",
-    "@dfinity/utils": "^2.1.2"
+    "@dfinity/utils": "^2.1.3"
   }
 }

--- a/packages/ledger-icrc/package.json
+++ b/packages/ledger-icrc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ledger-icrc",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A library for interfacing with ICRC ledgers on the Internet Computer.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/nns-proto/package.json
+++ b/packages/nns-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns-proto",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The protobuf source used by nns-js to support hardware wallets.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -56,6 +56,6 @@
     "@dfinity/ledger-icp": "^2.2.2",
     "@dfinity/nns-proto": "^1.0.1",
     "@dfinity/principal": "^1.0.1",
-    "@dfinity/utils": "^2.1.2"
+    "@dfinity/utils": "^2.1.3"
   }
 }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A library for interfacing with the Internet Computer's Network Nervous System.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "@dfinity/agent": "^1.0.1",
     "@dfinity/candid": "^1.0.1",
-    "@dfinity/ledger-icp": "^2.2.1",
+    "@dfinity/ledger-icp": "^2.2.2",
     "@dfinity/nns-proto": "^1.0.1",
     "@dfinity/principal": "^1.0.1",
     "@dfinity/utils": "^2.1.2"

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/sns",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A library for interfacing with a Service Nervous System (SNS) project.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -38,9 +38,9 @@
   "peerDependencies": {
     "@dfinity/agent": "^1.0.1",
     "@dfinity/candid": "^1.0.1",
-    "@dfinity/ledger-icrc": "^2.2.0",
+    "@dfinity/ledger-icrc": "^2.2.1",
     "@dfinity/principal": "^1.0.1",
-    "@dfinity/utils": "^2.1.2"
+    "@dfinity/utils": "^2.1.3"
   },
   "dependencies": {
     "@noble/hashes": "^1.3.2"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/utils",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A collection of utilities and constants for NNS/SNS projects.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",


### PR DESCRIPTION
# Motivation

I want to prepare a release of Oisy for mainnet in which I like to embed only released version of ic-js. Therefore the motivation behind releasing ic-js.

# Changes

 - bump versions according their respective changes
- add overview to CHANGELOG
- add interesting entry in CHANGELOG according git history
