### PR TITLE
chore: lint rules to prevent import from @dfinity/*/src

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,17 @@
     "scripts/**/*"
   ],
   "rules": {
-    "@typescript-eslint/consistent-type-imports": "error"
+    "@typescript-eslint/consistent-type-imports": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": [
+          {
+            "group": ["@dfinity/*/src"],
+            "message": "Libraries should not reference sources from each other but should access only the exposed types."
+          }
+        ]
+      }
+    ]
   }
 }

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -4,7 +4,7 @@ import {
   createServices,
   hexStringToUint8Array,
   toNullable,
-} from "@dfinity/utils/src";
+} from "@dfinity/utils";
 import type {
   _SERVICE as IcManagementService,
   bitcoin_get_utxos_query_result,

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -4,7 +4,7 @@ import {
   createServices,
   hexStringToUint8Array,
   toNullable,
-} from "@dfinity/utils";
+} from "@dfinity/utils/src";
 import type {
   _SERVICE as IcManagementService,
   bitcoin_get_utxos_query_result,


### PR DESCRIPTION
# Motivation

There was an issue in release [2024.03.25-1345Z](https://github.com/dfinity/ic-js/releases/tag/2024.03.25-1345Z) because one function was imported as `@dfinity/utils/src` which works fine when the workspace is build but, can lead to issue when used in a dapp. In that case I noticed the error in Oisy.

Given that it was not the first time it happens, thanks Webstorm and other editor auto-import features, this PR provides an eslint rule which aims to detect those type of import to prevent the issue to happen.

# Changes

- new eslint rule `no-restricted-imports`

# Test

Validated locally and in the CI: https://github.com/dfinity/ic-js/actions/runs/8421833902/job/23059661608?pr=590
