### PR TITLE
Add SubnetRentalRequest NnsFunction

### DIFF
--- a/packages/nns/src/enums/governance.enums.ts
+++ b/packages/nns/src/enums/governance.enums.ts
@@ -133,6 +133,7 @@ export enum NnsFunction {
   UpdateSshReadOnlyAccessForAllUnassignedNodes = 49,
   ReviseElectedHostosVersions = 50,
   DeployHostosToSomeNodes = 51,
+  SubnetRentalRequest = 52,
 }
 
 // Reference: https://github.com/dfinity/ic/blob/f4b2e28525ae9b030bd9edfc982e796417db2b80/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs#L3286-L3287


### PR DESCRIPTION
# Motivation

There is a new proposal type to rent subnets, using NNS function 52.

# Changes

Add `SubnetRentalRequest` value to `NnsFunction` enum.

# Tests

not tested

# Todos

- [ ] Add entry to changelog (if necessary).
not added