### PR TITLE
Add optional includeEmptyNeurons to listNeurons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - Add support for `wasm_memory_limit` in the canister settings.
+- Add optional `includeEmptyNeurons` parameter to `listNeurons`.
 
 ## Fix
 

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -208,11 +208,13 @@ If an array of neuron IDs is provided, precisely those neurons will be fetched.
 If `certified` is true, the request is fetched as an update call, otherwise
 it is fetched using a query call.
 
-| Method        | Type                                                                                                               |
-| ------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `listNeurons` | `({ certified, neuronIds, }: { certified: boolean; neuronIds?: bigint[] or undefined; }) => Promise<NeuronInfo[]>` |
+The backend treats `includeEmptyNeurons` as true if absent.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L130)
+| Method        | Type                                                                                                                                                                                |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listNeurons` | `({ certified, neuronIds, includeEmptyNeurons, }: { certified: boolean; neuronIds?: bigint[] or undefined; includeEmptyNeurons?: boolean or undefined; }) => Promise<NeuronInfo[]>` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L131)
 
 ##### :gear: listKnownNeurons
 
@@ -226,7 +228,7 @@ it is fetched using a query call.
 | ------------------ | ------------------------------------------------- |
 | `listKnownNeurons` | `(certified?: boolean) => Promise<KnownNeuron[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L153)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L156)
 
 ##### :gear: getLastestRewardEvent
 
@@ -239,7 +241,7 @@ it's fetched using a query call.
 | ----------------------- | ----------------------------------------------- |
 | `getLastestRewardEvent` | `(certified?: boolean) => Promise<RewardEvent>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L175)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L178)
 
 ##### :gear: listProposals
 
@@ -258,7 +260,7 @@ Parameters:
 - `request`: the options to list the proposals (limit number of results, topics to search for, etc.)
 - `certified`: query or update calls
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L191)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L194)
 
 ##### :gear: stakeNeuron
 
@@ -266,7 +268,7 @@ Parameters:
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `stakeNeuron` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, fee, }: { stake: bigint; principal: Principal; fromSubAccount?: number[] or undefined; ledgerCanister: LedgerCanister; createdAt?: bigint or undefined; fee?: bigint or undefined; }) => Promise<...>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L210)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L213)
 
 ##### :gear: stakeNeuronIcrc1
 
@@ -274,7 +276,7 @@ Parameters:
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `stakeNeuronIcrc1` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, fee, }: { stake: bigint; principal: Principal; fromSubAccount?: Uint8Array or undefined; ledgerCanister: LedgerCanister; createdAt?: bigint or undefined; fee?: bigint or undefined; }) => Promise<...>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L276)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L279)
 
 ##### :gear: increaseDissolveDelay
 
@@ -284,7 +286,7 @@ Increases dissolve delay of a neuron
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `increaseDissolveDelay` | `({ neuronId, additionalDissolveDelaySeconds, }: { neuronId: bigint; additionalDissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L341)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L344)
 
 ##### :gear: setDissolveDelay
 
@@ -295,7 +297,7 @@ The new date is now + dissolveDelaySeconds.
 | ------------------ | ------------------------------------------------------------------------------------------------------------- |
 | `setDissolveDelay` | `({ neuronId, dissolveDelaySeconds, }: { neuronId: bigint; dissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L367)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L370)
 
 ##### :gear: startDissolving
 
@@ -305,7 +307,7 @@ Start dissolving process of a neuron
 | ----------------- | ------------------------------------- |
 | `startDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L390)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L393)
 
 ##### :gear: stopDissolving
 
@@ -315,7 +317,7 @@ Stop dissolving process of a neuron
 | ---------------- | ------------------------------------- |
 | `stopDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L404)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L407)
 
 ##### :gear: joinCommunityFund
 
@@ -325,7 +327,7 @@ Neuron joins the community fund
 | ------------------- | ------------------------------------- |
 | `joinCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L418)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L421)
 
 ##### :gear: autoStakeMaturity
 
@@ -340,7 +342,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to request a change of the auto stake feature
 - `autoStake`: `true` to enable the auto-stake maturity for this neuron, `false` to turn it off
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L436)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L439)
 
 ##### :gear: leaveCommunityFund
 
