### PR TITLE
NNS1-2886: Remove hardware wallet specific code paths from ledger-icp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - ICP transactions, as provided by the Index canister, have been extended to include their block timestamp information.
 - When no fee is specified when making an ICP transaction, use the mandatory fee
   of 10000 e8s (0.0001 ICP) instead of fetching the fee from the network.
+- Remove hardware wallet specific code paths from `@dfinity/ledger-icp`.
 
 # 2024.03.25-1430Z
 

--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -171,7 +171,7 @@ const data = await metadata();
 
 ### :factory: LedgerCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L34)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L29)
 
 #### Methods
 
@@ -187,7 +187,7 @@ const data = await metadata();
 | -------- | ----------------------------------------------------- |
 | `create` | `(options?: LedgerCanisterOptions) => LedgerCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L45)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L40)
 
 ##### :gear: accountBalance
 
@@ -206,7 +206,7 @@ Parameters:
 - `params.accountIdentifier`: The account identifier provided either as hex string or as an AccountIdentifier.
 - `params.certified`: query or update call.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L81)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L76)
 
 ##### :gear: transactionFee
 
@@ -216,7 +216,7 @@ Returns the transaction fee of the ledger canister
 | ---------------- | ----------------------- |
 | `transactionFee` | `() => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L104)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L93)
 
 ##### :gear: transfer
 
@@ -227,7 +227,7 @@ Returns the index of the block containing the tx if it was successful.
 | ---------- | ----------------------------------------------- |
 | `transfer` | `(request: TransferRequest) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L117)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L106)
 
 ##### :gear: icrc1Transfer
 
@@ -238,7 +238,7 @@ Returns the index of the block containing the tx if it was successful.
 | --------------- | ---------------------------------------------------- |
 | `icrc1Transfer` | `(request: Icrc1TransferRequest) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L140)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L126)
 
 ### :factory: IndexCanister
 

