### PR TITLE
NNS1-2886: Remove hardwallet options from ledger-icp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - When no fee is specified when making an ICP transaction, use the mandatory fee
   of 10000 e8s (0.0001 ICP) instead of fetching the fee from the network.
 - Remove hardware wallet specific code paths from `@dfinity/ledger-icp`.
+- Remove hardware wallet specific options from LedgerCanister.
 
 # 2024.03.25-1430Z
 

--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -171,7 +171,7 @@ const data = await metadata();
 
 ### :factory: LedgerCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L29)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L25)
 
 #### Methods
 
@@ -187,7 +187,7 @@ const data = await metadata();
 | -------- | ----------------------------------------------------- |
 | `create` | `(options?: LedgerCanisterOptions) => LedgerCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L40)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L33)
 
 ##### :gear: accountBalance
 
@@ -206,7 +206,7 @@ Parameters:
 - `params.accountIdentifier`: The account identifier provided either as hex string or as an AccountIdentifier.
 - `params.certified`: query or update call.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L76)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L61)
 
 ##### :gear: transactionFee
 
@@ -216,7 +216,7 @@ Returns the transaction fee of the ledger canister
 | ---------------- | ----------------------- |
 | `transactionFee` | `() => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L93)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L78)
 
 ##### :gear: transfer
 
@@ -227,7 +227,7 @@ Returns the index of the block containing the tx if it was successful.
 | ---------- | ----------------------------------------------- |
 | `transfer` | `(request: TransferRequest) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L106)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L91)
 
 ##### :gear: icrc1Transfer
 
@@ -238,7 +238,7 @@ Returns the index of the block containing the tx if it was successful.
 | --------------- | ---------------------------------------------------- |
 | `icrc1Transfer` | `(request: Icrc1TransferRequest) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L126)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L111)
 
 ### :factory: IndexCanister
 

--- a/packages/ledger-icp/src/ledger.canister.ts
+++ b/packages/ledger-icp/src/ledger.canister.ts
@@ -14,17 +14,13 @@ import {
   mapTransferError,
 } from "./errors/ledger.errors";
 import type { BlockHeight } from "./types/common";
-import type {
-  LedgerCanisterCall,
-  LedgerCanisterOptions,
-} from "./types/ledger.options";
+import type { LedgerCanisterOptions } from "./types/ledger.options";
 import type { AccountBalanceParams } from "./types/ledger.params";
 import type {
   Icrc1TransferRequest,
   TransferRequest,
 } from "./types/ledger_converters";
 import { paramToAccountIdentifier } from "./utils/params.utils";
-import { queryCall, updateCall } from "./utils/proto.utils";
 
 export class LedgerCanister {
   private constructor(
@@ -32,9 +28,6 @@ export class LedgerCanister {
     private readonly canisterId: Principal,
     private readonly service: ActorSubclass<LedgerService>,
     private readonly certifiedService: ActorSubclass<LedgerService>,
-    private readonly updateFetcher: LedgerCanisterCall,
-    private readonly queryFetcher: LedgerCanisterCall,
-    private readonly hardwareWallet: boolean = false,
   ) {}
 
   public static create(options: LedgerCanisterOptions = {}) {
@@ -50,15 +43,7 @@ export class LedgerCanister {
       certifiedIdlFactory,
     });
 
-    return new LedgerCanister(
-      agent,
-      canisterId,
-      service,
-      certifiedService,
-      options.updateCallOverride ?? updateCall,
-      options.queryCallOverride ?? queryCall,
-      options.hardwareWallet,
-    );
+    return new LedgerCanister(agent, canisterId, service, certifiedService);
   }
 
   /**

--- a/packages/ledger-icp/src/types/ledger.options.ts
+++ b/packages/ledger-icp/src/types/ledger.options.ts
@@ -1,23 +1,4 @@
-import type { Agent } from "@dfinity/agent";
-import type { Principal } from "@dfinity/principal";
 import type { CanisterOptions } from "@dfinity/utils";
 import type { _SERVICE as LedgerService } from "../../candid/ledger";
 
-export type LedgerCanisterCall = (params: {
-  agent: Agent;
-  canisterId: Principal;
-  methodName: string;
-  arg: ArrayBuffer;
-}) => Promise<Uint8Array>;
-
-export interface LedgerCanisterOptions extends CanisterOptions<LedgerService> {
-  // The method to use for performing an update call. Primarily overridden
-  // in test for mocking.
-  updateCallOverride?: LedgerCanisterCall;
-  // The method to use for performing a query call. Primarily overridden
-  // in test for mocking.
-  queryCallOverride?: LedgerCanisterCall;
-  // Ledger IC App needs requests built with Protobuf.
-  // This flag ensures that the methods use Protobuf.
-  hardwareWallet?: boolean;
-}
+export type LedgerCanisterOptions = CanisterOptions<LedgerService>;


### PR DESCRIPTION
# Motivation

`dfinity/ledger-icp` now uses the same code path for hardware wallet transaction and normal transaction.
The `LedgerCanister` factory method still accepts some options specific to hardware wallet code that no longer exists.

# Changes

Remove the obsolete options.

# Tests

Still pass.

# Todos

- [x] Add entry to changelog (if necessary).