@@ -350,7 +352,7 @@ Neuron leaves the community fund
 | -------------------- | ------------------------------------- |
 | `leaveCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L451)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L454)
 
 ##### :gear: setNodeProviderAccount
 
@@ -361,7 +363,7 @@ Where the reward is paid to.
 | ------------------------ | ---------------------------------------------- |
 | `setNodeProviderAccount` | `(accountIdentifier: string) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L468)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L471)
 
 ##### :gear: mergeNeurons
 
@@ -371,7 +373,7 @@ Merge two neurons
 | -------------- | --------------------------------------------------------------------------------- |
 | `mergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L488)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L491)
 
 ##### :gear: simulateMergeNeurons
 
@@ -381,7 +383,7 @@ Simulate merging two neurons
 | ---------------------- | --------------------------------------------------------------------------------------- |
 | `simulateMergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<NeuronInfo>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L505)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L508)
 
 ##### :gear: splitNeuron
 
@@ -391,7 +393,7 @@ Splits a neuron creating a new one
 | ------------- | ----------------------------------------------------------------------------------- |
 | `splitNeuron` | `({ neuronId, amount, }: { neuronId: bigint; amount: bigint; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L550)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L553)
 
 ##### :gear: getProposal
 
@@ -404,7 +406,7 @@ it is fetched using a query call.
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `getProposal` | `({ proposalId, certified, }: { proposalId: bigint; certified?: boolean or undefined; }) => Promise<ProposalInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L590)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L593)
 
 ##### :gear: makeProposal
 
@@ -414,7 +416,7 @@ Create new proposal
 | -------------- | ---------------------------------------------------------------- |
 | `makeProposal` | `(request: MakeProposalRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L608)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L611)
 
 ##### :gear: registerVote
 
@@ -424,7 +426,7 @@ Registers vote for a proposal from the neuron passed.
 | -------------- | ----------------------------------------------------------------------------------------------------------- |
 | `registerVote` | `({ neuronId, vote, proposalId, }: { neuronId: bigint; vote: Vote; proposalId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L629)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L632)
 
 ##### :gear: setFollowees
 
@@ -434,7 +436,7 @@ Edit neuron followees per topic
 | -------------- | ------------------------------------------------- |
 | `setFollowees` | `(followRequest: FollowRequest) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L651)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L654)
 
 ##### :gear: disburse
 
@@ -444,7 +446,7 @@ Disburse neuron on Account
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `disburse` | `({ neuronId, toAccountId, amount, }: { neuronId: bigint; toAccountId?: string or undefined; amount?: bigint or undefined; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L666)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L669)
 
 ##### :gear: mergeMaturity
 
@@ -454,7 +456,7 @@ Merge Maturity of a neuron
 | --------------- | ------------------------------------------------------------------------------------------------------- |
 | `mergeMaturity` | `({ neuronId, percentageToMerge, }: { neuronId: bigint; percentageToMerge: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L702)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L705)
 
 ##### :gear: stakeMaturity
 
@@ -469,7 +471,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to stake the maturity
 - `percentageToStake`: Optional. Percentage of the current maturity to stake. If not provided, all of the neuron's current maturity will be staked.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L731)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L734)
 
 ##### :gear: spawnNeuron
 
@@ -479,7 +481,7 @@ Merge Maturity of a neuron
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `spawnNeuron` | `({ neuronId, percentageToSpawn, newController, nonce, }: { neuronId: bigint; percentageToSpawn?: number or undefined; newController?: Principal or undefined; nonce?: bigint or undefined; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L753)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L756)
 
 ##### :gear: addHotkey
 
@@ -489,7 +491,7 @@ Add hotkey to neuron
 | ----------- | ------------------------------------------------------------------------------------------ |
 | `addHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L800)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L803)
 
 ##### :gear: removeHotkey
 
@@ -499,7 +501,7 @@ Remove hotkey to neuron
 | -------------- | ------------------------------------------------------------------------------------------ |
 | `removeHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L820)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L823)
 
 ##### :gear: claimOrRefreshNeuronFromAccount
 
@@ -509,7 +511,7 @@ Gets the NeuronID of a newly created neuron.
 | --------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `claimOrRefreshNeuronFromAccount` | `({ memo, controller, }: { memo: bigint; controller?: Principal or undefined; }) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L838)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L841)
 
 ##### :gear: claimOrRefreshNeuron
 
@@ -520,7 +522,7 @@ Uses query call only.
 | ---------------------- | ------------------------------------------------------------------------ |
 | `claimOrRefreshNeuron` | `(request: ClaimOrRefreshNeuronRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L869)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L872)
 
 ##### :gear: getNeuron
 
