### PR TITLE
build: upgrade didc v0.3.7

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install didc
         run: |
           mkdir -p .bin
-          curl -L https://github.com/dfinity/candid/releases/download/2023-09-27/didc-linux64 > .bin/didc
+          curl -L https://github.com/dfinity/candid/releases/download/2024-02-27/didc-linux64 > .bin/didc
           chmod +x .bin/didc
       - name: Add didc to the PATH
         run: echo "${PWD}/.bin" >> $GITHUB_PATH

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -44,7 +44,7 @@ jobs:
           # Gets didc
           echo "$PATH" | tr : "\n"
           mkdir -p "$HOME/.local/bin"
-          curl -Lf https://github.com/dfinity/candid/releases/download/2023-09-27/didc-linux64 | install -m 755 /dev/stdin "$HOME/.local/bin/didc"
+          curl -Lf https://github.com/dfinity/candid/releases/download/2024-02-27/didc-linux64 | install -m 755 /dev/stdin "$HOME/.local/bin/didc"
           # Gets prettier in a minute
           npm ci
           # Gets candid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - GovernanceCanister.listNeurons no longer throws an error when called with
   `certified: false` for hardware wallet transactions.
 
+## Build
+
+- Upgrade `didc` to `0.3.7` that converts candid files into JS and TS.
+
 # 2024.03.25-1430Z
 
 ## Overview

--- a/scripts/compile-idl-js
+++ b/scripts/compile-idl-js
@@ -4,10 +4,10 @@
 
 set -euo pipefail
 
-if [ "$(didc --version)" != "didc 0.3.5" ]; then
+if [ "$(didc --version)" != "didc 0.3.7" ]; then
   {
-    echo "didc version 0.3.5 is required. To install it on Mac:"
-    echo "curl -Lf https://github.com/dfinity/candid/releases/download/2023-09-27/didc-macos -o install_didc"
+    echo "didc version 0.3.7 is required. To install it on Mac:"
+    echo "curl -Lf https://github.com/dfinity/candid/releases/download/2024-02-27/didc-macos -o install_didc"
     echo "install -m 755 install_didc /$HOME/.local/bin/didc"
   } >&2
   exit 1


### PR DESCRIPTION
# Motivation

I've been using didc v0.3.7 for some time and I'm tired of having to switch tools just for this repository. Therefore, this PR bumps didc to v0.3.7.

Compared to v0.3.5, didc v0.3.7 generates nicer service interfaces. Interfaces which are for example useful when one install a canister in JS as they can import the `init` types.

# Changes

- bump didc v0.3.7 in GitHub Actions
- set min required version to 0.3.7