--- a/packages/ledger-icp/src/canisters/ledger/ledger.request.converts.ts
+++ b/packages/ledger-icp/src/canisters/ledger/ledger.request.converts.ts
@@ -1,4 +1,3 @@
-import type { ICPTs, Subaccount } from "@dfinity/nns-proto";
 import { arrayOfNumberToUint8Array, toNullable } from "@dfinity/utils";
 import type {
   TransferArg as Icrc1TransferRawRequest,
@@ -10,24 +9,6 @@ import type {
   Icrc1TransferRequest,
   TransferRequest,
 } from "../../types/ledger_converters";
-import { importNnsProto } from "../../utils/proto.utils";
-
-export const subAccountNumbersToSubaccount = async (
-  subAccountNumbers: number[],
-): Promise<Subaccount> => {
-  const bytes = new Uint8Array(subAccountNumbers).buffer;
-  const { Subaccount: SubaccountConstructor } = await importNnsProto();
-  const subaccount: Subaccount = new SubaccountConstructor();
-  subaccount.setSubAccount(new Uint8Array(bytes));
-  return subaccount;
-};
-
-export const toICPTs = async (amount: bigint): Promise<ICPTs> => {
-  const { ICPTs: ICPTsConstructor } = await importNnsProto();
-  const result = new ICPTsConstructor();
-  result.setE8s(amount.toString(10));
-  return result;
-};
 
 const e8sToTokens = (e8s: bigint): Tokens => ({ e8s });
 

--- a/packages/ledger-icp/src/errors/ledger.errors.ts
+++ b/packages/ledger-icp/src/errors/ledger.errors.ts
@@ -1,4 +1,3 @@
-import { convertStringToE8s } from "@dfinity/utils";
 import type {
   Icrc1TransferError as RawIcrc1TransferError,
   TransferError as RawTransferError,
@@ -89,51 +88,4 @@ export const mapIcrc1TransferError = (
   return new TransferError(
     `Unknown error type ${JSON.stringify(rawTransferError)}`,
   );
-};
-
-export const mapTransferProtoError = (responseBytes: Error): TransferError => {
-  const { message } = responseBytes;
-
-  if (message.includes("Reject code: 5")) {
-    // Match against the different error types.
-    // This string matching is fragile. It's a stop-gap solution until
-    // we migrate to the candid interface.
-
-    if (message.match(/Sending from (.*) is not allowed/)) {
-      return new InvalidSenderError();
-    }
-
-    {
-      const m = message.match(/transaction.*duplicate.* in block (\d+)/);
-      if (m && m.length > 1) {
-        return new TxDuplicateError(BigInt(m[1]));
-      }
-    }
-
-    {
-      const m = message.match(
-        /debit account.*, current balance: (\d*(\.\d*)?)/,
-      );
-      if (m && m.length > 1) {
-        const balance = convertStringToE8s(m[1]);
-        if (typeof balance === "bigint") {
-          return new InsufficientFundsError(balance);
-        }
-      }
-    }
-
-    if (message.includes("is in future")) {
-      return new TxCreatedInFutureError();
-    }
-
-    {
-      const m = message.match(/older than (\d+)/);
-      if (m && m.length > 1) {
-        return new TxTooOldError(Number.parseInt(m[1]));
-      }
-    }
-  }
-
-  // Unknown error. Throw as-is.
-  throw responseBytes;
 };

--- a/packages/ledger-icp/src/ledger.canister.spec.ts
+++ b/packages/ledger-icp/src/ledger.canister.spec.ts
@@ -1,23 +1,18 @@
 import { ActorSubclass } from "@dfinity/agent";
-import { Memo, Payment, SendRequest } from "@dfinity/nns-proto";
 import { Principal } from "@dfinity/principal";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
 import type { _SERVICE as LedgerService } from "../candid/ledger";
-import { AccountIdentifier } from "./account_identifier";
-import { toICPTs } from "./canisters/ledger/ledger.request.converts";
 import { TRANSACTION_FEE } from "./constants/constants";
 import {
   BadFeeError,
   InsufficientFundsError,
-  InvalidSenderError,
   TxCreatedInFutureError,
   TxDuplicateError,
   TxTooOldError,
 } from "./errors/ledger.errors";
 import { LedgerCanister } from "./ledger.canister";
 import { mockAccountIdentifier } from "./mocks/ledger.mock";
-import { E8s } from "./types/common";
 
 describe("LedgerCanister", () => {
   describe("accountBalance", () => {
@@ -87,40 +82,6 @@ describe("LedgerCanister", () => {
         const expectedFee = await ledger.transactionFee();
         expect(service.transfer_fee).toBeCalled();
         expect(expectedFee).toBe(fee);
-      });
-    });
-
-    describe("for hardware wallet", () => {
-      it("returns account balance with query call", async () => {
-        const queryFetcher = jest
-          .fn()
-          .mockResolvedValue(new Uint8Array(32).fill(0));
-        const ledger = LedgerCanister.create({
-          queryCallOverride: queryFetcher,
-          hardwareWallet: true,
-        });
-        const balance = await ledger.accountBalance({
-          accountIdentifier: mockAccountIdentifier,
-          certified: false,
-        });
-        expect(typeof balance).toEqual("bigint");
-        expect(queryFetcher).toBeCalled();
-      });
-
-      it("returns account balance with update call", async () => {
-        const updateFetcher = jest
-          .fn()
-          .mockResolvedValue(new Uint8Array(32).fill(0));
-        const ledger = LedgerCanister.create({
-          updateCallOverride: updateFetcher,
-          hardwareWallet: true,
-        });
-        const balance = await ledger.accountBalance({
-          accountIdentifier: mockAccountIdentifier,
-          certified: true,
-        });
-        expect(typeof balance).toEqual("bigint");
-        expect(updateFetcher).toBeCalled();
       });
     });
   });
@@ -401,237 +362,6 @@ describe("LedgerCanister", () => {
           });
 
         expect(call).rejects.toThrowError(TxCreatedInFutureError);
-      });
-    });
-
-    describe("for hardware wallet", () => {
-      const to = mockAccountIdentifier;
-      const amount = BigInt(100000);
-
-      it("handles invalid sender", async () => {
-        const ledger = LedgerCanister.create({
-          updateCallOverride: () => {
-            throw new Error(`Reject code: 5
-                Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'Sending from 2vxsx-fae is not allowed', rosetta-api/ledger_canister/src/main.rs:135:9`);
-          },
-          hardwareWallet: true,
-        });
-
-        const call = async () =>
-          await ledger.transfer({
-            to,
-            amount,
-          });
-
-        await expect(call).rejects.toThrow(new InvalidSenderError());
-      });
-
-      it("handles duplicate transaction", async () => {
-        const ledger = LedgerCanister.create({
-          updateCallOverride: () => {
-            throw new Error(`Reject code: 5
-                Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'transaction is a duplicate of another transaction in block 1235123', rosetta-api/ledger_canister/src/main.rs:135:9`);
-          },
-          hardwareWallet: true,
-        });
-
-        const call = async () =>
-          await ledger.transfer({
-            to,
-            amount,
-          });
-
-        await expect(call).rejects.toThrow(
-          new TxDuplicateError(BigInt(1235123)),
-        );
-      });
-
-      it("handles insufficient balance", async () => {
-        const ledger = LedgerCanister.create({
-          updateCallOverride: () => {
-            throw new Error(`Reject code: 5
-                Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'the debit account doesn't have enough funds to complete the transaction, current balance: 123.46789123', rosetta-api/ledger_canister/src/main.rs:135:9`);
-          },
-          hardwareWallet: true,
-        });
-
-        const call = async () =>
-          await ledger.transfer({
-            to,
-            amount,
-          });
-
-        await expect(call).rejects.toThrow(
-          new InsufficientFundsError(BigInt(12346789123)),
-        );
-      });
-
-      it("handles future tx", async () => {
-        const ledger = LedgerCanister.create({
-          updateCallOverride: () => {
-            throw new Error(`Reject code: 5
-                Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'transaction's created_at_time is in future', rosetta-api/ledger_canister/src/main.rs:135:9`);
-          },
-          hardwareWallet: true,
-        });
-
-        const call = async () =>
-          await ledger.transfer({
-            to,
-            amount,
-          });
-
-        await expect(call).rejects.toThrow(new TxCreatedInFutureError());
-      });
-
-      it("handles old tx", async () => {
-        const ledger = LedgerCanister.create({
-          updateCallOverride: () => {
-            throw new Error(`Reject code: 5
-                Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'transaction is older than 123 seconds', rosetta-api/ledger_canister/src/main.rs:135:9`);
-          },
-          hardwareWallet: true,
-        });
-
-        const call = async () =>
-          await ledger.transfer({
-            to,
-            amount,
-          });
-
-        await expect(call).rejects.toThrow(new TxTooOldError(123));
-      });
-
-      it("handles subaccount for hw", async () => {
-        const ledger = LedgerCanister.create({
-          updateCallOverride: jest
-            .fn()
-            .mockResolvedValue(new Uint8Array(32).fill(0)),
-          hardwareWallet: true,
-        });
-        const fromSubAccount = [
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0, 0, 0, 1,
-        ];
-
-        const res = await ledger.transfer({
-          to,
-          amount,
-          fromSubAccount,
-        });
-
-        expect(typeof res).toEqual("bigint");
-      });
-
-      const initExpectedRequest = async ({
-        to,
-        amount,
-        memo,
-        fee,
-      }: {
-        to: AccountIdentifier;
-        amount: bigint;
-        memo?: bigint;
-        fee?: E8s;
-      }): Promise<SendRequest> => {
-        const expectedRequest = new SendRequest();
-        expectedRequest.setTo(await to.toProto());
-
-        const payment = new Payment();
-        payment.setReceiverGets(await toICPTs(amount));
-        expectedRequest.setPayment(payment);
-
-        const requestMemo = new Memo();
-        requestMemo.setMemo((memo ?? BigInt(0)).toString());
-        expectedRequest.setMemo(requestMemo);
-
-        expectedRequest.setMaxFee(await toICPTs(fee ?? TRANSACTION_FEE));
-
-        return expectedRequest;
-      };
-
-      it("should set a default fee for a transfer", async () => {
-        const ledger = LedgerCanister.create({
-          updateCallOverride: () => Promise.resolve(new Uint8Array()),
-          hardwareWallet: true,
-        });
-
-        // @ts-ignore - private function
-        const spy = jest.spyOn(ledger, "updateFetcher");
-
-        const expectedRequest = await initExpectedRequest({ to, amount });
-
-        await ledger.transfer({
-          to,
-          amount,
-        });
-
-        expect(spy).toHaveBeenCalledWith({
-          // @ts-ignore - private variable
-          agent: ledger.agent,
-          // @ts-ignore - private variable
-          canisterId: ledger.canisterId,
-          methodName: "send_pb",
-          arg: expectedRequest.serializeBinary(),
-        });
-      });
-
-      it("should use custom fee for a transfer", async () => {
-        const ledger = LedgerCanister.create({
-          updateCallOverride: () => Promise.resolve(new Uint8Array()),
-          hardwareWallet: true,
-        });
-
-        // @ts-ignore - private function
-        const spy = jest.spyOn(ledger, "updateFetcher");
-
-        const fee = BigInt(990_000);
-
-        const expectedRequest = await initExpectedRequest({ to, amount, fee });
-
-        await ledger.transfer({
-          to,
-          amount,
-          fee,
-        });
-
-        expect(spy).toHaveBeenCalledWith({
-          // @ts-ignore - private variable
-          agent: ledger.agent,
-          // @ts-ignore - private variable
-          canisterId: ledger.canisterId,
-          methodName: "send_pb",
-          arg: expectedRequest.serializeBinary(),
-        });
-      });
-
-      it("should use custom memo for a transfer", async () => {
-        const ledger = LedgerCanister.create({
-          updateCallOverride: () => Promise.resolve(new Uint8Array()),
-          hardwareWallet: true,
-        });
-
-        // @ts-ignore - private function
-        const spy = jest.spyOn(ledger, "updateFetcher");
-
-        const memo = BigInt(990_000);
-
-        const expectedRequest = await initExpectedRequest({ to, amount, memo });
-
-        await ledger.transfer({
-          to,
-          amount,
-          memo,
-        });
-
-        expect(spy).toHaveBeenCalledWith({
-          // @ts-ignore - private variable
-          agent: ledger.agent,
-          // @ts-ignore - private variable
-          canisterId: ledger.canisterId,
-          methodName: "send_pb",
-          arg: expectedRequest.serializeBinary(),
-        });
       });
     });
   });
