### PR TITLE
feature: add API endpoint 'ecdsa_public_key' to ic-management

### DIFF
--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -237,7 +237,13 @@ Creates a canister. Only available on development instances.
 
 ##### :gear: ecdsaPublicKey
 
-Calculate a SEC1 encoded ECDSA public key for the given canister using the given derivation path. If the `canister_id` is unspecified, it will default to the canister ID of the caller. The `derivation_path` is a vector of variable length byte strings. Each byte string may be of arbitrary length, including empty. The total number of byte strings in the `derivation_path` must be at most 255. The `key_id` is a struct specifying both a `curve` and a `name`. The availability of a particular `key_id` depends on implementation.
+Calculate a SEC1 encoded ECDSA public key for the given canister using the given derivation path.
+
+If the `canister_id` is unspecified, the address will be derived from the canister ID of the caller canister. The caller canister is the canister that instantiated and invoked the `ICManagementCanister` service.
+
+The `derivation_path` is a vector of variable length byte strings. Each byte string may be of arbitrary length, including empty. The total number of byte strings in the `derivation_path` must be at most 255. The suggested standard to be used is [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
+
+The `key_id` is a struct specifying both a `curve` and a `name`. The availability of a particular `key_id` depends on implementation.
 
 | Method           | Type                                                                                                |
 | ---------------- | --------------------------------------------------------------------------------------------------- |
@@ -246,10 +252,10 @@ Calculate a SEC1 encoded ECDSA public key for the given canister using the given
 Parameters:
 
 - `params.keyId`: The key id for which the public key will be derived, consisting of a `name` and a `curve`.
-- `params.canisterId`: The canister ID for which the public key will be derived. It defaults to the caller's canister ID if unspecified.
-- `params.derivationPath`: The derivation path that will be used to derive the public key.
+- `params.canisterId`: The canister ID for which the public key will be derived. If unspecified, it defaults to the caller canister's ID.
+- `params.derivationPath`: The derivation path that will be used to derive the public key. The suggested standard is [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L327)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L333)
 
 <!-- TSDOC_END -->
 

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -54,7 +54,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 
 ### :factory: ICManagementCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L30)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L34)
 
 #### Methods
 
@@ -72,6 +72,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 - [canisterStatus](#gear-canisterstatus)
 - [deleteCanister](#gear-deletecanister)
 - [provisionalCreateCanisterWithCycles](#gear-provisionalcreatecanisterwithcycles)
+- [ecdsaPublicKey](#gear-ecdsapublickey)
 
 ##### :gear: create
 
@@ -234,14 +235,13 @@ Creates a canister. Only available on development instances.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L300)
 
-
-#### :gear: ecdsaPublicKey
+##### :gear: ecdsaPublicKey
 
 Calculate a SEC1 encoded ECDSA public key for the given canister using the given derivation path. If the `canister_id` is unspecified, it will default to the canister id of the caller. The `derivation_path` is a vector of variable length byte strings. Each byte string may be of arbitrary length, including empty. The total number of byte strings in the `derivation_path` must be at most 255. The `key_id` is a struct specifying both a `curve` and a `name`. The availability of a particular `key_id` depends on implementation.
 
-| Method           | Type                                                                                                 |
-| ---------------- | ---------------------------------------------------------------------------------------------------- |
-| `ecdsaPublicKey` | `({ keyId, canisterId, derivationPath, }?: EcdsaPublicKeyParams) => Promise<EcdsaPublicKeyResponse>` |
+| Method           | Type                                                                                                |
+| ---------------- | --------------------------------------------------------------------------------------------------- |
+| `ecdsaPublicKey` | `({ keyId, canisterId, derivationPath, }: EcdsaPublicKeyParams) => Promise<EcdsaPublicKeyResponse>` |
 
 Parameters:
 

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -79,7 +79,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 | -------- | ---------------------------------------------------------------- |
 | `create` | `(options: ICManagementCanisterOptions) => ICManagementCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L35)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L39)
 
 ##### :gear: createCanister
 
@@ -89,7 +89,7 @@ Create a new canister
 | ---------------- | ------------------------------------------------------------------------------------- |
 | `createCanister` | `({ settings, senderCanisterVersion, }?: CreateCanisterParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L75)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L79)
 
 ##### :gear: updateSettings
 
@@ -99,7 +99,7 @@ Update canister settings
 | ---------------- | ------------------------------------------------------------------------------------------- |
 | `updateSettings` | `({ canisterId, senderCanisterVersion, settings, }: UpdateSettingsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L96)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L100)
 
 ##### :gear: installCode
 
@@ -109,7 +109,7 @@ Install code to a canister
 | ------------- | ----------------------------------------------------------------------------------------------------- |
 | `installCode` | `({ mode, canisterId, wasmModule, arg, senderCanisterVersion, }: InstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L118)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L122)
 
 ##### :gear: uploadChunk
 
@@ -124,7 +124,7 @@ Parameters:
 - `params.canisterId`: The canister in which the chunks will be stored.
 - `params.chunk`: A chunk of Wasm module.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L143)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L147)
 
 ##### :gear: clearChunkStore
 
