### PR TITLE
Update IC and add conversions for new NNS Governance types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The current status of the libraries at the time of the release is as follows:
 - Extend `eip1559TransactionPrice` for Erc20.
 - Add "Protocol Canister Management" and "Service Nervous System Management" topics support.
 - Add `asNonNullish` function, like `assertNonNullish` but returns the value.
-- Support conversion of `InstallCode` action.
+- Support conversion of `InstallCode`, `StopOrStartCanister` and `UpdateCanisterSettings` actions, `SetVisibility` neuron operation, and `Neuron::visibility` attribute.
 
 ## Fix
 

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -155,7 +155,7 @@ Parameters:
 
 ### :factory: GovernanceCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L93)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L94)
 
 #### Methods
 
@@ -173,6 +173,7 @@ Parameters:
 - [joinCommunityFund](#gear-joincommunityfund)
 - [autoStakeMaturity](#gear-autostakematurity)
 - [leaveCommunityFund](#gear-leavecommunityfund)
+- [setVisibility](#gear-setvisibility)
 - [setNodeProviderAccount](#gear-setnodeprovideraccount)
 - [mergeNeurons](#gear-mergeneurons)
 - [simulateMergeNeurons](#gear-simulatemergeneurons)
@@ -197,7 +198,7 @@ Parameters:
 | -------- | ------------------------------------------------------------- |
 | `create` | `(options?: GovernanceCanisterOptions) => GovernanceCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L108)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L109)
 
 ##### :gear: listNeurons
 
@@ -214,7 +215,7 @@ The backend treats `includeEmptyNeurons` as true if absent.
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `listNeurons` | `({ certified, neuronIds, includeEmptyNeurons, }: { certified: boolean; neuronIds?: bigint[] or undefined; includeEmptyNeurons?: boolean or undefined; }) => Promise<NeuronInfo[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L148)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L149)
 
 ##### :gear: listKnownNeurons
 
@@ -228,7 +229,7 @@ it is fetched using a query call.
 | ------------------ | ------------------------------------------------- |
 | `listKnownNeurons` | `(certified?: boolean) => Promise<KnownNeuron[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L181)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L182)
 
 ##### :gear: getLastestRewardEvent
 
@@ -241,7 +242,7 @@ it's fetched using a query call.
 | ----------------------- | ----------------------------------------------- |
 | `getLastestRewardEvent` | `(certified?: boolean) => Promise<RewardEvent>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L203)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L204)
 
 ##### :gear: listProposals
 
@@ -260,7 +261,7 @@ Parameters:
 - `request`: the options to list the proposals (limit number of results, topics to search for, etc.)
 - `certified`: query or update calls
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L219)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L220)
 
 ##### :gear: stakeNeuron
 
@@ -268,7 +269,7 @@ Parameters:
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `stakeNeuron` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, fee, }: { stake: bigint; principal: Principal; fromSubAccount?: number[] or undefined; ledgerCanister: LedgerCanister; createdAt?: bigint or undefined; fee?: bigint or undefined; }) => Promise<...>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L238)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L239)
 
 ##### :gear: stakeNeuronIcrc1
 
@@ -276,7 +277,7 @@ Parameters:
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `stakeNeuronIcrc1` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, fee, }: { stake: bigint; principal: Principal; fromSubAccount?: Uint8Array or undefined; ledgerCanister: LedgerCanister; createdAt?: bigint or undefined; fee?: bigint or undefined; }) => Promise<...>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L304)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L305)
 
 ##### :gear: increaseDissolveDelay
 
@@ -286,7 +287,7 @@ Increases dissolve delay of a neuron
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `increaseDissolveDelay` | `({ neuronId, additionalDissolveDelaySeconds, }: { neuronId: bigint; additionalDissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L369)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L370)
 
 ##### :gear: setDissolveDelay
 
@@ -297,7 +298,7 @@ The new date is now + dissolveDelaySeconds.
 | ------------------ | ------------------------------------------------------------------------------------------------------------- |
 | `setDissolveDelay` | `({ neuronId, dissolveDelaySeconds, }: { neuronId: bigint; dissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L395)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L396)
 
 ##### :gear: startDissolving
 
@@ -307,7 +308,7 @@ Start dissolving process of a neuron
 | ----------------- | ------------------------------------- |
 | `startDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L418)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L419)
 
 ##### :gear: stopDissolving
 
@@ -317,7 +318,7 @@ Stop dissolving process of a neuron
 | ---------------- | ------------------------------------- |
 | `stopDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L432)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L433)
 
 ##### :gear: joinCommunityFund
 
@@ -327,7 +328,7 @@ Neuron joins the community fund
 | ------------------- | ------------------------------------- |
 | `joinCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L446)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L447)
 
 ##### :gear: autoStakeMaturity
 
@@ -342,7 +343,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to request a change of the auto stake feature
 - `autoStake`: `true` to enable the auto-stake maturity for this neuron, `false` to turn it off
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L464)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L465)
 
 ##### :gear: leaveCommunityFund
 
@@ -352,7 +353,17 @@ Neuron leaves the community fund
 | -------------------- | ------------------------------------- |
 | `leaveCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L479)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L480)
+
+##### :gear: setVisibility
+
+Set visibility of a neuron
+
+| Method          | Type                                                                |
+| --------------- | ------------------------------------------------------------------- |
+| `setVisibility` | `(neuronId: bigint, visibility: NeuronVisibility) => Promise<void>` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L494)
 
 ##### :gear: setNodeProviderAccount
 
@@ -363,7 +374,7 @@ Where the reward is paid to.
 | ------------------------ | ---------------------------------------------- |
 | `setNodeProviderAccount` | `(accountIdentifier: string) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L496)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L514)
 
 ##### :gear: mergeNeurons
 
@@ -373,7 +384,7 @@ Merge two neurons
 | -------------- | --------------------------------------------------------------------------------- |
 | `mergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L516)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L534)
 
 ##### :gear: simulateMergeNeurons
 
@@ -383,7 +394,7 @@ Simulate merging two neurons
 | ---------------------- | --------------------------------------------------------------------------------------- |
 | `simulateMergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<NeuronInfo>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L533)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L551)
 
 ##### :gear: splitNeuron
 
@@ -393,7 +404,7 @@ Splits a neuron creating a new one
 | ------------- | ----------------------------------------------------------------------------------- |
 | `splitNeuron` | `({ neuronId, amount, }: { neuronId: bigint; amount: bigint; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L578)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L596)
 
 ##### :gear: getProposal
 
@@ -406,7 +417,7 @@ it is fetched using a query call.
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `getProposal` | `({ proposalId, certified, }: { proposalId: bigint; certified?: boolean or undefined; }) => Promise<ProposalInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L618)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L636)
 
 ##### :gear: makeProposal
 
@@ -416,7 +427,7 @@ Create new proposal
 | -------------- | ---------------------------------------------------------------- |
 | `makeProposal` | `(request: MakeProposalRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L636)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L654)
 
 ##### :gear: registerVote
 
@@ -426,7 +437,7 @@ Registers vote for a proposal from the neuron passed.
 | -------------- | ----------------------------------------------------------------------------------------------------------- |
 | `registerVote` | `({ neuronId, vote, proposalId, }: { neuronId: bigint; vote: Vote; proposalId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L657)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L675)
 
 ##### :gear: setFollowees
 
@@ -436,7 +447,7 @@ Edit neuron followees per topic
 | -------------- | ------------------------------------------------- |
 | `setFollowees` | `(followRequest: FollowRequest) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L679)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L697)
 
 ##### :gear: disburse
 
@@ -446,7 +457,7 @@ Disburse neuron on Account
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `disburse` | `({ neuronId, toAccountId, amount, }: { neuronId: bigint; toAccountId?: string or undefined; amount?: bigint or undefined; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L694)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L712)
 
 ##### :gear: mergeMaturity
 
@@ -456,7 +467,7 @@ Merge Maturity of a neuron
 | --------------- | ------------------------------------------------------------------------------------------------------- |
 | `mergeMaturity` | `({ neuronId, percentageToMerge, }: { neuronId: bigint; percentageToMerge: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L730)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L748)
 
 ##### :gear: stakeMaturity
 
@@ -471,7 +482,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to stake the maturity
 - `percentageToStake`: Optional. Percentage of the current maturity to stake. If not provided, all of the neuron's current maturity will be staked.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L759)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L777)
 
 ##### :gear: spawnNeuron
 
