### PR TITLE
chore: fix test reporting

### DIFF
--- a/packages/nns/src/canisters/governance/request.converters.spec.ts
+++ b/packages/nns/src/canisters/governance/request.converters.spec.ts
@@ -1,6 +1,5 @@
 import { Principal } from "@dfinity/principal";
 import { arrayBufferToUint8Array, toNullable } from "@dfinity/utils";
-import { describe } from "node:test";
 import type { ManageNeuron as RawManageNeuron } from "../../../candid/governance";
 import { GovernanceParameters } from "../../types/governance_converters";
 import { toMakeProposalRawRequest } from "./request.converters";


### PR DESCRIPTION
# Motivation

An unexpected import if `describe` slipped in a recent test which lead `npm run test` to prinout following console log to the terminal when running the tests

> TAP version 13
> # Subtest: request.converters
>     # Subtest: should convert MakeProposalRequest to RawManageNeuron
>     ok 1 - should convert MakeProposalRequest to RawManageNeuron
>       ---
>       duration_ms: 0.252709
>       type: 'suite'
>       ...
>     1..1
> ok 1 - request.converters
>   ---
>   duration_ms: 0.772666
>   type: 'suite'
>   ...

# Changes

- Remove unexpected import of `describe`