@@ -138,7 +138,7 @@ Parameters:
 
 - `params.canisterId`: The canister in which the chunks are stored.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L163)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L167)
 
 ##### :gear: storedChunks
 
@@ -152,7 +152,7 @@ Parameters:
 
 - `params.canisterId`: The canister in which the chunks are stored.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L182)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L186)
 
 ##### :gear: installChunkedCode
 
@@ -172,7 +172,7 @@ Parameters:
 - `params.storeCanisterId`: Specifies the canister in whose chunk storage the chunks are stored (this parameter defaults to target_canister if not specified).
 - `params.wasmModuleHash`: The Wasm module hash as hex string. Used to check that the SHA-256 hash of wasm_module is equal to the wasm_module_hash parameter and can calls install_code with parameters.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L207)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L211)
 
 ##### :gear: uninstallCode
 
@@ -182,7 +182,7 @@ Uninstall code from a canister
 | --------------- | -------------------------------------------------------------------------------- |
 | `uninstallCode` | `({ canisterId, senderCanisterVersion, }: UninstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L240)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L244)
 
 ##### :gear: startCanister
 
@@ -192,7 +192,7 @@ Start a canister
 | --------------- | ------------------------------------------ |
 | `startCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L255)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L259)
 
 ##### :gear: stopCanister
 
@@ -202,7 +202,7 @@ Stop a canister
 | -------------- | ------------------------------------------ |
 | `stopCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L264)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L268)
 
 ##### :gear: canisterStatus
 
@@ -212,7 +212,7 @@ Get canister details (memory size, status, etc.)
 | ---------------- | ------------------------------------------------------------ |
 | `canisterStatus` | `(canisterId: Principal) => Promise<canister_status_result>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L273)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L277)
 
 ##### :gear: deleteCanister
 
@@ -222,7 +222,7 @@ Deletes a canister
 | ---------------- | ------------------------------------------ |
 | `deleteCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L284)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L288)
 
 ##### :gear: provisionalCreateCanisterWithCycles
 
@@ -232,7 +232,24 @@ Creates a canister. Only available on development instances.
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `provisionalCreateCanisterWithCycles` | `({ settings, amount, canisterId, }?: ProvisionalCreateCanisterWithCyclesParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L296)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L300)
+
+
+#### :gear: ecdsaPublicKey
+
+Calculate a SEC1 encoded ECDSA public key for the given canister using the given derivation path. If the `canister_id` is unspecified, it will default to the canister id of the caller. The `derivation_path` is a vector of variable length byte strings. Each byte string may be of arbitrary length, including empty. The total number of byte strings in the `derivation_path` must be at most 255. The `key_id` is a struct specifying both a `curve` and a `name`. The availability of a particular `key_id` depends on implementation.
+
+| Method           | Type                                                                                                 |
+| ---------------- | ---------------------------------------------------------------------------------------------------- |
+| `ecdsaPublicKey` | `({ keyId, canisterId, derivationPath, }?: EcdsaPublicKeyParams) => Promise<EcdsaPublicKeyResponse>` |
+
+Parameters:
+
+- `params.keyId`: The key id for which the public key will be derived, consisting of a `name` and a `curve`.
+- `params.canisterId`: The canister id for which the public key will be derived. It defaults to the caller's canister id if unspecified.
+- `params.derivationPath`: The derivation path that will be used to derive the public key.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L327)
 
 <!-- TSDOC_END -->
 

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -237,7 +237,7 @@ Creates a canister. Only available on development instances.
 
 ##### :gear: ecdsaPublicKey
 
