### PR TITLE
feat: function to create derivation path for Bitcoin addresses according to BIP-44

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7608,11 +7608,19 @@
       "name": "@dfinity/utils",
       "version": "2.3.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "bip44-constants": "^306.0.0"
+      },
       "peerDependencies": {
         "@dfinity/agent": "^1.3.0",
         "@dfinity/candid": "^1.3.0",
         "@dfinity/principal": "^1.3.0"
       }
+    },
+    "packages/utils/node_modules/bip44-constants": {
+      "version": "306.0.0",
+      "resolved": "https://registry.npmjs.org/bip44-constants/-/bip44-constants-306.0.0.tgz",
+      "integrity": "sha512-hkgChSBafO8deznUb52m3eLsSApUrvQWCfn8rO0LX0wuEe2q9l9kiKjG8RqnNqQJCqywU8UkXj4awYrpCnptrA=="
     }
   },
   "dependencies": {
@@ -8205,7 +8213,16 @@
     },
     "@dfinity/utils": {
       "version": "file:packages/utils",
-      "requires": {}
+      "requires": {
+        "bip44-constants": "^306.0.0"
+      },
+      "dependencies": {
+        "bip44-constants": {
+          "version": "306.0.0",
+          "resolved": "https://registry.npmjs.org/bip44-constants/-/bip44-constants-306.0.0.tgz",
+          "integrity": "sha512-hkgChSBafO8deznUb52m3eLsSApUrvQWCfn8rO0LX0wuEe2q9l9kiKjG8RqnNqQJCqywU8UkXj4awYrpCnptrA=="
+        }
+      }
     },
     "@esbuild/aix-ppc64": {
       "version": "0.20.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2792,6 +2792,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bip44-constants": {
+      "version": "308.0.0",
+      "resolved": "https://registry.npmjs.org/bip44-constants/-/bip44-constants-308.0.0.tgz",
+      "integrity": "sha512-3el0g/pLgpi2+1JgA3fEDXRQfaT0JwD9IZyLLNfaz51z/9FqF6sXjVMBfTWVpVoNrxq1id+e2F+X0WDYypliHg=="
+    },
     "node_modules/borc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
@@ -7609,18 +7614,13 @@
       "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "bip44-constants": "^306.0.0"
+        "bip44-constants": "^308.0.0"
       },
       "peerDependencies": {
         "@dfinity/agent": "^1.3.0",
         "@dfinity/candid": "^1.3.0",
         "@dfinity/principal": "^1.3.0"
       }
-    },
-    "packages/utils/node_modules/bip44-constants": {
-      "version": "306.0.0",
-      "resolved": "https://registry.npmjs.org/bip44-constants/-/bip44-constants-306.0.0.tgz",
-      "integrity": "sha512-hkgChSBafO8deznUb52m3eLsSApUrvQWCfn8rO0LX0wuEe2q9l9kiKjG8RqnNqQJCqywU8UkXj4awYrpCnptrA=="
     }
   },
   "dependencies": {
@@ -8214,14 +8214,7 @@
     "@dfinity/utils": {
       "version": "file:packages/utils",
       "requires": {
-        "bip44-constants": "^306.0.0"
-      },
-      "dependencies": {
-        "bip44-constants": {
-          "version": "306.0.0",
-          "resolved": "https://registry.npmjs.org/bip44-constants/-/bip44-constants-306.0.0.tgz",
-          "integrity": "sha512-hkgChSBafO8deznUb52m3eLsSApUrvQWCfn8rO0LX0wuEe2q9l9kiKjG8RqnNqQJCqywU8UkXj4awYrpCnptrA=="
-        }
+        "bip44-constants": "^308.0.0"
       }
     },
     "@esbuild/aix-ppc64": {
@@ -9569,6 +9562,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true
+    },
+    "bip44-constants": {
+      "version": "308.0.0",
+      "resolved": "https://registry.npmjs.org/bip44-constants/-/bip44-constants-308.0.0.tgz",
+      "integrity": "sha512-3el0g/pLgpi2+1JgA3fEDXRQfaT0JwD9IZyLLNfaz51z/9FqF6sXjVMBfTWVpVoNrxq1id+e2F+X0WDYypliHg=="
     },
     "borc": {
       "version": "2.1.2",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -52,6 +52,6 @@
     "@dfinity/principal": "^1.3.0"
   },
   "dependencies": {
-    "bip44-constants": "^306.0.0"
+    "bip44-constants": "^308.0.0"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -50,5 +50,8 @@
     "@dfinity/agent": "^1.3.0",
     "@dfinity/candid": "^1.3.0",
     "@dfinity/principal": "^1.3.0"
+  },
+  "dependencies": {
+    "bip44-constants": "^306.0.0"
   }
 }

