### PR TITLE
Fix updateNeuron not to change the neuron subaccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add support for `wasm_memory_limit` in the canister settings.
 
+## Fix
+
+- `updateNeuron` to not change the neuron subaccount.
+
 # 2024.06.11-1630Z
 
 ## Overview

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -1,6 +1,5 @@
 import type { AccountIdentifierHex } from "@dfinity/ledger-icp";
 import {
-  AccountIdentifier,
   accountIdentifierFromBytes,
   principalToAccountIdentifier,
 } from "@dfinity/ledger-icp";
@@ -138,7 +137,7 @@ export const toNeuronInfo = ({
   };
 };
 
-const toNeuron = ({
+export const toNeuron = ({
   neuron,
   canisterId,
 }: {
@@ -180,7 +179,13 @@ const toNeuron = ({
   ),
 });
 
-export const toRawNeuron = (neuron: Neuron): RawNeuron => ({
+export const toRawNeuron = ({
+  neuron,
+  account,
+}: {
+  neuron: Neuron;
+  account: Uint8Array;
+}): RawNeuron => ({
   id: nonNullish(neuron.id) ? toNullable({ id: neuron.id }) : [],
   staked_maturity_e8s_equivalent: toNullable(
     neuron.stakedMaturityE8sEquivalent,
@@ -204,7 +209,7 @@ export const toRawNeuron = (neuron: Neuron): RawNeuron => ({
   aging_since_timestamp_seconds: neuron.agingSinceTimestampSeconds,
   neuron_fees_e8s: neuron.neuronFees,
   hot_keys: neuron.hotKeys.map((p) => Principal.from(p)),
-  account: AccountIdentifier.fromHex(neuron.accountIdentifier).toUint8Array(),
+  account,
   joined_community_fund_timestamp_seconds: toNullable(
     neuron.joinedCommunityFundTimestampSeconds,
   ),

--- a/packages/nns/src/governance_test.canister.spec.ts
+++ b/packages/nns/src/governance_test.canister.spec.ts
@@ -1,0 +1,66 @@
+import { ActorSubclass } from "@dfinity/agent";
+import { mock } from "jest-mock-extended";
+import type { _SERVICE as GovernanceService } from "../candid/governance_test";
+import { toNeuron } from "./canisters/governance/response.converters";
+import { MAINNET_GOVERNANCE_CANISTER_ID } from "./constants/canister_ids";
+import { GovernanceTestCanister } from "./governance_test.canister";
+import { mockListNeuronsResponse, mockNeuron } from "./mocks/governance.mock";
+import type { Neuron } from "./types/governance_converters";
+
+describe("GovernanceTestCanister", () => {
+  describe("updateNeuron", () => {
+    it("should update maturity", async () => {
+      const service = mock<ActorSubclass<GovernanceService>>();
+      service.list_neurons.mockResolvedValue(mockListNeuronsResponse);
+
+      const governance = GovernanceTestCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+      });
+      const currentNeuron = toNeuron({
+        neuron: mockNeuron,
+        canisterId: MAINNET_GOVERNANCE_CANISTER_ID,
+      });
+      const newMaturity = 312_000_000n;
+      const newNeuron: Neuron = {
+        ...currentNeuron,
+        maturityE8sEquivalent: newMaturity,
+      };
+
+      await governance.updateNeuron(newNeuron);
+
+      const expectedNewRawNeuron = {
+        ...mockNeuron,
+        maturity_e8s_equivalent: newMaturity,
+      };
+
+      expect(service.update_neuron).toBeCalledWith(expectedNewRawNeuron);
+      expect(service.update_neuron).toBeCalledTimes(1);
+    });
+
+    it("should not update accountIdentifier", async () => {
+      const service = mock<ActorSubclass<GovernanceService>>();
+      service.list_neurons.mockResolvedValue(mockListNeuronsResponse);
+
+      const governance = GovernanceTestCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+      });
+      const currentNeuron = toNeuron({
+        neuron: mockNeuron,
+        canisterId: MAINNET_GOVERNANCE_CANISTER_ID,
+      });
+      const newAccountIdentifier = "1a2b3cff";
+      const newNeuron: Neuron = {
+        ...currentNeuron,
+        accountIdentifier: newAccountIdentifier,
+      };
+
+      expect(() => governance.updateNeuron(newNeuron)).rejects.toThrow(
+        "Neuron account identifier can't be changed",
+      );
+
+      expect(service.update_neuron).not.toBeCalled();
+    });
+  });
+});

--- a/packages/nns/src/governance_test.canister.ts
+++ b/packages/nns/src/governance_test.canister.ts
@@ -1,17 +1,25 @@
 import type { ActorSubclass } from "@dfinity/agent";
+import { principalToAccountIdentifier } from "@dfinity/ledger-icp";
 import type { Principal } from "@dfinity/principal";
-import { createServices, type CanisterOptions } from "@dfinity/utils";
+import {
+  assertNonNullish,
+  createServices,
+  type CanisterOptions,
+} from "@dfinity/utils";
 import { idlFactory } from "../candid/governance.idl";
 import type { _SERVICE as GovernanceService } from "../candid/governance_test";
 import { idlFactory as certifiedIdlFactory } from "../candid/governance_test.certified.idl";
+import { fromListNeurons } from "./canisters/governance/request.converters";
 import { toRawNeuron } from "./canisters/governance/response.converters";
 import { MAINNET_GOVERNANCE_CANISTER_ID } from "./constants/canister_ids";
 import type { Neuron } from "./types/governance_converters";
 
 export class GovernanceTestCanister {
   private constructor(
+    private readonly canisterId: Principal,
     private readonly certifiedService: ActorSubclass<GovernanceService>,
   ) {
+    this.canisterId = canisterId;
     this.certifiedService = certifiedService;
   }
 
@@ -28,7 +36,7 @@ export class GovernanceTestCanister {
       certifiedIdlFactory,
     });
 
-    return new GovernanceTestCanister(certifiedService);
+    return new GovernanceTestCanister(canisterId, certifiedService);
   }
 
   /**
@@ -36,7 +44,24 @@ export class GovernanceTestCanister {
    *
    * Only available in the governance test canister.
    */
-  updateNeuron(neuron: Neuron) {
-    this.certifiedService.update_neuron(toRawNeuron(neuron));
+  async updateNeuron(neuron: Neuron) {
+    assertNonNullish(neuron.id);
+    const rawListNeuronsRequest = fromListNeurons([neuron.id]);
+    const rawListNeuronsResponse = await this.certifiedService.list_neurons(
+      rawListNeuronsRequest,
+    );
+    const currentNeuron = rawListNeuronsResponse.full_neurons[0];
+    const currentAccountIdentifier = principalToAccountIdentifier(
+      this.canisterId,
+      Uint8Array.from(currentNeuron.account),
+    );
+    if (currentAccountIdentifier !== neuron.accountIdentifier) {
+      throw new Error("Neuron account identifier can't be changed");
+    }
+    const rawNeuron = toRawNeuron({
+      neuron,
+      account: Uint8Array.from(currentNeuron.account),
+    });
+    return this.certifiedService.update_neuron(rawNeuron);
   }
 }


### PR DESCRIPTION
# Motivation

Currently when you use `updateNeuron` on the `GovernanceTestCanister` for testing, there is no way not to change the neuron subaccount in the process while probably you would never want to change the neuron subaccount.
This is because when calling `update_neuron` the full neuron, including `account` (which is the neuron subaccount) must be specified but `nns-js` never returns the neuron subaccount. It only returns the `accountIdentifier` which is derived from the subaccount in a one-way fashion.

The current implementation of using the `accountIdentifier` as the neuron account is wrong and results in the neuron account changing each time `updateNeuron` is used.

So in order not to change the subaccount when calling `update_neuron` (and without changing the API of `nns-js`) we must first fetch the neuron to know its subaccount.

# Changes

1. Change `toRawNeuron` (which is only used in `updateNeuron`) to take an `account` parameter to use for the raw neuron.
2. Change `updateNeuron` to first fetch the existing neuron in order to use its account to pass to `toRawNeuron`.
3. Verify that the `account` of the fetched neuron matches the `accountIdentifier` of the passed neuron to make sure people don't try to change the `accountIdentifier` while it's not supported.

# Tests

1. Unit tests added
2. Tested manually by adding maturity in NNS dapp and seeing that the neuron account doesn't change.

# Todos

- [x] Add entry to changelog (if necessary).
