### PR TITLE
Add SubnetRental to Topic enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - `@dfinity/nns-proto` was updated with the most recent proto types, some of which were not backwards compatible.
 - The size of the nns-proto-js library has noticeably increased, as it now exposes all types instead of just a manually picked subset.
 
+## Features
+
+- Add "Subnet Rental" topic support.
+
 ## Build
 
 - Upgrade `agent-js` dependencies to `v1.3.0` and revert the default retry times value to 10, given that the issue is fixed.

--- a/packages/nns/src/enums/governance.enums.ts
+++ b/packages/nns/src/enums/governance.enums.ts
@@ -32,6 +32,7 @@ export enum Topic {
   ReplicaVersionManagement = 13,
   SnsAndCommunityFund = 14,
   ApiBoundaryNodeManagement = 15,
+  SubnetRental = 16,
 }
 
 // The proposal status, with respect to reward distribution.


### PR DESCRIPTION
# Motivation

The new proposal type to rent subnets, has its own topic.

# Changes

Add topic `SubnetRental` to `Topic` enum.

# Tests

not tested

# Todos

- [x] Add entry to changelog (if necessary).