--- a/packages/utils/src/utils/bitcoin.utils.spec.ts
+++ b/packages/utils/src/utils/bitcoin.utils.spec.ts
@@ -1,0 +1,72 @@
+import constants from "bip44-constants";
+import { generateDerivationPath } from "./bitcoin.utils";
+
+describe("generateDerivationPath", () => {
+  it("should generate a valid path for a known coin type as a string", () => {
+    const coinType = constants[0][2];
+    const path = generateDerivationPath(coinType);
+    const expectedCoinTypeValue = Object.entries(constants).find(
+      ([, [, , name]]) => name.toLowerCase() === coinType.toLowerCase(),
+    )?.[0];
+
+    expect(path).toBe(`m/44'/${expectedCoinTypeValue}'/0'/0/0`);
+  });
+
+  it("should generate a valid path for a known coin type as a number", () => {
+    const coinType = constants[0][0];
+    const path = generateDerivationPath(coinType);
+
+    expect(path).toBe(`m/44'/${coinType}'/0'/0/0`);
+  });
+
+  it("should generate a valid path with custom account, change, and address index", () => {
+    const coinType = constants[0][2];
+    const account = 1;
+    const change = 1;
+    const addressIndex = 5;
+    const path = generateDerivationPath(
+      coinType,
+      account,
+      change,
+      addressIndex,
+    );
+    const expectedCoinTypeValue = Object.entries(constants).find(
+      ([, [, , name]]) => name.toLowerCase() === coinType.toLowerCase(),
+    )?.[0];
+
+    expect(path).toBe(
+      `m/44'/${expectedCoinTypeValue}'/${account}'/${change}/${addressIndex}`,
+    );
+  });
+
+  it("should throw an error if coinType is an empty string", () => {
+    expect(() => {
+      generateDerivationPath("");
+    }).toThrow("coinType cannot be empty");
+  });
+
+  it("should throw an error for an invalid coin type as a string", () => {
+    let invalidCoinType = "11111111111";
+    while (constants.some((row) => row[1] === invalidCoinType)) {
+      invalidCoinType = (parseInt(invalidCoinType) + 1).toString();
+    }
+
+    expect(() => {
+      generateDerivationPath(invalidCoinType);
+    }).toThrow(
+      new RegExp(`^Invalid coinType: ${invalidCoinType}. Valid options are:`),
+    );
+  });
+
+  it("should throw an error for an invalid coin type as a number", () => {
+    const invalidCoinType = constants.length + 1;
+
+    expect(() => {
+      generateDerivationPath(invalidCoinType);
+    }).toThrow(
+      new RegExp(
+        `^Invalid coinType number: ${invalidCoinType}. Valid options are:`,
+      ),
+    );
+  });
+});

