### PR TITLE
feat: expose candid type RetrieveErc20Request

### DIFF
--- a/packages/cketh/src/index.ts
+++ b/packages/cketh/src/index.ts
@@ -2,6 +2,7 @@ export type {
   Eip1559TransactionPrice,
   EthTransaction,
   MinterInfo,
+  RetrieveErc20Request,
   RetrieveEthRequest,
   RetrieveEthStatus,
   TxFinalizedStatus,


### PR DESCRIPTION
# Motivation

Randomly noticed another type, `RetrieveErc20Request`, which is used since quite some time in Oisy but, is actually not directly exposed by the ckETH library module.

# Changes

- Expose `RetrieveErc20Request` in `@dfinity/cketh`

# Notes

Searched for other potential not exposed types in Oisy, there weren't.
