### PR TITLE
chore: remove duplicated tests

### DIFF
--- a/packages/ledger-icrc/src/index-ng.canister.spec.ts
+++ b/packages/ledger-icrc/src/index-ng.canister.spec.ts
@@ -132,43 +132,4 @@ describe("Index canister", () => {
       expect(res).toEqual(balance);
     });
   });
-
-  describe("balance", () => {
-    it("should return the balance of main account", async () => {
-      const service = mock<ActorSubclass<IcrcIndexNgService>>();
-      const balance = BigInt(100);
-      service.icrc1_balance_of.mockResolvedValue(balance);
-
-      const canister = IcrcIndexNgCanister.create({
-        canisterId: ledgerCanisterIdMock,
-        certifiedServiceOverride: service,
-      });
-
-      const owner = Principal.fromText("aaaaa-aa");
-      const res = await canister.balance({
-        owner,
-      });
-      expect(service.icrc1_balance_of).toBeCalled();
-      expect(res).toEqual(balance);
-    });
-
-    it("should return the balance of subaccount", async () => {
-      const service = mock<ActorSubclass<IcrcIndexNgService>>();
-      const balance = BigInt(100);
-      service.icrc1_balance_of.mockResolvedValue(balance);
-
-      const canister = IcrcIndexNgCanister.create({
-        canisterId: ledgerCanisterIdMock,
-        certifiedServiceOverride: service,
-      });
-
-      const owner = Principal.fromText("aaaaa-aa");
-      const subaccount = arrayOfNumberToUint8Array([0, 0, 1]);
-      const res = await canister.balance({
-        owner,
-        subaccount,
-      });
-      expect(res).toEqual(balance);
-    });
-  });
 });


### PR DESCRIPTION
# Motivation

I guess there was a merge conflicts at some point, I spotted two tests that were duplicated.

# Changes

- Remove duplicate suite `describe(balance)` in Index canister test.
