### PR TITLE
feat: remove ic-mgmt getUtxos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 2024.XX.YY-hhmmZ
 
+## Breaking changes
+
+- `bitcoinGetUtxos` and `bitcoinGetUtxosQuery` have been removed from the `@dfinity/ic-management` library. Instead, use `getUtxos` from the new Bitcoin canister exposed in `@dfinity/ckbtc` to access similar data.
+
 ## Features
 
 - Canister status response extended with query statistics.

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -54,7 +54,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 
 ### :factory: ICManagementCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L35)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L30)
 
 #### Methods
 
@@ -72,8 +72,6 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 - [canisterStatus](#gear-canisterstatus)
 - [deleteCanister](#gear-deletecanister)
 - [provisionalCreateCanisterWithCycles](#gear-provisionalcreatecanisterwithcycles)
-- [bitcoinGetUtxos](#gear-bitcoingetutxos)
-- [bitcoinGetUtxosQuery](#gear-bitcoingetutxosquery)
 
 ##### :gear: create
 
@@ -81,7 +79,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 | -------- | ---------------------------------------------------------------- |
 | `create` | `(options: ICManagementCanisterOptions) => ICManagementCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L40)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L35)
 
 ##### :gear: createCanister
 
@@ -91,7 +89,7 @@ Create a new canister
 | ---------------- | ------------------------------------------------------------------------------------- |
 | `createCanister` | `({ settings, senderCanisterVersion, }?: CreateCanisterParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L80)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L75)
 
 ##### :gear: updateSettings
 
@@ -101,7 +99,7 @@ Update canister settings
 | ---------------- | ------------------------------------------------------------------------------------------- |
 | `updateSettings` | `({ canisterId, senderCanisterVersion, settings, }: UpdateSettingsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L101)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L96)
 
 ##### :gear: installCode
 
@@ -111,7 +109,7 @@ Install code to a canister
 | ------------- | ----------------------------------------------------------------------------------------------------- |
 | `installCode` | `({ mode, canisterId, wasmModule, arg, senderCanisterVersion, }: InstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L123)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L118)
 
 ##### :gear: uploadChunk
 
@@ -126,7 +124,7 @@ Parameters:
 - `params.canisterId`: The canister in which the chunks will be stored.
 - `params.chunk`: A chunk of Wasm module.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L148)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L143)
 
 ##### :gear: clearChunkStore
 
@@ -140,7 +138,7 @@ Parameters:
 
 - `params.canisterId`: The canister in which the chunks are stored.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L168)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L163)
 
 ##### :gear: storedChunks
 
@@ -154,7 +152,7 @@ Parameters:
 
 - `params.canisterId`: The canister in which the chunks are stored.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L187)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L182)
 
 ##### :gear: installChunkedCode
 
@@ -174,7 +172,7 @@ Parameters:
 - `params.storeCanisterId`: Specifies the canister in whose chunk storage the chunks are stored (this parameter defaults to target_canister if not specified).
 - `params.wasmModuleHash`: The Wasm module hash as hex string. Used to check that the SHA-256 hash of wasm_module is equal to the wasm_module_hash parameter and can calls install_code with parameters.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L212)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L207)
 
 ##### :gear: uninstallCode
 
@@ -184,7 +182,7 @@ Uninstall code from a canister
 | --------------- | -------------------------------------------------------------------------------- |
 | `uninstallCode` | `({ canisterId, senderCanisterVersion, }: UninstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L245)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L240)
 
 ##### :gear: startCanister
 
@@ -194,7 +192,7 @@ Start a canister
 | --------------- | ------------------------------------------ |
 | `startCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L260)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L255)
 
 ##### :gear: stopCanister
 
@@ -204,7 +202,7 @@ Stop a canister
 | -------------- | ------------------------------------------ |
 | `stopCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L269)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L264)
 
 ##### :gear: canisterStatus
 
@@ -214,7 +212,7 @@ Get canister details (memory size, status, etc.)
 | ---------------- | ------------------------------------------------------------ |
 | `canisterStatus` | `(canisterId: Principal) => Promise<canister_status_result>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L278)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L273)
 
 ##### :gear: deleteCanister
 
