### PR TITLE
NNS1-2886: Don't fetch ICP fee when not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Features
 
 - ICP transactions, as provided by the Index canister, have been extended to include their block timestamp information.
+- When no fee is specified when making an ICP transaction, use the mandatory fee
+  of 10000 e8s (0.0001 ICP) instead of fetching the fee from the network.
 
 # 2024.03.25-1430Z
 

--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -238,7 +238,7 @@ Returns the index of the block containing the tx if it was successful.
 | --------------- | ---------------------------------------------------- |
 | `icrc1Transfer` | `(request: Icrc1TransferRequest) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L147)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L140)
 
 ### :factory: IndexCanister
 

--- a/packages/ledger-icp/src/ledger.canister.spec.ts
+++ b/packages/ledger-icp/src/ledger.canister.spec.ts
@@ -130,11 +130,8 @@ describe("LedgerCanister", () => {
       const to = mockAccountIdentifier;
       const amount = BigInt(100000);
 
-      it("fetches transaction fee if not present", async () => {
+      it("uses default transaction fee if not present", async () => {
         const service = mock<ActorSubclass<LedgerService>>();
-        service.transfer_fee.mockResolvedValue({
-          transfer_fee: { e8s: BigInt(10_000) },
-        });
         service.transfer.mockResolvedValue({
           Ok: BigInt(1234),
         });
@@ -147,7 +144,16 @@ describe("LedgerCanister", () => {
           amount,
         });
 
-        expect(service.transfer_fee).toBeCalled();
+        expect(service.transfer_fee).not.toBeCalled();
+        expect(service.transfer).toBeCalledWith({
+          amount: { e8s: amount },
+          created_at_time: [],
+          fee: { e8s: TRANSACTION_FEE },
+          from_subaccount: [],
+          memo: 0n,
+          to: to.toUint8Array(),
+        });
+        expect(service.transfer).toBeCalledTimes(1);
       });
 
       it("calls transfer certified service with data", async () => {

--- a/packages/ledger-icp/src/ledger.canister.spec.ts
+++ b/packages/ledger-icp/src/ledger.canister.spec.ts
@@ -646,9 +646,6 @@ describe("LedgerCanister", () => {
 
       it("fetches transaction fee if not present", async () => {
         const service = mock<ActorSubclass<LedgerService>>();
-        service.transfer_fee.mockResolvedValue({
-          transfer_fee: { e8s: BigInt(10_000) },
-        });
         service.icrc1_transfer.mockResolvedValue({
           Ok: BigInt(1234),
         });
@@ -661,7 +658,16 @@ describe("LedgerCanister", () => {
           amount,
         });
 
-        expect(service.transfer_fee).toBeCalled();
+        expect(service.transfer_fee).not.toBeCalled();
+        expect(service.icrc1_transfer).toBeCalledWith({
+          amount,
+          created_at_time: [],
+          fee: [TRANSACTION_FEE],
+          from_subaccount: [],
+          memo: [],
+          to,
+        });
+        expect(service.icrc1_transfer).toBeCalledTimes(1);
       });
 
       it("calls transfer certified service with data", async () => {

--- a/packages/ledger-icp/src/ledger.canister.ts
+++ b/packages/ledger-icp/src/ledger.canister.ts
@@ -118,13 +118,6 @@ export class LedgerCanister {
     if (this.hardwareWallet) {
       return this.transferHardwareWallet(request);
     }
-    // When candid is implemented, the previous lines will go away.
-    // But the transaction fee method is not supported by Ledger App yet.
-    if (request.fee === undefined) {
-      request.fee = this.hardwareWallet
-        ? TRANSACTION_FEE
-        : await this.transactionFee();
-    }
     const rawRequest = toTransferRawRequest(request);
     const response = await this.certifiedService.transfer(rawRequest);
     if ("Err" in response) {

--- a/packages/ledger-icp/src/ledger.canister.ts
+++ b/packages/ledger-icp/src/ledger.canister.ts
@@ -140,12 +140,6 @@ export class LedgerCanister {
   public icrc1Transfer = async (
     request: Icrc1TransferRequest,
   ): Promise<BlockHeight> => {
-    // The transaction fee method is not supported by Ledger App yet.
-    if (request.fee === undefined) {
-      request.fee = this.hardwareWallet
-        ? TRANSACTION_FEE
-        : await this.transactionFee();
-    }
     const rawRequest = toIcrc1TransferRawRequest(request);
     const response = await this.certifiedService.icrc1_transfer(rawRequest);
     if ("Err" in response) {


### PR DESCRIPTION
# Motivation

The NNS dapp now requires version 2.4.9 of the Internet Computer Ledger app.
See for context: https://forum.dfinity.org/t/nns-dapp-to-remove-protobuf-dependency-upgrade-your-ledger-ic-app-to-2-4-9/27712
This means that we no longer need to use a separate code path with protocol buffers when making hardware wallet transactions but can instead use the exact same code path as for normal transactions.

One more thing that's different between hardware wallet transactions and normal transactions is that if you don't specify a fee, we make a call to fetch the fee, except when you use a hardware wallet, in which case we use a hard coded default fee of 10,000 e8s.
According to the interface documentation, this is the [only allowed value](https://github.com/dfinity/ic/blob/bfbd6755bff274c2d0b97d6a33e0152dd9cbefcb/rs/rosetta-api/icp_ledger/ledger.did#L44) for the fee.
So making a transaction to fetch it (but only when not using a hardware wallet) is rather unnecessary.

So in order to make the code path really the same and be able to remove the [hardwareWallet option](https://github.com/dfinity/ic-js/blob/31065ac9048b0b9ee883cf15bb67ab38872be07f/packages/ledger-icp/src/types/ledger.options.ts#L22), we remove the [code to fetch the fee](https://github.com/dfinity/ic-js/blob/31065ac9048b0b9ee883cf15bb67ab38872be07f/packages/ledger-icp/src/ledger.canister.ts#L126) and rely on the [existing hardcoded fallback](https://github.com/dfinity/ic-js/blob/31065ac9048b0b9ee883cf15bb67ab38872be07f/packages/ledger-icp/src/canisters/ledger/ledger.request.converts.ts#L43).

# Changes

1. Remove the code to fetch the fee if `this.hardwareWallet === false`.
2. Same for the icrc1 version of the method.

# Tests

Update the tests not expect the transaction fee call and to expect the default fee to be set.

# Todos

- [x] Add entry to changelog (if necessary).
