### PR TITLE
feat: redo smart_contract_address in ckETH minterInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Protocol buffers for hardware wallet transactions are no longer supported. Internet Computer Ledger app 2.4.9 or later is now required.
 - GovernanceCanister.listNeurons no longer throws an error when called with `certified: false` for hardware wallet transactions.
-- The field `smart_contract_address` was removed from ckETH minter information, and additional fields related to ERC20 support have been added.
 - Potential errors thrown by `withdrawEth` provide now unparsed details.
 
 ## Features
@@ -16,6 +15,7 @@
 - Remove dependency on `@dfinity/nns-proto` from `@dfinity/ledger-icp`.
 - Remove hardware wallet specific code and `@dfinity/nns-proto` dependency from `@dfinity/nns`.
 - Add support for `withdrawErc20`.
+- Additional fields related to ERC20 have been added to ckETH `minterInfo`.
 
 ## Build
 

--- a/packages/cketh/candid/minter.certified.idl.js
+++ b/packages/cketh/candid/minter.certified.idl.js
@@ -73,6 +73,10 @@ export const idlFactory = ({ IDL }) => {
     'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'reserved_cycles' : IDL.Nat,
   });
+  const EventSource = IDL.Record({
+    'transaction_hash' : IDL.Text,
+    'log_index' : IDL.Nat,
+  });
   const UnsignedTransaction = IDL.Record({
     'destination' : IDL.Text,
     'value' : IDL.Nat,
@@ -89,9 +93,13 @@ export const idlFactory = ({ IDL }) => {
       })
     ),
   });