@@ -224,7 +222,7 @@ Deletes a canister
 | ---------------- | ------------------------------------------ |
 | `deleteCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L289)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L284)
 
 ##### :gear: provisionalCreateCanisterWithCycles
 
@@ -234,39 +232,7 @@ Creates a canister. Only available on development instances.
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `provisionalCreateCanisterWithCycles` | `({ settings, amount, canisterId, }?: ProvisionalCreateCanisterWithCyclesParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L301)
-
-##### :gear: bitcoinGetUtxos
-
-Given a `get_utxos_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet` or `testnet`), the function returns all unspent transaction outputs (UTXOs) associated with the provided address in the specified Bitcoin network based on the current view of the Bitcoin blockchain available to the Bitcoin component.
-
-| Method            | Type                                                                   |
-| ----------------- | ---------------------------------------------------------------------- |
-| `bitcoinGetUtxos` | `(params: BitcoinGetUtxosParams) => Promise<bitcoin_get_utxos_result>` |
-
-Parameters:
-
-- `params.network`: Tesnet or mainnet.
-- `params.filter`: The optional filter parameter can be used to restrict the set of returned UTXOs, either providing a minimum number of confirmations or a page reference when pagination is used for addresses with many UTXOs.
-- `params.address`: A Bitcoin address.
-
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L328)
-
-##### :gear: bitcoinGetUtxosQuery
-
-This method is identical to `bitcoinGetUtxos`, but exposed as a query.
-
-| Method                 | Type                                                                              |
-| ---------------------- | --------------------------------------------------------------------------------- |
-| `bitcoinGetUtxosQuery` | `(params: BitcoinGetUtxosQueryParams) => Promise<bitcoin_get_utxos_query_result>` |
-
-Parameters:
-
-- `params.network`: Tesnet or mainnet.
-- `params.filter`: The optional filter parameter can be used to restrict the set of returned UTXOs, either providing a minimum number of confirmations or a page reference when pagination is used for addresses with many UTXOs.
-- `params.address`: A Bitcoin address.
-
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L346)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L296)
 
 <!-- TSDOC_END -->
 

