### PR TITLE
fix: incorrect import path in ic-mgmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# 2024.03.25-1415Z
+
+## Overview
+
+The current status of the libraries at the time of the release is as follows:
+
+| Library                  | Version | Status         |
+| ------------------------ |---------|----------------|
+| `@dfinity/ckbtc`         | v2.3.1  | Unchanged️️    |
+| `@dfinity/cketh`         | v2.0.1  | Unchanged️     |
+| `@dfinity/cmc`           | v3.0.3  | Unchanged️     |
+| `@dfinity/ic-management` | v3.1.1  | Patched 🩹     |
+| `@dfinity/ledger-icp`    | v2.2.2  | Unchanged️️    |
+| `@dfinity/ledger-icrc`   | v2.1.1  | Unchanged️️    |
+| `@dfinity/nns`           | v4.0.2  | Unchanged️     |
+| `@dfinity/nns-proto`     | v1.0.2  | Unchanged️     |
+| `@dfinity/sns`           | v3.0.2  | Unchanged️️    |
+| `@dfinity/utils`         | v2.1.3  | Unchanged️     |
+
+## Fix
+
+- Incorrect import path to utils in ic-management: `@dfinity/utils/src`.
+
 # 2024.03.25-1345Z
 
 ## Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,18 @@
 
 The current status of the libraries at the time of the release is as follows:
 
-| Library                  | Version | Status         |
-| ------------------------ |---------|----------------|
-| `@dfinity/ckbtc`         | v2.3.1  | Unchanged️️    |
-| `@dfinity/cketh`         | v2.0.1  | Unchanged️     |
-| `@dfinity/cmc`           | v3.0.3  | Unchanged️     |
-| `@dfinity/ic-management` | v3.1.1  | Patched 🩹     |
-| `@dfinity/ledger-icp`    | v2.2.2  | Unchanged️️    |
-| `@dfinity/ledger-icrc`   | v2.1.1  | Unchanged️️    |
-| `@dfinity/nns`           | v4.0.2  | Unchanged️     |
-| `@dfinity/nns-proto`     | v1.0.2  | Unchanged️     |
-| `@dfinity/sns`           | v3.0.2  | Unchanged️️    |
-| `@dfinity/utils`         | v2.1.3  | Unchanged️     |
+| Library                  | Version | Status      |
+| ------------------------ | ------- | ----------- |
+| `@dfinity/ckbtc`         | v2.3.1  | Unchanged️️ |
+| `@dfinity/cketh`         | v2.0.1  | Unchanged️  |
+| `@dfinity/cmc`           | v3.0.3  | Unchanged️  |
+| `@dfinity/ic-management` | v3.1.1  | Patched 🩹  |
+| `@dfinity/ledger-icp`    | v2.2.2  | Unchanged️️ |
+| `@dfinity/ledger-icrc`   | v2.1.1  | Unchanged️️ |
+| `@dfinity/nns`           | v4.0.2  | Unchanged️  |
+| `@dfinity/nns-proto`     | v1.0.2  | Unchanged️  |
+| `@dfinity/sns`           | v3.0.2  | Unchanged️️ |
+| `@dfinity/utils`         | v2.1.3  | Unchanged️  |
 
 ## Fix
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "2024.03.25-1345Z",
+  "version": "2024.03.25-1415ZZ",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/ic-js",
-      "version": "2024.03.25-1345Z",
+      "version": "2024.03.25-1415ZZ",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/utils",
@@ -7294,7 +7294,7 @@
     },
     "packages/ic-management": {
       "name": "@dfinity/ic-management",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^1.0.1",
@@ -7310,7 +7310,7 @@
       "peerDependencies": {
         "@dfinity/agent": "^1.0.1",
         "@dfinity/candid": "^1.0.1",
-        "@dfinity/nns-proto": "^1.0.1",
+        "@dfinity/nns-proto": "^1.0.2",
         "@dfinity/principal": "^1.0.1",
         "@dfinity/utils": "^2.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "2024.03.25-1345Z",
+  "version": "2024.03.25-1415ZZ",
   "description": "A collection of library for interfacing with the Internet Computer.",
   "license": "Apache-2.0",
   "workspaces": [

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -54,7 +54,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 
 ### :factory: ICManagementCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L36)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L39)
 
 #### Methods
 
@@ -82,7 +82,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 | -------- | ---------------------------------------------------------------- |
 | `create` | `(options: ICManagementCanisterOptions) => ICManagementCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L41)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L44)
 
 ##### :gear: createCanister
 
@@ -92,7 +92,7 @@ Create a new canister
 | ---------------- | ------------------------------------------------------------------------------------- |
 | `createCanister` | `({ settings, senderCanisterVersion, }?: CreateCanisterParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L81)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L84)
 
 ##### :gear: updateSettings
 
@@ -102,7 +102,7 @@ Update canister settings
 | ---------------- | ------------------------------------------------------------------------------------------- |
 | `updateSettings` | `({ canisterId, senderCanisterVersion, settings, }: UpdateSettingsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L102)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L105)
 
 ##### :gear: installCode
 
@@ -112,7 +112,7 @@ Install code to a canister
 | ------------- | ----------------------------------------------------------------------------------------------------- |
 | `installCode` | `({ mode, canisterId, wasmModule, arg, senderCanisterVersion, }: InstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L124)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L127)
 
 ##### :gear: uploadChunk
 
@@ -127,7 +127,7 @@ Parameters:
 - `params.canisterId`: The canister in which the chunks will be stored.
 - `params.chunk`: A chunk of Wasm module.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L149)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L152)
 
 ##### :gear: clearChunkStore
 
