### PR TITLE
Change InstallCode converters to be more consistent with other action…

### DIFF
--- a/packages/nns/src/canisters/governance/request.converters.spec.ts
+++ b/packages/nns/src/canisters/governance/request.converters.spec.ts
@@ -1,11 +1,12 @@
 import { Principal } from "@dfinity/principal";
 import { arrayBufferToUint8Array, toNullable } from "@dfinity/utils";
 import type { ManageNeuron as RawManageNeuron } from "../../../candid/governance";
-import { CanisterAction, LogVisibility } from "../../enums/governance.enums";
 import {
-  GovernanceParameters,
-  InstallMode,
-} from "../../types/governance_converters";
+  CanisterAction,
+  CanisterInstallMode,
+  LogVisibility,
+} from "../../enums/governance.enums";
+import { GovernanceParameters } from "../../types/governance_converters";
 import { toMakeProposalRawRequest } from "./request.converters";
 
 describe("request.converters", () => {
@@ -525,7 +526,7 @@ describe("request.converters", () => {
             wasmModule: Uint8Array.from([4, 5, 6]),
             skipStoppingBeforeInstalling: true,
             canisterId: "miw6j-knlcl-xq",
-            installMode: InstallMode.Reinstall,
+            installMode: CanisterInstallMode.Reinstall,
           },
         },
         neuronId,

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -89,7 +89,6 @@ import type {
   Tokens,
   VotingRewardParameters,
 } from "../../types/governance_converters";
-import { InstallMode } from "../../types/governance_converters";
 
 const fromProposalId = (proposalId: ProposalId): RawNeuronId => ({
   id: proposalId,
@@ -424,37 +423,27 @@ const fromCreateServiceNervousSystem = (
       : [],
 });
 
-const fromInstallMode = (installMode: Option<InstallMode>): Option<number> => {
-  if (isNullish(installMode)) {
-    return undefined;
+const fromInstallCode = (installCode: InstallCode): RawInstallCode => {
+  if (installCode.wasmModule === undefined) {
+    throw new Error("wasmModule not found");
   }
-  switch (installMode) {
-    case InstallMode.Unspecified:
-      return 0;
-    case InstallMode.Install:
-      return 1;
-    case InstallMode.Reinstall:
-      return 2;
-    case InstallMode.Upgrade:
-      return 3;
-    default:
-      return 0;
-  }
-};
 
-const fromInstallCode = (installCode: InstallCode): RawInstallCode => ({
-  arg: toNullable(installCode.arg),
-  wasm_module: toNullable(installCode.wasmModule),
-  skip_stopping_before_installing: toNullable(
-    installCode.skipStoppingBeforeInstalling,
-  ),
-  canister_id: toNullable(
-    nonNullish(installCode.canisterId)
-      ? Principal.fromText(installCode.canisterId)
-      : undefined,
-  ),
-  install_mode: toNullable(fromInstallMode(installCode.installMode)),
-});
+  return {
+    arg: toNullable(
+      arrayBufferToUint8Array(installCode.arg ?? new ArrayBuffer(0)),
+    ),
+    wasm_module: toNullable(arrayBufferToUint8Array(installCode.wasmModule)),
+    skip_stopping_before_installing: toNullable(
+      installCode.skipStoppingBeforeInstalling,
+    ),
+    canister_id: toNullable(
+      nonNullish(installCode.canisterId)
+        ? Principal.fromText(installCode.canisterId)
+        : undefined,
+    ),
+    install_mode: toNullable(installCode.installMode as number),
+  };
+};
 
 const fromCanisterSettings = (
   canisterSettings: Option<CanisterSettings>,

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -60,6 +60,7 @@ import type {
 } from "../../../candid/governance";
 import type {
   CanisterAction,
+  CanisterInstallMode,
   LogVisibility,
   NeuronType,
   NeuronVisibility,
@@ -111,7 +112,6 @@ import type {
   Tokens,
   VotingRewardParameters,
 } from "../../types/governance_converters";
-import { InstallMode } from "../../types/governance_converters";
 
 export const toNeuronInfo = ({
   neuronId,
@@ -542,19 +542,15 @@ const toAction = (action: RawAction): Action => {
     const installCode = action.InstallCode;
     return {
       InstallCode: {
-        arg: installCode.arg.length
-          ? Uint8Array.from(fromDefinedNullable(installCode.arg))
-          : undefined,
-        wasmModule: installCode.wasm_module.length
-          ? Uint8Array.from(fromDefinedNullable(installCode.wasm_module))
-          : undefined,
         skipStoppingBeforeInstalling: fromNullable(
           installCode.skip_stopping_before_installing,
         ),
         canisterId: installCode.canister_id.length
           ? installCode.canister_id[0].toString()
           : undefined,
-        installMode: toInstallMode(fromNullable(installCode.install_mode)),
+        installMode: fromNullable(installCode.install_mode) as
+          | CanisterInstallMode
+          | undefined,
       },
     };
   }
@@ -587,24 +583,6 @@ const toAction = (action: RawAction): Action => {
   }
 
   throw new UnsupportedValueError(action);
-};
-
-const toInstallMode = (installMode: Option<number>): Option<InstallMode> => {
-  if (isNullish(installMode)) {
-    return undefined;
-  }
-  switch (installMode) {
-    case 0:
-      return InstallMode.Unspecified;
-    case 1:
-      return InstallMode.Install;
-    case 2:
-      return InstallMode.Reinstall;
-    case 3:
-      return InstallMode.Upgrade;
-    default:
-      return InstallMode.Unspecified;
-  }
 };
 
 const toTally = (tally: RawTally): Tally => {

--- a/packages/nns/src/enums/governance.enums.ts
+++ b/packages/nns/src/enums/governance.enums.ts
@@ -176,3 +176,11 @@ export enum NeuronVisibility {
   Private = 1,
   Public = 2,
 }
+
+// Reference: https://github.com/dfinity/ic/blob/3b3ffedc6aa481fd9b92eefaf46beded9e51a344/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs#L2354-L2359
+export enum CanisterInstallMode {
+  Unspecified = 0,
+  Install = 1,
+  Reinstall = 2,
+  Upgrade = 3,
+}

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -19,6 +19,7 @@ import {
 } from "../candid/governance";
 import {
   CanisterAction,
+  CanisterInstallMode,
   LogVisibility,
   NeuronVisibility,
   Topic,
@@ -39,7 +40,6 @@ import {
 import {
   Action,
   InstallCode,
-  InstallMode,
   MakeProposalRequest,
   NetworkEconomics,
   StopOrStartCanister,
@@ -836,11 +836,9 @@ describe("GovernanceCanister", () => {
       };
 
       const expectedInstallCode: InstallCode = {
-        arg: Uint8Array.from([1, 2, 3]),
-        wasmModule: Uint8Array.from([4, 5, 6]),
         skipStoppingBeforeInstalling: true,
         canisterId: "miw6j-knlcl-xq",
-        installMode: InstallMode.Upgrade,
+        installMode: CanisterInstallMode.Upgrade,
       };
 
       const rawProposal = {

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -3,6 +3,7 @@ import type { AccountIdentifierHex } from "@dfinity/ledger-icp";
 import type { Principal } from "@dfinity/principal";
 import type {
   CanisterAction,
+  CanisterInstallMode,
   LogVisibility,
   NeuronState,
   NeuronType,
@@ -192,18 +193,12 @@ export interface ManageNeuron {
   command: Option<Command>;
   neuronIdOrSubaccount: Option<NeuronIdOrSubaccount>;
 }
-export enum InstallMode {
-  Unspecified,
-  Install,
-  Reinstall,
-  Upgrade,
-}
 export interface InstallCode {
-  arg: Option<Uint8Array>;
-  wasmModule: Option<Uint8Array>;
+  arg?: ArrayBuffer;
+  wasmModule?: ArrayBuffer;
   skipStoppingBeforeInstalling: Option<boolean>;
   canisterId: Option<PrincipalString>;
-  installMode: Option<number>;
+  installMode: Option<CanisterInstallMode>;
 }
 export interface StopOrStartCanister {
   canisterId: Option<PrincipalString>;


### PR DESCRIPTION
# Motivation

Change InstallCode converters to be more consistent with other action types

# Changes

* CanisterInstallMode is converted to an enum in defined in the `governance.enums.ts`
* The 2 fields that might be large are no longer converted for responses, similar as `ExecuteNnsFunction::payload`

# Tests

Unit tests

# Changelog

Not adding to changelog because it already has a related entry. This PR improves it.
