### PR TITLE
feat: remove canisterInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2024.XX.YY-hhMMZ
+
+## Breaking changes
+
+- `@dfinity/ic-management` function `canisterInfo` removed because users cannot call this method (see [documentation](https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-canister-info)).
+
 # 2024.04.29-0930Z
 
 ## Overview
@@ -17,7 +23,7 @@ The current status of the libraries at the time of the release is as follows:
 | `@dfinity/sns`           | v3.0.3  | Maintained ⚙️       |
 | `@dfinity/utils`         | v2.2.0  | Enhanced 🔧         |
 
-# Breaking changes
+## Breaking changes
 
 - Protocol buffers for hardware wallet transactions are no longer supported. Internet Computer Ledger app 2.4.9 or later is now required.
 - GovernanceCanister.listNeurons no longer throws an error when called with `certified: false` for hardware wallet transactions.

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -54,7 +54,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 
 ### :factory: ICManagementCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L39)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L35)
 
 #### Methods
 
@@ -70,7 +70,6 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 - [startCanister](#gear-startcanister)
 - [stopCanister](#gear-stopcanister)
 - [canisterStatus](#gear-canisterstatus)
-- [canisterInfo](#gear-canisterinfo)
 - [deleteCanister](#gear-deletecanister)
 - [provisionalCreateCanisterWithCycles](#gear-provisionalcreatecanisterwithcycles)
 - [bitcoinGetUtxos](#gear-bitcoingetutxos)
@@ -82,7 +81,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 | -------- | ---------------------------------------------------------------- |
 | `create` | `(options: ICManagementCanisterOptions) => ICManagementCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L44)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L40)
 
 ##### :gear: createCanister
 
@@ -92,7 +91,7 @@ Create a new canister
 | ---------------- | ------------------------------------------------------------------------------------- |
 | `createCanister` | `({ settings, senderCanisterVersion, }?: CreateCanisterParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L84)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L80)
 
 ##### :gear: updateSettings
 
@@ -102,7 +101,7 @@ Update canister settings
 | ---------------- | ------------------------------------------------------------------------------------------- |
 | `updateSettings` | `({ canisterId, senderCanisterVersion, settings, }: UpdateSettingsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L105)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L101)
 
 ##### :gear: installCode
 
@@ -112,7 +111,7 @@ Install code to a canister
 | ------------- | ----------------------------------------------------------------------------------------------------- |
 | `installCode` | `({ mode, canisterId, wasmModule, arg, senderCanisterVersion, }: InstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L127)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L123)
 
 ##### :gear: uploadChunk
 
@@ -127,7 +126,7 @@ Parameters:
 - `params.canisterId`: The canister in which the chunks will be stored.
 - `params.chunk`: A chunk of Wasm module.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L152)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L148)
 
 ##### :gear: clearChunkStore
 
@@ -141,7 +140,7 @@ Parameters:
 
 - `params.canisterId`: The canister in which the chunks are stored.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L172)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L168)
 
 ##### :gear: storedChunks
 
@@ -155,7 +154,7 @@ Parameters:
 
 - `params.canisterId`: The canister in which the chunks are stored.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L191)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L187)
 
 ##### :gear: installChunkedCode
 
@@ -175,7 +174,7 @@ Parameters:
 - `params.storeCanisterId`: Specifies the canister in whose chunk storage the chunks are stored (this parameter defaults to target_canister if not specified).
 - `params.wasmModuleHash`: The Wasm module hash as hex string. Used to check that the SHA-256 hash of wasm_module is equal to the wasm_module_hash parameter and can calls install_code with parameters.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L216)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L212)
 
 ##### :gear: uninstallCode
 
@@ -185,7 +184,7 @@ Uninstall code from a canister
 | --------------- | -------------------------------------------------------------------------------- |
 | `uninstallCode` | `({ canisterId, senderCanisterVersion, }: UninstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L249)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L245)
 
 ##### :gear: startCanister
 
@@ -195,7 +194,7 @@ Start a canister
 | --------------- | ------------------------------------------ |
 | `startCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L264)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L260)
 
 ##### :gear: stopCanister
 
@@ -205,7 +204,7 @@ Stop a canister
 | -------------- | ------------------------------------------ |
 | `stopCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L273)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L269)
 
 ##### :gear: canisterStatus
 
@@ -215,17 +214,7 @@ Get canister details (memory size, status, etc.)
 | ---------------- | ------------------------------------------------------------ |
 | `canisterStatus` | `(canisterId: Principal) => Promise<canister_status_result>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L282)
-
-##### :gear: canisterInfo
-
-Get canister info (controllers, module hash, changes, etc.)
-
-| Method         | Type                                                                                        |
-| -------------- | ------------------------------------------------------------------------------------------- |
-| `canisterInfo` | `({ canisterId, numRequestChanges, }: CanisterInfoParams) => Promise<canister_info_result>` |
-
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L295)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L278)
 
 ##### :gear: deleteCanister
 
@@ -235,7 +224,7 @@ Deletes a canister
 | ---------------- | ------------------------------------------ |
 | `deleteCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L310)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L289)
 
 ##### :gear: provisionalCreateCanisterWithCycles
 
@@ -245,7 +234,7 @@ Creates a canister. Only available on development instances.
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `provisionalCreateCanisterWithCycles` | `({ settings, amount, canisterId, }?: ProvisionalCreateCanisterWithCyclesParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L322)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L301)
 
 ##### :gear: bitcoinGetUtxos
 