@@ -141,7 +141,7 @@ Parameters:
 
 - `params.canisterId`: The canister in which the chunks are stored.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L169)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L172)
 
 ##### :gear: storedChunks
 
@@ -155,7 +155,7 @@ Parameters:
 
 - `params.canisterId`: The canister in which the chunks are stored.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L188)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L191)
 
 ##### :gear: installChunkedCode
 
@@ -175,7 +175,7 @@ Parameters:
 - `params.storeCanisterId`: Specifies the canister in whose chunk storage the chunks are stored (this parameter defaults to target_canister if not specified).
 - `params.wasmModuleHash`: The Wasm module hash as hex string. Used to check that the SHA-256 hash of wasm_module is equal to the wasm_module_hash parameter and can calls install_code with parameters.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L213)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L216)
 
 ##### :gear: uninstallCode
 
@@ -185,7 +185,7 @@ Uninstall code from a canister
 | --------------- | -------------------------------------------------------------------------------- |
 | `uninstallCode` | `({ canisterId, senderCanisterVersion, }: UninstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L246)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L249)
 
 ##### :gear: startCanister
 
@@ -195,7 +195,7 @@ Start a canister
 | --------------- | ------------------------------------------ |
 | `startCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L261)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L264)
 
 ##### :gear: stopCanister
 
@@ -205,7 +205,7 @@ Stop a canister
 | -------------- | ------------------------------------------ |
 | `stopCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L270)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L273)
 
 ##### :gear: canisterStatus
 
@@ -215,7 +215,7 @@ Get canister details (memory size, status, etc.)
 | ---------------- | ------------------------------------------------------------ |
 | `canisterStatus` | `(canisterId: Principal) => Promise<canister_status_result>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L279)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L282)
 
 ##### :gear: canisterInfo
 
@@ -225,7 +225,7 @@ Get canister info (controllers, module hash, changes, etc.)
 | -------------- | ------------------------------------------------------------------------------------------- |
 | `canisterInfo` | `({ canisterId, numRequestChanges, }: CanisterInfoParams) => Promise<canister_info_result>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L292)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L295)
 
 ##### :gear: deleteCanister
 
@@ -235,7 +235,7 @@ Deletes a canister
 | ---------------- | ------------------------------------------ |
 | `deleteCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L307)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L310)
 
 ##### :gear: provisionalCreateCanisterWithCycles
 
@@ -245,7 +245,7 @@ Creates a canister. Only available on development instances.
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `provisionalCreateCanisterWithCycles` | `({ settings, amount, canisterId, }?: ProvisionalCreateCanisterWithCyclesParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L319)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L322)
 
 ##### :gear: bitcoinGetUtxos
 
@@ -261,7 +261,7 @@ Parameters:
 - `params.filter`: The optional filter parameter can be used to restrict the set of returned UTXOs, either providing a minimum number of confirmations or a page reference when pagination is used for addresses with many UTXOs.
 - `params.address`: A Bitcoin address.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L346)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L349)
 
 ##### :gear: bitcoinGetUtxosQuery
 
@@ -277,7 +277,7 @@ Parameters:
 - `params.filter`: The optional filter parameter can be used to restrict the set of returned UTXOs, either providing a minimum number of confirmations or a page reference when pagination is used for addresses with many UTXOs.
 - `params.address`: A Bitcoin address.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L364)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L367)
 
 <!-- TSDOC_END -->
 

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-management",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A library for interfacing with the IC management canister.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -1,7 +1,10 @@
 import type { CallConfig } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
-import { createServices, toNullable } from "@dfinity/utils";
-import { hexStringToUint8Array } from "@dfinity/utils/src";
+import {
+  createServices,
+  hexStringToUint8Array,
+  toNullable,
+} from "@dfinity/utils";
 import type {
   _SERVICE as IcManagementService,
   bitcoin_get_utxos_query_result,


### PR DESCRIPTION
# Motivation

There was an incorrect import path `@dfinity/utils/src` in ic-management. Probably side effect of auto-import of webstorm.

# Notes

Some day I should take the time to setup an eslint rule to detect those.

# Changes

- fix import
- prepare patch release
