### PR TITLE
Fix TokenAmountV2.fromNumber for decimals < 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - `@dfinity/nns-proto` was updated with the most recent proto types, some of which were not backwards compatible.
 - The size of the nns-proto-js library has noticeably increased, as it now exposes all types instead of just a manually picked subset.
 
+## Fix
+
+- Fixed `TokenAmountV2.fromNumber` for tokens with fewer than 8 decimals.
+
 ## Build
 
 - Upgrade `agent-js` dependencies to `v1.3.0` and revert the default retry times value to 10, given that the issue is fixed.

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -532,7 +532,7 @@ Parameters:
 | -------- | -------------- |
 | `toUlps` | `() => bigint` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L322)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L324)
 
 ##### :gear: toE8s
 
@@ -540,7 +540,7 @@ Parameters:
 | ------- | -------------- |
 | `toE8s` | `() => bigint` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L330)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L332)
 
 ### :factory: Canister
 

--- a/packages/utils/src/parser/token.spec.ts
+++ b/packages/utils/src/parser/token.spec.ts
@@ -420,6 +420,20 @@ describe("TokenAmountV2 with 2 decimals", () => {
     );
   });
 
+  it.only("can be initialized from a number", () => {
+    expect(
+      TokenAmountV2.fromNumber({
+        token: token,
+        amount: 100000000.91,
+      }),
+    ).toEqual(
+      TokenAmountV2.fromUlps({
+        token: token,
+        amount: 10000000091n,
+      }),
+    );
+  });
+
   it("returns the value in e8s", () => {
     expect(
       (

--- a/packages/utils/src/parser/token.spec.ts
+++ b/packages/utils/src/parser/token.spec.ts
@@ -420,7 +420,7 @@ describe("TokenAmountV2 with 2 decimals", () => {
     );
   });
 
-  it.only("can be initialized from a number", () => {
+  it("can be initialized from a number", () => {
     expect(
       TokenAmountV2.fromNumber({
         token: token,

--- a/packages/utils/src/parser/token.ts
+++ b/packages/utils/src/parser/token.ts
@@ -299,7 +299,9 @@ export class TokenAmountV2 {
     token: Token;
   }): TokenAmountV2 {
     const tokenAmount = TokenAmountV2.fromString({
-      amount: amount.toFixed(DECIMALS_CONVERSION_SUPPORTED),
+      amount: amount.toFixed(
+        Math.min(DECIMALS_CONVERSION_SUPPORTED, token.decimals),
+      ),
       token,
     });
     if (tokenAmount instanceof TokenAmountV2) {


### PR DESCRIPTION
# Motivation

When creating a `TokenAmountV2` from a `number`, we first convert it to a string with 8 decimals.
When the number has more decimals, they are just truncated. But number input components in gix-components don't allow more than 8 decimals.
But when the token allows fewer than 8 decimals, this results in an error.
The happened to be one of the few combinations without a unit test but will be needed for ckUSDC.

# Changes

When converting the number to a string with a fixed number of decimals, instead of always using 8 decimals, use the minimum of 8 and the number of decimals the token allows.

# Tests

1. Added a unit test.
2. Tested in NNS dapp that this error no longer appears:

<img width="356" alt="image" src="https://github.com/dfinity/ic-js/assets/122978264/a1002c5e-234b-4fee-af8b-44fafff5343b">

# Todos

- [x] Add entry to changelog (if necessary).