@@ -481,7 +492,7 @@ Merge Maturity of a neuron
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `spawnNeuron` | `({ neuronId, percentageToSpawn, newController, nonce, }: { neuronId: bigint; percentageToSpawn?: number or undefined; newController?: Principal or undefined; nonce?: bigint or undefined; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L781)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L799)
 
 ##### :gear: addHotkey
 
@@ -491,7 +502,7 @@ Add hotkey to neuron
 | ----------- | ------------------------------------------------------------------------------------------ |
 | `addHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L828)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L846)
 
 ##### :gear: removeHotkey
 
@@ -501,7 +512,7 @@ Remove hotkey to neuron
 | -------------- | ------------------------------------------------------------------------------------------ |
 | `removeHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L848)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L866)
 
 ##### :gear: claimOrRefreshNeuronFromAccount
 
@@ -511,7 +522,7 @@ Gets the NeuronID of a newly created neuron.
 | --------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `claimOrRefreshNeuronFromAccount` | `({ memo, controller, }: { memo: bigint; controller?: Principal or undefined; }) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L866)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L884)
 
 ##### :gear: claimOrRefreshNeuron
 
@@ -522,7 +533,7 @@ Uses query call only.
 | ---------------------- | ------------------------------------------------------------------------ |
 | `claimOrRefreshNeuron` | `(request: ClaimOrRefreshNeuronRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L897)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L915)
 
 ##### :gear: getNeuron
 
@@ -532,7 +543,7 @@ Return the data of the neuron provided as id.
 | ----------- | ----------------------------------------------------------------------------------------------------------- |
 | `getNeuron` | `({ certified, neuronId, }: { certified: boolean; neuronId: bigint; }) => Promise<NeuronInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L948)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L966)
 
 ### :factory: SnsWasmCanister
 