-  const EventSource = IDL.Record({
-    'transaction_hash' : IDL.Text,
-    'log_index' : IDL.Nat,
+  const ReimbursementIndex = IDL.Variant({
+    'CkErc20' : IDL.Record({
+      'cketh_ledger_burn_index' : IDL.Nat,
+      'ledger_id' : IDL.Principal,
+      'ckerc20_ledger_burn_index' : IDL.Nat,
+    }),
+    'CkEth' : IDL.Record({ 'ledger_burn_index' : IDL.Nat }),
   });
   const TransactionReceipt = IDL.Record({
     'effective_gas_price' : IDL.Nat,
@@ -126,6 +134,7 @@ export const idlFactory = ({ IDL }) => {
         'address' : IDL.Text,
         'ckerc20_token_symbol' : IDL.Text,
       }),
+      'QuarantinedDeposit' : IDL.Record({ 'event_source' : EventSource }),
       'SyncedToBlock' : IDL.Record({ 'block_number' : IDL.Nat }),
       'AcceptedDeposit' : IDL.Record({
         'principal' : IDL.Principal,
@@ -139,6 +148,7 @@ export const idlFactory = ({ IDL }) => {
         'withdrawal_id' : IDL.Nat,
         'transaction' : UnsignedTransaction,
       }),
+      'QuarantinedReimbursement' : IDL.Record({ 'index' : ReimbursementIndex }),
       'MintedCkEth' : IDL.Record({
         'event_source' : EventSource,
         'mint_block_index' : IDL.Nat,
@@ -221,6 +231,7 @@ export const idlFactory = ({ IDL }) => {
     'erc20_helper_contract_address' : IDL.Opt(IDL.Text),
     'supported_ckerc20_tokens' : IDL.Opt(IDL.Vec(CkErc20Token)),
     'last_gas_fee_estimate' : IDL.Opt(GasFeeEstimate),
+    'smart_contract_address' : IDL.Opt(IDL.Text),
     'minimum_withdrawal_amount' : IDL.Opt(IDL.Nat),
     'erc20_balances' : IDL.Opt(
       IDL.Vec(

--- a/packages/cketh/candid/minter.d.ts
+++ b/packages/cketh/candid/minter.d.ts
@@ -77,6 +77,7 @@ export interface Event {
           ckerc20_token_symbol: string;
         };
       }
+    | { QuarantinedDeposit: { event_source: EventSource } }
     | { SyncedToBlock: { block_number: bigint } }
     | {
         AcceptedDeposit: {
@@ -94,6 +95,7 @@ export interface Event {
           transaction: UnsignedTransaction;
         };
       }
+    | { QuarantinedReimbursement: { index: ReimbursementIndex } }
     | {
         MintedCkEth: {
           event_source: EventSource;
@@ -226,6 +228,7 @@ export interface MinterInfo {
   erc20_helper_contract_address: [] | [string];
   supported_ckerc20_tokens: [] | [Array<CkErc20Token>];
   last_gas_fee_estimate: [] | [GasFeeEstimate];
+  smart_contract_address: [] | [string];
   minimum_withdrawal_amount: [] | [bigint];
   erc20_balances:
     | []
@@ -239,6 +242,15 @@ export interface QueryStats {
   num_calls_total: bigint;
   request_payload_bytes_total: bigint;
 }
+export type ReimbursementIndex =
+  | {
+      CkErc20: {
+        cketh_ledger_burn_index: bigint;
+        ledger_id: Principal;
+        ckerc20_ledger_burn_index: bigint;
+      };
+    }
+  | { CkEth: { ledger_burn_index: bigint } };
 export interface RetrieveErc20Request {
   ckerc20_block_index: bigint;
   cketh_block_index: bigint;

--- a/packages/cketh/candid/minter.did
+++ b/packages/cketh/candid/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit eb447cf74b (2024-04-19) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
+// Generated from IC repo commit 869840deaf (2024-04-29) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
 type EthereumNetwork = variant {
     // The public Ethereum mainnet.
     Mainnet;
@@ -135,7 +135,11 @@ type MinterInfo = record {
     // Ethereum address controlled by the minter via threshold ECDSA.
     minter_address: opt text;
 
-    // Address of the helper smart contract.
+    // (Deprecated) Address of the ETH helper smart contract.
+    // Use `eth_helper_contract_address`.
+    smart_contract_address: opt text;
+
+    // Address of the ETH helper smart contract.
     eth_helper_contract_address: opt text;
 
     // Address of the ERC20 helper smart contract
@@ -297,6 +301,11 @@ type EventSource = record {
     log_index : nat;
 };
 
+type ReimbursementIndex = variant {
+    CkEth : record { ledger_burn_index : nat };
+    CkErc20 : record { cketh_ledger_burn_index : nat; ledger_id : principal; ckerc20_ledger_burn_index: nat };
+};
+
 type TransactionReceipt = record {
     block_hash : text;
     block_number : nat;
@@ -424,6 +433,12 @@ type Event = record {
             erc20_contract_address : text;
             mint_block_index : nat;
             ckerc20_token_symbol: text;
+        };
+        QuarantinedDeposit : record {
+            event_source : EventSource;
+        };
+        QuarantinedReimbursement : record {
+            index : ReimbursementIndex;
         };
     };
 };

--- a/packages/cketh/candid/minter.idl.js
+++ b/packages/cketh/candid/minter.idl.js
@@ -73,6 +73,10 @@ export const idlFactory = ({ IDL }) => {
     'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'reserved_cycles' : IDL.Nat,
   });
+  const EventSource = IDL.Record({
+    'transaction_hash' : IDL.Text,
+    'log_index' : IDL.Nat,
+  });
   const UnsignedTransaction = IDL.Record({
     'destination' : IDL.Text,
     'value' : IDL.Nat,
@@ -89,9 +93,13 @@ export const idlFactory = ({ IDL }) => {
       })
     ),
   });
-  const EventSource = IDL.Record({
-    'transaction_hash' : IDL.Text,
-    'log_index' : IDL.Nat,
+  const ReimbursementIndex = IDL.Variant({
+    'CkErc20' : IDL.Record({
+      'cketh_ledger_burn_index' : IDL.Nat,
+      'ledger_id' : IDL.Principal,
+      'ckerc20_ledger_burn_index' : IDL.Nat,
+    }),
+    'CkEth' : IDL.Record({ 'ledger_burn_index' : IDL.Nat }),
   });
   const TransactionReceipt = IDL.Record({
     'effective_gas_price' : IDL.Nat,
@@ -126,6 +134,7 @@ export const idlFactory = ({ IDL }) => {
         'address' : IDL.Text,
         'ckerc20_token_symbol' : IDL.Text,
       }),
+      'QuarantinedDeposit' : IDL.Record({ 'event_source' : EventSource }),
       'SyncedToBlock' : IDL.Record({ 'block_number' : IDL.Nat }),
       'AcceptedDeposit' : IDL.Record({
         'principal' : IDL.Principal,
@@ -139,6 +148,7 @@ export const idlFactory = ({ IDL }) => {
         'withdrawal_id' : IDL.Nat,
         'transaction' : UnsignedTransaction,
       }),
+      'QuarantinedReimbursement' : IDL.Record({ 'index' : ReimbursementIndex }),
       'MintedCkEth' : IDL.Record({
         'event_source' : EventSource,
         'mint_block_index' : IDL.Nat,
@@ -221,6 +231,7 @@ export const idlFactory = ({ IDL }) => {
     'erc20_helper_contract_address' : IDL.Opt(IDL.Text),
     'supported_ckerc20_tokens' : IDL.Opt(IDL.Vec(CkErc20Token)),
     'last_gas_fee_estimate' : IDL.Opt(GasFeeEstimate),
+    'smart_contract_address' : IDL.Opt(IDL.Text),
     'minimum_withdrawal_amount' : IDL.Opt(IDL.Nat),
     'erc20_balances' : IDL.Opt(
       IDL.Vec(

--- a/packages/cketh/src/minter.canister.spec.ts
+++ b/packages/cketh/src/minter.canister.spec.ts
@@ -720,6 +720,7 @@ describe("ckETH minter canister", () => {
           ],
         ],
         eth_helper_contract_address: toNullable(ckETHSmartContractAddressMock),
+        smart_contract_address: toNullable(ckETHSmartContractAddressMock),
         supported_ckerc20_tokens: [],
       };
 


### PR DESCRIPTION
# Motivation

The field `smart_contract_address` has been added back (and marked as deprecated) in the `minter_info` of ckETH.

# Changes

- bump candid files
- redo field in test mock data
- update CHANGELOG to transform "breaking changes" into a "features" entry
