### PR TITLE
build: agent-js v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - `updateNeuron` to not change the neuron subaccount.
 - `list_neurons` to use old `ListNeurons` type for hardware wallet compatibility.
 
+## Build
+
+- Upgrade `agent-js` dependencies to `v1.4.0`.
+
 # 2024.06.11-1630Z
 
 ## Overview

--- a/package-lock.json
+++ b/package-lock.json
@@ -717,9 +717,10 @@
       "dev": true
     },
     "node_modules/@dfinity/agent": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-1.3.0.tgz",
-      "integrity": "sha512-gFc2CqjWURv/Th+vxwHIb7Y39TpRZccjyRm8c51LtyAGLYSpSwJDWbzM/y66h++DSSc3A+1DjN/dRT+6ik3xLw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-1.4.0.tgz",
+      "integrity": "sha512-/zgGajZpxtbu+kLXtFx2e9V2+HbMUjrtGWx9ZEwtVwhVxKgVi/2kGQpFRPEDFJ461V7wdTwCig4OkMxVU4shTw==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@noble/curves": "^1.4.0",
@@ -730,17 +731,18 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^1.3.0",
-        "@dfinity/principal": "^1.3.0"
+        "@dfinity/candid": "^1.4.0",
+        "@dfinity/principal": "^1.4.0"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-1.3.0.tgz",
-      "integrity": "sha512-tt5NYfpv8C+3iKS3Awbi+NAIxjwjIRUOLT+1ys/xpA+6DNEqwgfU8WZu0+bKnf/xlASCyJXUmoMzQ6I01GBp9A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-1.4.0.tgz",
+      "integrity": "sha512-PsTJVn63ZM4A/6Xs5coI0zMFevSwJ8hcyh38LdH/92n6wi9UOTis1yc4qL5MZvvRCUAD0c3rVjELL+49E9sPyA==",
+      "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "^1.3.0"
+        "@dfinity/principal": "^1.4.0"
       }
     },
     "node_modules/@dfinity/ckbtc": {
@@ -776,9 +778,10 @@
       "link": true
     },
     "node_modules/@dfinity/principal": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.3.0.tgz",
-      "integrity": "sha512-04Ly9/VxztgmSk3LeUv1H+aA/8zCfed5gzgydVKBv9U0pk2lcCjUOMhv3G+1UCUSd8GwzrWaSwIsrzrAcHZm/g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.4.0.tgz",
+      "integrity": "sha512-SuTBVlc71ub89ji0WN5/T100zUG2uIMn5x4+We4vS4nJ0R3/Xt89XJsHepjd5SQTSQPOvP7eQ+S8cQKWRz/RkA==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.3.1"
@@ -1653,9 +1656,10 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
-      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@noble/hashes": "1.4.0"
@@ -2764,6 +2768,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "peer": true
     },
     "node_modules/bech32": {
@@ -2775,6 +2780,7 @@
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
       "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": "*"
@@ -2796,6 +2802,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
       "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "bignumber.js": "^9.0.0",
@@ -2828,6 +2835,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
@@ -2923,6 +2931,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
@@ -3126,6 +3135,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/concat-map": {
@@ -3268,6 +3278,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
       "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ==",
+      "license": "BSD-2-Clause",
       "peer": true
     },
     "node_modules/detect-newline": {
@@ -4576,6 +4587,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "BSD-3-Clause",
       "peer": true
     },
     "node_modules/ignore": {
@@ -4956,6 +4968,7 @@
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
       "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -5656,6 +5669,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
       "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "delimit-stream": "0.1.0"
@@ -6386,6 +6400,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -6661,6 +6676,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
       "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
+      "license": "ISC",
       "peer": true
     },
     "node_modules/sisteransi": {
@@ -6793,6 +6809,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -6816,6 +6833,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "peer": true
     },
     "node_modules/string-length": {
@@ -7314,6 +7332,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/v8-to-istanbul": {
@@ -7498,9 +7517,9 @@
         "bech32": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^1.3.0",
-        "@dfinity/candid": "^1.3.0",
-        "@dfinity/principal": "^1.3.0",
+        "@dfinity/agent": "^1.4.0",
+        "@dfinity/candid": "^1.4.0",
+        "@dfinity/principal": "^1.4.0",
         "@dfinity/utils": "^2.3.1"
       }
     },
@@ -7509,9 +7528,9 @@
       "version": "3.1.1",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^1.3.0",
-        "@dfinity/candid": "^1.3.0",
-        "@dfinity/principal": "^1.3.0",
+        "@dfinity/agent": "^1.4.0",
+        "@dfinity/candid": "^1.4.0",
+        "@dfinity/principal": "^1.4.0",
         "@dfinity/utils": "^2.3.1"
       }
     },