--- a/packages/ic-management/src/ic-management.canister.spec.ts
+++ b/packages/ic-management/src/ic-management.canister.spec.ts
@@ -3,13 +3,10 @@ import { ServiceResponse, toNullable } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
 import type {
   _SERVICE as IcManagementService,
-  bitcoin_get_utxos_query_result,
-  bitcoin_get_utxos_result,
   chunk_hash,
 } from "../candid/ic-management";
 import { ICManagementCanister } from "./ic-management.canister";
 import {
-  bitcoinAddressMock,
   mappedMockCanisterSettings,
   mockCanisterId,
   mockCanisterSettings,
@@ -17,14 +14,12 @@ import {
   mockPrincipalText,
 } from "./ic-management.mock";
 import {
-  BitcoinGetUtxosQueryParams,
   CanisterSettings,
   InstallCodeParams,
   InstallMode,
   LogVisibility,
   UnsupportedLogVisibility,
   toInstallMode,
-  type BitcoinGetUtxosParams,
   type ClearChunkStoreParams,
   type InstallChunkedCodeParams,
   type StoredChunksParams,
@@ -449,124 +444,6 @@ describe("ICManagementCanister", () => {
       const icManagement = await createICManagement(service);
 
       const call = () => icManagement.provisionalCreateCanisterWithCycles();
-
-      expect(call).rejects.toThrowError(Error);
-    });
-  });
-
-  describe("bitcoinGetUtxos", () => {
-    const params: BitcoinGetUtxosParams = {
-      network: "testnet",
-      filter: { min_confirmations: 2 },
-      address: bitcoinAddressMock,
-    };
-
-    it("returns get utxos result when success", async () => {
-      const response: bitcoin_get_utxos_result = {
-        next_page: [],
-        tip_height: 123,
-        tip_block_hash: new Uint8Array([1, 2, 3]),
-        utxos: [
-          {
-            height: 456,
-            value: 789n,
-            outpoint: {
-              txid: new Uint8Array([4, 5, 6]),
-              vout: 1,
-            },
-          },
-          {
-            height: 789,
-            value: 7n,
-            outpoint: {
-              txid: new Uint8Array([7, 8, 9]),
-              vout: 2,
-            },
-          },
-        ],
-      };
-      const service = mock<IcManagementService>();
-      service.bitcoin_get_utxos.mockResolvedValue(response);
-
-      const icManagement = await createICManagement(service);
-
-      const res = await icManagement.bitcoinGetUtxos(params);
-
-      expect(res).toEqual(response);
-      expect(service.bitcoin_get_utxos).toHaveBeenCalledWith({
-        network: { testnet: null },
-        filter: [{ min_confirmations: 2 }],
-        address: bitcoinAddressMock,
-      });
-    });
-
-    it("throws Error", async () => {
-      const error = new Error("Test");
-      const service = mock<IcManagementService>();
-      service.bitcoin_get_utxos.mockRejectedValue(error);
-
-      const icManagement = await createICManagement(service);
-
-      const call = () => icManagement.bitcoinGetUtxos(params);
-
-      expect(call).rejects.toThrowError(Error);
-    });
-  });
-
-  describe("bitcoinGetUtxosQuery", () => {
-    const params: BitcoinGetUtxosQueryParams = {
-      network: "testnet",
-      filter: { min_confirmations: 2 },
-      address: bitcoinAddressMock,
-    };
-
-    it("returns get utxos query result when success", async () => {
-      const response: bitcoin_get_utxos_query_result = {
-        next_page: [],
-        tip_height: 123,
-        tip_block_hash: new Uint8Array([1, 2, 3]),
-        utxos: [
-          {
-            height: 456,
-            value: 789n,
-            outpoint: {
-              txid: new Uint8Array([4, 5, 6]),
-              vout: 1,
-            },
-          },
-          {
-            height: 789,
-            value: 7n,
-            outpoint: {
-              txid: new Uint8Array([7, 8, 9]),
-              vout: 2,
-            },
-          },
-        ],
-      };
-      const service = mock<IcManagementService>();
-      service.bitcoin_get_utxos_query.mockResolvedValue(response);
-
-      const icManagement = await createICManagement(service);
-
-      const res = await icManagement.bitcoinGetUtxosQuery(params);
-
-      expect(res).toEqual(response);
-      expect(service.bitcoin_get_utxos_query).toHaveBeenCalledWith({
-        network: { testnet: null },
-        filter: [{ min_confirmations: 2 }],
-        address: bitcoinAddressMock,
-      });
-    });
-
-    it("throws Error", async () => {
-      const error = new Error("Test");
-      const service = mock<IcManagementService>();
-      service.bitcoin_get_utxos_query.mockRejectedValue(error);
-
-      const icManagement = await createICManagement(service);
-
-      const call = () => icManagement.bitcoinGetUtxosQuery(params);
 
       expect(call).rejects.toThrowError(Error);
     });

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -7,19 +7,14 @@ import {
 } from "@dfinity/utils";
 import type {
   _SERVICE as IcManagementService,
-  bitcoin_get_utxos_query_result,
-  bitcoin_get_utxos_result,
   chunk_hash,
 } from "../candid/ic-management";
 import { idlFactory as certifiedIdlFactory } from "../candid/ic-management.certified.idl";
 import { idlFactory } from "../candid/ic-management.idl";
 import type { ICManagementCanisterOptions } from "./types/canister.options";
 import {
-  toBitcoinGetUtxosParams,
   toCanisterSettings,
   toInstallMode,
-  type BitcoinGetUtxosParams,
-  type BitcoinGetUtxosQueryParams,
   type ClearChunkStoreParams,
   type CreateCanisterParams,
   type InstallChunkedCodeParams,
@@ -312,41 +307,5 @@ export class ICManagementCanister {
       });
 
     return canister_id;
-  };
-
-  /**
-   * Given a `get_utxos_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet` or `testnet`), the function returns all unspent transaction outputs (UTXOs) associated with the provided address in the specified Bitcoin network based on the current view of the Bitcoin blockchain available to the Bitcoin component.
-   *
-   * @link https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-bitcoin_get_utxos
-   *
-   * @param {Object} params
-   * @param {BitcoinNetwork} params.network Tesnet or mainnet.
-   * @param {Object} params.filter The optional filter parameter can be used to restrict the set of returned UTXOs, either providing a minimum number of confirmations or a page reference when pagination is used for addresses with many UTXOs.
-   * @param {string} params.address A Bitcoin address.
-   * @returns {Promise<bitcoin_get_utxos_result>} The UTXOs are returned sorted by block height in descending order.
-   */
-  bitcoinGetUtxos = (
-    params: BitcoinGetUtxosParams,
-  ): Promise<bitcoin_get_utxos_result> => {
-    const { bitcoin_get_utxos } = this.service;
-    return bitcoin_get_utxos(toBitcoinGetUtxosParams(params));
-  };
-
-  /**
-   * This method is identical to `bitcoinGetUtxos`, but exposed as a query.
-   *
-   * @link https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-bitcoin_get_utxos_query
-   *
-   * @param {Object} params
-   * @param {BitcoinNetwork} params.network Tesnet or mainnet.
-   * @param {Object} params.filter The optional filter parameter can be used to restrict the set of returned UTXOs, either providing a minimum number of confirmations or a page reference when pagination is used for addresses with many UTXOs.
-   * @param {string} params.address A Bitcoin address.
-   * @returns {Promise<bitcoin_get_utxos_result>} The UTXOs are returned sorted by block height in descending order.
-   */
-  bitcoinGetUtxosQuery = (
-    params: BitcoinGetUtxosQueryParams,
-  ): Promise<bitcoin_get_utxos_query_result> => {
-    const { bitcoin_get_utxos_query } = this.service;
-    return bitcoin_get_utxos_query(toBitcoinGetUtxosParams(params));
   };
 }

--- a/packages/ic-management/src/index.ts
+++ b/packages/ic-management/src/index.ts
@@ -1,13 +1,3 @@
-export type {
-  bitcoin_get_utxos_query_result,
-  bitcoin_get_utxos_result,
-  bitcoin_network,
-  block_hash,
-  chunk_hash,
-  outpoint,
-  satoshi,
-  utxo,
-} from "../candid/ic-management";
 export { ICManagementCanister } from "./ic-management.canister";
 export * from "./types/canister.options";
 export * from "./types/ic-management.params";

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -1,8 +1,6 @@
 import { Principal } from "@dfinity/principal";
 import { isNullish, toNullable } from "@dfinity/utils";
 import type {
-  bitcoin_get_utxos_args,
-  bitcoin_get_utxos_query_args,
   canister_install_mode,
   canister_settings,
   chunk_hash,
@@ -131,33 +129,3 @@ export interface ProvisionalTopUpCanisterParams {
   canisterId: Principal;
   amount: bigint;
 }
-
-export type BitcoinNetwork = "testnet" | "mainnet";
-
-export type BitcoinGetUtxosParams = Omit<
-  bitcoin_get_utxos_args,
-  "network" | "filter"
-> & {
-  network: BitcoinNetwork;
-  filter?: { page: Uint8Array | number[] } | { min_confirmations: number };
-};
-
-export type BitcoinGetUtxosQueryParams = Omit<
-  bitcoin_get_utxos_query_args,
-  "network" | "filter"
-> & {
-  network: BitcoinNetwork;
-  filter?: { page: Uint8Array | number[] } | { min_confirmations: number };
-};
-
-export const toBitcoinGetUtxosParams = <
-  T extends BitcoinGetUtxosParams | BitcoinGetUtxosQueryParams,
->({
-  network,
-  filter,
-  ...rest
-}: T): bitcoin_get_utxos_args | bitcoin_get_utxos_query_args => ({
-  filter: toNullable(filter),
-  network: network === "testnet" ? { testnet: null } : { mainnet: null },
-  ...rest,
-});


### PR DESCRIPTION
# Motivation

Deprecate the `getUtxos` functions of the ic-mgmt library. Replaced by similar functions in the new Bitcoin canister (see #644).

# Changes

- Remove code `bitcoinGetUtxos` and `bitcoinGetUtxosQuery`
