### PR TITLE
Update candid in ledger-icp package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2024.xx.yy-hhmmZ
+
+## Features
+
+- ICP transactions, as provided by the Index canister, have been extended to include their block timestamp information.
+
 # 2024.03.25-1415Z
 
 ## Overview

--- a/packages/ledger-icp/candid/index.certified.idl.js
+++ b/packages/ledger-icp/candid/index.certified.idl.js
@@ -35,6 +35,7 @@ export const idlFactory = ({ IDL }) => {
     'memo' : IDL.Nat64,
     'icrc1_memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'operation' : Operation,
+    'timestamp' : IDL.Opt(TimeStamp),
     'created_at_time' : IDL.Opt(TimeStamp),
   });
   const TransactionWithId = IDL.Record({

--- a/packages/ledger-icp/candid/index.d.ts
+++ b/packages/ledger-icp/candid/index.d.ts
@@ -87,6 +87,7 @@ export interface Transaction {
   memo: bigint;
   icrc1_memo: [] | [Uint8Array | number[]];
   operation: Operation;
+  timestamp: [] | [TimeStamp];
   created_at_time: [] | [TimeStamp];
 }
 export interface TransactionWithId {

--- a/packages/ledger-icp/candid/index.did
+++ b/packages/ledger-icp/candid/index.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit fff2052 (2024-03-07 tags: release-2024-03-06_23-01+p2p) 'rs/rosetta-api/icp_ledger/index/index.did' by import-candid
+// Generated from IC repo commit c0dc8b76c4 (2024-03-25) 'rs/rosetta-api/icp_ledger/index/index.did' by import-candid
 type Account = record { owner : principal; subaccount : opt vec nat8 };
 type GetAccountIdentifierTransactionsArgs = record {
   max_results : nat64;
@@ -59,6 +59,7 @@ type Transaction = record {
   icrc1_memo : opt vec nat8;
   operation : Operation;
   created_at_time : opt TimeStamp;
+  timestamp : opt TimeStamp;
 };
 type TransactionWithId = record { id : nat64; transaction : Transaction };
 service : (InitArg) -> {

--- a/packages/ledger-icp/candid/index.idl.js
+++ b/packages/ledger-icp/candid/index.idl.js
@@ -35,6 +35,7 @@ export const idlFactory = ({ IDL }) => {
     'memo' : IDL.Nat64,
     'icrc1_memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'operation' : Operation,
+    'timestamp' : IDL.Opt(TimeStamp),
     'created_at_time' : IDL.Opt(TimeStamp),
   });
   const TransactionWithId = IDL.Record({

--- a/packages/ledger-icp/candid/ledger.did
+++ b/packages/ledger-icp/candid/ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit fff2052 (2024-03-07 tags: release-2024-03-06_23-01+p2p) 'rs/rosetta-api/icp_ledger/ledger.did' by import-candid
+// Generated from IC repo commit c0dc8b76c4 (2024-03-25) 'rs/rosetta-api/icp_ledger/ledger.did' by import-candid
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.

--- a/packages/ledger-icp/src/index.canister.spec.ts
+++ b/packages/ledger-icp/src/index.canister.spec.ts
@@ -80,7 +80,42 @@ describe("IndexCanister", () => {
     const transactionsMock = {
       Ok: {
         balance: 1234n,
-        transactions: [{ id: 1n }, { id: 2n }],
+        transactions: [
+          {
+            id: 1n,
+            transaction: {
+              memo: 123n,
+              icrc1_memo: [],
+              operation: {
+                Mint: {
+                  to: "test",
+                  amount: {
+                    e8s: 1000000n,
+                  },
+                },
+              },
+              created_at_time: [{ timestamp_nanos: 100000123n }],
+              timestamp: [],
+            },
+          },
+          {
+            id: 2n,
+            transaction: {
+              memo: 123n,
+              icrc1_memo: [],
+              operation: {
+                Mint: {
+                  to: "test",
+                  amount: {
+                    e8s: 1000000n,
+                  },
+                },
+              },
+              created_at_time: [],
+              timestamp: [{ timestamp_nanos: 100000456n }],
+            },
+          },
+        ],
         oldest_tx_id: [],
       } as GetAccountIdentifierTransactionsResponse,
     };

--- a/packages/ledger-icrc/candid/icrc_index-ng.did
+++ b/packages/ledger-icrc/candid/icrc_index-ng.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit c3c5dc8 (2024-03-15 tags: release-2024-03-14_23-01-p2p) 'rs/rosetta-api/icrc1/index-ng/index-ng.did' by import-candid
+// Generated from IC repo commit c0dc8b76c4 (2024-03-25) 'rs/rosetta-api/icrc1/index-ng/index-ng.did' by import-candid
 type Tokens = nat;
 
 type InitArg = record {

--- a/packages/ledger-icrc/candid/icrc_index.did
+++ b/packages/ledger-icrc/candid/icrc_index.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit c3c5dc8 (2024-03-15 tags: release-2024-03-14_23-01-p2p) 'rs/rosetta-api/icrc1/index/index.did' by import-candid
+// Generated from IC repo commit c0dc8b76c4 (2024-03-25) 'rs/rosetta-api/icrc1/index/index.did' by import-candid
 type TxId = nat;
 
 type Account = record { owner : principal; subaccount : opt blob };

--- a/packages/ledger-icrc/candid/icrc_ledger.did
+++ b/packages/ledger-icrc/candid/icrc_ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit c3c5dc8 (2024-03-15 tags: release-2024-03-14_23-01-p2p) 'rs/rosetta-api/icrc1/ledger/ledger.did' by import-candid
+// Generated from IC repo commit c0dc8b76c4 (2024-03-25) 'rs/rosetta-api/icrc1/ledger/ledger.did' by import-candid
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.


### PR DESCRIPTION
# Motivation

ICP transactions, as provided by the Index canister, have been extended to include their block timestamp information.

# Changes

Ran the following to update all candid and then undo everything except the `ledger-icp` package.
```
scripts/import-candid ../../ic
scripts/compile-idl-js
git checkout packages/{sns,nns,ic-management,cmc,cketh,ckbtc}
```

# Tests

Included transaction data in the test transactions in the unit test.
The transactions are returned exactly as returned from the canister but this should help with test coverage in case that ever changes in the future.

# Todos

- [x] Add entry to changelog (if necessary).