### PR TITLE
Do not commit changes without token

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,21 +10,26 @@ jobs:
   formatting:
     runs-on: ubuntu-20.04
 
+    # In order trigger the CLA after committing formatting changes, we need to
+    # use the GIX_CREATE_PR_PAT token. This token is not available on PRs
+    # created from a fork. So on PRs created from a fork, we don't commit
+    # changes and instead just fail if the formatting is incorrect.
     steps:
+      - name: Check if PR is from a fork
+        id: check_fork
+        run: echo "::set-output name=is_pr_from_fork::${{ github.event.pull_request.head.repo.full_name != github.repository }}"
+
       - name: Checkout
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.check_fork.outputs.is_pr_from_fork == 'false'
         uses: actions/checkout@v2
         with:
-          # Must be used in order to allow Commit Formatting changes to trigger the CLA when it creates a new commit
           token: ${{ secrets.GIX_CREATE_PR_PAT }}
       - name: Checkout Fork
-        # in forks the token is not available
-        if: github.event.pull_request.head.repo.full_name != github.repository
+        if: steps.check_fork.outputs.is_pr_from_fork == 'true'
         uses: actions/checkout@v2
 
       - name: Install shfmt
         run: sudo snap install --classic shfmt
-
       - name: Format shell scripts
         run: ./scripts/fmt-sh
 
@@ -33,9 +38,14 @@ jobs:
       - name: Format ts
         run: npm run format
 
+      - name: Check formatting changes
+        id: check_format
+        run: |
+          git diff --exit-code || echo "::set-output name=formatting_needed::true"
+
       - name: Commit Formatting changes
+        if: steps.check_fork.outputs.is_fork == 'false' && steps.check_format.outputs.formatting_needed == 'true'
         uses: EndBug/add-and-commit@v7.2.0
-        if: ${{ github.event_name == 'pull_request' }}
         with:
           add: .
           default_author: github_actions
@@ -43,6 +53,10 @@ jobs:
           # do not pull: if this branch is behind, then we might as well let
           # the pushing fail
           pull_strategy: "NO-PULL"
+
+      - name: Fail for formatting issues in forks
+        if: steps.check_fork.outputs.is_fork == 'true' && steps.check_format.outputs.formatting_needed == 'true'
+        run: exit 1
 
   build-candid:
     runs-on: ubuntu-20.04

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -60,7 +60,9 @@ jobs:
 
       - name: Fail for formatting issues in forks
         if: steps.check_fork.outputs.is_pr_from_fork == 'true' && steps.check_format.outputs.formatting_needed == 'true'
-        run: exit 1
+        run: |
+          echo "Formatting changes are needed but couldn't be committed because the PR was created from a fork."
+          exit 1
 
   build-candid:
     runs-on: ubuntu-20.04

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,7 +17,8 @@ jobs:
     steps:
       - name: Check if PR is from a fork
         id: check_fork
-        run: echo "::set-output name=is_pr_from_fork::${{ github.event.pull_request.head.repo.full_name != github.repository }}"
+        run: |
+          echo "is_pr_from_fork=${{ github.event.pull_request.head.repo.full_name != github.repository }}" >> $GITHUB_OUTPUT
 
       - name: Checkout
         if: steps.check_fork.outputs.is_pr_from_fork == 'false'
@@ -41,8 +42,11 @@ jobs:
       - name: Check formatting changes
         id: check_format
         run: |
-          git diff --exit-code || echo "::set-output name=formatting_needed::true"
-
+          if git diff --exit-code; then
+            echo "formatting_needed=false" >> $GITHUB_OUTPUT
+          else
+            echo "formatting_needed=true" >> $GITHUB_OUTPUT
+          fi
       - name: Commit Formatting changes
         if: steps.check_fork.outputs.is_fork == 'false' && steps.check_format.outputs.formatting_needed == 'true'
         uses: EndBug/add-and-commit@v7.2.0

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -48,7 +48,7 @@ jobs:
             echo "formatting_needed=true" >> $GITHUB_OUTPUT
           fi
       - name: Commit Formatting changes
-        if: steps.check_fork.outputs.is_fork == 'false' && steps.check_format.outputs.formatting_needed == 'true'
+        if: steps.check_fork.outputs.is_pr_from_fork == 'false' && steps.check_format.outputs.formatting_needed == 'true'
         uses: EndBug/add-and-commit@v7.2.0
         with:
           add: .
@@ -59,7 +59,7 @@ jobs:
           pull_strategy: "NO-PULL"
 
       - name: Fail for formatting issues in forks
-        if: steps.check_fork.outputs.is_fork == 'true' && steps.check_format.outputs.formatting_needed == 'true'
+        if: steps.check_fork.outputs.is_pr_from_fork == 'true' && steps.check_format.outputs.formatting_needed == 'true'
         run: exit 1
 
   build-candid:

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -33,7 +33,13 @@ import {
   NetworkEconomics,
 } from "./types/governance_converters";
 
-const unexpectedGovernanceError: GovernanceErrorDetail = { error_message: "Error updating neuron", error_type: 0, }; describe("GovernanceCanister", () => { const error: GovernanceErrorDetail = {
+const unexpectedGovernanceError: GovernanceErrorDetail = {
+  error_message: "Error updating neuron",
+  error_type: 0,
+};
+
+describe("GovernanceCanister", () => {
+  const error: GovernanceErrorDetail = {
     error_message: "Some error",
     error_type: 1,
   };

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -33,13 +33,7 @@ import {
   NetworkEconomics,
 } from "./types/governance_converters";
 
-const unexpectedGovernanceError: GovernanceErrorDetail = {
-  error_message: "Error updating neuron",
-  error_type: 0,
-};
-
-describe("GovernanceCanister", () => {
-  const error: GovernanceErrorDetail = {
+const unexpectedGovernanceError: GovernanceErrorDetail = { error_message: "Error updating neuron", error_type: 0, }; describe("GovernanceCanister", () => { const error: GovernanceErrorDetail = {
     error_message: "Some error",
     error_type: 1,
   };

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -33,7 +33,12 @@ import {
   NetworkEconomics,
 } from "./types/governance_converters";
 
-const unexpectedGovernanceError: GovernanceErrorDetail = { error_message: "Error updating neuron", error_type: 0, }; describe("GovernanceCanister", () => { const error: GovernanceErrorDetail = {
+const unexpectedGovernanceError: GovernanceErrorDetail = {
+  error_message: "Error updating neuron",
+  error_type: 0,
+};
+describe("GovernanceCanister", () => {
+  const error: GovernanceErrorDetail = {
     error_message: "Some error",
     error_type: 1,
   };

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -37,6 +37,7 @@ const unexpectedGovernanceError: GovernanceErrorDetail = {
   error_message: "Error updating neuron",
   error_type: 0,
 };
+
 describe("GovernanceCanister", () => {
   const error: GovernanceErrorDetail = {
     error_message: "Some error",


### PR DESCRIPTION
# Motivation

Dependabot makes pull requests from a repo fork. These PRs can't run CI with personal access token.
This means that if formatting changes are committed, CLA will get stuck which is confusing and requires manual intervention anyway.
It's less confusing if we just fail if formatting changes are required in this case, which they usually aren't for dependabot changes.

# Changes

In `.github/workflows/checks.yml` when we checkout without token, don't try to commit changes back to the PR but fail instead.

# Tests

See CI:
* Without formatting: https://github.com/dfinity/ic-js/actions/runs/9561929327/job/26357217738?pr=660
* With formatting: https://github.com/dfinity/ic-js/actions/runs/9561952761/job/26357293034?pr=660

Not sure how to test the fork case without first merging this PR.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary