### PR TITLE
fix: Bitcoin canister undefined functions

### DIFF
--- a/packages/ckbtc/src/bitcoin.canister.ts
+++ b/packages/ckbtc/src/bitcoin.canister.ts
@@ -3,8 +3,8 @@ import type {
   _SERVICE as BitcoinService,
   get_utxos_response,
 } from "../candid/bitcoin";
-import { idlFactory as certifiedIdlFactory } from "../candid/minter.certified.idl";
-import { idlFactory } from "../candid/minter.idl";
+import { idlFactory as certifiedIdlFactory } from "../candid/bitcoin.certified.idl";
+import { idlFactory } from "../candid/bitcoin.idl";
 import { toGetUtxosParams, type GetUtxosParams } from "./types/bitcoin.params";
 import type { CkBTCCanisterOptions } from "./types/canister.options";
 


### PR DESCRIPTION
# Motivation

There was a typo in the `import` of the Candid IDL files (copy/paste of "minter" not updated to "bitcoin"). As a result, when using the library IRL, the functions of the actors were actually undefined.

# Changes

- Import Bitcoin DID IDL files

# Screenshots

Before:

<img width="1536" alt="Capture d’écran 2024-06-04 à 09 33 44" src="https://github.com/dfinity/ic-js/assets/16886711/85ba3d52-b9c3-4947-8b8a-c73d2623708f">

After fix:

<img width="1536" alt="Capture d’écran 2024-06-04 à 09 47 46" src="https://github.com/dfinity/ic-js/assets/16886711/5cd85baf-846a-4de4-9c74-c7797a96497f">

