### PR TITLE
chore: use https for registry.npmjs.org

### DIFF
--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -11,7 +11,7 @@ const nextVersion = async ({ project, currentVersion }) => {
     .slice(0, 10)}`;
 
   const { versions } = await (
-    await fetch(`http://registry.npmjs.org/@dfinity/${project}`)
+    await fetch(`https://registry.npmjs.org/@dfinity/${project}`)
   ).json();
 
   // The wip version has never been published


### PR DESCRIPTION
# Motivation

Spotted an ugly typo used for comparing version when preparing next - i.e. `http` instead of `https://`.

# Notes

I should probably create a library once with this script, we used it in 5 repo at the foundation and I use it in few in Juno as well.

# Changes

- Update `httpS://registry.npmjs.org`