-Calculate a SEC1 encoded ECDSA public key for the given canister using the given derivation path. If the `canister_id` is unspecified, it will default to the canister id of the caller. The `derivation_path` is a vector of variable length byte strings. Each byte string may be of arbitrary length, including empty. The total number of byte strings in the `derivation_path` must be at most 255. The `key_id` is a struct specifying both a `curve` and a `name`. The availability of a particular `key_id` depends on implementation.
+Calculate a SEC1 encoded ECDSA public key for the given canister using the given derivation path. If the `canister_id` is unspecified, it will default to the canister ID of the caller. The `derivation_path` is a vector of variable length byte strings. Each byte string may be of arbitrary length, including empty. The total number of byte strings in the `derivation_path` must be at most 255. The `key_id` is a struct specifying both a `curve` and a `name`. The availability of a particular `key_id` depends on implementation.
 
 | Method           | Type                                                                                                |
 | ---------------- | --------------------------------------------------------------------------------------------------- |
@@ -246,7 +246,7 @@ Calculate a SEC1 encoded ECDSA public key for the given canister using the given
 Parameters:
 
 - `params.keyId`: The key id for which the public key will be derived, consisting of a `name` and a `curve`.
-- `params.canisterId`: The canister id for which the public key will be derived. It defaults to the caller's canister id if unspecified.
+- `params.canisterId`: The canister ID for which the public key will be derived. It defaults to the caller's canister ID if unspecified.
 - `params.derivationPath`: The derivation path that will be used to derive the public key.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L327)

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -239,11 +239,11 @@ Creates a canister. Only available on development instances.
 
 Calculate a SEC1 encoded ECDSA public key for the given canister using the given derivation path.
 
