### PR TITLE
feat: eip_1559_transaction_price for Erc20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - Add support for `wasm_memory_limit` in the canister settings.
+- Extend `eip1559TransactionPrice` for Erc20.
 
 ## Fix
 

--- a/packages/cketh/README.md
+++ b/packages/cketh/README.md
@@ -53,7 +53,7 @@ const address = await getSmartContractAddress({});
 
 ### :factory: CkETHMinterCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L20)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L23)
 
 #### Methods
 
@@ -71,7 +71,7 @@ const address = await getSmartContractAddress({});
 | -------- | ------------------------------------------------------------------------ |
 | `create` | `(options: CkETHMinterCanisterOptions<_SERVICE>) => CkETHMinterCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L21)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L24)
 
 ##### :gear: getSmartContractAddress
 
@@ -86,7 +86,7 @@ Parameters:
 - `params`: The parameters to resolve the ckETH smart contract address.
 - `params.certified`: query or update call
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L39)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L42)
 
 ##### :gear: withdrawEth
 
@@ -107,7 +107,7 @@ Parameters:
 - `params.address`: The destination ETH address.
 - `params.amount`: The ETH amount in wei.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L59)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L62)
 
 ##### :gear: withdrawErc20
 
@@ -129,22 +129,23 @@ Parameters:
 - `params.amount`: The ETH amount in wei.
 - `params.ledgerCanisterId`: The ledger canister ID of the ckErc20.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L96)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L99)
 
 ##### :gear: eip1559TransactionPrice
 
-Estimate the price of a transaction issued by the minter when converting ckETH to ETH.
+Estimate the price of a transaction issued by the minter when converting ckETH to ETH and ckER20 to ERC20.
 
-| Method                    | Type                                                                |
-| ------------------------- | ------------------------------------------------------------------- |
-| `eip1559TransactionPrice` | `({ certified, }: QueryParams) => Promise<Eip1559TransactionPrice>` |
+| Method                    | Type                                                                                          |
+| ------------------------- | --------------------------------------------------------------------------------------------- |
+| `eip1559TransactionPrice` | `({ certified, ...rest }: Eip1559TransactionPriceParams) => Promise<Eip1559TransactionPrice>` |
 
 Parameters:
 
-- `params`: The parameters to get the minter info.
-- `params.certified`: query or update call
+- `params`: - The parameters to get the minter info.
+- `params.ckErc20LedgerId`: - The optional identifier for a particular ckERC20 ledger.
+- `params.certified`: - Indicates whether this is a certified query or an update call.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L130)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L134)
 
 ##### :gear: retrieveEthStatus
 
@@ -154,7 +155,7 @@ Retrieve the status of a withdrawal request.
 | ------------------- | ---------------------------------------------------- |
 | `retrieveEthStatus` | `(blockIndex: bigint) => Promise<RetrieveEthStatus>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L144)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L149)
 
 ##### :gear: getMinterInfo
 
@@ -169,7 +170,7 @@ Parameters:
 - `params`: The parameters to get the minter info.
 - `params.certified`: query or update call
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L157)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L162)
 
 ### :factory: CkETHOrchestratorCanister
 

