### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next
+
+## Features
+
+- Support conversion of `InstallCode`, `StopOrStartCanister` and `UpdateCanisterSettings` actions, `SetVisibility` neuron operation, and `Neuron::visibility` attribute.
+
 # 2024.07.22-0645Z
 
 ## Overview
@@ -24,7 +30,6 @@ The current status of the libraries at the time of the release is as follows:
 - Extend `eip1559TransactionPrice` for Erc20.
 - Add "Protocol Canister Management" and "Service Nervous System Management" topics support.
 - Add `asNonNullish` function, like `assertNonNullish` but returns the value.
-- Support conversion of `InstallCode`, `StopOrStartCanister` and `UpdateCanisterSettings` actions, `SetVisibility` neuron operation, and `Neuron::visibility` attribute.
 
 ## Fix
 


### PR DESCRIPTION
# Motivation

I just discovered that https://github.com/dfinity/ic-js/pull/681 and https://github.com/dfinity/ic-js/pull/686 added changelog entries to an existing release, instead of the "Next" release.

# Changes

Move the changelog entry to the "Next" release.

# Tests

no

# Todos

- [x] Add entry to changelog (if necessary).