--- a/packages/utils/src/utils/bitcoin.utils.ts
+++ b/packages/utils/src/utils/bitcoin.utils.ts
@@ -1,0 +1,64 @@
+import constants from "bip44-constants";
+
+/**
+ * Generates a BIP-44 derivation path to be used to derive an address.
+ *
+ * BIP-44 defines a specific structure for hierarchical deterministic (HD) wallets.
+ * The derivation path is constructed as: m / purpose' / coin_type' / account' / change / address_index
+ * where the ' indicates that the value is hardened.
+ * The purpose is a constant set to 44' (or 0x8000002C) following the [BIP-43](https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki) recommendation.
+ *
+ * @param coinType - Type of the coin, either as a string, a symbol or number (e.g., "bitcoin" or "BTC" or 0). See [SLIP-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) for a list of supported coins.
+ * @param account - Account index, allows for multiple accounts (default: 0)
+ * @param change - Change index, differentiates between external (0) and internal (1) addresses (default: 0)
+ * @param addressIndex - Index of the address (default: 0)
+ * @returns The BIP-44 derivation path as a string
+ * @throws Error if the coinType is invalid
+ */
+export const generateDerivationPath = (
+  coinType: string | number,
+  account: number = 0,
+  change: 0 | 1 = 0,
+  addressIndex: number = 0,
+): string => {
+  // Purpose is a constant set to 44' (or 0x8000002C) following the BIP-43 recommendation.
+  // It indicates that the subtree of the node is used according to BIP-44 specification.
+  // Source: https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki
+  const purpose: number = 44;
+
+  const getCoinType = (coinType: string | number): number => {
+    if (coinType === "") {
+      throw new Error("coinType cannot be empty");
+    }
+    if (typeof coinType === "string") {
+      const coinTypeEntry = Object.entries(constants).find(
+        ([, [, symbol, name]]) =>
+          symbol.toLowerCase() === coinType.toLowerCase() ||
+          name.toLowerCase() === coinType.toLowerCase(),
+      );
+      if (!coinTypeEntry) {
+        throw new Error(
+          `Invalid coinType: ${coinType}. Valid options are: ${Object.values(
+            constants,
+          )
+            .map(
+              ([, [symbol, name]]) => `${name}${symbol ? ` (${symbol})` : ""}`,
+            )
+            .join(", ")}`,
+        );
+      }
+      return Number(coinTypeEntry[0]);
+    }
+
+    if (!constants.some(row => row[0] === coinType)) {
+      throw new Error(
+        `Invalid coinType number: ${coinType}. Valid options are: ${Object.keys(constants).join(", ")}`,
+      );
+    }
+
+    return coinType;
+  };
+
+  const coinTypeValue = getCoinType(coinType);
+  return `m/${purpose}'/${coinTypeValue}'/${account}'/${change}/${addressIndex}`;
+};

--- a/packages/utils/src/utils/bitcoin.utils.ts
+++ b/packages/utils/src/utils/bitcoin.utils.ts
@@ -50,7 +50,7 @@ export const generateDerivationPath = (
       return Number(coinTypeEntry[0]);
     }
 
-    if (!constants.some(row => row[0] === coinType)) {
+    if (!constants.some((row) => row[0] === coinType)) {
       throw new Error(
         `Invalid coinType number: ${coinType}. Valid options are: ${Object.keys(constants).join(", ")}`,
       );


### PR DESCRIPTION
# Motivation

We created an util function that aids in creating a **derivation path** for Bitcoin addresses, according to specifics in [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).

The type of coins that the user can specify is given by the official list of registered coins maintained by _Satoshilabs_ in [SLIP-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md).
To retrieve such list, we use the official package [bip44-constants](https://www.npmjs.com/package/bip44-constants) ([source](https://github.com/bitcoinjs/bip44-constants)) that is basically an auto-updated scraped list from the official list in [SLIP-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md).

# Changes

- Install package [bip44-constants](https://www.npmjs.com/package/bip44-constants).
- Create function `generateDerivationPath`.
- Create tests.

# Tests

Basic tests were created for the different behaviors of the function, especially when the chosen coin is not among the official list.

# Todos

- [ ] Add entry to changelog (if necessary).