### PR TITLE
fix: CI parse error "Invalid numeric literal at line 2, column 2"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,9 +13,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install latest npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
# Motivation

I faced today the same error as the one I noticed in ic-js few weeks ago in Juno's CI. After debugging locally, I figured out the root cause of the issue, not being able to extract the version of a library with an npm command and jq, was related to the fact that for some reason providing `--json` to the npm commands did not simply output the json anymore but also some build information. Before trying to resolve the issue, I bumped npm to check if it was not a potential npm issue and, indeed, bumping to a newer version of npm resolved the issue.

Therefore this PR that ensures the latest version of npm is always used in CI Actions. Likewise, the PR also bumps Node LTS (20) given that we aim to use last version.

Resolves #618.

