### PR TITLE
feat: icrc2 approve support for icp ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Canister status response extended with query statistics.
 - Add `metadata` function to ledger ICP.
+- Add optional parameters to ICP ledger `transactionFee`.
 
 # 2024.05.14-0630Z
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Canister status response extended with query statistics.
 - Add `metadata` function to ledger ICP.
-- Add optional parameters to ICP ledger `transactionFee`.
+- Add optional parameters to ICP ledger `transactionFee`. 
+- Add support for `icrc2_approve` on the ICP ledger canister in `@dfinity/ledger-icp`.
 
 # 2024.05.14-0630Z
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Canister status response extended with query statistics.
 - Add `metadata` function to ledger ICP.
-- Add optional parameters to ICP ledger `transactionFee`. 
+- Add optional parameters to ICP ledger `transactionFee`.
 - Add support for `icrc2_approve` on the ICP ledger canister in `@dfinity/ledger-icp`.
 
 # 2024.05.14-0630Z

--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -216,13 +216,17 @@ Parameters:
 
 ##### :gear: transactionFee
 
-Returns the transaction fee of the ledger canister
+Returns the transaction fee of the ICP ledger canister.
 
-| Method           | Type                    |
-| ---------------- | ----------------------- |
-| `transactionFee` | `() => Promise<bigint>` |
+| Method           | Type                                        |
+| ---------------- | ------------------------------------------- |
+| `transactionFee` | `(params?: QueryParams) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L81)
+Parameters:
+
+- `params`: - Optional query parameters for the request, defaulting to `{ certified: false }` for backwards compatibility reason.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L83)
 
 ##### :gear: transfer
 
@@ -233,7 +237,7 @@ Returns the index of the block containing the tx if it was successful.
 | ---------- | ----------------------------------------------- |
 | `transfer` | `(request: TransferRequest) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L94)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L101)
 
 ##### :gear: icrc1Transfer
 