@@ -7520,9 +7539,9 @@
       "version": "3.0.7",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^1.3.0",
-        "@dfinity/candid": "^1.3.0",
-        "@dfinity/principal": "^1.3.0",
+        "@dfinity/agent": "^1.4.0",
+        "@dfinity/candid": "^1.4.0",
+        "@dfinity/principal": "^1.4.0",
         "@dfinity/utils": "^2.3.1"
       }
     },
@@ -7531,9 +7550,9 @@
       "version": "5.0.1",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^1.3.0",
-        "@dfinity/candid": "^1.3.0",
-        "@dfinity/principal": "^1.3.0",
+        "@dfinity/agent": "^1.4.0",
+        "@dfinity/candid": "^1.4.0",
+        "@dfinity/principal": "^1.4.0",
         "@dfinity/utils": "^2.3.1"
       }
     },
@@ -7542,9 +7561,9 @@
       "version": "2.3.1",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^1.3.0",
-        "@dfinity/candid": "^1.3.0",
-        "@dfinity/principal": "^1.3.0",
+        "@dfinity/agent": "^1.4.0",
+        "@dfinity/candid": "^1.4.0",
+        "@dfinity/principal": "^1.4.0",
         "@dfinity/utils": "^2.3.1"
       }
     },
@@ -7553,9 +7572,9 @@
       "version": "2.3.3",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^1.3.0",
-        "@dfinity/candid": "^1.3.0",
-        "@dfinity/principal": "^1.3.0",
+        "@dfinity/agent": "^1.4.0",
+        "@dfinity/candid": "^1.4.0",
+        "@dfinity/principal": "^1.4.0",
         "@dfinity/utils": "^2.3.1"
       }
     },
@@ -7571,10 +7590,10 @@
         "@types/randombytes": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^1.3.0",
-        "@dfinity/candid": "^1.3.0",
+        "@dfinity/agent": "^1.4.0",
+        "@dfinity/candid": "^1.4.0",
         "@dfinity/ledger-icp": "^2.3.1",
-        "@dfinity/principal": "^1.3.0",
+        "@dfinity/principal": "^1.4.0",
         "@dfinity/utils": "^2.3.1"
       }
     },
@@ -7597,10 +7616,10 @@
         "@noble/hashes": "^1.3.2"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^1.3.0",
-        "@dfinity/candid": "^1.3.0",
+        "@dfinity/agent": "^1.4.0",
+        "@dfinity/candid": "^1.4.0",
         "@dfinity/ledger-icrc": "^2.3.3",
-        "@dfinity/principal": "^1.3.0",
+        "@dfinity/principal": "^1.4.0",
         "@dfinity/utils": "^2.3.1"
       }
     },
@@ -7609,9 +7628,9 @@
       "version": "2.3.1",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^1.3.0",
-        "@dfinity/candid": "^1.3.0",
-        "@dfinity/principal": "^1.3.0"
+        "@dfinity/agent": "^1.4.0",
+        "@dfinity/candid": "^1.4.0",
+        "@dfinity/principal": "^1.4.0"
       }
     }
   },
@@ -8125,9 +8144,9 @@
       "dev": true
     },
     "@dfinity/agent": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-1.3.0.tgz",
-      "integrity": "sha512-gFc2CqjWURv/Th+vxwHIb7Y39TpRZccjyRm8c51LtyAGLYSpSwJDWbzM/y66h++DSSc3A+1DjN/dRT+6ik3xLw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-1.4.0.tgz",
+      "integrity": "sha512-/zgGajZpxtbu+kLXtFx2e9V2+HbMUjrtGWx9ZEwtVwhVxKgVi/2kGQpFRPEDFJ461V7wdTwCig4OkMxVU4shTw==",
       "peer": true,
       "requires": {
         "@noble/curves": "^1.4.0",
@@ -8139,9 +8158,9 @@
       }
     },
     "@dfinity/candid": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-1.3.0.tgz",
-      "integrity": "sha512-tt5NYfpv8C+3iKS3Awbi+NAIxjwjIRUOLT+1ys/xpA+6DNEqwgfU8WZu0+bKnf/xlASCyJXUmoMzQ6I01GBp9A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-1.4.0.tgz",
+      "integrity": "sha512-PsTJVn63ZM4A/6Xs5coI0zMFevSwJ8hcyh38LdH/92n6wi9UOTis1yc4qL5MZvvRCUAD0c3rVjELL+49E9sPyA==",
       "peer": true,
       "requires": {}
     },
