### PR TITLE
feat: expose types Eip1559TransactionPriceParams

### DIFF
--- a/packages/cketh/src/index.ts
+++ b/packages/cketh/src/index.ts
@@ -16,4 +16,5 @@ export type {
 export * from "./errors/minter.errors";
 export { CkETHMinterCanister } from "./minter.canister";
 export { CkETHOrchestratorCanister } from "./orchestrator.canister";
+export type { Eip1559TransactionPriceParams } from "./types/minter.params";
 export * from "./utils/minter.utils";


### PR DESCRIPTION
# Motivation

The params `Eip1559TransactionPriceParams` type was added to `eip1559TransactionPrice` but, the params themselves have not been made public in PR #666.

# Changes

- Expose the params to the consumer of the library.