@@ -244,7 +248,7 @@ Returns the index of the block containing the tx if it was successful.
 | --------------- | ---------------------------------------------------- |
 | `icrc1Transfer` | `(request: Icrc1TransferRequest) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L114)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L121)
 
 ### :factory: IndexCanister
 

--- a/packages/ledger-icp/src/canisters/ledger/ledger.request.converts.ts
+++ b/packages/ledger-icp/src/canisters/ledger/ledger.request.converts.ts
@@ -1,12 +1,14 @@
 import { arrayOfNumberToUint8Array, toNullable } from "@dfinity/utils";
 import type {
   TransferArg as Icrc1TransferRawRequest,
+  ApproveArgs as Icrc2ApproveRawRequest,
   Tokens,
   TransferArgs as TransferRawRequest,
 } from "../../../candid/ledger";
 import { TRANSACTION_FEE } from "../../constants/constants";
 import type {
   Icrc1TransferRequest,
+  Icrc2ApproveRequest,
   TransferRequest,
 } from "../../types/ledger_converters";
 
@@ -52,4 +54,24 @@ export const toIcrc1TransferRawRequest = ({
   memo: toNullable(icrc1Memo),
   created_at_time: toNullable(createdAt),
   from_subaccount: toNullable(fromSubAccount),
+});
+
+export const toIcrc2ApproveRawRequest = ({
+  fee,
+  createdAt,
+  memo,
+  fromSubAccount,
+  expected_allowance,
+  expires_at,
+  amount,
+  ...rest
+}: Icrc2ApproveRequest): Icrc2ApproveRawRequest => ({
+  ...rest,
+  fee: toNullable(fee ?? TRANSACTION_FEE),
+  memo: toNullable(memo),
+  from_subaccount: toNullable(fromSubAccount),
+  created_at_time: toNullable(createdAt),
+  amount,
+  expected_allowance: toNullable(expected_allowance),
+  expires_at: toNullable(expires_at),
 });

--- a/packages/ledger-icp/src/canisters/ledger/ledger.request.converts.ts
+++ b/packages/ledger-icp/src/canisters/ledger/ledger.request.converts.ts
@@ -59,7 +59,7 @@ export const toIcrc1TransferRawRequest = ({
 export const toIcrc2ApproveRawRequest = ({
   fee,
   createdAt,
-  memo,
+  icrc1Memo,
   fromSubAccount,
   expected_allowance,
   expires_at,
@@ -68,7 +68,7 @@ export const toIcrc2ApproveRawRequest = ({
 }: Icrc2ApproveRequest): Icrc2ApproveRawRequest => ({
   ...rest,
   fee: toNullable(fee ?? TRANSACTION_FEE),
-  memo: toNullable(memo),
+  memo: toNullable(icrc1Memo),
   from_subaccount: toNullable(fromSubAccount),
   created_at_time: toNullable(createdAt),
   amount,

--- a/packages/ledger-icp/src/errors/ledger.errors.ts
+++ b/packages/ledger-icp/src/errors/ledger.errors.ts
@@ -1,10 +1,16 @@
 import type {
+  Icrc1BlockIndex,
+  Icrc1Tokens,
+  ApproveError as RawApproveError,
   Icrc1TransferError as RawIcrc1TransferError,
   TransferError as RawTransferError,
 } from "../../candid/ledger";
 import type { BlockHeight } from "../types/common";
 
-export class TransferError extends Error {}
+export class IcrcError extends Error {}
+
+export class TransferError extends IcrcError {}
+export class ApproveError extends IcrcError {}
 
 export class InvalidSenderError extends TransferError {}
 
@@ -30,8 +36,40 @@ export class TxDuplicateError extends TransferError {
   }
 }
 
-export class BadFeeError extends TransferError {
+export class BadFeeError extends IcrcError {
   constructor(public readonly expectedFee: bigint) {
+    super();
+  }
+}
+
+export class GenericError extends ApproveError {
+  constructor(
+    public readonly message: string,
+    public readonly error_code: bigint,
+  ) {
+    super();
+  }
+}
+
+export class TemporarilyUnavailableError extends ApproveError {}
+
+export class DuplicateError extends ApproveError {
+  constructor(public readonly duplicateOf: Icrc1BlockIndex) {
+    super();
+  }
+}
+
+export class AllowanceChangedError extends ApproveError {
+  constructor(public readonly currentAllowance: Icrc1Tokens) {
+    super();
+  }
+}
+
+export class CreatedInFutureError extends ApproveError {}
+export class TooOldError extends ApproveError {}
+
+export class ExpiredError extends ApproveError {
+  constructor(public readonly ledgerTime: bigint) {
     super();
   }
 }
@@ -87,5 +125,62 @@ export const mapIcrc1TransferError = (
   // Edge case
   return new TransferError(
     `Unknown error type ${JSON.stringify(rawTransferError)}`,
+  );
+};
+
+export const mapIcrc2ApproveError = (
+  rawApproveError: RawApproveError,
+): ApproveError => {
+  /**
+   * export type ApproveError =
+   *   | { InsufficientFunds: { balance: Icrc1Tokens } };
+   */
+
+  if ("GenericError" in rawApproveError) {
+    return new GenericError(
+      rawApproveError.GenericError.message,
+      rawApproveError.GenericError.error_code,
+    );
+  }
+
+  if ("TemporarilyUnavailable" in rawApproveError) {
+    return new TemporarilyUnavailableError();
+  }
+
+  if ("Duplicate" in rawApproveError) {
+    return new DuplicateError(rawApproveError.Duplicate.duplicate_of);
+  }
+
+  if ("BadFee" in rawApproveError) {
+    return new BadFeeError(rawApproveError.BadFee.expected_fee);
+  }
+
+  if ("AllowanceChanged" in rawApproveError) {
+    return new DuplicateError(
+      rawApproveError.AllowanceChanged.current_allowance,
+    );
+  }
+
+  if ("CreatedInFuture" in rawApproveError) {
+    return new CreatedInFutureError();
+  }
+
+  if ("TooOld" in rawApproveError) {
+    return new TooOldError();
+  }
+
+  if ("Expired" in rawApproveError) {
+    return new ExpiredError(rawApproveError.Expired.ledger_time);
+  }
+
+  if ("InsufficientFunds" in rawApproveError) {
+    return new InsufficientFundsError(
+      rawApproveError.InsufficientFunds.balance,
+    );
+  }
+
+  // Edge case
+  return new ApproveError(
+    `Unknown error type ${JSON.stringify(rawApproveError)}`,
   );
 };

--- a/packages/ledger-icp/src/errors/ledger.errors.ts
+++ b/packages/ledger-icp/src/errors/ledger.errors.ts
@@ -156,7 +156,7 @@ export const mapIcrc2ApproveError = (
   }
 
   if ("AllowanceChanged" in rawApproveError) {
-    return new DuplicateError(
+    return new AllowanceChangedError(
       rawApproveError.AllowanceChanged.current_allowance,
     );
   }

--- a/packages/ledger-icp/src/index.ts
+++ b/packages/ledger-icp/src/index.ts
@@ -1,5 +1,10 @@
 export type * from "../candid/index";
-export type { Value } from "../candid/ledger";
+export type {
+  Icrc1BlockIndex,
+  Icrc1Timestamp,
+  Icrc1Tokens,
+  Value,
+} from "../candid/ledger";
 export { AccountIdentifier, SubAccount } from "./account_identifier";
 export * from "./errors/ledger.errors";
 export { IndexCanister } from "./index.canister";

--- a/packages/ledger-icp/src/ledger.canister.spec.ts
+++ b/packages/ledger-icp/src/ledger.canister.spec.ts
@@ -2,17 +2,24 @@ import { ActorSubclass } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
-import { _SERVICE as LedgerService, Value } from "../candid/ledger";
+import {
+  _SERVICE as LedgerService,
+  Value,
+  type Account,
+  type ApproveArgs as Icrc2ApproveRawRequest,
+} from "../candid/ledger";
 import { TRANSACTION_FEE } from "./constants/constants";
 import {
   BadFeeError,
+  CreatedInFutureError,
   InsufficientFundsError,
   TxCreatedInFutureError,
   TxDuplicateError,
   TxTooOldError,
 } from "./errors/ledger.errors";
 import { LedgerCanister } from "./ledger.canister";
-import { mockAccountIdentifier } from "./mocks/ledger.mock";
+import { mockAccountIdentifier, mockPrincipal } from "./mocks/ledger.mock";
+import type { Icrc2ApproveRequest } from "./types/ledger_converters";
 
 describe("LedgerCanister", () => {
   describe("accountBalance", () => {
@@ -681,6 +688,215 @@ describe("LedgerCanister", () => {
 
         expect(call).rejects.toThrowError(TxCreatedInFutureError);
       });
+    });
+  });
+
+  describe("icrc2Approve", () => {
+    const approveRequest: Icrc2ApproveRequest = {
+      spender: {
+        owner: mockPrincipal,
+        subaccount: [],
+      },
+      amount: BigInt(100_000_000),
+      expires_at: 123n,
+    };
+
+    const approveRawRequest: Icrc2ApproveRawRequest = {
+      expected_allowance: [],
+      expires_at: [123n],
+      from_subaccount: [],
+      spender: {
+        owner: mockPrincipal,
+        subaccount: [],
+      },
+      fee: [],
+      memo: [],
+      created_at_time: [],
+      amount: BigInt(100_000_000),
+    };
+
+    it("should return the block height successfully", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      const blockHeight = BigInt(100);
+      service.icrc2_approve.mockResolvedValue({ Ok: blockHeight });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+      });
+
+      const res = await ledger.icrc2Approve(approveRequest);
+      expect(res).toEqual(blockHeight);
+      expect(service.icrc2_approve).toBeCalledWith({
+        ...approveRawRequest,
+        fee: [TRANSACTION_FEE],
+      });
+    });
+
+    it("should call approve with default fee", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      const blockHeight = BigInt(100);
+      service.icrc2_approve.mockResolvedValue({ Ok: blockHeight });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+      });
+
+      const res = await ledger.icrc2Approve(approveRequest);
+      expect(res).toEqual(blockHeight);
+      expect(service.icrc2_approve).toBeCalledWith({
+        ...approveRawRequest,
+        fee: [TRANSACTION_FEE],
+      });
+    });
+
+    it("should call approve with custom fee", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      const blockHeight = BigInt(100);
+      service.icrc2_approve.mockResolvedValue({ Ok: blockHeight });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+      });
+
+      const res = await ledger.icrc2Approve({
+        ...approveRequest,
+        fee: 123n,
+      });
+      expect(res).toEqual(blockHeight);
+      expect(service.icrc2_approve).toBeCalledWith({
+        ...approveRawRequest,
+        fee: [123n],
+      });
+    });
+
+    it("should call approve with memo", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      const blockHeight = BigInt(100);
+      service.icrc2_approve.mockResolvedValue({ Ok: blockHeight });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+      });
+
+      const icrc1Memo = arrayOfNumberToUint8Array([1, 2, 3, 4, 5]);
+
+      const res = await ledger.icrc2Approve({
+        ...approveRequest,
+        icrc1Memo,
+      });
+      expect(res).toEqual(blockHeight);
+      expect(service.icrc2_approve).toBeCalledWith({
+        ...approveRawRequest,
+        fee: [TRANSACTION_FEE],
+        memo: [icrc1Memo],
+      });
+    });
+
+    it("should call approve with created at", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      const blockHeight = BigInt(100);
+      service.icrc2_approve.mockResolvedValue({ Ok: blockHeight });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+      });
+
+      const res = await ledger.icrc2Approve({
+        ...approveRequest,
+        createdAt: 456n,
+      });
+      expect(res).toEqual(blockHeight);
+      expect(service.icrc2_approve).toBeCalledWith({
+        ...approveRawRequest,
+        fee: [TRANSACTION_FEE],
+        created_at_time: [456n],
+      });
+    });
+
+    it("should call approve with expected allowance", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      const blockHeight = BigInt(100);
+      service.icrc2_approve.mockResolvedValue({ Ok: blockHeight });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+      });
+
+      const res = await ledger.icrc2Approve({
+        ...approveRequest,
+        expected_allowance: 999n,
+      });
+      expect(res).toEqual(blockHeight);
+      expect(service.icrc2_approve).toBeCalledWith({
+        ...approveRawRequest,
+        fee: [TRANSACTION_FEE],
+        expected_allowance: [999n],
+      });
+    });
+
+    it("should call approve with a from subaccount", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      const blockHeight = BigInt(100);
+      service.icrc2_approve.mockResolvedValue({ Ok: blockHeight });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+      });
+
+      const res = await ledger.icrc2Approve({
+        ...approveRequest,
+        fromSubAccount: arrayOfNumberToUint8Array([4, 3, 2, 1]),
+      });
+      expect(res).toEqual(blockHeight);
+      expect(service.icrc2_approve).toBeCalledWith({
+        ...approveRawRequest,
+        fee: [TRANSACTION_FEE],
+        from_subaccount: [arrayOfNumberToUint8Array([4, 3, 2, 1])],
+      });
+    });
+
+    it("should call approve with a spender with subaccount", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      const blockHeight = BigInt(100);
+      service.icrc2_approve.mockResolvedValue({ Ok: blockHeight });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+      });
+
+      const spender: Account = {
+        owner: mockPrincipal,
+        subaccount: [arrayOfNumberToUint8Array([9, 8, 7, 6])],
+      };
+
+      const res = await ledger.icrc2Approve({
+        ...approveRequest,
+        spender,
+      });
+      expect(res).toEqual(blockHeight);
+      expect(service.icrc2_approve).toBeCalledWith({
+        ...approveRawRequest,
+        fee: [TRANSACTION_FEE],
+        spender,
+      });
+    });
+
+    it("should raise CreatedInFutureError", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      service.icrc2_approve.mockResolvedValue({
+        Err: {
+          CreatedInFuture: { ledger_time: BigInt(1234) },
+        },
+      });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+      });
+
+      const call = async () => await ledger.icrc2Approve(approveRequest);
+
+      expect(call).rejects.toThrowError(CreatedInFutureError);
     });
   });
 });

--- a/packages/ledger-icp/src/ledger.canister.spec.ts
+++ b/packages/ledger-icp/src/ledger.canister.spec.ts
@@ -10,9 +10,15 @@ import {
 } from "../candid/ledger";
 import { TRANSACTION_FEE } from "./constants/constants";
 import {
+  AllowanceChangedError,
   BadFeeError,
   CreatedInFutureError,
+  DuplicateError,
+  ExpiredError,
+  GenericError,
   InsufficientFundsError,
+  TemporarilyUnavailableError,
+  TooOldError,
   TxCreatedInFutureError,
   TxDuplicateError,
   TxTooOldError,
@@ -881,6 +887,96 @@ describe("LedgerCanister", () => {
       });
     });
 
+    it("should raise GenericError", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      service.icrc2_approve.mockResolvedValue({
+        Err: {
+          GenericError: { message: "This is a test", error_code: 123n },
+        },
+      });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+      });
+
+      const call = async () => await ledger.icrc2Approve(approveRequest);
+
+      expect(call).rejects.toThrowError(GenericError);
+    });
+
+    it("should raise TemporarilyUnavailableError", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      service.icrc2_approve.mockResolvedValue({
+        Err: {
+          TemporarilyUnavailable: null,
+        },
+      });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+      });
+
+      const call = async () => await ledger.icrc2Approve(approveRequest);
+
+      expect(call).rejects.toThrowError(TemporarilyUnavailableError);
+    });
+
+    it("should raise DuplicateError", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      service.icrc2_approve.mockResolvedValue({
+        Err: {
+          Duplicate: { duplicate_of: 888n },
+        },
+      });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+      });
+
+      const call = async () => await ledger.icrc2Approve(approveRequest);
+
+      expect(call).rejects.toThrowError(DuplicateError);
+    });
+
+    it("should raise BadFeeError", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      service.icrc2_approve.mockResolvedValue({
+        Err: {
+          BadFee: { expected_fee: 666n },
+        },
+      });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+      });
+
+      const call = async () => await ledger.icrc2Approve(approveRequest);
+
+      expect(call).rejects.toThrowError(BadFeeError);
+    });
+
+    it("should raise AllowanceChangedError", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      service.icrc2_approve.mockResolvedValue({
+        Err: {
+          AllowanceChanged: { current_allowance: 444n },
+        },
+      });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+      });
+
+      const call = async () => await ledger.icrc2Approve(approveRequest);
+
+      expect(call).rejects.toThrowError(AllowanceChangedError);
+    });
+
     it("should raise CreatedInFutureError", async () => {
       const service = mock<ActorSubclass<LedgerService>>();
       service.icrc2_approve.mockResolvedValue({
@@ -897,6 +993,60 @@ describe("LedgerCanister", () => {
       const call = async () => await ledger.icrc2Approve(approveRequest);
 
       expect(call).rejects.toThrowError(CreatedInFutureError);
+    });
+
+    it("should raise TooOldError", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      service.icrc2_approve.mockResolvedValue({
+        Err: {
+          TooOld: null,
+        },
+      });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+      });
+
+      const call = async () => await ledger.icrc2Approve(approveRequest);
+
+      expect(call).rejects.toThrowError(TooOldError);
+    });
+
+    it("should raise ExpiredError", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      service.icrc2_approve.mockResolvedValue({
+        Err: {
+          Expired: { ledger_time: BigInt(1234) },
+        },
+      });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+      });
+
+      const call = async () => await ledger.icrc2Approve(approveRequest);
+
+      expect(call).rejects.toThrowError(ExpiredError);
+    });
+
+    it("should raise InsufficientFundsError", async () => {
+      const service = mock<ActorSubclass<LedgerService>>();
+      service.icrc2_approve.mockResolvedValue({
+        Err: {
+          InsufficientFunds: { balance: 333888n },
+        },
+      });
+
+      const ledger = LedgerCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+      });
+
+      const call = async () => await ledger.icrc2Approve(approveRequest);
+
+      expect(call).rejects.toThrowError(InsufficientFundsError);
     });
   });
 });

--- a/packages/ledger-icp/src/ledger.canister.ts
+++ b/packages/ledger-icp/src/ledger.canister.ts
@@ -75,13 +75,20 @@ export class LedgerCanister extends Canister<LedgerService> {
   };
 
   /**
-   * Returns the transaction fee of the ledger canister
-   * @returns {BigInt}
+   * Returns the transaction fee of the ICP ledger canister.
+   *
+   * @param {QueryParams} [params={certified: false}] - Optional query parameters for the request, defaulting to `{ certified: false }` for backwards compatibility reason.
+   * @returns {Promise<bigint>} A promise that resolves to the transaction fee as a bigint.
    */
-  public transactionFee = async () => {
+  public transactionFee = async (
+    params: QueryParams = { certified: false },
+  ): Promise<bigint> => {
+    const { transfer_fee } = this.caller(params);
+
     const {
       transfer_fee: { e8s },
-    } = await this.service.transfer_fee({});
+    } = await transfer_fee({});
+
     return e8s;
   };
 

--- a/packages/ledger-icp/src/mocks/ledger.mock.ts
+++ b/packages/ledger-icp/src/mocks/ledger.mock.ts
@@ -1,5 +1,11 @@
+import { Principal } from "@dfinity/principal";
 import { AccountIdentifier } from "../account_identifier";
 
 export const mockAccountIdentifier = AccountIdentifier.fromHex(
   "3e8bbceef8b9338e56a1b561a127326e6614894ab9b0739df4cc3664d40a5958",
 );
+
+export const mockPrincipalText =
+  "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe";
+
+export const mockPrincipal = Principal.fromText(mockPrincipalText);

--- a/packages/ledger-icp/src/types/ledger_converters.ts
+++ b/packages/ledger-icp/src/types/ledger_converters.ts
@@ -36,3 +36,25 @@ export type Icrc1TransferRequest = {
   // https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#transaction_deduplication
   createdAt?: Icrc1Timestamp;
 };
+
+/**
+ * Params for an icrc2_approve.
+ *
+ * @param {Account} spender The account of the spender.
+ * @param {Tokens} amount The amount of tokens to approve.
+ * @param {Subaccount?} from_subaccount The subaccount to transfer tokens from.
+ * @param {Uint8Array|number?} memo Approve memo.
+ * @param {Timestamp?} created_at_time nanoseconds since unix epoc to trigger deduplication and avoid other issues
+ * @param {Tokens?} fee The fee of the transfer when it's not the default fee.
+ * @param {Tokens?} expected_allowance The optional allowance expected. If the expected_allowance field is set, the ledger MUST ensure that the current allowance for the spender from the caller's account is equal to the given value and return the AllowanceChanged error otherwise.
+ * @param {Timestamp?} expires_at When the approval expires. If the field is set, it's greater than the current ledger time.
+ */
+export type Icrc2ApproveRequest = Omit<
+  Icrc1TransferRequest,
+  "to" | "icrc1Memo"
+> & {
+  memo?: Uint8Array | number[];
+  expected_allowance?: Icrc1Tokens;
+  expires_at?: Icrc1Timestamp;
+  spender: Account;
+};

--- a/packages/ledger-icp/src/types/ledger_converters.ts
+++ b/packages/ledger-icp/src/types/ledger_converters.ts
@@ -43,17 +43,13 @@ export type Icrc1TransferRequest = {
  * @param {Account} spender The account of the spender.
  * @param {Tokens} amount The amount of tokens to approve.
  * @param {Subaccount?} from_subaccount The subaccount to transfer tokens from.
- * @param {Uint8Array|number?} memo Approve memo.
+ * @param {Uint8Array|number?} icrc1Memo Approve memo.
  * @param {Timestamp?} created_at_time nanoseconds since unix epoc to trigger deduplication and avoid other issues
  * @param {Tokens?} fee The fee of the transfer when it's not the default fee.
  * @param {Tokens?} expected_allowance The optional allowance expected. If the expected_allowance field is set, the ledger MUST ensure that the current allowance for the spender from the caller's account is equal to the given value and return the AllowanceChanged error otherwise.
  * @param {Timestamp?} expires_at When the approval expires. If the field is set, it's greater than the current ledger time.
  */
-export type Icrc2ApproveRequest = Omit<
-  Icrc1TransferRequest,
-  "to" | "icrc1Memo"
-> & {
-  memo?: Uint8Array | number[];
+export type Icrc2ApproveRequest = Omit<Icrc1TransferRequest, "to"> & {
   expected_allowance?: Icrc1Tokens;
   expires_at?: Icrc1Timestamp;
   spender: Account;


### PR DESCRIPTION
# Motivation

In the signer standard working group, the common example of usage of the new wallet standards is the ICRC2 approve function. While this function is available in the ledger ICRC library, it has not been exposed so far in the ICP ledger library.

# Changes

- Add `icrc2Approve` function (following `icrc1Transfer` pattern) to the ICP ledger lib.