@@ -261,7 +250,7 @@ Parameters:
 - `params.filter`: The optional filter parameter can be used to restrict the set of returned UTXOs, either providing a minimum number of confirmations or a page reference when pagination is used for addresses with many UTXOs.
 - `params.address`: A Bitcoin address.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L349)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L328)
 
 ##### :gear: bitcoinGetUtxosQuery
 
@@ -277,7 +266,7 @@ Parameters:
 - `params.filter`: The optional filter parameter can be used to restrict the set of returned UTXOs, either providing a minimum number of confirmations or a page reference when pagination is used for addresses with many UTXOs.
 - `params.address`: A Bitcoin address.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L367)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L346)
 
 <!-- TSDOC_END -->
 

--- a/packages/ic-management/src/ic-management.canister.spec.ts
+++ b/packages/ic-management/src/ic-management.canister.spec.ts
@@ -28,10 +28,7 @@ import {
   type StoredChunksParams,
   type UploadChunkParams,
 } from "./types/ic-management.params";
-import {
-  CanisterInfoResponse,
-  CanisterStatusResponse,
-} from "./types/ic-management.responses";
+import { CanisterStatusResponse } from "./types/ic-management.responses";
 
 describe("ICManagementCanister", () => {
   const mockAgent: HttpAgent = mock<HttpAgent>();
@@ -305,46 +302,6 @@ describe("ICManagementCanister", () => {
       const icManagement = await createICManagement(service);
 
       const call = () => icManagement.canisterStatus(mockCanisterId);
-
-      expect(call).rejects.toThrowError(Error);
-    });
-  });
-
-  describe("canisterInfo", () => {
-    it("returns canister info when success", async () => {
-      const response: CanisterInfoResponse = {
-        controllers: [mockPrincipal],
-        module_hash: [new Uint8Array([1, 2, 3])],
-        recent_changes: [],
-        total_num_changes: BigInt(0),
-      };
-      const service = mock<IcManagementService>();
-      service.canister_info.mockResolvedValue(response);
-
-      const icManagement = await createICManagement(service);
-
-      const res = await icManagement.canisterInfo({
-        canisterId: mockCanisterId,
-      });
-
-      expect(res).toEqual(response);
-      expect(service.canister_info).toHaveBeenCalledWith({
-        canister_id: mockCanisterId,
-        num_requested_changes: [],
-      });
-    });
-
-    it("throws Error", async () => {
-      const error = new Error("Test");
-      const service = mock<IcManagementService>();
-      service.canister_info.mockRejectedValue(error);
-
-      const icManagement = await createICManagement(service);
-
-      const call = () =>
-        icManagement.canisterInfo({
-          canisterId: mockCanisterId,
-        });
 
       expect(call).rejects.toThrowError(Error);
     });

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -20,7 +20,6 @@ import {
   toInstallMode,
   type BitcoinGetUtxosParams,
   type BitcoinGetUtxosQueryParams,
-  type CanisterInfoParams,
   type ClearChunkStoreParams,
   type CreateCanisterParams,
   type InstallChunkedCodeParams,
@@ -31,10 +30,7 @@ import {
   type UpdateSettingsParams,
   type UploadChunkParams,
 } from "./types/ic-management.params";
-import type {
-  CanisterInfoResponse,
-  CanisterStatusResponse,
-} from "./types/ic-management.responses";
+import type { CanisterStatusResponse } from "./types/ic-management.responses";
 
 export class ICManagementCanister {
   private constructor(private readonly service: IcManagementService) {
@@ -282,23 +278,6 @@ export class ICManagementCanister {
   canisterStatus = (canisterId: Principal): Promise<CanisterStatusResponse> =>
     this.service.canister_status({
       canister_id: canisterId,
-    });
-
-  /**
-   * Get canister info (controllers, module hash, changes, etc.)
-   *
-   * @param {Object} params
-   * @param {Principal} params.canisterId
-   * @param {BigInt} params.numRequestChanges
-   * @returns {Promise<CanisterInfoResponse>}
-   */
-  canisterInfo = ({
-    canisterId,
-    numRequestChanges,
-  }: CanisterInfoParams): Promise<CanisterInfoResponse> =>
-    this.service.canister_info({
-      canister_id: canisterId,
-      num_requested_changes: toNullable(numRequestChanges),
     });
 
   /**

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -98,11 +98,6 @@ export interface UninstallCodeParams {
   senderCanisterVersion?: bigint;
 }
 
-export interface CanisterInfoParams {
-  canisterId: Principal;
-  numRequestChanges?: bigint;
-}
-
 export interface ProvisionalCreateCanisterWithCyclesParams {
   amount?: bigint;
   settings?: CanisterSettings;

--- a/packages/ic-management/src/types/ic-management.responses.ts
+++ b/packages/ic-management/src/types/ic-management.responses.ts
@@ -5,8 +5,3 @@ export type CanisterStatusResponse = ServiceResponse<
   IcManagementService,
   "canister_status"
 >;
-
-export type CanisterInfoResponse = ServiceResponse<
-  IcManagementService,
-  "canister_info"
->;


### PR DESCRIPTION
# Motivation

Ic-mgmt `canisterInfo` cannot be called by users. According @mraszykt he only way to call this function is to proxy the call via a cycles wallet. Per extension, exposing the feature in ic-js leads to some confusion (which happened to be the case today even by employee of the foundtion). Therefore, let's remove it.

# Changes

- remove `canisterInfo` in `@dfinity/ic-management`
