### PR TITLE
chore: download did script

### DIFF
--- a/packages/ic-management/candid/ic-management.did
+++ b/packages/ic-management/candid/ic-management.did
@@ -1,3 +1,4 @@
+// Generated from dfinity/interface-spec commit 17ae77a0a25781545af9533f4e2ff569f52d1eb4 for file 'spec/_attachments/ic.did'
 type canister_id = principal;
 type wasm_module = blob;
 

--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -110,7 +110,6 @@ import_did "rs/rosetta-api/icrc1/index-ng/index-ng.did" "icrc_index-ng.did" "led
 
 mkdir -p packages/ckbtc/candid
 import_did "rs/bitcoin/ckbtc/minter/ckbtc_minter.did" "minter.did" "ckbtc"
-curl https://raw.githubusercontent.com/dfinity/interface-spec/master/spec/_attachments/ic.did -o packages/ic-management/candid/ic-management.did
 
 mkdir -p packages/cketh/candid
 import_did "rs/ethereum/cketh/minter/cketh_minter.did" "minter.did" "cketh"

--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -23,6 +23,34 @@ import_did() {
   } >"${out_path}"
 }
 
+download_did() {
+  local raw_url="$1"
+  local out_filename="$2"
+  local pkg="$3"
+
+  local out_path="packages/${pkg}/candid/${out_filename}"
+
+  # Extract repository, branch, and file path from the raw URL
+  local repo=$(echo "$raw_url" | awk -F '/' '{print $4"/"$5}')
+  local branch=$(echo "$raw_url" | awk -F '/' '{print $6}')
+  local file_path=$(echo "$raw_url" | awk -F "$branch/" '{print $2}')
+
+  # Get the latest commit hash for the specified file
+  local api_url="https://api.github.com/repos/${repo}/commits?path=${file_path}&sha=${branch}"
+  local commit_hash=$(curl -s "$api_url" | jq -r '.[0].sha')
+
+  if [ -z "$commit_hash" ]; then
+    echo "Failed to retrieve commit hash for ${file_path} in ${repo}."
+    return 1
+  fi
+
+  echo "Downloading ${raw_url} -> REPO_ROOT/${out_path}"
+  {
+    echo "// Generated from ${repo} commit ${commit_hash} for file '${file_path}'"
+    curl -s "$raw_url"
+  } >"${out_path}"
+}
+
 : Move to root of the repo
 cd "$(dirname "$(realpath "$0")")/.."
 
@@ -82,11 +110,12 @@ import_did "rs/rosetta-api/icrc1/index-ng/index-ng.did" "icrc_index-ng.did" "led
 
 mkdir -p packages/ckbtc/candid
 import_did "rs/bitcoin/ckbtc/minter/ckbtc_minter.did" "minter.did" "ckbtc"
+curl https://raw.githubusercontent.com/dfinity/interface-spec/master/spec/_attachments/ic.did -o packages/ic-management/candid/ic-management.did
 
 mkdir -p packages/cketh/candid
 import_did "rs/ethereum/cketh/minter/cketh_minter.did" "minter.did" "cketh"
 import_did "rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did" "orchestrator.did" "cketh"
 
 mkdir -p packages/ic-management/candid
-curl https://raw.githubusercontent.com/dfinity/interface-spec/master/spec/_attachments/ic.did -o packages/ic-management/candid/ic-management.did
+download_did https://raw.githubusercontent.com/dfinity/interface-spec/master/spec/_attachments/ic.did "ic-management.did" "ic-management"
 : Fin


### PR DESCRIPTION
# Motivation

In #643, we need to download another did file from a repository other than the IC repository. Therefore, we have to use a one more curl command in our `import-candid` script. This PR creates a function for handling such did files in import-candid, and also uses the GitHub API to collect the commit hash and add it as a comment in the generated file.