@@ -8189,9 +8208,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.3.0.tgz",
-      "integrity": "sha512-04Ly9/VxztgmSk3LeUv1H+aA/8zCfed5gzgydVKBv9U0pk2lcCjUOMhv3G+1UCUSd8GwzrWaSwIsrzrAcHZm/g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.4.0.tgz",
+      "integrity": "sha512-SuTBVlc71ub89ji0WN5/T100zUG2uIMn5x4+We4vS4nJ0R3/Xt89XJsHepjd5SQTSQPOvP7eQ+S8cQKWRz/RkA==",
       "peer": true,
       "requires": {
         "@noble/hashes": "^1.3.1"
@@ -8757,9 +8776,9 @@
       }
     },
     "@noble/curves": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
-      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
       "peer": true,
       "requires": {
         "@noble/hashes": "1.4.0"

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^1.3.0",
-    "@dfinity/candid": "^1.3.0",
-    "@dfinity/principal": "^1.3.0",
+    "@dfinity/agent": "^1.4.0",
+    "@dfinity/candid": "^1.4.0",
+    "@dfinity/principal": "^1.4.0",
     "@dfinity/utils": "^2.3.1"
   },
   "dependencies": {

--- a/packages/cketh/package.json
+++ b/packages/cketh/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^1.3.0",
-    "@dfinity/candid": "^1.3.0",
-    "@dfinity/principal": "^1.3.0",
+    "@dfinity/agent": "^1.4.0",
+    "@dfinity/candid": "^1.4.0",
+    "@dfinity/principal": "^1.4.0",
     "@dfinity/utils": "^2.3.1"
   }
 }

--- a/packages/cmc/package.json
+++ b/packages/cmc/package.json
@@ -36,9 +36,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^1.3.0",
-    "@dfinity/candid": "^1.3.0",
-    "@dfinity/principal": "^1.3.0",
+    "@dfinity/agent": "^1.4.0",
+    "@dfinity/candid": "^1.4.0",
+    "@dfinity/principal": "^1.4.0",
     "@dfinity/utils": "^2.3.1"
   }
 }

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -34,9 +34,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^1.3.0",
-    "@dfinity/candid": "^1.3.0",
-    "@dfinity/principal": "^1.3.0",
+    "@dfinity/agent": "^1.4.0",
+    "@dfinity/candid": "^1.4.0",
+    "@dfinity/principal": "^1.4.0",
     "@dfinity/utils": "^2.3.1"
   }
 }

--- a/packages/ledger-icp/package.json
+++ b/packages/ledger-icp/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^1.3.0",
-    "@dfinity/candid": "^1.3.0",
-    "@dfinity/principal": "^1.3.0",
+    "@dfinity/agent": "^1.4.0",
+    "@dfinity/candid": "^1.4.0",
+    "@dfinity/principal": "^1.4.0",
     "@dfinity/utils": "^2.3.1"
   }
 }

--- a/packages/ledger-icrc/package.json
+++ b/packages/ledger-icrc/package.json
@@ -37,9 +37,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^1.3.0",
-    "@dfinity/candid": "^1.3.0",
-    "@dfinity/principal": "^1.3.0",
+    "@dfinity/agent": "^1.4.0",
+    "@dfinity/candid": "^1.4.0",
+    "@dfinity/principal": "^1.4.0",
     "@dfinity/utils": "^2.3.1"
   }
 }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -51,10 +51,10 @@
     "network-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^1.3.0",
-    "@dfinity/candid": "^1.3.0",
+    "@dfinity/agent": "^1.4.0",
+    "@dfinity/candid": "^1.4.0",
     "@dfinity/ledger-icp": "^2.3.1",
-    "@dfinity/principal": "^1.3.0",
+    "@dfinity/principal": "^1.4.0",
     "@dfinity/utils": "^2.3.1"
   }
 }

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -36,10 +36,10 @@
     "sns"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^1.3.0",
-    "@dfinity/candid": "^1.3.0",
+    "@dfinity/agent": "^1.4.0",
+    "@dfinity/candid": "^1.4.0",
     "@dfinity/ledger-icrc": "^2.3.3",
-    "@dfinity/principal": "^1.3.0",
+    "@dfinity/principal": "^1.4.0",
     "@dfinity/utils": "^2.3.1"
   },
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -47,8 +47,8 @@
     "service-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^1.3.0",
-    "@dfinity/candid": "^1.3.0",
-    "@dfinity/principal": "^1.3.0"
+    "@dfinity/agent": "^1.4.0",
+    "@dfinity/candid": "^1.4.0",
+    "@dfinity/principal": "^1.4.0"
   }
 }


### PR DESCRIPTION
# Motivation

Agent-js v1.4.0 allows the removal of 'unsafe-eval' and 'unsafe-inline' in CSPs.

# Changes

- Bump agent-js v1.4.0.