@@ -929,76 +659,6 @@ describe("LedgerCanister", () => {
           });
 
         expect(call).rejects.toThrowError(TxCreatedInFutureError);
-      });
-    });
-
-    describe("for hardware wallet", () => {
-      const to = {
-        owner: Principal.fromHex("abcd"),
-        subaccount: [] as [],
-      };
-      const amount = BigInt(100000);
-
-      it("should set a default fee for a transfer", async () => {
-        const service = mock<ActorSubclass<LedgerService>>();
-        service.icrc1_transfer.mockResolvedValue({
-          Ok: BigInt(1234),
-        });
-        const ledger = LedgerCanister.create({
-          certifiedServiceOverride: service,
-          serviceOverride: service,
-          hardwareWallet: true,
-        });
-
-        const icrc1Memo = new Uint8Array();
-        await ledger.icrc1Transfer({
-          to,
-          amount,
-          icrc1Memo,
-        });
-
-        expect(service.transfer_fee).not.toBeCalled();
-
-        expect(service.icrc1_transfer).toBeCalledWith({
-          to,
-          fee: [BigInt(10000)],
-          amount,
-          memo: [icrc1Memo],
-          created_at_time: [],
-          from_subaccount: [],
-        });
-      });
-
-      it("should use custom fee for a transfer", async () => {
-        const service = mock<ActorSubclass<LedgerService>>();
-        service.icrc1_transfer.mockResolvedValue({
-          Ok: BigInt(1234),
-        });
-        const ledger = LedgerCanister.create({
-          certifiedServiceOverride: service,
-          serviceOverride: service,
-          hardwareWallet: true,
-        });
-
-        const fee = BigInt(990_000);
-        const icrc1Memo = new Uint8Array();
-        await ledger.icrc1Transfer({
-          to,
-          amount,
-          fee,
-          icrc1Memo,
-        });
-
-        expect(service.transfer_fee).not.toBeCalled();
-
-        expect(service.icrc1_transfer).toBeCalledWith({
-          to,
-          fee: [fee],
-          amount,
-          memo: [icrc1Memo],
-          created_at_time: [],
-          from_subaccount: [],
-        });
       });
     });
   });

