### PR TITLE
Remove nns-proto dep from readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Install any library of this repo in your project from [npm](https://www.npmjs.co
 npm i @dfinity/utils
 npm i @dfinity/ledger-icp
 npm i @dfinity/ledger-icrc
-npm i @dfinity/nns-proto @dfinity/nns
+npm i @dfinity/nns
 npm i @dfinity/sns
 npm i @dfinity/cmc
 npm i @dfinity/ckbtc

--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -24,7 +24,7 @@ npm i @dfinity/ledger-icp
 The bundle needs peer dependencies, be sure that following resources are available in your project as well.
 
 ```bash
-npm i @dfinity/agent @dfinity/candid @dfinity/principal @dfinity/utils @dfinity/nns-proto
+npm i @dfinity/agent @dfinity/candid @dfinity/principal @dfinity/utils
 ```
 
 ## Usage

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -21,7 +21,7 @@ npm i @dfinity/nns
 The bundle needs peer dependencies, be sure that following resources are available in your project as well.
 
 ```bash
-npm i @dfinity/agent @dfinity/candid @dfinity/principal @dfinity/utils @dfinity/nns-proto
+npm i @dfinity/agent @dfinity/candid @dfinity/principal @dfinity/utils
 ```
 
 ## Usage


### PR DESCRIPTION
# Motivation

Keep readme files up to date. The nns-proto is not needed anymore for nns-js and ledger-icp

# Changes

* Remove the mention of nns-proto in the installation steps of nns-js and ledger-icp as well as the main readme file.

# Tests

Not necessary.

# Todos

- [ ] Add entry to changelog (if necessary). Not necessary.