--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit de29a1a (2024-07-18 tags: release-2024-07-18_01-30--github-base) 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit 2b109fb9ba (2024-07-25) 'rs/nns/gtc/canister/gtc.did' by import-candid
 type AccountState = record {
   authenticated_principal_id : opt principal;
   successfully_transferred_neurons : vec TransferredNeuron;

--- a/packages/nns/candid/governance.certified.idl.js
+++ b/packages/nns/candid/governance.certified.idl.js
@@ -41,6 +41,7 @@ export const idlFactory = ({ IDL }) => {
   const IncreaseDissolveDelay = IDL.Record({
     'additional_dissolve_delay_seconds' : IDL.Nat32,
   });
+  const SetVisibility = IDL.Record({ 'visibility' : IDL.Opt(IDL.Int32) });
   const SetDissolveTimestamp = IDL.Record({
     'dissolve_timestamp_seconds' : IDL.Nat64,
   });
@@ -51,6 +52,7 @@ export const idlFactory = ({ IDL }) => {
     'StopDissolving' : IDL.Record({}),
     'StartDissolving' : IDL.Record({}),
     'IncreaseDissolveDelay' : IncreaseDissolveDelay,
+    'SetVisibility' : SetVisibility,
     'JoinCommunityFund' : IDL.Record({}),
     'LeaveCommunityFund' : IDL.Record({}),
     'SetDissolveTimestamp' : SetDissolveTimestamp,
@@ -101,12 +103,29 @@ export const idlFactory = ({ IDL }) => {
     'command' : IDL.Opt(Command),
     'neuron_id_or_subaccount' : IDL.Opt(NeuronIdOrSubaccount),
   });
+  const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
+  const CanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'controllers' : IDL.Opt(Controllers),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
+  const UpdateCanisterSettings = IDL.Record({
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'settings' : IDL.Opt(CanisterSettings),
+  });
   const InstallCode = IDL.Record({
     'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
     'canister_id' : IDL.Opt(IDL.Principal),
     'install_mode' : IDL.Opt(IDL.Int32),
+  });
+  const StopOrStartCanister = IDL.Record({
+    'action' : IDL.Opt(IDL.Int32),
+    'canister_id' : IDL.Opt(IDL.Principal),
   });
   const Percentage = IDL.Record({ 'basis_points' : IDL.Opt(IDL.Nat64) });
   const Duration = IDL.Record({ 'seconds' : IDL.Opt(IDL.Nat64) });
@@ -288,7 +307,9 @@ export const idlFactory = ({ IDL }) => {
   const Action = IDL.Variant({
     'RegisterKnownNeuron' : KnownNeuron,
     'ManageNeuron' : ManageNeuron,
+    'UpdateCanisterSettings' : UpdateCanisterSettings,
     'InstallCode' : InstallCode,
+    'StopOrStartCanister' : StopOrStartCanister,
     'CreateServiceNervousSystem' : CreateServiceNervousSystem,
     'ExecuteNnsFunction' : ExecuteNnsFunction,
     'RewardNodeProvider' : RewardNodeProvider,
@@ -455,10 +476,12 @@ export const idlFactory = ({ IDL }) => {
   });
   const CfNeuron = IDL.Record({
     'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
+    'hotkeys' : IDL.Opt(Principals),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
   const CfParticipant = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
     'hotkey_principal' : IDL.Text,
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
@@ -600,6 +623,7 @@ export const idlFactory = ({ IDL }) => {
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,
+    'visibility' : IDL.Opt(IDL.Int32),
     'transfer' : IDL.Opt(NeuronStakeTransfer),
     'known_neuron_data' : IDL.Opt(KnownNeuronData),
     'spawn_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
@@ -658,6 +682,7 @@ export const idlFactory = ({ IDL }) => {
     'stake_e8s' : IDL.Nat64,
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'retrieved_at_timestamp_seconds' : IDL.Nat64,
+    'visibility' : IDL.Opt(IDL.Int32),
     'known_neuron_data' : IDL.Opt(KnownNeuronData),
     'voting_power' : IDL.Nat64,
     'age_seconds' : IDL.Nat64,
@@ -924,6 +949,7 @@ export const init = ({ IDL }) => {
   const IncreaseDissolveDelay = IDL.Record({
     'additional_dissolve_delay_seconds' : IDL.Nat32,
   });
+  const SetVisibility = IDL.Record({ 'visibility' : IDL.Opt(IDL.Int32) });
   const SetDissolveTimestamp = IDL.Record({
     'dissolve_timestamp_seconds' : IDL.Nat64,
   });
@@ -934,6 +960,7 @@ export const init = ({ IDL }) => {
     'StopDissolving' : IDL.Record({}),
     'StartDissolving' : IDL.Record({}),
     'IncreaseDissolveDelay' : IncreaseDissolveDelay,
+    'SetVisibility' : SetVisibility,
     'JoinCommunityFund' : IDL.Record({}),
     'LeaveCommunityFund' : IDL.Record({}),
     'SetDissolveTimestamp' : SetDissolveTimestamp,
@@ -984,12 +1011,29 @@ export const init = ({ IDL }) => {
     'command' : IDL.Opt(Command),
     'neuron_id_or_subaccount' : IDL.Opt(NeuronIdOrSubaccount),
   });
+  const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
+  const CanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'controllers' : IDL.Opt(Controllers),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
+  const UpdateCanisterSettings = IDL.Record({
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'settings' : IDL.Opt(CanisterSettings),
+  });
   const InstallCode = IDL.Record({
     'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
     'canister_id' : IDL.Opt(IDL.Principal),
     'install_mode' : IDL.Opt(IDL.Int32),
+  });
+  const StopOrStartCanister = IDL.Record({
+    'action' : IDL.Opt(IDL.Int32),
+    'canister_id' : IDL.Opt(IDL.Principal),
   });
   const Percentage = IDL.Record({ 'basis_points' : IDL.Opt(IDL.Nat64) });
   const Duration = IDL.Record({ 'seconds' : IDL.Opt(IDL.Nat64) });
@@ -1171,7 +1215,9 @@ export const init = ({ IDL }) => {
   const Action = IDL.Variant({
     'RegisterKnownNeuron' : KnownNeuron,
     'ManageNeuron' : ManageNeuron,
+    'UpdateCanisterSettings' : UpdateCanisterSettings,
     'InstallCode' : InstallCode,
+    'StopOrStartCanister' : StopOrStartCanister,
     'CreateServiceNervousSystem' : CreateServiceNervousSystem,
     'ExecuteNnsFunction' : ExecuteNnsFunction,
     'RewardNodeProvider' : RewardNodeProvider,
@@ -1338,10 +1384,12 @@ export const init = ({ IDL }) => {
   });
   const CfNeuron = IDL.Record({
     'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
+    'hotkeys' : IDL.Opt(Principals),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
   const CfParticipant = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
     'hotkey_principal' : IDL.Text,
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
@@ -1483,6 +1531,7 @@ export const init = ({ IDL }) => {
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,
+    'visibility' : IDL.Opt(IDL.Int32),
     'transfer' : IDL.Opt(NeuronStakeTransfer),
     'known_neuron_data' : IDL.Opt(KnownNeuronData),
     'spawn_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -8,7 +8,9 @@ export interface AccountIdentifier {
 export type Action =
   | { RegisterKnownNeuron: KnownNeuron }
   | { ManageNeuron: ManageNeuron }
+  | { UpdateCanisterSettings: UpdateCanisterSettings }
   | { InstallCode: InstallCode }
+  | { StopOrStartCanister: StopOrStartCanister }
   | { CreateServiceNervousSystem: CreateServiceNervousSystem }
   | { ExecuteNnsFunction: ExecuteNnsFunction }
   | { RewardNodeProvider: RewardNodeProvider }
@@ -47,6 +49,14 @@ export type By =
 export interface Canister {
   id: [] | [Principal];
 }
+export interface CanisterSettings {
+  freezing_threshold: [] | [bigint];
+  controllers: [] | [Controllers];
+  log_visibility: [] | [number];
+  wasm_memory_limit: [] | [bigint];
+  memory_allocation: [] | [bigint];
+  compute_allocation: [] | [bigint];
+}
 export interface CanisterStatusResultV2 {
   status: [] | [number];
   freezing_threshold: [] | [bigint];
@@ -62,10 +72,12 @@ export interface CanisterSummary {
 }
 export interface CfNeuron {
   has_created_neuron_recipes: [] | [boolean];
+  hotkeys: [] | [Principals];
   nns_neuron_id: bigint;
   amount_icp_e8s: bigint;
 }
 export interface CfParticipant {
+  controller: [] | [Principal];
   hotkey_principal: string;
   cf_neurons: Array<CfNeuron>;
 }
@@ -135,6 +147,9 @@ export interface Committed_1 {
 }
 export interface Configure {
   operation: [] | [Operation];
+}
+export interface Controllers {
+  controllers: Array<Principal>;
 }
 export interface Countries {
   iso_codes: Array<string>;
@@ -438,6 +453,7 @@ export interface Neuron {
   dissolve_state: [] | [DissolveState];
   followees: Array<[number, Followees]>;
   neuron_fees_e8s: bigint;
+  visibility: [] | [number];
   transfer: [] | [NeuronStakeTransfer];
   known_neuron_data: [] | [KnownNeuronData];
   spawn_at_timestamp_seconds: [] | [bigint];
@@ -476,6 +492,7 @@ export interface NeuronInfo {
   stake_e8s: bigint;
   joined_community_fund_timestamp_seconds: [] | [bigint];
   retrieved_at_timestamp_seconds: bigint;
+  visibility: [] | [number];
   known_neuron_data: [] | [KnownNeuronData];
   voting_power: bigint;
   age_seconds: bigint;
@@ -578,6 +595,7 @@ export type Operation =
   | { StopDissolving: {} }
   | { StartDissolving: {} }
   | { IncreaseDissolveDelay: IncreaseDissolveDelay }
+  | { SetVisibility: SetVisibility }
   | { JoinCommunityFund: {} }
   | { LeaveCommunityFund: {} }
   | { SetDissolveTimestamp: SetDissolveTimestamp };
@@ -718,6 +736,9 @@ export interface SetSnsTokenSwapOpenTimeWindow {
   request: [] | [SetOpenTimeWindowRequest];
   swap_canister_id: [] | [Principal];
 }
+export interface SetVisibility {
+  visibility: [] | [number];
+}
 export interface SettleCommunityFundParticipation {
   result: [] | [Result_8];
   open_sns_token_swap_proposal_id: [] | [bigint];
@@ -746,6 +767,10 @@ export interface StakeMaturity {
 export interface StakeMaturityResponse {
   maturity_e8s: bigint;
   staked_maturity_e8s: bigint;
+}
+export interface StopOrStartCanister {
+  action: [] | [number];
+  canister_id: [] | [Principal];
 }
 export interface SwapBackgroundInformation {
   ledger_index_canister_summary: [] | [CanisterSummary];
@@ -796,6 +821,10 @@ export interface TimeWindow {
 }
 export interface Tokens {
   e8s: [] | [bigint];
+}
+export interface UpdateCanisterSettings {
+  canister_id: [] | [Principal];
+  settings: [] | [CanisterSettings];
 }
 export interface UpdateNodeProvider {
   reward_account: [] | [AccountIdentifier];

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,9 +1,11 @@
-// Generated from IC repo commit de29a1a (2024-07-18 tags: release-2024-07-18_01-30--github-base) 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 2b109fb9ba (2024-07-25) 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
   ManageNeuron : ManageNeuron;
+  UpdateCanisterSettings : UpdateCanisterSettings;
   InstallCode : InstallCode;
+  StopOrStartCanister : StopOrStartCanister;
   CreateServiceNervousSystem : CreateServiceNervousSystem;
   ExecuteNnsFunction : ExecuteNnsFunction;
   RewardNodeProvider : RewardNodeProvider;
@@ -28,6 +30,14 @@ type By = variant {
   Memo : nat64;
 };
 type Canister = record { id : opt principal };
+type CanisterSettings = record {
+  freezing_threshold : opt nat64;
+  controllers : opt Controllers;
+  log_visibility : opt int32;
+  wasm_memory_limit : opt nat64;
+  memory_allocation : opt nat64;
+  compute_allocation : opt nat64;
+};
 type CanisterStatusResultV2 = record {
   status : opt int32;
   freezing_threshold : opt nat64;
@@ -43,10 +53,12 @@ type CanisterSummary = record {
 };
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
+  hotkeys : opt Principals;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
 type CfParticipant = record {
+  controller : opt principal;
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };
@@ -112,6 +124,7 @@ type Committed_1 = record {
   sns_governance_canister_id : opt principal;
 };
 type Configure = record { operation : opt Operation };
+type Controllers = record { controllers : vec principal };
 type Countries = record { iso_codes : vec text };
 type CreateServiceNervousSystem = record {
   url : opt text;
@@ -367,6 +380,7 @@ type Neuron = record {
   dissolve_state : opt DissolveState;
   followees : vec record { int32; Followees };
   neuron_fees_e8s : nat64;
+  visibility : opt int32;
   transfer : opt NeuronStakeTransfer;
   known_neuron_data : opt KnownNeuronData;
   spawn_at_timestamp_seconds : opt nat64;
@@ -401,6 +415,7 @@ type NeuronInfo = record {
   stake_e8s : nat64;
   joined_community_fund_timestamp_seconds : opt nat64;
   retrieved_at_timestamp_seconds : nat64;
+  visibility : opt int32;
   known_neuron_data : opt KnownNeuronData;
   voting_power : nat64;
   age_seconds : nat64;
@@ -495,6 +510,7 @@ type Operation = variant {
   StopDissolving : record {};
   StartDissolving : record {};
   IncreaseDissolveDelay : IncreaseDissolveDelay;
+  SetVisibility : SetVisibility;
   JoinCommunityFund : record {};
   LeaveCommunityFund : record {};
   SetDissolveTimestamp : SetDissolveTimestamp;
@@ -616,6 +632,7 @@ type SetSnsTokenSwapOpenTimeWindow = record {
   request : opt SetOpenTimeWindowRequest;
   swap_canister_id : opt principal;
 };
+type SetVisibility = record { visibility : opt int32 };
 type SettleCommunityFundParticipation = record {
   result : opt Result_8;
   open_sns_token_swap_proposal_id : opt nat64;
@@ -636,6 +653,10 @@ type StakeMaturity = record { percentage_to_stake : opt nat32 };
 type StakeMaturityResponse = record {
   maturity_e8s : nat64;
   staked_maturity_e8s : nat64;
+};
+type StopOrStartCanister = record {
+  action : opt int32;
+  canister_id : opt principal;
 };
 type SwapBackgroundInformation = record {
   ledger_index_canister_summary : opt CanisterSummary;
@@ -681,6 +702,10 @@ type TimeWindow = record {
   end_timestamp_seconds : nat64;
 };
 type Tokens = record { e8s : opt nat64 };
+type UpdateCanisterSettings = record {
+  canister_id : opt principal;
+  settings : opt CanisterSettings;
+};
 type UpdateNodeProvider = record { reward_account : opt AccountIdentifier };
 type VotingRewardParameters = record {
   reward_rate_transition_duration : opt Duration;

--- a/packages/nns/candid/governance.idl.js
+++ b/packages/nns/candid/governance.idl.js
@@ -41,6 +41,7 @@ export const idlFactory = ({ IDL }) => {
   const IncreaseDissolveDelay = IDL.Record({
     'additional_dissolve_delay_seconds' : IDL.Nat32,
   });
+  const SetVisibility = IDL.Record({ 'visibility' : IDL.Opt(IDL.Int32) });
   const SetDissolveTimestamp = IDL.Record({
     'dissolve_timestamp_seconds' : IDL.Nat64,
   });
@@ -51,6 +52,7 @@ export const idlFactory = ({ IDL }) => {
     'StopDissolving' : IDL.Record({}),
     'StartDissolving' : IDL.Record({}),
     'IncreaseDissolveDelay' : IncreaseDissolveDelay,
+    'SetVisibility' : SetVisibility,
     'JoinCommunityFund' : IDL.Record({}),
     'LeaveCommunityFund' : IDL.Record({}),
     'SetDissolveTimestamp' : SetDissolveTimestamp,
@@ -101,12 +103,29 @@ export const idlFactory = ({ IDL }) => {
     'command' : IDL.Opt(Command),
     'neuron_id_or_subaccount' : IDL.Opt(NeuronIdOrSubaccount),
   });
+  const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
+  const CanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'controllers' : IDL.Opt(Controllers),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
+  const UpdateCanisterSettings = IDL.Record({
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'settings' : IDL.Opt(CanisterSettings),
+  });
   const InstallCode = IDL.Record({
     'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
     'canister_id' : IDL.Opt(IDL.Principal),
     'install_mode' : IDL.Opt(IDL.Int32),
+  });
+  const StopOrStartCanister = IDL.Record({
+    'action' : IDL.Opt(IDL.Int32),
+    'canister_id' : IDL.Opt(IDL.Principal),
   });
   const Percentage = IDL.Record({ 'basis_points' : IDL.Opt(IDL.Nat64) });
   const Duration = IDL.Record({ 'seconds' : IDL.Opt(IDL.Nat64) });
@@ -288,7 +307,9 @@ export const idlFactory = ({ IDL }) => {
   const Action = IDL.Variant({
     'RegisterKnownNeuron' : KnownNeuron,
     'ManageNeuron' : ManageNeuron,
+    'UpdateCanisterSettings' : UpdateCanisterSettings,
     'InstallCode' : InstallCode,
+    'StopOrStartCanister' : StopOrStartCanister,
     'CreateServiceNervousSystem' : CreateServiceNervousSystem,
     'ExecuteNnsFunction' : ExecuteNnsFunction,
     'RewardNodeProvider' : RewardNodeProvider,
@@ -455,10 +476,12 @@ export const idlFactory = ({ IDL }) => {
   });
   const CfNeuron = IDL.Record({
     'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
+    'hotkeys' : IDL.Opt(Principals),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
   const CfParticipant = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
     'hotkey_principal' : IDL.Text,
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
@@ -600,6 +623,7 @@ export const idlFactory = ({ IDL }) => {
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,
+    'visibility' : IDL.Opt(IDL.Int32),
     'transfer' : IDL.Opt(NeuronStakeTransfer),
     'known_neuron_data' : IDL.Opt(KnownNeuronData),
     'spawn_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
@@ -658,6 +682,7 @@ export const idlFactory = ({ IDL }) => {
     'stake_e8s' : IDL.Nat64,
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'retrieved_at_timestamp_seconds' : IDL.Nat64,
+    'visibility' : IDL.Opt(IDL.Int32),
     'known_neuron_data' : IDL.Opt(KnownNeuronData),
     'voting_power' : IDL.Nat64,
     'age_seconds' : IDL.Nat64,
@@ -940,6 +965,7 @@ export const init = ({ IDL }) => {
   const IncreaseDissolveDelay = IDL.Record({
     'additional_dissolve_delay_seconds' : IDL.Nat32,
   });
+  const SetVisibility = IDL.Record({ 'visibility' : IDL.Opt(IDL.Int32) });
   const SetDissolveTimestamp = IDL.Record({
     'dissolve_timestamp_seconds' : IDL.Nat64,
   });
@@ -950,6 +976,7 @@ export const init = ({ IDL }) => {
     'StopDissolving' : IDL.Record({}),
     'StartDissolving' : IDL.Record({}),
     'IncreaseDissolveDelay' : IncreaseDissolveDelay,
+    'SetVisibility' : SetVisibility,
     'JoinCommunityFund' : IDL.Record({}),
     'LeaveCommunityFund' : IDL.Record({}),
     'SetDissolveTimestamp' : SetDissolveTimestamp,
@@ -1000,12 +1027,29 @@ export const init = ({ IDL }) => {
     'command' : IDL.Opt(Command),
     'neuron_id_or_subaccount' : IDL.Opt(NeuronIdOrSubaccount),
   });
+  const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
+  const CanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'controllers' : IDL.Opt(Controllers),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
+  const UpdateCanisterSettings = IDL.Record({
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'settings' : IDL.Opt(CanisterSettings),
+  });
   const InstallCode = IDL.Record({
     'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
     'canister_id' : IDL.Opt(IDL.Principal),
     'install_mode' : IDL.Opt(IDL.Int32),
+  });
+  const StopOrStartCanister = IDL.Record({
+    'action' : IDL.Opt(IDL.Int32),
+    'canister_id' : IDL.Opt(IDL.Principal),
   });
   const Percentage = IDL.Record({ 'basis_points' : IDL.Opt(IDL.Nat64) });
   const Duration = IDL.Record({ 'seconds' : IDL.Opt(IDL.Nat64) });
@@ -1187,7 +1231,9 @@ export const init = ({ IDL }) => {
   const Action = IDL.Variant({
     'RegisterKnownNeuron' : KnownNeuron,
     'ManageNeuron' : ManageNeuron,
+    'UpdateCanisterSettings' : UpdateCanisterSettings,
     'InstallCode' : InstallCode,
+    'StopOrStartCanister' : StopOrStartCanister,
     'CreateServiceNervousSystem' : CreateServiceNervousSystem,
     'ExecuteNnsFunction' : ExecuteNnsFunction,
     'RewardNodeProvider' : RewardNodeProvider,
@@ -1354,10 +1400,12 @@ export const init = ({ IDL }) => {
   });
   const CfNeuron = IDL.Record({
     'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
+    'hotkeys' : IDL.Opt(Principals),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
   const CfParticipant = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
     'hotkey_principal' : IDL.Text,
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
@@ -1499,6 +1547,7 @@ export const init = ({ IDL }) => {
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,
+    'visibility' : IDL.Opt(IDL.Int32),
     'transfer' : IDL.Opt(NeuronStakeTransfer),
     'known_neuron_data' : IDL.Opt(KnownNeuronData),
     'spawn_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/candid/governance_test.certified.idl.js
+++ b/packages/nns/candid/governance_test.certified.idl.js
@@ -41,6 +41,7 @@ export const idlFactory = ({ IDL }) => {
   const IncreaseDissolveDelay = IDL.Record({
     'additional_dissolve_delay_seconds' : IDL.Nat32,
   });
+  const SetVisibility = IDL.Record({ 'visibility' : IDL.Opt(IDL.Int32) });
   const SetDissolveTimestamp = IDL.Record({
     'dissolve_timestamp_seconds' : IDL.Nat64,
   });
@@ -51,6 +52,7 @@ export const idlFactory = ({ IDL }) => {
     'StopDissolving' : IDL.Record({}),
     'StartDissolving' : IDL.Record({}),
     'IncreaseDissolveDelay' : IncreaseDissolveDelay,
+    'SetVisibility' : SetVisibility,
     'JoinCommunityFund' : IDL.Record({}),
     'LeaveCommunityFund' : IDL.Record({}),
     'SetDissolveTimestamp' : SetDissolveTimestamp,
@@ -101,12 +103,29 @@ export const idlFactory = ({ IDL }) => {
     'command' : IDL.Opt(Command),
     'neuron_id_or_subaccount' : IDL.Opt(NeuronIdOrSubaccount),
   });
+  const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
+  const CanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'controllers' : IDL.Opt(Controllers),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
+  const UpdateCanisterSettings = IDL.Record({
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'settings' : IDL.Opt(CanisterSettings),
+  });
   const InstallCode = IDL.Record({
     'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
     'canister_id' : IDL.Opt(IDL.Principal),
     'install_mode' : IDL.Opt(IDL.Int32),
+  });
+  const StopOrStartCanister = IDL.Record({
+    'action' : IDL.Opt(IDL.Int32),
+    'canister_id' : IDL.Opt(IDL.Principal),
   });
   const Percentage = IDL.Record({ 'basis_points' : IDL.Opt(IDL.Nat64) });
   const Duration = IDL.Record({ 'seconds' : IDL.Opt(IDL.Nat64) });
@@ -288,7 +307,9 @@ export const idlFactory = ({ IDL }) => {
   const Action = IDL.Variant({
     'RegisterKnownNeuron' : KnownNeuron,
     'ManageNeuron' : ManageNeuron,
+    'UpdateCanisterSettings' : UpdateCanisterSettings,
     'InstallCode' : InstallCode,
+    'StopOrStartCanister' : StopOrStartCanister,
     'CreateServiceNervousSystem' : CreateServiceNervousSystem,
     'ExecuteNnsFunction' : ExecuteNnsFunction,
     'RewardNodeProvider' : RewardNodeProvider,
@@ -455,10 +476,12 @@ export const idlFactory = ({ IDL }) => {
   });
   const CfNeuron = IDL.Record({
     'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
+    'hotkeys' : IDL.Opt(Principals),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
   const CfParticipant = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
     'hotkey_principal' : IDL.Text,
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
@@ -600,6 +623,7 @@ export const idlFactory = ({ IDL }) => {
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,
+    'visibility' : IDL.Opt(IDL.Int32),
     'transfer' : IDL.Opt(NeuronStakeTransfer),
     'known_neuron_data' : IDL.Opt(KnownNeuronData),
     'spawn_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
@@ -658,6 +682,7 @@ export const idlFactory = ({ IDL }) => {
     'stake_e8s' : IDL.Nat64,
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'retrieved_at_timestamp_seconds' : IDL.Nat64,
+    'visibility' : IDL.Opt(IDL.Int32),
     'known_neuron_data' : IDL.Opt(KnownNeuronData),
     'voting_power' : IDL.Nat64,
     'age_seconds' : IDL.Nat64,
@@ -925,6 +950,7 @@ export const init = ({ IDL }) => {
   const IncreaseDissolveDelay = IDL.Record({
     'additional_dissolve_delay_seconds' : IDL.Nat32,
   });
+  const SetVisibility = IDL.Record({ 'visibility' : IDL.Opt(IDL.Int32) });
   const SetDissolveTimestamp = IDL.Record({
     'dissolve_timestamp_seconds' : IDL.Nat64,
   });
@@ -935,6 +961,7 @@ export const init = ({ IDL }) => {
     'StopDissolving' : IDL.Record({}),
     'StartDissolving' : IDL.Record({}),
     'IncreaseDissolveDelay' : IncreaseDissolveDelay,
+    'SetVisibility' : SetVisibility,
     'JoinCommunityFund' : IDL.Record({}),
     'LeaveCommunityFund' : IDL.Record({}),
     'SetDissolveTimestamp' : SetDissolveTimestamp,
@@ -985,12 +1012,29 @@ export const init = ({ IDL }) => {
     'command' : IDL.Opt(Command),
     'neuron_id_or_subaccount' : IDL.Opt(NeuronIdOrSubaccount),
   });
+  const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
+  const CanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'controllers' : IDL.Opt(Controllers),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
+  const UpdateCanisterSettings = IDL.Record({
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'settings' : IDL.Opt(CanisterSettings),
+  });
   const InstallCode = IDL.Record({
     'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
     'canister_id' : IDL.Opt(IDL.Principal),
     'install_mode' : IDL.Opt(IDL.Int32),
+  });
+  const StopOrStartCanister = IDL.Record({
+    'action' : IDL.Opt(IDL.Int32),
+    'canister_id' : IDL.Opt(IDL.Principal),
   });
   const Percentage = IDL.Record({ 'basis_points' : IDL.Opt(IDL.Nat64) });
   const Duration = IDL.Record({ 'seconds' : IDL.Opt(IDL.Nat64) });
@@ -1172,7 +1216,9 @@ export const init = ({ IDL }) => {
   const Action = IDL.Variant({
     'RegisterKnownNeuron' : KnownNeuron,
     'ManageNeuron' : ManageNeuron,
+    'UpdateCanisterSettings' : UpdateCanisterSettings,
     'InstallCode' : InstallCode,
+    'StopOrStartCanister' : StopOrStartCanister,
     'CreateServiceNervousSystem' : CreateServiceNervousSystem,
     'ExecuteNnsFunction' : ExecuteNnsFunction,
     'RewardNodeProvider' : RewardNodeProvider,
@@ -1339,10 +1385,12 @@ export const init = ({ IDL }) => {
   });
   const CfNeuron = IDL.Record({
     'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
+    'hotkeys' : IDL.Opt(Principals),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
   const CfParticipant = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
     'hotkey_principal' : IDL.Text,
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
@@ -1484,6 +1532,7 @@ export const init = ({ IDL }) => {
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,
+    'visibility' : IDL.Opt(IDL.Int32),
     'transfer' : IDL.Opt(NeuronStakeTransfer),
     'known_neuron_data' : IDL.Opt(KnownNeuronData),
     'spawn_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/candid/governance_test.d.ts
+++ b/packages/nns/candid/governance_test.d.ts
@@ -8,7 +8,9 @@ export interface AccountIdentifier {
 export type Action =
   | { RegisterKnownNeuron: KnownNeuron }
   | { ManageNeuron: ManageNeuron }
+  | { UpdateCanisterSettings: UpdateCanisterSettings }
   | { InstallCode: InstallCode }
+  | { StopOrStartCanister: StopOrStartCanister }
   | { CreateServiceNervousSystem: CreateServiceNervousSystem }
   | { ExecuteNnsFunction: ExecuteNnsFunction }
   | { RewardNodeProvider: RewardNodeProvider }
@@ -47,6 +49,14 @@ export type By =
 export interface Canister {
   id: [] | [Principal];
 }
+export interface CanisterSettings {
+  freezing_threshold: [] | [bigint];
+  controllers: [] | [Controllers];
+  log_visibility: [] | [number];
+  wasm_memory_limit: [] | [bigint];
+  memory_allocation: [] | [bigint];
+  compute_allocation: [] | [bigint];
+}
 export interface CanisterStatusResultV2 {
   status: [] | [number];
   freezing_threshold: [] | [bigint];
@@ -62,10 +72,12 @@ export interface CanisterSummary {
 }
 export interface CfNeuron {
   has_created_neuron_recipes: [] | [boolean];
+  hotkeys: [] | [Principals];
   nns_neuron_id: bigint;
   amount_icp_e8s: bigint;
 }
 export interface CfParticipant {
+  controller: [] | [Principal];
   hotkey_principal: string;
   cf_neurons: Array<CfNeuron>;
 }
@@ -135,6 +147,9 @@ export interface Committed_1 {
 }
 export interface Configure {
   operation: [] | [Operation];
+}
+export interface Controllers {
+  controllers: Array<Principal>;
 }
 export interface Countries {
   iso_codes: Array<string>;
@@ -438,6 +453,7 @@ export interface Neuron {
   dissolve_state: [] | [DissolveState];
   followees: Array<[number, Followees]>;
   neuron_fees_e8s: bigint;
+  visibility: [] | [number];
   transfer: [] | [NeuronStakeTransfer];
   known_neuron_data: [] | [KnownNeuronData];
   spawn_at_timestamp_seconds: [] | [bigint];
@@ -476,6 +492,7 @@ export interface NeuronInfo {
   stake_e8s: bigint;
   joined_community_fund_timestamp_seconds: [] | [bigint];
   retrieved_at_timestamp_seconds: bigint;
+  visibility: [] | [number];
   known_neuron_data: [] | [KnownNeuronData];
   voting_power: bigint;
   age_seconds: bigint;
@@ -578,6 +595,7 @@ export type Operation =
   | { StopDissolving: {} }
   | { StartDissolving: {} }
   | { IncreaseDissolveDelay: IncreaseDissolveDelay }
+  | { SetVisibility: SetVisibility }
   | { JoinCommunityFund: {} }
   | { LeaveCommunityFund: {} }
   | { SetDissolveTimestamp: SetDissolveTimestamp };
@@ -718,6 +736,9 @@ export interface SetSnsTokenSwapOpenTimeWindow {
   request: [] | [SetOpenTimeWindowRequest];
   swap_canister_id: [] | [Principal];
 }
+export interface SetVisibility {
+  visibility: [] | [number];
+}
 export interface SettleCommunityFundParticipation {
   result: [] | [Result_8];
   open_sns_token_swap_proposal_id: [] | [bigint];
@@ -746,6 +767,10 @@ export interface StakeMaturity {
 export interface StakeMaturityResponse {
   maturity_e8s: bigint;
   staked_maturity_e8s: bigint;
+}
+export interface StopOrStartCanister {
+  action: [] | [number];
+  canister_id: [] | [Principal];
 }
 export interface SwapBackgroundInformation {
   ledger_index_canister_summary: [] | [CanisterSummary];
@@ -796,6 +821,10 @@ export interface TimeWindow {
 }
 export interface Tokens {
   e8s: [] | [bigint];
+}
+export interface UpdateCanisterSettings {
+  canister_id: [] | [Principal];
+  settings: [] | [CanisterSettings];
 }
 export interface UpdateNodeProvider {
   reward_account: [] | [AccountIdentifier];

--- a/packages/nns/candid/governance_test.did
+++ b/packages/nns/candid/governance_test.did
@@ -1,9 +1,11 @@
-// Generated from IC repo commit de29a1a (2024-07-18 tags: release-2024-07-18_01-30--github-base) 'rs/nns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 2b109fb9ba (2024-07-25) 'rs/nns/governance/canister/governance_test.did' by import-candid
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
   ManageNeuron : ManageNeuron;
+  UpdateCanisterSettings : UpdateCanisterSettings;
   InstallCode : InstallCode;
+  StopOrStartCanister : StopOrStartCanister;
   CreateServiceNervousSystem : CreateServiceNervousSystem;
   ExecuteNnsFunction : ExecuteNnsFunction;
   RewardNodeProvider : RewardNodeProvider;
@@ -28,6 +30,14 @@ type By = variant {
   Memo : nat64;
 };
 type Canister = record { id : opt principal };
+type CanisterSettings = record {
+  freezing_threshold : opt nat64;
+  controllers : opt Controllers;
+  log_visibility : opt int32;
+  wasm_memory_limit : opt nat64;
+  memory_allocation : opt nat64;
+  compute_allocation : opt nat64;
+};
 type CanisterStatusResultV2 = record {
   status : opt int32;
   freezing_threshold : opt nat64;
@@ -43,10 +53,12 @@ type CanisterSummary = record {
 };
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
+  hotkeys : opt Principals;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
 type CfParticipant = record {
+  controller : opt principal;
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };
@@ -112,6 +124,7 @@ type Committed_1 = record {
   sns_governance_canister_id : opt principal;
 };
 type Configure = record { operation : opt Operation };
+type Controllers = record { controllers : vec principal };
 type Countries = record { iso_codes : vec text };
 type CreateServiceNervousSystem = record {
   url : opt text;
@@ -367,6 +380,7 @@ type Neuron = record {
   dissolve_state : opt DissolveState;
   followees : vec record { int32; Followees };
   neuron_fees_e8s : nat64;
+  visibility : opt int32;
   transfer : opt NeuronStakeTransfer;
   known_neuron_data : opt KnownNeuronData;
   spawn_at_timestamp_seconds : opt nat64;
@@ -401,6 +415,7 @@ type NeuronInfo = record {
   stake_e8s : nat64;
   joined_community_fund_timestamp_seconds : opt nat64;
   retrieved_at_timestamp_seconds : nat64;
+  visibility : opt int32;
   known_neuron_data : opt KnownNeuronData;
   voting_power : nat64;
   age_seconds : nat64;
@@ -495,6 +510,7 @@ type Operation = variant {
   StopDissolving : record {};
   StartDissolving : record {};
   IncreaseDissolveDelay : IncreaseDissolveDelay;
+  SetVisibility : SetVisibility;
   JoinCommunityFund : record {};
   LeaveCommunityFund : record {};
   SetDissolveTimestamp : SetDissolveTimestamp;
@@ -616,6 +632,7 @@ type SetSnsTokenSwapOpenTimeWindow = record {
   request : opt SetOpenTimeWindowRequest;
   swap_canister_id : opt principal;
 };
+type SetVisibility = record { visibility : opt int32 };
 type SettleCommunityFundParticipation = record {
   result : opt Result_8;
   open_sns_token_swap_proposal_id : opt nat64;
@@ -636,6 +653,10 @@ type StakeMaturity = record { percentage_to_stake : opt nat32 };
 type StakeMaturityResponse = record {
   maturity_e8s : nat64;
   staked_maturity_e8s : nat64;
+};
+type StopOrStartCanister = record {
+  action : opt int32;
+  canister_id : opt principal;
 };
 type SwapBackgroundInformation = record {
   ledger_index_canister_summary : opt CanisterSummary;
@@ -681,6 +702,10 @@ type TimeWindow = record {
   end_timestamp_seconds : nat64;
 };
 type Tokens = record { e8s : opt nat64 };
+type UpdateCanisterSettings = record {
+  canister_id : opt principal;
+  settings : opt CanisterSettings;
+};
 type UpdateNodeProvider = record { reward_account : opt AccountIdentifier };
 type VotingRewardParameters = record {
   reward_rate_transition_duration : opt Duration;

--- a/packages/nns/candid/governance_test.idl.js
+++ b/packages/nns/candid/governance_test.idl.js
@@ -41,6 +41,7 @@ export const idlFactory = ({ IDL }) => {
   const IncreaseDissolveDelay = IDL.Record({
     'additional_dissolve_delay_seconds' : IDL.Nat32,
   });
+  const SetVisibility = IDL.Record({ 'visibility' : IDL.Opt(IDL.Int32) });
   const SetDissolveTimestamp = IDL.Record({
     'dissolve_timestamp_seconds' : IDL.Nat64,
   });
@@ -51,6 +52,7 @@ export const idlFactory = ({ IDL }) => {
     'StopDissolving' : IDL.Record({}),
     'StartDissolving' : IDL.Record({}),
     'IncreaseDissolveDelay' : IncreaseDissolveDelay,
+    'SetVisibility' : SetVisibility,
     'JoinCommunityFund' : IDL.Record({}),
     'LeaveCommunityFund' : IDL.Record({}),
     'SetDissolveTimestamp' : SetDissolveTimestamp,
@@ -101,12 +103,29 @@ export const idlFactory = ({ IDL }) => {
     'command' : IDL.Opt(Command),
     'neuron_id_or_subaccount' : IDL.Opt(NeuronIdOrSubaccount),
   });
+  const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
+  const CanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'controllers' : IDL.Opt(Controllers),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
+  const UpdateCanisterSettings = IDL.Record({
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'settings' : IDL.Opt(CanisterSettings),
+  });
   const InstallCode = IDL.Record({
     'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
     'canister_id' : IDL.Opt(IDL.Principal),
     'install_mode' : IDL.Opt(IDL.Int32),
+  });
+  const StopOrStartCanister = IDL.Record({
+    'action' : IDL.Opt(IDL.Int32),
+    'canister_id' : IDL.Opt(IDL.Principal),
   });
   const Percentage = IDL.Record({ 'basis_points' : IDL.Opt(IDL.Nat64) });
   const Duration = IDL.Record({ 'seconds' : IDL.Opt(IDL.Nat64) });
@@ -288,7 +307,9 @@ export const idlFactory = ({ IDL }) => {
   const Action = IDL.Variant({
     'RegisterKnownNeuron' : KnownNeuron,
     'ManageNeuron' : ManageNeuron,
+    'UpdateCanisterSettings' : UpdateCanisterSettings,
     'InstallCode' : InstallCode,
+    'StopOrStartCanister' : StopOrStartCanister,
     'CreateServiceNervousSystem' : CreateServiceNervousSystem,
     'ExecuteNnsFunction' : ExecuteNnsFunction,
     'RewardNodeProvider' : RewardNodeProvider,
@@ -455,10 +476,12 @@ export const idlFactory = ({ IDL }) => {
   });
   const CfNeuron = IDL.Record({
     'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
+    'hotkeys' : IDL.Opt(Principals),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
   const CfParticipant = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
     'hotkey_principal' : IDL.Text,
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
@@ -600,6 +623,7 @@ export const idlFactory = ({ IDL }) => {
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,
+    'visibility' : IDL.Opt(IDL.Int32),
     'transfer' : IDL.Opt(NeuronStakeTransfer),
     'known_neuron_data' : IDL.Opt(KnownNeuronData),
     'spawn_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
@@ -658,6 +682,7 @@ export const idlFactory = ({ IDL }) => {
     'stake_e8s' : IDL.Nat64,
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'retrieved_at_timestamp_seconds' : IDL.Nat64,
+    'visibility' : IDL.Opt(IDL.Int32),
     'known_neuron_data' : IDL.Opt(KnownNeuronData),
     'voting_power' : IDL.Nat64,
     'age_seconds' : IDL.Nat64,
@@ -941,6 +966,7 @@ export const init = ({ IDL }) => {
   const IncreaseDissolveDelay = IDL.Record({
     'additional_dissolve_delay_seconds' : IDL.Nat32,
   });
+  const SetVisibility = IDL.Record({ 'visibility' : IDL.Opt(IDL.Int32) });
   const SetDissolveTimestamp = IDL.Record({
     'dissolve_timestamp_seconds' : IDL.Nat64,
   });
@@ -951,6 +977,7 @@ export const init = ({ IDL }) => {
     'StopDissolving' : IDL.Record({}),
     'StartDissolving' : IDL.Record({}),
     'IncreaseDissolveDelay' : IncreaseDissolveDelay,
+    'SetVisibility' : SetVisibility,
     'JoinCommunityFund' : IDL.Record({}),
     'LeaveCommunityFund' : IDL.Record({}),
     'SetDissolveTimestamp' : SetDissolveTimestamp,
@@ -1001,12 +1028,29 @@ export const init = ({ IDL }) => {
     'command' : IDL.Opt(Command),
     'neuron_id_or_subaccount' : IDL.Opt(NeuronIdOrSubaccount),
   });
+  const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
+  const CanisterSettings = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'controllers' : IDL.Opt(Controllers),
+    'log_visibility' : IDL.Opt(IDL.Int32),
+    'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
+    'memory_allocation' : IDL.Opt(IDL.Nat64),
+    'compute_allocation' : IDL.Opt(IDL.Nat64),
+  });
+  const UpdateCanisterSettings = IDL.Record({
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'settings' : IDL.Opt(CanisterSettings),
+  });
   const InstallCode = IDL.Record({
     'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
     'canister_id' : IDL.Opt(IDL.Principal),
     'install_mode' : IDL.Opt(IDL.Int32),
+  });
+  const StopOrStartCanister = IDL.Record({
+    'action' : IDL.Opt(IDL.Int32),
+    'canister_id' : IDL.Opt(IDL.Principal),
   });
   const Percentage = IDL.Record({ 'basis_points' : IDL.Opt(IDL.Nat64) });
   const Duration = IDL.Record({ 'seconds' : IDL.Opt(IDL.Nat64) });
@@ -1188,7 +1232,9 @@ export const init = ({ IDL }) => {
   const Action = IDL.Variant({
     'RegisterKnownNeuron' : KnownNeuron,
     'ManageNeuron' : ManageNeuron,
+    'UpdateCanisterSettings' : UpdateCanisterSettings,
     'InstallCode' : InstallCode,
+    'StopOrStartCanister' : StopOrStartCanister,
     'CreateServiceNervousSystem' : CreateServiceNervousSystem,
     'ExecuteNnsFunction' : ExecuteNnsFunction,
     'RewardNodeProvider' : RewardNodeProvider,
@@ -1355,10 +1401,12 @@ export const init = ({ IDL }) => {
   });
   const CfNeuron = IDL.Record({
     'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
+    'hotkeys' : IDL.Opt(Principals),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
   const CfParticipant = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
     'hotkey_principal' : IDL.Text,
     'cf_neurons' : IDL.Vec(CfNeuron),
   });
@@ -1500,6 +1548,7 @@ export const init = ({ IDL }) => {
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,
+    'visibility' : IDL.Opt(IDL.Int32),
     'transfer' : IDL.Opt(NeuronStakeTransfer),
     'known_neuron_data' : IDL.Opt(KnownNeuronData),
     'spawn_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/candid/sns_wasm.certified.idl.js
+++ b/packages/nns/candid/sns_wasm.certified.idl.js
@@ -44,12 +44,15 @@ export const idlFactory = ({ IDL }) => {
       IdealMatchedParticipationFunction
     ),
   });
+  const Principals = IDL.Record({ 'principals' : IDL.Vec(IDL.Principal) });
   const CfNeuron = IDL.Record({
     'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
+    'hotkeys' : IDL.Opt(Principals),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
   const CfParticipant = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
     'hotkey_principal' : IDL.Text,
     'cf_neurons' : IDL.Vec(CfNeuron),
   });

--- a/packages/nns/candid/sns_wasm.d.ts
+++ b/packages/nns/candid/sns_wasm.d.ts
@@ -17,10 +17,12 @@ export interface Canister {
 }
 export interface CfNeuron {
   has_created_neuron_recipes: [] | [boolean];
+  hotkeys: [] | [Principals];
   nns_neuron_id: bigint;
   amount_icp_e8s: bigint;
 }
 export interface CfParticipant {
+  controller: [] | [Principal];
   hotkey_principal: string;
   cf_neurons: Array<CfNeuron>;
 }
@@ -174,6 +176,9 @@ export interface PrettySnsVersion {
   ledger_wasm_hash: string;
   governance_wasm_hash: string;
   index_wasm_hash: string;
+}
+export interface Principals {
+  principals: Array<Principal>;
 }
 export type Result = { Error: SnsWasmError } | { Hash: Uint8Array | number[] };
 export type Result_1 = { Ok: Ok } | { Error: SnsWasmError };

--- a/packages/nns/candid/sns_wasm.did
+++ b/packages/nns/candid/sns_wasm.did
@@ -1,14 +1,16 @@
-// Generated from IC repo commit de29a1a (2024-07-18 tags: release-2024-07-18_01-30--github-base) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit 2b109fb9ba (2024-07-25) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
 type Canister = record { id : opt principal };
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
+  hotkeys : opt Principals;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
 type CfParticipant = record {
+  controller : opt principal;
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };
@@ -126,6 +128,7 @@ type PrettySnsVersion = record {
   governance_wasm_hash : text;
   index_wasm_hash : text;
 };
+type Principals = record { principals : vec principal };
 type Result = variant { Error : SnsWasmError; Hash : blob };
 type Result_1 = variant { Ok : Ok; Error : SnsWasmError };
 type SnsCanisterIds = record {

--- a/packages/nns/candid/sns_wasm.idl.js
+++ b/packages/nns/candid/sns_wasm.idl.js
@@ -44,12 +44,15 @@ export const idlFactory = ({ IDL }) => {
       IdealMatchedParticipationFunction
     ),
   });
+  const Principals = IDL.Record({ 'principals' : IDL.Vec(IDL.Principal) });
   const CfNeuron = IDL.Record({
     'has_created_neuron_recipes' : IDL.Opt(IDL.Bool),
+    'hotkeys' : IDL.Opt(Principals),
     'nns_neuron_id' : IDL.Nat64,
     'amount_icp_e8s' : IDL.Nat64,
   });
   const CfParticipant = IDL.Record({
+    'controller' : IDL.Opt(IDL.Principal),
     'hotkey_principal' : IDL.Text,
     'cf_neurons' : IDL.Vec(CfNeuron),
   });

--- a/packages/nns/src/canisters/governance/request.converters.spec.ts
+++ b/packages/nns/src/canisters/governance/request.converters.spec.ts
@@ -1,6 +1,7 @@
 import { Principal } from "@dfinity/principal";
 import { arrayBufferToUint8Array, toNullable } from "@dfinity/utils";
 import type { ManageNeuron as RawManageNeuron } from "../../../candid/governance";
+import { CanisterAction, LogVisibility } from "../../enums/governance.enums";
 import {
   GovernanceParameters,
   InstallMode,
@@ -546,6 +547,126 @@ describe("request.converters", () => {
                     skip_stopping_before_installing: [true],
                     canister_id: [Principal.fromText("miw6j-knlcl-xq")],
                     install_mode: [2],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        neuron_id_or_subaccount: [
+          {
+            NeuronId: {
+              id: neuronId,
+            },
+          },
+        ],
+      };
+
+      const result = toMakeProposalRawRequest(mockRequest);
+      expect(result).toEqual(expectedOutput);
+    });
+
+    it("StopOrStartCanister", () => {
+      const principalId =
+        "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe";
+      const summary = "Proposal summary";
+
+      const mockRequest = {
+        url,
+        title,
+        summary,
+        action: {
+          StopOrStartCanister: {
+            canisterId: "miw6j-knlcl-xq",
+            action: CanisterAction.Stop,
+          },
+        },
+        neuronId,
+      };
+
+      const expectedOutput: RawManageNeuron = {
+        id: [],
+        command: [
+          {
+            MakeProposal: {
+              url,
+              title: toNullable(title),
+              summary,
+              action: [
+                {
+                  StopOrStartCanister: {
+                    canister_id: [Principal.fromText("miw6j-knlcl-xq")],
+                    action: [1],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        neuron_id_or_subaccount: [
+          {
+            NeuronId: {
+              id: neuronId,
+            },
+          },
+        ],
+      };
+
+      const result = toMakeProposalRawRequest(mockRequest);
+      expect(result).toEqual(expectedOutput);
+    });
+
+    it("UpdateCanisterSettings", () => {
+      const principalId =
+        "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe";
+      const summary = "Proposal summary";
+
+      const mockRequest = {
+        url,
+        title,
+        summary,
+        action: {
+          UpdateCanisterSettings: {
+            canisterId: "miw6j-knlcl-xq",
+            settings: {
+              controllers: ["miw6j-knlcl-xq"],
+              freezingThreshold: 100n,
+              memoryAllocation: 234567n,
+              computeAllocation: 1n,
+              wasmMemoryLimit: 123456n,
+              logVisibility: LogVisibility.Controllers,
+            },
+          },
+        },
+        neuronId,
+      };
+
+      const expectedOutput: RawManageNeuron = {
+        id: [],
+        command: [
+          {
+            MakeProposal: {
+              url,
+              title: toNullable(title),
+              summary,
+              action: [
+                {
+                  UpdateCanisterSettings: {
+                    canister_id: [Principal.fromText("miw6j-knlcl-xq")],
+                    settings: [
+                      {
+                        controllers: [
+                          {
+                            controllers: [Principal.fromText("miw6j-knlcl-xq")],
+                          },
+                        ],
+                        freezing_threshold: [100n],
+                        memory_allocation: [234567n],
+                        compute_allocation: [1n],
+                        wasm_memory_limit: [123456n],
+                        log_visibility: [1],
+                      },
+                    ],
                   },
                 },
               ],

--- a/packages/nns/src/enums/governance.enums.ts
+++ b/packages/nns/src/enums/governance.enums.ts
@@ -151,3 +151,28 @@ export enum NeuronType {
   // accounts in the Genesis Token Canister, or those descended from such neurons.
   Ect = 2,
 }
+
+// Reference: https://github.com/dfinity/ic/blob/3b3ffedc6aa481fd9b92eefaf46beded9e51a344/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs#L2506-L2512
+export enum LogVisibility {
+  Unspecified = 0,
+  /// The log is visible to the controllers of the dapp canister.
+  Controllers = 1,
+  /// The log is visible to the public.
+  Public = 2,
+}
+
+// Reference: https://github.com/dfinity/ic/blob/3b3ffedc6aa481fd9b92eefaf46beded9e51a344/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs#L2419-L2423
+export enum CanisterAction {
+  Unspecified = 0,
+  // Stop a canister.
+  Stop = 1,
+  // Start a canister.
+  Start = 2,
+}
+
+// Reference: https://github.com/dfinity/ic/blob/3b3ffedc6aa481fd9b92eefaf46beded9e51a344/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs#L3929-L3958
+export enum NeuronVisibility {
+  Unspecified = 0,
+  Private = 1,
+  Public = 2,
+}

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -50,6 +50,7 @@ import {
   toRegisterVoteRequest,
   toRemoveHotkeyRequest,
   toSetDissolveDelayRequest,
+  toSetVisibilityRequest,
   toSpawnNeuronRequest,
   toSplitRawRequest,
   toStakeMaturityRequest,
@@ -69,7 +70,7 @@ import {
 } from "./canisters/governance/services";
 import { MAINNET_GOVERNANCE_CANISTER_ID } from "./constants/canister_ids";
 import { E8S_PER_TOKEN } from "./constants/constants";
-import type { Vote } from "./enums/governance.enums";
+import type { NeuronVisibility, Vote } from "./enums/governance.enums";
 import {
   CouldNotClaimNeuronError,
   GovernanceError,
@@ -478,6 +479,23 @@ export class GovernanceCanister {
    */
   public leaveCommunityFund = async (neuronId: NeuronId): Promise<void> => {
     const request = toLeaveCommunityFundRequest(neuronId);
+
+    await manageNeuron({
+      request,
+      service: this.certifiedService,
+    });
+  };
+
+  /**
+   * Set visibility of a neuron
+   *
+   * @throws {@link GovernanceError}
+   */
+  public setVisibility = async (
+    neuronId: NeuronId,
+    visibility: NeuronVisibility,
+  ): Promise<void> => {
+    const request = toSetVisibilityRequest({ neuronId, visibility });
 
     await manageNeuron({
       request,

--- a/packages/nns/src/mocks/governance.mock.ts
+++ b/packages/nns/src/mocks/governance.mock.ts
@@ -19,6 +19,7 @@ export const mockNeuronInfo: NeuronInfo = {
   known_neuron_data: [],
   voting_power: one,
   age_seconds: one,
+  visibility: [1],
 };
 export const mockNeuron: Neuron = {
   id: [{ id: mockNeuronId }],
@@ -42,6 +43,7 @@ export const mockNeuron: Neuron = {
   transfer: [],
   known_neuron_data: [],
   spawn_at_timestamp_seconds: [],
+  visibility: [1],
 };
 export const mockListNeuronsResponse: ListNeuronsResponse = {
   neuron_infos: [[mockNeuronId, mockNeuronInfo]],

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -2,8 +2,11 @@ import type { DerEncodedPublicKey } from "@dfinity/agent";
 import type { AccountIdentifierHex } from "@dfinity/ledger-icp";
 import type { Principal } from "@dfinity/principal";
 import type {
+  CanisterAction,
+  LogVisibility,
   NeuronState,
   NeuronType,
+  NeuronVisibility,
   ProposalRewardStatus,
   ProposalStatus,
   Topic,
@@ -25,6 +28,8 @@ export type Action =
   | { CreateServiceNervousSystem: CreateServiceNervousSystem }
   | { ManageNeuron: ManageNeuron }
   | { InstallCode: InstallCode }
+  | { StopOrStartCanister: StopOrStartCanister }
+  | { UpdateCanisterSettings: UpdateCanisterSettings }
   | { ApproveGenesisKyc: ApproveGenesisKyc }
   | { ManageNetworkEconomics: NetworkEconomics }
   | { RewardNodeProvider: RewardNodeProvider }
@@ -132,6 +137,9 @@ export interface SetDissolveTimestamp {
 export interface ChangeAutoStakeMaturity {
   requestedSettingForAutoStakeMaturity: boolean;
 }
+export interface SetVisibility {
+  visibility: Option<NeuronVisibility>;
+}
 export interface ListProposalsRequest {
   // Limit on the number of [ProposalInfo] to return. If no value is
   // specified, or if a value greater than 100 is specified, 100
@@ -196,6 +204,22 @@ export interface InstallCode {
   skipStoppingBeforeInstalling: Option<boolean>;
   canisterId: Option<PrincipalString>;
   installMode: Option<number>;
+}
+export interface StopOrStartCanister {
+  canisterId: Option<PrincipalString>;
+  action: Option<CanisterAction>;
+}
+export interface CanisterSettings {
+  freezingThreshold: Option<bigint>;
+  controllers: Option<Array<PrincipalString>>;
+  logVisibility: Option<LogVisibility>;
+  wasmMemoryLimit: Option<bigint>;
+  memoryAllocation: Option<bigint>;
+  computeAllocation: Option<bigint>;
+}
+export interface UpdateCanisterSettings {
+  canisterId: Option<PrincipalString>;
+  settings: Option<CanisterSettings>;
 }
 export interface Merge {
   sourceNeuronId: Option<NeuronId>;
@@ -306,6 +330,7 @@ export interface Neuron {
   joinedCommunityFundTimestampSeconds: Option<bigint>;
   dissolveState: Option<DissolveState>;
   followees: Array<Followees>;
+  visibility: Option<NeuronVisibility>;
 }
 export type NeuronIdOrSubaccount =
   | { Subaccount: Array<number> }
@@ -322,6 +347,7 @@ export interface NeuronInfo {
   votingPower: bigint;
   ageSeconds: bigint;
   fullNeuron: Option<Neuron>;
+  visibility: Option<NeuronVisibility>;
 }
 
 export interface NodeProvider {
@@ -337,7 +363,8 @@ export type Operation =
   | { JoinCommunityFund: Record<string, never> }
   | { LeaveCommunityFund: Record<string, never> }
   | { SetDissolveTimestamp: SetDissolveTimestamp }
-  | { ChangeAutoStakeMaturity: ChangeAutoStakeMaturity };
+  | { ChangeAutoStakeMaturity: ChangeAutoStakeMaturity }
+  | { SetVisibility: SetVisibility };
 export interface Proposal {
   title: Option<string>;
   url: string;


### PR DESCRIPTION
# Motivation

New types in NNS Governance are added which includes new variants which will fail the automatic update. Add converters for request/response involving those variants

# Changes

1. Ran scripts/import-candid ../../ic and scripts/compile-idl-js.
2. Get rid of everything other than nns changes: `packages/{ckbtc,cketh,cmc,ledger-icp,ledger-icrc,sns,ic-management}`
3. Added conversion for UpdateCanisterSettings, StopOrStartCansiter, SetVisibility and Neuron::visibility

# Tests

Unit tests

# Todos

- [ x] Add entry to changelog (if necessary).