--- a/packages/ledger-icp/src/ledger.canister.ts
+++ b/packages/ledger-icp/src/ledger.canister.ts
@@ -4,19 +4,14 @@ import { createServices } from "@dfinity/utils";
 import type { _SERVICE as LedgerService } from "../candid/ledger";
 import { idlFactory as certifiedIdlFactory } from "../candid/ledger.certified.idl";
 import { idlFactory } from "../candid/ledger.idl";
-import type { AccountIdentifier } from "./account_identifier";
 import {
-  subAccountNumbersToSubaccount,
-  toICPTs,
   toIcrc1TransferRawRequest,
   toTransferRawRequest,
 } from "./canisters/ledger/ledger.request.converts";
 import { MAINNET_LEDGER_CANISTER_ID } from "./constants/canister_ids";
-import { TRANSACTION_FEE } from "./constants/constants";
 import {
   mapIcrc1TransferError,
   mapTransferError,
-  mapTransferProtoError,
 } from "./errors/ledger.errors";
 import type { BlockHeight } from "./types/common";
 import type {
@@ -29,7 +24,7 @@ import type {
   TransferRequest,
 } from "./types/ledger_converters";
 import { paramToAccountIdentifier } from "./utils/params.utils";
-import { importNnsProto, queryCall, updateCall } from "./utils/proto.utils";
+import { queryCall, updateCall } from "./utils/proto.utils";
 
 export class LedgerCanister {
   private constructor(
@@ -84,12 +79,6 @@ export class LedgerCanister {
   }: AccountBalanceParams): Promise<bigint> => {
     const accountIdentifier = paramToAccountIdentifier(accountIdentifierParam);
 
-    if (this.hardwareWallet) {
-      return this.accountBalanceHardwareWallet({
-        accountIdentifier,
-        certified,
-      });
-    }
     const service = certified ? this.certifiedService : this.service;
     const tokens = await service.account_balance({
       account: accountIdentifier.toUint8Array(),
@@ -115,9 +104,6 @@ export class LedgerCanister {
    * @throws {@link TransferError}
    */
   public transfer = async (request: TransferRequest): Promise<BlockHeight> => {
-    if (this.hardwareWallet) {
-      return this.transferHardwareWallet(request);
-    }
     const rawRequest = toTransferRawRequest(request);
     const response = await this.certifiedService.transfer(rawRequest);
     if ("Err" in response) {
@@ -146,88 +132,5 @@ export class LedgerCanister {
       throw mapIcrc1TransferError(response.Err);
     }
     return response.Ok;
-  };
-
-  private accountBalanceHardwareWallet = async ({
-    accountIdentifier,
-    certified = true,
-  }: {
-    accountIdentifier: AccountIdentifier;
-    certified?: boolean;
-  }): Promise<bigint> => {
-    const callMethod = certified ? this.updateFetcher : this.queryFetcher;
-
-    const { AccountBalanceRequest: AccountBalanceRequestConstructor, ICPTs } =
-      await importNnsProto();
-
-    const request = new AccountBalanceRequestConstructor();
-    request.setAccount(await accountIdentifier.toProto());
-
-    const responseBytes = await callMethod({
-      agent: this.agent,
-      canisterId: this.canisterId,
-      methodName: "account_balance_pb",
-      arg: request.serializeBinary(),
-    });
-
-    return BigInt(
-      ICPTs.deserializeBinary(new Uint8Array(responseBytes)).getE8s(),
-    );
-  };
-
-  private transferHardwareWallet = async ({
-    to,
-    amount,
-    memo,
-    fee,
-    fromSubAccount,
-    createdAt,
-  }: TransferRequest): Promise<BlockHeight> => {
-    const { SendRequest, Payment, Memo, TimeStamp, BlockHeight } =
-      await importNnsProto();
-
-    const request = new SendRequest();
-    request.setTo(await to.toProto());
-
-    const payment = new Payment();
-    payment.setReceiverGets(await toICPTs(amount));
-    request.setPayment(payment);
-
-    request.setMaxFee(await toICPTs(fee ?? TRANSACTION_FEE));
-
-    // Always explicitly set the memo for compatibility with ledger wallet - hardware wallet
-    const requestMemo = new Memo();
-    requestMemo.setMemo((memo ?? BigInt(0)).toString());
-    request.setMemo(requestMemo);
-
-    if (createdAt !== undefined) {
-      const timestamp = new TimeStamp();
-      timestamp.setTimestampNanos(createdAt.toString());
-      request.setCreatedAtTime(timestamp);
-    }
-
-    if (fromSubAccount !== undefined) {
-      request.setFromSubaccount(
-        await subAccountNumbersToSubaccount(fromSubAccount),
-      );
-    }
-
-    try {
-      const responseBytes = await this.updateFetcher({
-        agent: this.agent,
-        canisterId: this.canisterId,
-        methodName: "send_pb",
-        arg: request.serializeBinary(),
-      });
-
-      // Successful tx. Return the block height.
-      return BigInt(BlockHeight.deserializeBinary(responseBytes).getHeight());
-    } catch (err) {
-      if (err instanceof Error) {
-        throw mapTransferProtoError(err);
-      }
-
-      throw err;
-    }
   };
 }


### PR DESCRIPTION
# Motivation

The NNS dapp now requires version 2.4.9 of the Internet Computer Ledger app.
See for context: https://forum.dfinity.org/t/nns-dapp-to-remove-protobuf-dependency-upgrade-your-ledger-ic-app-to-2-4-9/27712
This means that we no longer need to use a separate code path with protocol buffers when making hardware wallet transactions but can instead use the exact same code path as for normal transactions.

NNS-dapp already doesn't use hardware wallet specific code paths since https://github.com/dfinity/nns-dapp/pull/4373

# Changes

1. Remove all code paths in `packages/ledger-icp` that check `this.hardwareWallet`.
2. Remove all functions that became unused as a result.

# Tests

Remove hardware wallet specific unit tests.

# Todos

- [x] Add entry to changelog (if necessary).
