### PR TITLE
chore: add NNS team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-# The codebase is owned by the Governance & Identity Experience team at DFINITY
-# For questions, reach out to: <gix@dfinity.org>
-* @dfinity/gix
+* @dfinity/gix @dfinity/nns-team


### PR DESCRIPTION
# Motivation

We were requested by PRODSEC to enable Code Owners approval in the branch protections. Before doing so, we should add the NNS team to the CODEOWNERS file; otherwise, PRs will always require Gix team approval. This way, both NNS and Gix can approve PRs.