--- a/packages/cketh/candid/minter.certified.idl.js
+++ b/packages/cketh/candid/minter.certified.idl.js
@@ -7,6 +7,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const UpgradeArg = IDL.Record({
     'next_transaction_nonce' : IDL.Opt(IDL.Nat),
+    'evm_rpc_id' : IDL.Opt(IDL.Principal),
     'ledger_suite_orchestrator_id' : IDL.Opt(IDL.Principal),
     'erc20_helper_contract_address' : IDL.Opt(IDL.Text),
     'last_erc20_scraped_block_number' : IDL.Opt(IDL.Nat),
@@ -37,6 +38,9 @@ export const idlFactory = ({ IDL }) => {
     'chain_id' : IDL.Nat,
     'address' : IDL.Text,
     'ckerc20_token_symbol' : IDL.Text,
+  });
+  const Eip1559TransactionPriceArg = IDL.Record({
+    'ckerc20_ledger_id' : IDL.Principal,
   });
   const Eip1559TransactionPrice = IDL.Record({
     'max_priority_fee_per_gas' : IDL.Nat,
@@ -348,7 +352,11 @@ export const idlFactory = ({ IDL }) => {
   });
   return IDL.Service({
     'add_ckerc20_token' : IDL.Func([AddCkErc20Token], [], []),
-    'eip_1559_transaction_price' : IDL.Func([], [Eip1559TransactionPrice], []),
+    'eip_1559_transaction_price' : IDL.Func(
+        [IDL.Opt(Eip1559TransactionPriceArg)],
+        [Eip1559TransactionPrice],
+        [],
+      ),
     'get_canister_status' : IDL.Func([], [CanisterStatusResponse], []),
     'get_events' : IDL.Func(
         [IDL.Record({ 'start' : IDL.Nat64, 'length' : IDL.Nat64 })],
@@ -395,6 +403,7 @@ export const init = ({ IDL }) => {
   });
   const UpgradeArg = IDL.Record({
     'next_transaction_nonce' : IDL.Opt(IDL.Nat),
+    'evm_rpc_id' : IDL.Opt(IDL.Principal),
     'ledger_suite_orchestrator_id' : IDL.Opt(IDL.Principal),
     'erc20_helper_contract_address' : IDL.Opt(IDL.Text),
     'last_erc20_scraped_block_number' : IDL.Opt(IDL.Nat),

--- a/packages/cketh/candid/minter.d.ts
+++ b/packages/cketh/candid/minter.d.ts
@@ -46,6 +46,9 @@ export interface Eip1559TransactionPrice {
   timestamp: [] | [bigint];
   gas_limit: bigint;
 }
+export interface Eip1559TransactionPriceArg {
+  ckerc20_ledger_id: Principal;
+}
 export interface EthTransaction {
   transaction_hash: string;
 }
@@ -315,6 +318,7 @@ export interface UnsignedTransaction {
 }
 export interface UpgradeArg {
   next_transaction_nonce: [] | [bigint];
+  evm_rpc_id: [] | [Principal];
   ledger_suite_orchestrator_id: [] | [Principal];
   erc20_helper_contract_address: [] | [string];
   last_erc20_scraped_block_number: [] | [bigint];
@@ -371,7 +375,10 @@ export type WithdrawalStatus =
   | { Pending: null };
 export interface _SERVICE {
   add_ckerc20_token: ActorMethod<[AddCkErc20Token], undefined>;
-  eip_1559_transaction_price: ActorMethod<[], Eip1559TransactionPrice>;
+  eip_1559_transaction_price: ActorMethod<
+    [[] | [Eip1559TransactionPriceArg]],
+    Eip1559TransactionPrice
+  >;
   get_canister_status: ActorMethod<[], CanisterStatusResponse>;
   get_events: ActorMethod<
     [{ start: bigint; length: bigint }],

--- a/packages/cketh/candid/minter.did
+++ b/packages/cketh/candid/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 246d0ce (2024-06-13 tags: release-2024-06-12_23-01-base) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
+// Generated from IC repo commit e3fca54 (2024-06-19 tags: release-2024-06-19_23-01-base) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
 type EthereumNetwork = variant {
     // The public Ethereum mainnet.
     Mainnet;
@@ -98,12 +98,25 @@ type UpgradeArg = record {
 
     // Change the last scraped block number of the ERC-20 helper smart contract.
     last_erc20_scraped_block_number : opt nat;
+
+    // The principal of the EVM RPC canister that handles the communication
+    // with the Ethereum blockchain.
+    evm_rpc_id : opt principal;
 };
 
 type MinterArg = variant { UpgradeArg : UpgradeArg; InitArg : InitArg };
 
+// Argument to Eip1559TransactionPrice.
+// When specified, it is to lookup transaction price for a ckERC20 token withdrawal.
+// When not specified (null), it is for ETH withdrawal.
+type Eip1559TransactionPriceArg = record {
+    // The ledger ID for that ckERC20 token.
+    ckerc20_ledger_id : principal;
+};
+
 // Estimate price of an EIP-1559 transaction
-// when converting ckETH to ETH, see https://eips.ethereum.org/EIPS/eip-1559
+// when converting ckETH to ETH or ckERC20 to ERC20, see
+// https://eips.ethereum.org/EIPS/eip-1559
 type Eip1559TransactionPrice = record {
     // Maximum amount of gas transaction is authorized to consume.
     gas_limit : nat;
@@ -544,7 +557,7 @@ service : (MinterArg) -> {
     smart_contract_address : () -> (text) query;
 
     // Estimate the price of a transaction issued by the minter when converting ckETH to ETH.
-    eip_1559_transaction_price : () -> (Eip1559TransactionPrice) query;
+    eip_1559_transaction_price : (opt Eip1559TransactionPriceArg) -> (Eip1559TransactionPrice) query;
 
     // Returns internal minter parameters
     get_minter_info : () -> (MinterInfo) query;

--- a/packages/cketh/candid/minter.idl.js
+++ b/packages/cketh/candid/minter.idl.js
@@ -7,6 +7,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const UpgradeArg = IDL.Record({
     'next_transaction_nonce' : IDL.Opt(IDL.Nat),
+    'evm_rpc_id' : IDL.Opt(IDL.Principal),
     'ledger_suite_orchestrator_id' : IDL.Opt(IDL.Principal),
     'erc20_helper_contract_address' : IDL.Opt(IDL.Text),
     'last_erc20_scraped_block_number' : IDL.Opt(IDL.Nat),
@@ -37,6 +38,9 @@ export const idlFactory = ({ IDL }) => {
     'chain_id' : IDL.Nat,
     'address' : IDL.Text,
     'ckerc20_token_symbol' : IDL.Text,
+  });
+  const Eip1559TransactionPriceArg = IDL.Record({
+    'ckerc20_ledger_id' : IDL.Principal,
   });
   const Eip1559TransactionPrice = IDL.Record({
     'max_priority_fee_per_gas' : IDL.Nat,
@@ -349,7 +353,7 @@ export const idlFactory = ({ IDL }) => {
   return IDL.Service({
     'add_ckerc20_token' : IDL.Func([AddCkErc20Token], [], []),
     'eip_1559_transaction_price' : IDL.Func(
-        [],
+        [IDL.Opt(Eip1559TransactionPriceArg)],
         [Eip1559TransactionPrice],
         ['query'],
       ),
@@ -399,6 +403,7 @@ export const init = ({ IDL }) => {
   });
   const UpgradeArg = IDL.Record({
     'next_transaction_nonce' : IDL.Opt(IDL.Nat),
+    'evm_rpc_id' : IDL.Opt(IDL.Principal),
     'ledger_suite_orchestrator_id' : IDL.Opt(IDL.Principal),
     'erc20_helper_contract_address' : IDL.Opt(IDL.Text),
     'last_erc20_scraped_block_number' : IDL.Opt(IDL.Nat),

--- a/packages/cketh/src/minter.canister.spec.ts
+++ b/packages/cketh/src/minter.canister.spec.ts
@@ -626,22 +626,38 @@ describe("ckETH minter canister", () => {
   });
 
   describe("Estimate withdrawal fee", () => {
-    it("should return estimated fee", async () => {
-      const result = {
-        ...gasFeeEstimate,
-        gas_limit: 89n,
-        timestamp: toNullable(99999999n),
-      };
+    const eip1559Result = {
+      ...gasFeeEstimate,
+      gas_limit: 89n,
+      timestamp: toNullable(99999999n),
+    };
 
+    it("should return estimated fee", async () => {
       const service = mock<ActorSubclass<CkETHMinterService>>();
-      service.eip_1559_transaction_price.mockResolvedValue(result);
+      service.eip_1559_transaction_price.mockResolvedValue(eip1559Result);
 
       const canister = minter(service);
 
       const res = await canister.eip1559TransactionPrice({});
 
-      expect(service.eip_1559_transaction_price).toBeCalled();
-      expect(res).toEqual(result);
+      expect(service.eip_1559_transaction_price).toBeCalledWith([]);
+      expect(res).toEqual(eip1559Result);
+    });
+
+    it("should return estimated fee for a particular Erc20 ledger ID", async () => {
+      const service = mock<ActorSubclass<CkETHMinterService>>();
+      service.eip_1559_transaction_price.mockResolvedValue(eip1559Result);
+
+      const canister = minter(service);
+
+      const res = await canister.eip1559TransactionPrice({
+        ckErc20LedgerId: ledgerCanisterIdMock,
+      });
+
+      expect(service.eip_1559_transaction_price).toBeCalledWith([
+        { ckerc20_ledger_id: ledgerCanisterIdMock },
+      ]);
+      expect(res).toEqual(eip1559Result);
     });
 
     it("should bubble errors", async () => {

--- a/packages/cketh/src/minter.canister.ts
+++ b/packages/cketh/src/minter.canister.ts
@@ -1,6 +1,5 @@
 import type { Principal } from "@dfinity/principal";
-import type { QueryParams } from "@dfinity/utils";
-import { Canister, createServices } from "@dfinity/utils";
+import { Canister, createServices, type QueryParams } from "@dfinity/utils";
 import type {
   _SERVICE as CkETHMinterService,
   Eip1559TransactionPrice,
@@ -16,6 +15,10 @@ import {
   createWithdrawEthError,
 } from "./errors/minter.errors";
 import type { CkETHMinterCanisterOptions } from "./types/canister.options";
+import {
+  toEip1559TransactionPriceParams,
+  type Eip1559TransactionPriceParams,
+} from "./types/minter.params";
 
 export class CkETHMinterCanister extends Canister<CkETHMinterService> {
   static create(options: CkETHMinterCanisterOptions<CkETHMinterService>) {
@@ -120,20 +123,22 @@ export class CkETHMinterCanister extends Canister<CkETHMinterService> {
   };
 
   /**
-   * Estimate the price of a transaction issued by the minter when converting ckETH to ETH.
+   * Estimate the price of a transaction issued by the minter when converting ckETH to ETH and ckER20 to ERC20.
    *
-   * @param {QueryParams} params The parameters to get the minter info.
-   * @param {boolean} params.certified query or update call
+   * @param {Eip1559TransactionPriceParams} params - The parameters to get the minter info.
+   * @param {Principal} [params.ckErc20LedgerId] - The optional identifier for a particular ckERC20 ledger.
+   * @param {boolean} [params.certified] - Indicates whether this is a certified query or an update call.
    *
-   * @returns {Promise<Eip1559TransactionPrice>} The estimated gas fee and limit
+   * @returns {Promise<Eip1559TransactionPrice>} - The estimated gas fee and limit.
    */
   eip1559TransactionPrice = ({
     certified,
-  }: QueryParams): Promise<Eip1559TransactionPrice> => {
+    ...rest
+  }: Eip1559TransactionPriceParams): Promise<Eip1559TransactionPrice> => {
     const { eip_1559_transaction_price } = this.caller({
       certified,
     });
-    return eip_1559_transaction_price();
+    return eip_1559_transaction_price(toEip1559TransactionPriceParams(rest));
   };
 
   /**

--- a/packages/cketh/src/types/minter.params.ts
+++ b/packages/cketh/src/types/minter.params.ts
@@ -1,0 +1,12 @@
+import type { Principal } from "@dfinity/principal";
+import { isNullish, toNullable, type QueryParams } from "@dfinity/utils";
+import type { Eip1559TransactionPriceArg } from "../../candid/minter";
+
+export type Eip1559TransactionPriceParams = {
+  ckErc20LedgerId?: Principal;
+} & QueryParams;
+
+export const toEip1559TransactionPriceParams = ({
+  ckErc20LedgerId: ckerc20_ledger_id,
+}: Eip1559TransactionPriceParams): [] | [Eip1559TransactionPriceArg] =>
+  toNullable(isNullish(ckerc20_ledger_id) ? undefined : { ckerc20_ledger_id });


### PR DESCRIPTION
# Motivation

The function `eip_1559_transaction_price` has been extended with an additional parameter that allows querying the transaction price for ckErc20.

# Changes

- Copy did from #665
- Add the optional parameter `ckErc20LedgerId` for the function `eip1559TransactionPrice`
- If parameter is set, pass the parameter along as object to the Candid call else undefined
