### PR TITLE
feat: candid nat to bigint utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Features
 
+- Provide a new utility to convert Candid `Nat` to `BigInt`. This utility is useful for interpreting the fees provided by the SNS Aggregator.
 - Support conversion of `InstallCode`, `StopOrStartCanister` and `UpdateCanisterSettings` actions, `SetVisibility` neuron operation, and `Neuron::visibility` attribute.
 
 # 2024.07.22-0645Z

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -50,7 +50,7 @@ npm i @dfinity/agent @dfinity/candid @dfinity/principal
 - [asciiStringToByteArray](#gear-asciistringtobytearray)
 - [hexStringToUint8Array](#gear-hexstringtouint8array)
 - [uint8ArrayToHexString](#gear-uint8arraytohexstring)
-- [candidNatToBigInt](#gear-candidnattobigint)
+- [candidNatArrayToBigInt](#gear-candidnatarraytobigint)
 - [encodeBase32](#gear-encodebase32)
 - [decodeBase32](#gear-decodebase32)
 - [bigEndianCrc32](#gear-bigendiancrc32)
@@ -240,11 +240,11 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/arrays.utils.ts#L60)
 
-#### :gear: candidNatToBigInt
+#### :gear: candidNatArrayToBigInt
 
-| Function            | Type                                                                |
-| ------------------- | ------------------------------------------------------------------- |
-| `candidNatToBigInt` | `([lowPart, highPart]: [number, (number or undefined)?]) => bigint` |
+| Function                 | Type                                                                |
+| ------------------------ | ------------------------------------------------------------------- |
+| `candidNatArrayToBigInt` | `([lowPart, highPart]: [number, (number or undefined)?]) => bigint` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/arrays.utils.ts#L70)
 

--- a/packages/utils/src/utils/arrays.utils.spec.ts
+++ b/packages/utils/src/utils/arrays.utils.spec.ts
@@ -1,8 +1,10 @@
+import { expect } from "@jest/globals";
 import {
   arrayBufferToUint8Array,
   arrayOfNumberToUint8Array,
   asciiStringToByteArray,
   bigIntToUint8Array,
+  candidNatToBigInt,
   hexStringToUint8Array,
   numberToUint8Array,
   uint8ArrayToArrayOfNumber,
@@ -74,5 +76,18 @@ describe("arrays-utils", () => {
 
   it("should convert array of numbers to string", () => {
     expect(uint8ArrayToHexString(Array.from(hexArray))).toEqual(hex);
+  });
+
+  it("should convert Candid Nat to BigInt", () => {
+    // DOGMI fee
+    expect(candidNatToBigInt([705032704, 1])).toBe(5_000_000_000n);
+    expect(candidNatToBigInt([705032704, 0])).toBe(70_5032_704n);
+    expect(candidNatToBigInt([705032704])).toBe(70_5032_704n);
+
+    // Common SNS fees
+    expect(candidNatToBigInt([10000])).toBe(10_000n);
+    expect(candidNatToBigInt([20000])).toBe(20_000n);
+    expect(candidNatToBigInt([100000])).toBe(100_000n);
+    expect(candidNatToBigInt([1000000])).toBe(1_000_000n);
   });
 });

--- a/packages/utils/src/utils/arrays.utils.spec.ts
+++ b/packages/utils/src/utils/arrays.utils.spec.ts
@@ -4,7 +4,7 @@ import {
   arrayOfNumberToUint8Array,
   asciiStringToByteArray,
   bigIntToUint8Array,
-  candidNatToBigInt,
+  candidNatArrayToBigInt,
   hexStringToUint8Array,
   numberToUint8Array,
   uint8ArrayToArrayOfNumber,
@@ -80,14 +80,14 @@ describe("arrays-utils", () => {
 
   it("should convert Candid Nat to BigInt", () => {
     // DOGMI fee
-    expect(candidNatToBigInt([705032704, 1])).toBe(5_000_000_000n);
-    expect(candidNatToBigInt([705032704, 0])).toBe(70_5032_704n);
-    expect(candidNatToBigInt([705032704])).toBe(70_5032_704n);
+    expect(candidNatArrayToBigInt([705032704, 1])).toBe(5_000_000_000n);
+    expect(candidNatArrayToBigInt([705032704, 0])).toBe(70_5032_704n);
+    expect(candidNatArrayToBigInt([705032704])).toBe(70_5032_704n);
 
     // Common SNS fees
-    expect(candidNatToBigInt([10000])).toBe(10_000n);
-    expect(candidNatToBigInt([20000])).toBe(20_000n);
-    expect(candidNatToBigInt([100000])).toBe(100_000n);
-    expect(candidNatToBigInt([1000000])).toBe(1_000_000n);
+    expect(candidNatArrayToBigInt([10000])).toBe(10_000n);
+    expect(candidNatArrayToBigInt([20000])).toBe(20_000n);
+    expect(candidNatArrayToBigInt([100000])).toBe(100_000n);
+    expect(candidNatArrayToBigInt([1000000])).toBe(1_000_000n);
   });
 });

--- a/packages/utils/src/utils/arrays.utils.spec.ts
+++ b/packages/utils/src/utils/arrays.utils.spec.ts
@@ -81,6 +81,8 @@ describe("arrays-utils", () => {
   it("should convert Candid Nat to BigInt", () => {
     // DOGMI fee
     expect(candidNatArrayToBigInt([705032704, 1])).toBe(5_000_000_000n);
+
+    // Interpretation of the fees without high bits
     expect(candidNatArrayToBigInt([705032704, 0])).toBe(70_5032_704n);
     expect(candidNatArrayToBigInt([705032704])).toBe(70_5032_704n);
 

--- a/packages/utils/src/utils/arrays.utils.ts
+++ b/packages/utils/src/utils/arrays.utils.ts
@@ -73,5 +73,6 @@ export const candidNatArrayToBigInt = ([lowPart, highPart]: [
 ]): bigint => {
   const low = BigInt(lowPart);
   const high = BigInt(highPart ?? 0);
+
   return (high << 32n) + low;
 };

--- a/packages/utils/src/utils/arrays.utils.ts
+++ b/packages/utils/src/utils/arrays.utils.ts
@@ -66,3 +66,13 @@ export const uint8ArrayToHexString = (bytes: Uint8Array | number[]) => {
     "",
   );
 };
+
+export const candidNatToBigInt = ([lowPart, highPart]: [
+  number,
+  number?,
+]): bigint => {
+  const low = BigInt(lowPart);
+  const high = BigInt(highPart ?? 0);
+
+  return (high << 32n) + low;
+};

--- a/packages/utils/src/utils/arrays.utils.ts
+++ b/packages/utils/src/utils/arrays.utils.ts
@@ -67,7 +67,7 @@ export const uint8ArrayToHexString = (bytes: Uint8Array | number[]) => {
   );
 };
 
-export const candidNatToBigInt = ([lowPart, highPart]: [
+export const candidNatArrayToBigInt = ([lowPart, highPart]: [
   number,
   number?,
 ]): bigint => {

--- a/packages/utils/src/utils/arrays.utils.ts
+++ b/packages/utils/src/utils/arrays.utils.ts
@@ -73,6 +73,5 @@ export const candidNatArrayToBigInt = ([lowPart, highPart]: [
 ]): bigint => {
   const low = BigInt(lowPart);
   const high = BigInt(highPart ?? 0);
-
   return (high << 32n) + low;
 };


### PR DESCRIPTION
# Motivation

In NNS dapp and Oisy, the displayed fees of the DOGMI SNS are currently incorrectly displayed (see [forum](https://forum.dfinity.org/t/dogmi-sns-transfer-wrong-transfer-fee/34114/1)). This is the result of an incorrect intepretation of the SNS aggregator results which provides the fees encoded in Candid Nat.

# Changes

- Provide a utility to transform Candid `Nat` to `BigInt`
# Todos

- [x] Add entry to changelog (if necessary).
