### PR TITLE
Add --silent to `npm pack`

### DIFF
--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -5,7 +5,7 @@
 function publish_npm() {
   local lib=$1
 
-  LOCAL_SHASUM=$(npm pack -w packages/"$lib" --json | jq '.[] | .shasum' | sed -r 's/^"|"$//g')
+  LOCAL_SHASUM=$(npm --silent pack -w packages/"$lib" --json | jq '.[] | .shasum' | sed -r 's/^"|"$//g')
 
   NPM_TARBALL=$(npm show @dfinity/"$lib" dist.tarball)
   NPM_SHASUM=$(curl -s "$NPM_TARBALL" 2>&1 | shasum | cut -f1 -d' ')


### PR DESCRIPTION
# Motivation

@frederikrothenberger discovered that the outupt of `npm pack` is different depending on the npm version.

Later versions of `npm` output some commands. Adding `--silent` ensures that the output is a valid JSON without the commands.

# Changes

* Add `--silent` to `publish-npm.sh`.

# Tests

Tested manually.

# Todos

- [ ] Add entry to changelog (if necessary). NOT necessary.