@@ -530,7 +532,7 @@ Return the data of the neuron provided as id.
 | ----------- | ----------------------------------------------------------------------------------------------------------- |
 | `getNeuron` | `({ certified, neuronId, }: { certified: boolean; neuronId: bigint; }) => Promise<NeuronInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L920)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L923)
 
 ### :factory: SnsWasmCanister
 

--- a/packages/nns/candid/governance.certified.idl.js
+++ b/packages/nns/candid/governance.certified.idl.js
@@ -674,6 +674,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const ListNeurons = IDL.Record({
     'neuron_ids' : IDL.Vec(IDL.Nat64),
+    'include_empty_neurons_readable_by_caller' : IDL.Opt(IDL.Bool),
     'include_neurons_readable_by_caller' : IDL.Bool,
   });
   const ListNeuronsResponse = IDL.Record({

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -323,6 +323,7 @@ export interface ListKnownNeuronsResponse {
 }
 export interface ListNeurons {
   neuron_ids: BigUint64Array | bigint[];
+  include_empty_neurons_readable_by_caller: [] | [boolean];
   include_neurons_readable_by_caller: boolean;
 }
 export interface ListNeuronsResponse {

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit e3fca54 (2024-06-19 tags: release-2024-06-19_23-01-base) 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit f16b6a7376 (2024-06-24) 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
@@ -264,6 +264,7 @@ type LedgerParameters = record {
 type ListKnownNeuronsResponse = record { known_neurons : vec KnownNeuron };
 type ListNeurons = record {
   neuron_ids : vec nat64;
+  include_empty_neurons_readable_by_caller : opt bool;
   include_neurons_readable_by_caller : bool;
 };
 type ListNeuronsResponse = record {

--- a/packages/nns/candid/governance.idl.js
+++ b/packages/nns/candid/governance.idl.js
@@ -674,6 +674,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const ListNeurons = IDL.Record({
     'neuron_ids' : IDL.Vec(IDL.Nat64),
+    'include_empty_neurons_readable_by_caller' : IDL.Opt(IDL.Bool),
     'include_neurons_readable_by_caller' : IDL.Bool,
   });
   const ListNeuronsResponse = IDL.Record({

--- a/packages/nns/candid/governance_test.certified.idl.js
+++ b/packages/nns/candid/governance_test.certified.idl.js
@@ -674,6 +674,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const ListNeurons = IDL.Record({
     'neuron_ids' : IDL.Vec(IDL.Nat64),
+    'include_empty_neurons_readable_by_caller' : IDL.Opt(IDL.Bool),
     'include_neurons_readable_by_caller' : IDL.Bool,
   });
   const ListNeuronsResponse = IDL.Record({

--- a/packages/nns/candid/governance_test.d.ts
+++ b/packages/nns/candid/governance_test.d.ts
@@ -323,6 +323,7 @@ export interface ListKnownNeuronsResponse {
 }
 export interface ListNeurons {
   neuron_ids: BigUint64Array | bigint[];
+  include_empty_neurons_readable_by_caller: [] | [boolean];
   include_neurons_readable_by_caller: boolean;
 }
 export interface ListNeuronsResponse {

--- a/packages/nns/candid/governance_test.did
+++ b/packages/nns/candid/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit e3fca54 (2024-06-19 tags: release-2024-06-19_23-01-base) 'rs/nns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit f16b6a7376 (2024-06-24) 'rs/nns/governance/canister/governance_test.did' by import-candid
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
@@ -264,6 +264,7 @@ type LedgerParameters = record {
 type ListKnownNeuronsResponse = record { known_neurons : vec KnownNeuron };
 type ListNeurons = record {
   neuron_ids : vec nat64;
+  include_empty_neurons_readable_by_caller : opt bool;
   include_neurons_readable_by_caller : bool;
 };
 type ListNeuronsResponse = record {

--- a/packages/nns/candid/governance_test.idl.js
+++ b/packages/nns/candid/governance_test.idl.js
@@ -674,6 +674,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const ListNeurons = IDL.Record({
     'neuron_ids' : IDL.Vec(IDL.Nat64),
+    'include_empty_neurons_readable_by_caller' : IDL.Opt(IDL.Bool),
     'include_neurons_readable_by_caller' : IDL.Bool,
   });
   const ListNeuronsResponse = IDL.Record({

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -976,9 +976,16 @@ const fromClaimOrRefreshBy = (by: By): RawBy => {
   }
 };
 
-export const fromListNeurons = (neuronIds?: NeuronId[]): RawListNeurons => ({
+export const fromListNeurons = ({
+  neuronIds,
+  includeEmptyNeurons,
+}: {
+  neuronIds?: NeuronId[];
+  includeEmptyNeurons?: boolean;
+}): RawListNeurons => ({
   neuron_ids: BigUint64Array.from(neuronIds ?? []),
   include_neurons_readable_by_caller: neuronIds ? false : true,
+  include_empty_neurons_readable_by_caller: toNullable(includeEmptyNeurons),
 });
 
 export const fromManageNeuron = ({

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -434,7 +434,33 @@ describe("GovernanceCanister", () => {
       const neurons = await governance.listNeurons({
         certified: true,
       });
-      expect(service.list_neurons).toBeCalled();
+      expect(service.list_neurons).toBeCalledWith({
+        neuron_ids: new BigUint64Array(),
+        include_neurons_readable_by_caller: true,
+        include_empty_neurons_readable_by_caller: [],
+      });
+      expect(service.list_neurons).toBeCalledTimes(1);
+      expect(neurons.length).toBe(1);
+    });
+
+    it("list user neurons excluding empty neurons", async () => {
+      const service = mock<ActorSubclass<GovernanceService>>();
+      service.list_neurons.mockResolvedValue(mockListNeuronsResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+      });
+      const neurons = await governance.listNeurons({
+        certified: true,
+        includeEmptyNeurons: false,
+      });
+      expect(service.list_neurons).toBeCalledWith({
+        neuron_ids: new BigUint64Array(),
+        include_neurons_readable_by_caller: true,
+        include_empty_neurons_readable_by_caller: [false],
+      });
+      expect(service.list_neurons).toBeCalledTimes(1);
       expect(neurons.length).toBe(1);
     });
   });

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -126,15 +126,18 @@ export class GovernanceCanister {
    * If `certified` is true, the request is fetched as an update call, otherwise
    * it is fetched using a query call.
    *
+   * The backend treats `includeEmptyNeurons` as true if absent.
    */
   public listNeurons = async ({
     certified = true,
     neuronIds,
+    includeEmptyNeurons,
   }: {
     certified: boolean;
     neuronIds?: NeuronId[];
+    includeEmptyNeurons?: boolean;
   }): Promise<NeuronInfo[]> => {
-    const rawRequest = fromListNeurons(neuronIds);
+    const rawRequest = fromListNeurons({ neuronIds, includeEmptyNeurons });
     const raw_response =
       await this.getGovernanceService(certified).list_neurons(rawRequest);
     return toArrayOfNeuronInfo({

--- a/packages/nns/src/governance_test.canister.ts
+++ b/packages/nns/src/governance_test.canister.ts
@@ -46,7 +46,7 @@ export class GovernanceTestCanister {
    */
   async updateNeuron(neuron: Neuron) {
     assertNonNullish(neuron.id);
-    const rawListNeuronsRequest = fromListNeurons([neuron.id]);
+    const rawListNeuronsRequest = fromListNeurons({ neuronIds: [neuron.id] });
     const rawListNeuronsResponse = await this.certifiedService.list_neurons(
       rawListNeuronsRequest,
     );


### PR DESCRIPTION
# Motivation

When neurons are disbursed or merged they don't stop existing but become empty neurons.
Those neurons are not displayed in NNS dapp but are always included in the response and filtered out on the client.
This unnecessarily wasteful so an optional parameter is being added which can be used to stop including empty neurons.

The functionality is not yet implemented but the parameter is added already so that we can start passing it.

# Changes

1. Ran `scripts/import-candid ../../ic`
2. Ran `scripts/compile-idl-js`
3. Reverted all canisters except the governance canisters.
4. Added optional `includeEmptyNeurons` parameter to `listNeurons` and pass it on to the backend. Note that the backend treats absent as `true`.

# Tests

1. Unit tests added and updated.
2. Tested manually with NNS dapp. Functionality itself could not be tested because it's not implemented yet but passing the parameter doesn't break anything.

# Todos

- [x] Add entry to changelog (if necessary).
