### PR TITLE
feat: update cketh candid files

### DIFF
--- a/packages/cketh/candid/minter.did
+++ b/packages/cketh/candid/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a3831c8 (2024-07-11 tags: release-2024-07-10_23-01-base) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
+// Generated from IC repo commit de29a1a (2024-07-18 tags: release-2024-07-18_01-30--github-base) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
 type EthereumNetwork = variant {
     // The public Ethereum mainnet.
     Mainnet;

--- a/packages/cketh/candid/orchestrator.certified.idl.js
+++ b/packages/cketh/candid/orchestrator.certified.idl.js
@@ -28,32 +28,16 @@ export const idlFactory = ({ IDL }) => {
     'chain_id' : IDL.Nat,
     'address' : IDL.Text,
   });
-  const LedgerSubaccount = IDL.Vec(IDL.Nat8);
-  const LedgerAccount = IDL.Record({
-    'owner' : IDL.Principal,
-    'subaccount' : IDL.Opt(LedgerSubaccount),
-  });
-  const LedgerFeatureFlags = IDL.Record({ 'icrc2' : IDL.Bool });
   const LedgerInitArg = IDL.Record({
-    'decimals' : IDL.Opt(IDL.Nat8),
+    'decimals' : IDL.Nat8,
     'token_symbol' : IDL.Text,
     'transfer_fee' : IDL.Nat,
-    'minting_account' : LedgerAccount,
-    'initial_balances' : IDL.Vec(IDL.Tuple(LedgerAccount, IDL.Nat)),
-    'maximum_number_of_accounts' : IDL.Opt(IDL.Nat64),
-    'accounts_overflow_trim_quantity' : IDL.Opt(IDL.Nat64),
-    'fee_collector_account' : IDL.Opt(LedgerAccount),
-    'max_memo_length' : IDL.Opt(IDL.Nat16),
     'token_logo' : IDL.Text,
     'token_name' : IDL.Text,
-    'feature_flags' : IDL.Opt(LedgerFeatureFlags),
   });
   const AddErc20Arg = IDL.Record({
     'contract' : Erc20Contract,
     'ledger_init_arg' : LedgerInitArg,
-    'git_commit_hash' : IDL.Text,
-    'ledger_compressed_wasm_hash' : IDL.Text,
-    'index_compressed_wasm_hash' : IDL.Text,
   });
   const OrchestratorArg = IDL.Variant({
     'UpgradeArg' : UpgradeArg,
@@ -107,10 +91,16 @@ export const idlFactory = ({ IDL }) => {
     'archives' : IDL.Vec(IDL.Principal),
     'ckerc20_token_symbol' : IDL.Text,
   });
+  const LedgerSuiteVersion = IDL.Record({
+    'archive_compressed_wasm_hash' : IDL.Text,
+    'ledger_compressed_wasm_hash' : IDL.Text,
+    'index_compressed_wasm_hash' : IDL.Text,
+  });
   const OrchestratorInfo = IDL.Record({
     'cycles_management' : CyclesManagement,
     'managed_canisters' : IDL.Vec(ManagedCanisters),
     'more_controller_ids' : IDL.Vec(IDL.Principal),
+    'ledger_suite_version' : IDL.Opt(LedgerSuiteVersion),
     'minter_id' : IDL.Opt(IDL.Principal),
   });
   return IDL.Service({
@@ -152,32 +142,16 @@ export const init = ({ IDL }) => {
     'chain_id' : IDL.Nat,
     'address' : IDL.Text,
   });
-  const LedgerSubaccount = IDL.Vec(IDL.Nat8);
-  const LedgerAccount = IDL.Record({
-    'owner' : IDL.Principal,
-    'subaccount' : IDL.Opt(LedgerSubaccount),
-  });
-  const LedgerFeatureFlags = IDL.Record({ 'icrc2' : IDL.Bool });
   const LedgerInitArg = IDL.Record({
-    'decimals' : IDL.Opt(IDL.Nat8),
+    'decimals' : IDL.Nat8,
     'token_symbol' : IDL.Text,
     'transfer_fee' : IDL.Nat,
-    'minting_account' : LedgerAccount,
-    'initial_balances' : IDL.Vec(IDL.Tuple(LedgerAccount, IDL.Nat)),
-    'maximum_number_of_accounts' : IDL.Opt(IDL.Nat64),
-    'accounts_overflow_trim_quantity' : IDL.Opt(IDL.Nat64),
-    'fee_collector_account' : IDL.Opt(LedgerAccount),
-    'max_memo_length' : IDL.Opt(IDL.Nat16),
     'token_logo' : IDL.Text,
     'token_name' : IDL.Text,
-    'feature_flags' : IDL.Opt(LedgerFeatureFlags),
   });
   const AddErc20Arg = IDL.Record({
     'contract' : Erc20Contract,
     'ledger_init_arg' : LedgerInitArg,
-    'git_commit_hash' : IDL.Text,
-    'ledger_compressed_wasm_hash' : IDL.Text,
-    'index_compressed_wasm_hash' : IDL.Text,
   });
   const OrchestratorArg = IDL.Variant({
     'UpgradeArg' : UpgradeArg,

--- a/packages/cketh/candid/orchestrator.d.ts
+++ b/packages/cketh/candid/orchestrator.d.ts
@@ -5,9 +5,6 @@ import type { Principal } from "@dfinity/principal";
 export interface AddErc20Arg {
   contract: Erc20Contract;
   ledger_init_arg: LedgerInitArg;
-  git_commit_hash: string;
-  ledger_compressed_wasm_hash: string;
-  index_compressed_wasm_hash: string;
 }
 export interface CanisterStatusResponse {
   status: CanisterStatusType;
@@ -45,28 +42,18 @@ export interface InitArg {
   more_controller_ids: Array<Principal>;
   minter_id: [] | [Principal];
 }
-export interface LedgerAccount {
-  owner: Principal;
-  subaccount: [] | [LedgerSubaccount];
-}
-export interface LedgerFeatureFlags {
-  icrc2: boolean;
-}
 export interface LedgerInitArg {
-  decimals: [] | [number];
+  decimals: number;
   token_symbol: string;
   transfer_fee: bigint;
-  minting_account: LedgerAccount;
-  initial_balances: Array<[LedgerAccount, bigint]>;
-  maximum_number_of_accounts: [] | [bigint];
-  accounts_overflow_trim_quantity: [] | [bigint];
-  fee_collector_account: [] | [LedgerAccount];
-  max_memo_length: [] | [number];
   token_logo: string;
   token_name: string;
-  feature_flags: [] | [LedgerFeatureFlags];
 }
-export type LedgerSubaccount = Uint8Array | number[];
+export interface LedgerSuiteVersion {
+  archive_compressed_wasm_hash: string;
+  ledger_compressed_wasm_hash: string;
+  index_compressed_wasm_hash: string;
+}
 export interface ManagedCanisterIds {
   ledger: [] | [Principal];
   index: [] | [Principal];
@@ -94,6 +81,7 @@ export interface OrchestratorInfo {
   cycles_management: CyclesManagement;
   managed_canisters: Array<ManagedCanisters>;
   more_controller_ids: Array<Principal>;
+  ledger_suite_version: [] | [LedgerSuiteVersion];
   minter_id: [] | [Principal];
 }
 export interface QueryStats {

--- a/packages/cketh/candid/orchestrator.did
+++ b/packages/cketh/candid/orchestrator.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a3831c8 (2024-07-11 tags: release-2024-07-10_23-01-base) 'rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did' by import-candid
+// Generated from IC repo commit de29a1a (2024-07-18 tags: release-2024-07-18_01-30--github-base) 'rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did' by import-candid
 type OrchestratorArg = variant {
     UpgradeArg : UpgradeArg;
     InitArg : InitArg;
@@ -21,7 +21,8 @@ type UpgradeArg = record {
     // Hexadecimal encoding of the SHA-1 git commit hash used for this upgrade, e.g.,
     // "51d01d3936498d4010de54505d6433e9ad5cc62b", corresponding to a git revision in the
     // [IC repository](https://github.com/dfinity/ic).
-    // This field is expected to be present, if any of the wasm hashes below is present.
+    // If this field is present, the orchestrator will register all embedded wasms (ledger, index, and archive) in its stable memory,
+    // so that those exact wasms can be used to upgrade managed canisters as specified below.
     git_commit_hash: opt text;
 
    // Hexadecimal encoding of the SHA2-256 ledger compressed wasm hash, e.g.,
@@ -49,21 +50,6 @@ type UpgradeArg = record {
 type AddErc20Arg = record {
    contract: Erc20Contract;
    ledger_init_arg: LedgerInitArg;
-
-    // Hexadecimal encoding of the SHA-1 git commit hash used for this upgrade, e.g.,
-    // "51d01d3936498d4010de54505d6433e9ad5cc62b", corresponding to a git revision in the
-    // [IC repository](https://github.com/dfinity/ic).
-    git_commit_hash: text;
-
-   // Hexadecimal encoding of the SHA2-256 ledger compressed wasm hash, e.g.,
-   // "3148f7a9f1b0ee39262c8abe3b08813480cf78551eee5a60ab1cf38433b5d9b0".
-   // This exact version will be used for the new ledger canister created for this ERC-20 token.
-   ledger_compressed_wasm_hash: text;
-
-   // Hexadecimal encoding of the SHA2-256 index compressed wasm hash, e.g.,
-   // "3a6d39b5e94cdef5203bca62720e75a28cd071ff434d22b9746403ac7ae59614".
-   // This exact version will be used for the new index canister created for this ERC-20 token.
-   index_compressed_wasm_hash: text;
 };
 
 type Erc20Contract = record {
@@ -72,31 +58,13 @@ type Erc20Contract = record {
 };
 
 // ICRC1 ledger initialization argument that will be used when the orchestrator spawns a new ledger canister.
-// The `archive_options` field will be set by the orchestrator.
+// Other fields, such as `archive_options`, needed to initialize a new ledger will be set by the orchestrator.
 type LedgerInitArg = record {
-    minting_account : LedgerAccount;
-    fee_collector_account : opt LedgerAccount;
     transfer_fee : nat;
-    decimals : opt nat8;
-    max_memo_length : opt nat16;
+    decimals : nat8;
     token_symbol : text;
     token_name : text;
     token_logo : text;
-    initial_balances : vec record { LedgerAccount; nat };
-    feature_flags : opt LedgerFeatureFlags;
-    maximum_number_of_accounts : opt nat64;
-    accounts_overflow_trim_quantity : opt nat64;
-};
-
-type LedgerAccount = record {
-    owner : principal;
-    subaccount : opt LedgerSubaccount;
-};
-
-type LedgerSubaccount = blob;
-
-type LedgerFeatureFlags = record {
-    icrc2 : bool;
 };
 
 type ManagedCanisterIds = record {
@@ -158,6 +126,25 @@ type OrchestratorInfo = record {
 
     // ckETH minter canister id.
     minter_id : opt principal;
+
+   // Ledger suite version that will be used to spawn off a new ledger suite (ledger and index canisters) when an ERC-20 token is added.
+   ledger_suite_version: opt LedgerSuiteVersion;
+};
+
+type LedgerSuiteVersion = record {
+   // Hexadecimal encoding of the SHA2-256 ledger compressed wasm hash, e.g.,
+   // "3148f7a9f1b0ee39262c8abe3b08813480cf78551eee5a60ab1cf38433b5d9b0".
+   // This exact version will be used to spawn off a new ledger canister when an ERC-20 token is added.
+   ledger_compressed_wasm_hash: text;
+
+   // Hexadecimal encoding of the SHA2-256 index compressed wasm hash, e.g.,
+   // "3a6d39b5e94cdef5203bca62720e75a28cd071ff434d22b9746403ac7ae59614".
+   // This exact version will be used to spawn off a new index canister when an ERC-20 token is added.
+   index_compressed_wasm_hash: text;
+
+   // Hexadecimal encoding of the SHA2-256 archive compressed wasm hash, e.g.,
+   // "e59ec306ef67d0ec2e8919e8f6366aff31c666346e238d07d52f616bef61ccab".
+   archive_compressed_wasm_hash: text;
 };
 
 type UpdateCyclesManagement = record {
@@ -213,7 +200,7 @@ service : (OrchestratorArg) -> {
    // Return internal orchestrator parameters
    get_orchestrator_info : () -> (OrchestratorInfo) query;
 
-   // Retrieve the status of the minter canister.
+   // Retrieve the status of the canister.
    get_canister_status : () -> (CanisterStatusResponse);
 
 }

--- a/packages/cketh/candid/orchestrator.idl.js
+++ b/packages/cketh/candid/orchestrator.idl.js
@@ -28,32 +28,16 @@ export const idlFactory = ({ IDL }) => {
     'chain_id' : IDL.Nat,
     'address' : IDL.Text,
   });
-  const LedgerSubaccount = IDL.Vec(IDL.Nat8);
-  const LedgerAccount = IDL.Record({
-    'owner' : IDL.Principal,
-    'subaccount' : IDL.Opt(LedgerSubaccount),
-  });
-  const LedgerFeatureFlags = IDL.Record({ 'icrc2' : IDL.Bool });
   const LedgerInitArg = IDL.Record({
-    'decimals' : IDL.Opt(IDL.Nat8),
+    'decimals' : IDL.Nat8,
     'token_symbol' : IDL.Text,
     'transfer_fee' : IDL.Nat,
-    'minting_account' : LedgerAccount,
-    'initial_balances' : IDL.Vec(IDL.Tuple(LedgerAccount, IDL.Nat)),
-    'maximum_number_of_accounts' : IDL.Opt(IDL.Nat64),
-    'accounts_overflow_trim_quantity' : IDL.Opt(IDL.Nat64),
-    'fee_collector_account' : IDL.Opt(LedgerAccount),
-    'max_memo_length' : IDL.Opt(IDL.Nat16),
     'token_logo' : IDL.Text,
     'token_name' : IDL.Text,
-    'feature_flags' : IDL.Opt(LedgerFeatureFlags),
   });
   const AddErc20Arg = IDL.Record({
     'contract' : Erc20Contract,
     'ledger_init_arg' : LedgerInitArg,
-    'git_commit_hash' : IDL.Text,
-    'ledger_compressed_wasm_hash' : IDL.Text,
-    'index_compressed_wasm_hash' : IDL.Text,
   });
   const OrchestratorArg = IDL.Variant({
     'UpgradeArg' : UpgradeArg,
@@ -107,10 +91,16 @@ export const idlFactory = ({ IDL }) => {
     'archives' : IDL.Vec(IDL.Principal),
     'ckerc20_token_symbol' : IDL.Text,
   });
+  const LedgerSuiteVersion = IDL.Record({
+    'archive_compressed_wasm_hash' : IDL.Text,
+    'ledger_compressed_wasm_hash' : IDL.Text,
+    'index_compressed_wasm_hash' : IDL.Text,
+  });
   const OrchestratorInfo = IDL.Record({
     'cycles_management' : CyclesManagement,
     'managed_canisters' : IDL.Vec(ManagedCanisters),
     'more_controller_ids' : IDL.Vec(IDL.Principal),
+    'ledger_suite_version' : IDL.Opt(LedgerSuiteVersion),
     'minter_id' : IDL.Opt(IDL.Principal),
   });
   return IDL.Service({
@@ -152,32 +142,16 @@ export const init = ({ IDL }) => {
     'chain_id' : IDL.Nat,
     'address' : IDL.Text,
   });
-  const LedgerSubaccount = IDL.Vec(IDL.Nat8);
-  const LedgerAccount = IDL.Record({
-    'owner' : IDL.Principal,
-    'subaccount' : IDL.Opt(LedgerSubaccount),
-  });
-  const LedgerFeatureFlags = IDL.Record({ 'icrc2' : IDL.Bool });
   const LedgerInitArg = IDL.Record({
-    'decimals' : IDL.Opt(IDL.Nat8),
+    'decimals' : IDL.Nat8,
     'token_symbol' : IDL.Text,
     'transfer_fee' : IDL.Nat,
-    'minting_account' : LedgerAccount,
-    'initial_balances' : IDL.Vec(IDL.Tuple(LedgerAccount, IDL.Nat)),
-    'maximum_number_of_accounts' : IDL.Opt(IDL.Nat64),
-    'accounts_overflow_trim_quantity' : IDL.Opt(IDL.Nat64),
-    'fee_collector_account' : IDL.Opt(LedgerAccount),
-    'max_memo_length' : IDL.Opt(IDL.Nat16),
     'token_logo' : IDL.Text,
     'token_name' : IDL.Text,
-    'feature_flags' : IDL.Opt(LedgerFeatureFlags),
   });
   const AddErc20Arg = IDL.Record({
     'contract' : Erc20Contract,
     'ledger_init_arg' : LedgerInitArg,
-    'git_commit_hash' : IDL.Text,
-    'ledger_compressed_wasm_hash' : IDL.Text,
-    'index_compressed_wasm_hash' : IDL.Text,
   });
   const OrchestratorArg = IDL.Variant({
     'UpgradeArg' : UpgradeArg,

--- a/packages/cketh/src/orchestrator.canister.spec.ts
+++ b/packages/cketh/src/orchestrator.canister.spec.ts
@@ -58,6 +58,13 @@ describe("ckETH orchestrator canister", () => {
           cycles_for_ledger_creation: 2_000_000_000_000n,
         },
         managed_canisters: [ckSepoliaUSDCInfoMock],
+        ledger_suite_version: [
+          {
+            archive_compressed_wasm_hash: "1234",
+            ledger_compressed_wasm_hash: "abcd",
+            index_compressed_wasm_hash: "efgdh",
+          },
+        ],
       };
 
       const service = mock<ActorSubclass<CkETHOrchestratorService>>();


### PR DESCRIPTION
# Motivation

This PR update the ckETH candid files as provided in bot PR #682 and add the new additional candid optional fields to the orchestrator info mock.

# Changes

- Copy did files from #682.
- Update `orchestratorInfoMock` with `ledger_suite_version` field.


# Todos

- [ ] Add entry to changelog (if necessary).
