### PR TITLE
icrc index getLedgerId

### DIFF
--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -275,12 +275,13 @@ Parameters:
 
 ### :factory: IcrcIndexCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L13)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L14)
 
 #### Methods
 
 - [create](#gear-create)
 - [getTransactions](#gear-gettransactions)
+- [getLedgerId](#gear-getledgerid)
 
 ##### :gear: create
 
@@ -288,7 +289,7 @@ Parameters:
 | -------- | --------------------------------------------------------------------- |
 | `create` | `(options: IcrcLedgerCanisterOptions<_SERVICE>) => IcrcIndexCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L14)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L15)
 
 ##### :gear: getTransactions
 
@@ -303,7 +304,17 @@ Index Canister only holds the transactions ids in state, not the whole transacti
 | ----------------- | -------------------------------------------------------------------- |
 | `getTransactions` | `(params: GetAccountTransactionsParams) => Promise<GetTransactions>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L33)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L34)
+
+##### :gear: getLedgerId
+
+Returns the ledger canister ID related to the index canister.
+
+| Method        | Type                                          |
+| ------------- | --------------------------------------------- |
+| `getLedgerId` | `(params: QueryParams) => Promise<Principal>` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L51)
 
 ### :factory: IcrcIndexNgCanister
 

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -281,7 +281,7 @@ Parameters:
 
 - [create](#gear-create)
 - [getTransactions](#gear-gettransactions)
-- [getLedgerId](#gear-getledgerid)
+- [ledgerId](#gear-ledgerid)
 
 ##### :gear: create
 
@@ -306,13 +306,13 @@ Index Canister only holds the transactions ids in state, not the whole transacti
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L34)
 
-##### :gear: getLedgerId
+##### :gear: ledgerId
 
 Returns the ledger canister ID related to the index canister.
 
-| Method        | Type                                          |
-| ------------- | --------------------------------------------- |
-| `getLedgerId` | `(params: QueryParams) => Promise<Principal>` |
+| Method     | Type                                          |
+| ---------- | --------------------------------------------- |
+| `ledgerId` | `(params: QueryParams) => Promise<Principal>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L51)
 

--- a/packages/ledger-icrc/src/index.canister.spec.ts
+++ b/packages/ledger-icrc/src/index.canister.spec.ts
@@ -92,7 +92,7 @@ describe("Index canister", () => {
     });
   });
 
-  describe("getLedgerId", () => {
+  describe("ledgerId", () => {
     it("should return ledger id", async () => {
       const service = mock<ActorSubclass<IcrcIndexService>>();
       service.ledger_id.mockResolvedValue(ledgerCanisterIdMock);
@@ -102,7 +102,7 @@ describe("Index canister", () => {
         certifiedServiceOverride: service,
       });
 
-      const result = await canister.getLedgerId({
+      const result = await canister.ledgerId({
         certified: true,
       });
 

--- a/packages/ledger-icrc/src/index.canister.spec.ts
+++ b/packages/ledger-icrc/src/index.canister.spec.ts
@@ -8,8 +8,10 @@ import type {
 } from "../candid/icrc_index";
 import { IndexError } from "./errors/index.errors";
 import { IcrcIndexCanister } from "./index.canister";
-import { indexCanisterIdMock } from "./mocks/ledger.mock";
+import {indexCanisterIdMock, ledgerCanisterIdMock} from "./mocks/ledger.mock";
 import { IcrcAccount } from "./types/ledger.responses";
+import type {_SERVICE as IcrcIndexNgService} from "../candid/icrc_index-ng";
+import {IcrcIndexNgCanister} from "./index-ng.canister";
 
 describe("Index canister", () => {
   afterEach(() => jest.clearAllMocks());
@@ -89,6 +91,24 @@ describe("Index canister", () => {
           max_results: BigInt(10),
         });
       expect(call).rejects.toThrowError(IndexError);
+    });
+  });
+
+  describe("getLedgerId", () => {
+    it("should return ledger id", async () => {
+      const service = mock<ActorSubclass<IcrcIndexService>>();
+      service.ledger_id.mockResolvedValue(ledgerCanisterIdMock);
+
+      const canister = IcrcIndexCanister.create({
+        canisterId: indexCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+
+      const result = await canister.getLedgerId({
+        certified: true,
+      });
+
+      expect(result).toEqual(ledgerCanisterIdMock);
     });
   });
 });

--- a/packages/ledger-icrc/src/index.canister.ts
+++ b/packages/ledger-icrc/src/index.canister.ts
@@ -1,4 +1,4 @@
-import { Principal } from "@dfinity/principal";
+import type { Principal } from "@dfinity/principal";
 import {Canister, createServices, type QueryParams} from "@dfinity/utils";
 import type {
   GetTransactions,

--- a/packages/ledger-icrc/src/index.canister.ts
+++ b/packages/ledger-icrc/src/index.canister.ts
@@ -1,4 +1,5 @@
-import { Canister, createServices } from "@dfinity/utils";
+import { Principal } from "@dfinity/principal";
+import {Canister, createServices, type QueryParams} from "@dfinity/utils";
 import type {
   GetTransactions,
   _SERVICE as IcrcIndexService,
@@ -42,5 +43,13 @@ export class IcrcIndexCanister extends Canister<IcrcIndexService> {
     }
 
     return response.Ok;
+  };
+
+  /**
+   * Returns the ledger canister ID related to the index canister.
+   */
+  getLedgerId = (params: QueryParams): Promise<Principal> => {
+    const { ledger_id } = this.caller(params);
+    return ledger_id();
   };
 }

--- a/packages/ledger-icrc/src/index.canister.ts
+++ b/packages/ledger-icrc/src/index.canister.ts
@@ -48,7 +48,7 @@ export class IcrcIndexCanister extends Canister<IcrcIndexService> {
   /**
    * Returns the ledger canister ID related to the index canister.
    */
-  getLedgerId = (params: QueryParams): Promise<Principal> => {
+  ledgerId = (params: QueryParams): Promise<Principal> => {
     const { ledger_id } = this.caller(params);
     return ledger_id();
   };


### PR DESCRIPTION
# Motivation

For the import token functionality, we need to ensure that the provided by users index canister is correctly associated with the same token and not mistakenly linked to a different ledger canister. To achieve this, we going to use the `ledger_id` API of the index canister, which returns the corresponding ledger canister ID. This PR introduces a function that makes the `ledger_id` request.

# Changes

- Add getLedgerId function.

# Tests

- Test for getLedgerId.
- Tested manually in nns-dapp against localhost.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.