### PR TITLE
feat: align icp ledger constructor implementation

### DIFF
--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -162,7 +162,7 @@ const data = await metadata();
 
 ### :factory: LedgerCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L25)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L24)
 
 #### Methods
 
@@ -178,7 +178,7 @@ const data = await metadata();
 | -------- | ----------------------------------------------------- |
 | `create` | `(options?: LedgerCanisterOptions) => LedgerCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L33)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L25)
 
 ##### :gear: accountBalance
 
@@ -197,7 +197,7 @@ Parameters:
 - `params.accountIdentifier`: The account identifier provided either as hex string or as an AccountIdentifier.
 - `params.certified`: query or update call.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L61)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L53)
 
 ##### :gear: transactionFee
 
@@ -207,7 +207,7 @@ Returns the transaction fee of the ledger canister
 | ---------------- | ----------------------- |
 | `transactionFee` | `() => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L78)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L70)
 
 ##### :gear: transfer
 
@@ -218,7 +218,7 @@ Returns the index of the block containing the tx if it was successful.
 | ---------- | ----------------------------------------------- |
 | `transfer` | `(request: TransferRequest) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L91)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L83)
 
 ##### :gear: icrc1Transfer
 
@@ -229,7 +229,7 @@ Returns the index of the block containing the tx if it was successful.
 | --------------- | ---------------------------------------------------- |
 | `icrc1Transfer` | `(request: Icrc1TransferRequest) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L111)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L103)
 
 ### :factory: IndexCanister
 

--- a/packages/ledger-icp/src/ledger.canister.ts
+++ b/packages/ledger-icp/src/ledger.canister.ts
@@ -1,6 +1,5 @@
-import type { ActorSubclass, Agent } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
-import { createServices } from "@dfinity/utils";
+import { Canister, createServices } from "@dfinity/utils";
 import type { _SERVICE as LedgerService } from "../candid/ledger";
 import { idlFactory as certifiedIdlFactory } from "../candid/ledger.certified.idl";
 import { idlFactory } from "../candid/ledger.idl";
@@ -22,19 +21,12 @@ import type {
 } from "./types/ledger_converters";
 import { paramToAccountIdentifier } from "./utils/params.utils";
 
-export class LedgerCanister {
-  private constructor(
-    private readonly agent: Agent,
-    private readonly canisterId: Principal,
-    private readonly service: ActorSubclass<LedgerService>,
-    private readonly certifiedService: ActorSubclass<LedgerService>,
-  ) {}
-
+export class LedgerCanister extends Canister<LedgerService> {
   public static create(options: LedgerCanisterOptions = {}) {
     const canisterId: Principal =
       options.canisterId ?? MAINNET_LEDGER_CANISTER_ID;
 
-    const { service, certifiedService, agent } = createServices<LedgerService>({
+    const { service, certifiedService } = createServices<LedgerService>({
       options: {
         ...options,
         canisterId,
@@ -43,7 +35,7 @@ export class LedgerCanister {
       certifiedIdlFactory,
     });
 
-    return new LedgerCanister(agent, canisterId, service, certifiedService);
+    return new LedgerCanister(canisterId, service, certifiedService);
   }
 
   /**


### PR DESCRIPTION
# Motivation

Unlike most libraries of the repo, we were not using the `Canister` abstract class in the ICP `LedgerCanister`. This PR aligns the implementation and will also allow us to use the inherited `caller` utilities in the implementation.

# Changes

- Extend standard implementation - `class LedgerCanister extends Canister<LedgerService>`