-If the `canister_id` is unspecified, the address will be derived from the canister ID of the caller canister. The caller canister is the canister that instantiated and invoked the `ICManagementCanister` service.
-
 The `derivation_path` is a vector of variable length byte strings. Each byte string may be of arbitrary length, including empty. The total number of byte strings in the `derivation_path` must be at most 255. The suggested standard to be used is [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
 
 The `key_id` is a struct specifying both a `curve` and a `name`. The availability of a particular `key_id` depends on implementation.
+
+The optional parameter `canister_id` can be set to specify the canister ID that will be used to derive the address.
 
 | Method           | Type                                                                                                |
 | ---------------- | --------------------------------------------------------------------------------------------------- |
@@ -252,7 +252,7 @@ The `key_id` is a struct specifying both a `curve` and a `name`. The availabilit
 Parameters:
 
 - `params.keyId`: The key id for which the public key will be derived, consisting of a `name` and a `curve`.
-- `params.canisterId`: The canister ID for which the public key will be derived. If unspecified, it defaults to the caller canister's ID.
+- `params.canisterId`: The specific canister ID for which the public key will be derived; it can be optional.
 - `params.derivationPath`: The derivation path that will be used to derive the public key. The suggested standard is [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L333)

--- a/packages/ic-management/src/ic-management.canister.spec.ts
+++ b/packages/ic-management/src/ic-management.canister.spec.ts
@@ -702,7 +702,7 @@ describe("ICManagementCanister", () => {
       expect(res).toEqual(response);
       expect(service.ecdsa_public_key).toHaveBeenCalledWith({
         key_id: keyId,
-        canister_id: canisterId,
+        canister_id: toNullable(canisterId),
         derivation_path: derivationPath,
       });
     });

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -316,17 +316,17 @@ export class ICManagementCanister {
   /**
    * Calculate a SEC1 encoded ECDSA public key for the given canister using the given derivation path.
    *
-   * If the `canister_id` is unspecified, the address will be derived from the canister ID of the caller canister. The caller canister is the canister that instantiated and invoked the `ICManagementCanister` service.
-   *
    * The `derivation_path` is a vector of variable length byte strings. Each byte string may be of arbitrary length, including empty. The total number of byte strings in the `derivation_path` must be at most 255. The suggested standard to be used is [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
    *
    * The `key_id` is a struct specifying both a `curve` and a `name`. The availability of a particular `key_id` depends on implementation.
+   *
+   * The optional parameter `canister_id` can be set to specify the canister ID that will be used to derive the address.
    *
    * @link https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-ecdsa_public_key
    *
    * @param {EcdsaPublicKeyParams} params
    * @param {KeyId} params.keyId The key id for which the public key will be derived, consisting of a `name` and a `curve`.
-   * @param {Principal} [params.canisterId] The canister ID for which the public key will be derived. If unspecified, it defaults to the caller canister's ID.
+   * @param {Principal} [params.canisterId] The specific canister ID for which the public key will be derived; it can be optional.
    * @param {string} params.derivationPath The derivation path that will be used to derive the public key. The suggested standard is [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
    * @returns {Promise<EcdsaPublicKeyResponse>} The return result is an extended public key consisting of an ECDSA `public_key`, encoded in SEC1 compressed form, and a `chain_code`, which can be used to deterministically derive child keys of the `public_key`.
    */

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -17,6 +17,7 @@ import {
   toInstallMode,
   type ClearChunkStoreParams,
   type CreateCanisterParams,
+  type EcdsaPublicKeyParams,
   type InstallChunkedCodeParams,
   type InstallCodeParams,
   type ProvisionalCreateCanisterWithCyclesParams,
@@ -25,7 +26,10 @@ import {
   type UpdateSettingsParams,
   type UploadChunkParams,
 } from "./types/ic-management.params";
-import type { CanisterStatusResponse } from "./types/ic-management.responses";
+import type {
+  CanisterStatusResponse,
+  EcdsaPublicKeyResponse,
+} from "./types/ic-management.responses";
 
 export class ICManagementCanister {
   private constructor(private readonly service: IcManagementService) {
@@ -308,4 +312,26 @@ export class ICManagementCanister {
 
     return canister_id;
   };
+
+  /**
+   * Calculate a SEC1 encoded ECDSA public key for the given canister using the given derivation path. If the `canister_id` is unspecified, it will default to the canister id of the caller. The `derivation_path` is a vector of variable length byte strings. Each byte string may be of arbitrary length, including empty. The total number of byte strings in the `derivation_path` must be at most 255. The `key_id` is a struct specifying both a `curve` and a `name`. The availability of a particular `key_id` depends on implementation.
+   *
+   * @link https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-ecdsa_public_key
+   *
+   * @param {EcdsaPublicKeyParams} params
+   * @param {KeyId} params.keyId The key id for which the public key will be derived, consisting of a `name` and a `curve`.
+   * @param {Principal} params.canisterId The canister id for which the public key will be derived. It defaults to the caller's canister id if unspecified.
+   * @param {string} params.derivationPath The derivation path that will be used to derive the public key.
+   * @returns {Promise<EcdsaPublicKeyResponse>} The return result is an extended public key consisting of an ECDSA `public_key`, encoded in SEC1 compressed form, and a `chain_code`, which can be used to deterministically derive child keys of the `public_key`.
+   */
+  ecdsaPublicKey = ({
+    keyId,
+    canisterId,
+    derivationPath,
+  }: EcdsaPublicKeyParams): Promise<EcdsaPublicKeyResponse> =>
+    this.service.ecdsa_public_key({
+      key_id: keyId,
+      canister_id: toNullable(canisterId),
+      derivation_path: derivationPath,
+    });
 }

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -314,14 +314,20 @@ export class ICManagementCanister {
   };
 
   /**
-   * Calculate a SEC1 encoded ECDSA public key for the given canister using the given derivation path. If the `canister_id` is unspecified, it will default to the canister id of the caller. The `derivation_path` is a vector of variable length byte strings. Each byte string may be of arbitrary length, including empty. The total number of byte strings in the `derivation_path` must be at most 255. The `key_id` is a struct specifying both a `curve` and a `name`. The availability of a particular `key_id` depends on implementation.
+   * Calculate a SEC1 encoded ECDSA public key for the given canister using the given derivation path.
+   *
+   * If the `canister_id` is unspecified, the address will be derived from the canister ID of the caller canister. The caller canister is the canister that instantiated and invoked the `ICManagementCanister` service.
+   *
+   * The `derivation_path` is a vector of variable length byte strings. Each byte string may be of arbitrary length, including empty. The total number of byte strings in the `derivation_path` must be at most 255. The suggested standard to be used is [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
+   *
+   * The `key_id` is a struct specifying both a `curve` and a `name`. The availability of a particular `key_id` depends on implementation.
    *
    * @link https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-ecdsa_public_key
    *
    * @param {EcdsaPublicKeyParams} params
    * @param {KeyId} params.keyId The key id for which the public key will be derived, consisting of a `name` and a `curve`.
-   * @param {Principal} params.canisterId The canister id for which the public key will be derived. It defaults to the caller's canister id if unspecified.
-   * @param {string} params.derivationPath The derivation path that will be used to derive the public key.
+   * @param {Principal} [params.canisterId] The canister ID for which the public key will be derived. If unspecified, it defaults to the caller canister's ID.
+   * @param {string} params.derivationPath The derivation path that will be used to derive the public key. The suggested standard is [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
    * @returns {Promise<EcdsaPublicKeyResponse>} The return result is an extended public key consisting of an ECDSA `public_key`, encoded in SEC1 compressed form, and a `chain_code`, which can be used to deterministically derive child keys of the `public_key`.
    */
   ecdsaPublicKey = ({

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -129,3 +129,16 @@ export interface ProvisionalTopUpCanisterParams {
   canisterId: Principal;
   amount: bigint;
 }
+
+export type EcdsaCurve = { secp256k1: null };
+
+export type KeyId = {
+  name: string;
+  curve: EcdsaCurve;
+};
+
+export interface EcdsaPublicKeyParams {
+  keyId: KeyId;
+  canisterId?: Principal;
+  derivationPath: Array<Uint8Array | number[]>;
+}

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -130,12 +130,14 @@ export interface ProvisionalTopUpCanisterParams {
   amount: bigint;
 }
 
-export type EcdsaCurve = { secp256k1: null };
+export interface EcdsaCurve {
+  secp256k1: null;
+}
 
-export type KeyId = {
+export interface KeyId {
   name: string;
   curve: EcdsaCurve;
-};
+}
 
 export interface EcdsaPublicKeyParams {
   keyId: KeyId;

--- a/packages/ic-management/src/types/ic-management.responses.ts
+++ b/packages/ic-management/src/types/ic-management.responses.ts
@@ -5,3 +5,8 @@ export type CanisterStatusResponse = ServiceResponse<
   IcManagementService,
   "canister_status"
 >;
+
+export type EcdsaPublicKeyResponse = {
+  public_key: Uint8Array | number[];
+  chain_code: Uint8Array | number[];
+};


### PR DESCRIPTION
# Motivation

As first step, before including a function to generate a P2PKH address, we add the usage of [IC method `ecdsa_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-ecdsa_public_key).

# Changes

- Created types for parameters and response of API endpoint `ecdsa_public_key`, adapted to the current package.
- Created function `ecdsaPublicKey` in ic-management module.
- Created tests for `ecdsaPublicKey`.
- Included usage in README file.

# Tests

Created a new test specific to the usage of `ecdsaPublicKey`.

# Todos

- [ ] Add entry to changelog (if approved).
