### PR TITLE
Fix expiry in test-vector

### DIFF
--- a/scripts/test-vectors/20220923-spawn-neuron.ts
+++ b/scripts/test-vectors/20220923-spawn-neuron.ts
@@ -11,7 +11,7 @@ import { createBlob, splitPrincipal, writeToJson } from "./utils";
 const mockNeuronId = BigInt(15374508381553347371);
 const mockNeuronId2 = BigInt(8836564053576662908);
 const mockPrincipal = Principal.fromText(
-  "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
+  "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe",
 );
 
 const createCandidSpawnNeuron = ({
@@ -46,7 +46,7 @@ const createCandidSpawnNeuron = ({
       ? ["Controller : Self"]
       : splitPrincipal(newController).map(
           (data, i, elements) =>
-            `Controller [${i + 1}/${elements.length}] : ${data}`
+            `Controller [${i + 1}/${elements.length}] : ${data}`,
         );
 
   outputs.push(...controllerMessages);

--- a/scripts/test-vectors/20221206-increase-dd.ts
+++ b/scripts/test-vectors/20221206-increase-dd.ts
@@ -9,7 +9,7 @@ const mockNeuronId2 = BigInt(8836564053576662908);
 
 const createIncreaseDissolveDelayVector = (
   neuronId: NeuronId,
-  additionalDissolveDelaySeconds: number
+  additionalDissolveDelaySeconds: number,
 ) => {
   const params = {
     neuronId,

--- a/scripts/test-vectors/20230110-sns-add-hotkey.ts
+++ b/scripts/test-vectors/20230110-sns-add-hotkey.ts
@@ -24,7 +24,8 @@ interface Params extends SnsNeuronPermissionsParams {
 const createTestVector = (params: Params) => {
   const rawRequestBody = toAddPermissionsRequest(params);
   const canisterIdOutputs = splitPrincipal(params.canisterId).map(
-    (data, i, elements) => `Canister Id [${i + 1}/${elements.length}] : ${data}`
+    (data, i, elements) =>
+      `Canister Id [${i + 1}/${elements.length}] : ${data}`,
   );
   const neuronIdString = bytesToHexString(Array.from(params.neuronId.id));
   const neuronIdOutputs =
@@ -44,14 +45,14 @@ const createTestVector = (params: Params) => {
       }, [] as string[])
       ?.map(
         (data, i, elements) =>
-          `Neuron Id [${i + 1}/${elements.length}] : ${data}`
+          `Neuron Id [${i + 1}/${elements.length}] : ${data}`,
       ) || [];
   const principalOutputs = splitPrincipal(params.principal).map(
     (data, i, elements) =>
-      `Principal Id [${i + 1}/${elements.length}] : ${data}`
+      `Principal Id [${i + 1}/${elements.length}] : ${data}`,
   );
   const permissionOutputs = params.permissions.map(
-    (p) => `Add Permission : ${permissionMapper[p]}`
+    (p) => `Add Permission : ${permissionMapper[p]}`,
   );
   const output = [
     "Transaction type : Add Neuron Permissions",
@@ -86,10 +87,10 @@ const main = () => {
       61,
     ]);
     const principal1 = Principal.fromText(
-      "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae"
+      "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae",
     );
     const principal2 = Principal.fromText(
-      "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe"
+      "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe",
     );
     const canisterId1 = Principal.fromText("ppmzm-3aaaa-aaaaa-aacpq-cai");
     const canisterId2 = Principal.fromText("s24we-diaaa-aaaaa-aaaka-cai");

--- a/scripts/test-vectors/20230118-sns-manage-neuron.ts
+++ b/scripts/test-vectors/20230118-sns-manage-neuron.ts
@@ -30,14 +30,15 @@ interface DisburseParams extends SnsDisburseNeuronParams {
 const createDisburseVector = (params: DisburseParams) => {
   const rawRequestBody = toDisburseNeuronRequest(params);
   const canisterIdOutputs = splitPrincipal(params.canisterId).map(
-    (data, i, elements) => `Canister Id [${i + 1}/${elements.length}] : ${data}`
+    (data, i, elements) =>
+      `Canister Id [${i + 1}/${elements.length}] : ${data}`,
   );
   const neuronIdString = bytesToHexString(Array.from(params.neuronId.id));
   const neuronIdOutputs = splitString(neuronIdString, "Neuron Id");
   const disburseToAccountStr = encodeIcrcAccount(
     params.toAccount ?? {
       owner: defaultCaller,
-    }
+    },
   );
   const disburseToOutputs = splitString(disburseToAccountStr, "Disburse to");
   const amount = params.amount
@@ -73,7 +74,8 @@ interface SetDissolveParams {
 const createStopDissolveVector = (params: SetDissolveParams) => {
   const rawRequestBody = toStopDissolvingNeuronRequest(params.neuronId);
   const canisterIdOutputs = splitPrincipal(params.canisterId).map(
-    (data, i, elements) => `Canister Id [${i + 1}/${elements.length}] : ${data}`
+    (data, i, elements) =>
+      `Canister Id [${i + 1}/${elements.length}] : ${data}`,
   );
   const neuronIdString = bytesToHexString(Array.from(params.neuronId.id));
   const neuronIdOutputs = splitString(neuronIdString, "Neuron Id");
@@ -99,7 +101,8 @@ const createStopDissolveVector = (params: SetDissolveParams) => {
 const createStartDissolveVector = (params: SetDissolveParams) => {
   const rawRequestBody = toStartDissolvingNeuronRequest(params.neuronId);
   const canisterIdOutputs = splitPrincipal(params.canisterId).map(
-    (data, i, elements) => `Canister Id [${i + 1}/${elements.length}] : ${data}`
+    (data, i, elements) =>
+      `Canister Id [${i + 1}/${elements.length}] : ${data}`,
   );
   const neuronIdString = bytesToHexString(Array.from(params.neuronId.id));
   const neuronIdOutputs = splitString(neuronIdString, "Neuron Id");
@@ -134,10 +137,10 @@ const main = () => {
       61,
     ]);
     const principal1 = Principal.fromText(
-      "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae"
+      "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae",
     );
     const principal2 = Principal.fromText(
-      "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe"
+      "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe",
     );
     const snsAccount1 = {
       owner: principal1,

--- a/scripts/test-vectors/20230118-sns-remove-hotkey.ts
+++ b/scripts/test-vectors/20230118-sns-remove-hotkey.ts
@@ -25,16 +25,17 @@ interface Params extends SnsNeuronPermissionsParams {
 const createTestVector = (params: Params) => {
   const rawRequestBody = toRemovePermissionsRequest(params);
   const canisterIdOutputs = splitPrincipal(params.canisterId).map(
-    (data, i, elements) => `Canister Id [${i + 1}/${elements.length}] : ${data}`
+    (data, i, elements) =>
+      `Canister Id [${i + 1}/${elements.length}] : ${data}`,
   );
   const neuronIdString = bytesToHexString(Array.from(params.neuronId.id));
   const neuronIdOutputs = splitString(neuronIdString, "Neuron Id");
   const principalOutputs = splitPrincipal(params.principal).map(
     (data, i, elements) =>
-      `Principal Id [${i + 1}/${elements.length}] : ${data}`
+      `Principal Id [${i + 1}/${elements.length}] : ${data}`,
   );
   const permissionOutputs = params.permissions.map(
-    (p) => `Remove Permission : ${permissionMapper[p]}`
+    (p) => `Remove Permission : ${permissionMapper[p]}`,
   );
   const output = [
     "Transaction type : Remove Neuron Permissions",
@@ -69,10 +70,10 @@ const main = () => {
       61,
     ]);
     const principal1 = Principal.fromText(
-      "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae"
+      "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae",
     );
     const principal2 = Principal.fromText(
-      "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe"
+      "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe",
     );
     const canisterId1 = Principal.fromText("ppmzm-3aaaa-aaaaa-aacpq-cai");
     const canisterId2 = Principal.fromText("s24we-diaaa-aaaaa-aaaka-cai");

--- a/scripts/test-vectors/20230123-icrc-1.ts
+++ b/scripts/test-vectors/20230123-icrc-1.ts
@@ -50,7 +50,8 @@ const createTestVector = (params: Params) => {
 
   let outputTxType = isICP ? "Send ICP" : "Send Tokens";
   const canisterIdOutputs = splitPrincipal(params.canisterId).map(
-    (data, i, elements) => `Canister Id [${i + 1}/${elements.length}] : ${data}`
+    (data, i, elements) =>
+      `Canister Id [${i + 1}/${elements.length}] : ${data}`,
   );
 
   const fromOutputs = splitAccount(
@@ -58,14 +59,14 @@ const createTestVector = (params: Params) => {
       owner: params.owner,
       subaccount: params.from_subaccount,
     },
-    "From account"
+    "From account",
   );
   const toOutputs = splitAccount(
     {
       owner: params.to.owner,
       subaccount: fromNullable(params.to.subaccount),
     },
-    "To account"
+    "To account",
   );
 
   const amountToken = Number(params.amount) / Number(E8S_PER_TOKEN);
@@ -126,10 +127,10 @@ const main = () => {
       61,
     ]);
     const principal1 = Principal.fromText(
-      "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae"
+      "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae",
     );
     const principal2 = Principal.fromText(
-      "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe"
+      "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe",
     );
     const canisterId1 = Principal.fromText("ppmzm-3aaaa-aaaaa-aacpq-cai");
     const canisterId2 = Principal.fromText("s24we-diaaa-aaaaa-aaaka-cai");

--- a/scripts/test-vectors/20230125-sns-stake-maturity.ts
+++ b/scripts/test-vectors/20230125-sns-stake-maturity.ts
@@ -23,7 +23,8 @@ interface StakeMaturityParams extends SnsNeuronStakeMaturityParams {
 const createStakeMaturityVector = (params: StakeMaturityParams) => {
   const rawRequestBody = toStakeMaturityRequest(params);
   const canisterIdOutputs = splitPrincipal(params.canisterId).map(
-    (data, i, elements) => `Canister Id [${i + 1}/${elements.length}] : ${data}`
+    (data, i, elements) =>
+      `Canister Id [${i + 1}/${elements.length}] : ${data}`,
   );
   const neuronIdString = bytesToHexString(Array.from(params.neuronId.id));
   const neuronIdOutputs = splitString(neuronIdString, "Neuron Id");

--- a/scripts/test-vectors/20230321-disburse.ts
+++ b/scripts/test-vectors/20230321-disburse.ts
@@ -10,10 +10,10 @@ const mockNeuronId2 = BigInt(8836564053576662908);
 const amount1 = BigInt(20_000_000);
 const amount2 = BigInt(25_000_000);
 const account1 = AccountIdentifier.fromHex(
-  "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f"
+  "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f",
 );
 const account2 = AccountIdentifier.fromHex(
-  "b1cebc8480a0afc91198a87ddf52c6ca7eb7ccddb0cb398064f71d2bbaf2f72b"
+  "b1cebc8480a0afc91198a87ddf52c6ca7eb7ccddb0cb398064f71d2bbaf2f72b",
 );
 
 const createDisburseVector = ({

--- a/scripts/test-vectors/20230511-add-hotkey.ts
+++ b/scripts/test-vectors/20230511-add-hotkey.ts
@@ -8,10 +8,10 @@ import { createBlob, writeToJson } from "./utils";
 const mockNeuronId = BigInt(15374508381553347371);
 const mockNeuronId2 = BigInt(8836564053576662908);
 const principal1 = Principal.fromText(
-  "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae"
+  "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae",
 );
 const principal2 = Principal.fromText(
-  "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe"
+  "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe",
 );
 
 const createAddHotkeyVector = ({

--- a/scripts/test-vectors/20230511-remove-hotkey.ts
+++ b/scripts/test-vectors/20230511-remove-hotkey.ts
@@ -8,10 +8,10 @@ import { createBlob, writeToJson } from "./utils";
 const mockNeuronId = BigInt(15374508381553347371);
 const mockNeuronId2 = BigInt(8836564053576662908);
 const principal1 = Principal.fromText(
-  "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae"
+  "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae",
 );
 const principal2 = Principal.fromText(
-  "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe"
+  "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe",
 );
 
 const createRemoveHotkeyVector = ({

--- a/scripts/test-vectors/20230516-send-icp-stake-neuron.ts
+++ b/scripts/test-vectors/20230516-send-icp-stake-neuron.ts
@@ -16,19 +16,19 @@ import { TransferFn } from "./ledger.idl";
 import { createBlob, writeToJson } from "./utils";
 
 const account1 = AccountIdentifier.fromHex(
-  "d3e13d4777e22367532053190b6c6ccf57444a61337e996242b1abfb52cf92c8"
+  "d3e13d4777e22367532053190b6c6ccf57444a61337e996242b1abfb52cf92c8",
 );
 const account2 = AccountIdentifier.fromPrincipal({
   principal: Principal.fromText(
-    "bwz3t-ercuj-owo6s-4adfr-sbu4o-l72hg-kfhc5-5sapm-tj6bn-3scho-uqe"
+    "bwz3t-ercuj-owo6s-4adfr-sbu4o-l72hg-kfhc5-5sapm-tj6bn-3scho-uqe",
   ),
 });
 
 const defaultCaller = Principal.fromText(
-  "5upke-tazvi-6ufqc-i3v6r-j4gpu-dpwti-obhal-yb5xj-ue32x-ktkql-rqe"
+  "5upke-tazvi-6ufqc-i3v6r-j4gpu-dpwti-obhal-yb5xj-ue32x-ktkql-rqe",
 );
 const caller1 = Principal.fromText(
-  "bwz3t-ercuj-owo6s-4adfr-sbu4o-l72hg-kfhc5-5sapm-tj6bn-3scho-uqe"
+  "bwz3t-ercuj-owo6s-4adfr-sbu4o-l72hg-kfhc5-5sapm-tj6bn-3scho-uqe",
 );
 
 const subaccount1 = [
@@ -50,7 +50,7 @@ const randomBytes3 = new Uint8Array([178, 247, 215, 62, 199, 137, 175, 189]);
 
 const buildNeuronStakeSubAccount = (
   nonce: Uint8Array,
-  principal: Principal
+  principal: Principal,
 ): SubAccount => {
   const padding = asciiStringToByteArray("neuron-stake");
   const shaObj = sha256.create();
@@ -104,7 +104,7 @@ const createSendIcpVector = ({
     fromSubAccount === undefined
       ? undefined
       : (SubAccount.fromBytes(
-          arrayOfNumberToUint8Array(fromSubAccount)
+          arrayOfNumberToUint8Array(fromSubAccount),
         ) as SubAccount);
 
   return {

--- a/scripts/test-vectors/20230516-spawn-neuron.ts
+++ b/scripts/test-vectors/20230516-spawn-neuron.ts
@@ -8,10 +8,10 @@ import { createBlob, writeToJson } from "./utils";
 const mockNeuronId = BigInt(15374508381553347371);
 const mockNeuronId2 = BigInt(8836564053576662908);
 const principal1 = Principal.fromText(
-  "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae"
+  "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae",
 );
 const principal2 = Principal.fromText(
-  "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe"
+  "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe",
 );
 
 const createSpawnNeuronVector = ({

--- a/scripts/test-vectors/20230524-icrc-1.ts
+++ b/scripts/test-vectors/20230524-icrc-1.ts
@@ -50,7 +50,8 @@ const createTestVector = (params: Params) => {
 
   let outputTxType = isICP ? "Send ICP" : "Send Tokens";
   const canisterIdOutputs = splitPrincipal(params.canisterId).map(
-    (data, i, elements) => `Canister Id [${i + 1}/${elements.length}] : ${data}`
+    (data, i, elements) =>
+      `Canister Id [${i + 1}/${elements.length}] : ${data}`,
   );
 
   const fromOutputs = splitAccount(
@@ -58,14 +59,14 @@ const createTestVector = (params: Params) => {
       owner: params.owner,
       subaccount: params.from_subaccount,
     },
-    "From account"
+    "From account",
   );
   const toOutputs = splitAccount(
     {
       owner: params.to.owner,
       subaccount: fromNullable(params.to.subaccount),
     },
-    "To account"
+    "To account",
   );
 
   const amountToken = Number(params.amount) / Number(E8S_PER_TOKEN);
@@ -126,10 +127,10 @@ const main = () => {
       61,
     ]);
     const principal1 = Principal.fromText(
-      "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae"
+      "krpzt-buecq-u3umg-7kb7r-j5jpx-twqwa-3ykc4-y3cnk-7kwvw-5bq6z-mae",
     );
     const principal2 = Principal.fromText(
-      "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe"
+      "2dfd6-abjpf-eihu7-pwv6m-qnlbt-oszmg-kb26q-rvqms-onmuh-mwiq3-uqe",
     );
     const canisterId1 = Principal.fromText("ppmzm-3aaaa-aaaaa-aacpq-cai");
     const canisterId2 = Principal.fromText("s24we-diaaa-aaaaa-aaaka-cai");

--- a/scripts/test-vectors/20230712-sns-set-dissolve-timestamp.ts
+++ b/scripts/test-vectors/20230712-sns-set-dissolve-timestamp.ts
@@ -4,10 +4,10 @@ import { SnsSetDissolveTimestampParams } from "@dfinity/sns/src";
 import { toSetDissolveTimestampRequest } from "@dfinity/sns/src/converters/governance.converters";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 import {
-  secondsToDissolveDelayDuration,
   SECONDS_IN_DAY,
   SECONDS_IN_MONTH,
   SECONDS_IN_YEAR,
+  secondsToDissolveDelayDuration,
 } from "./date-utils";
 import { ManageNeuronFn } from "./sns-governance.idl";
 import { bytesToHexString, createBlob, writeToJson } from "./utils";
@@ -25,7 +25,7 @@ const createTestVector = (params: Params) => {
   const rawRequestBody = toSetDissolveTimestampRequest(params);
   const neuronIdString = bytesToHexString(Array.from(params.neuronId.id));
   const timestampLabel = secondsToDissolveDelayDuration(
-    params.dissolveTimestampSeconds - BigInt(nowInSeconds)
+    params.dissolveTimestampSeconds - BigInt(nowInSeconds),
   );
   console.log("in da test vector", params.dissolveTimestampSeconds);
   return {
@@ -58,15 +58,15 @@ const main = () => {
     const canisterId2 = Principal.fromText("s24we-diaaa-aaaaa-aaaka-cai");
     const inOneYear = BigInt(nowInSeconds + SECONDS_IN_YEAR);
     const nextYearAndAHalf = BigInt(
-      Math.round(nowInSeconds + SECONDS_IN_YEAR + SECONDS_IN_MONTH * 6)
+      Math.round(nowInSeconds + SECONDS_IN_YEAR + SECONDS_IN_MONTH * 6),
     );
     const inOneYearMonthsAndDays = BigInt(
       Math.round(
         nowInSeconds +
           SECONDS_IN_YEAR +
           SECONDS_IN_MONTH * 3 +
-          SECONDS_IN_DAY * 18
-      )
+          SECONDS_IN_DAY * 18,
+      ),
     );
     const inSixMonths = BigInt(Math.round(nowInSeconds + SECONDS_IN_MONTH * 6));
     const inEightYears = BigInt(Math.round(nowInSeconds + SECONDS_IN_YEAR * 8));

--- a/scripts/test-vectors/20230927-icrc-stake-neuron.ts
+++ b/scripts/test-vectors/20230927-icrc-stake-neuron.ts
@@ -48,8 +48,8 @@ const createTestVector = (params: Params) => {
   let outputTxType = isStakeNeuron
     ? "Stake Neuron"
     : isICP
-    ? "Send ICP"
-    : "Send Tokens";
+      ? "Send ICP"
+      : "Send Tokens";
   const canisterIdOutputs = splitPrincipal(params.canisterId).map(
     (data, i, elements) =>
       `Canister Id [${i + 1}/${elements.length}] : ${data}`,

--- a/scripts/test-vectors/20240730-icrc21.ts
+++ b/scripts/test-vectors/20240730-icrc21.ts
@@ -26,7 +26,7 @@ function hexStringToArrayBuffer(hexString: string): ArrayBuffer {
 const callRequest = {
   arg: hexStringToArrayBuffer("4449444C00017104746F6269"),
   canister_id: Principal.fromHex("00000000006000FD0101"),
-  ingress_expiry: BigInt('1712667140606000000'),
+  ingress_expiry: BigInt("1712667140606000000"),
   method_name: "greet",
   request_type: "query" as SubmitRequestType,
   sender: Principal.fromHex("04"),
@@ -37,7 +37,7 @@ const consentMessageRequest = {
     "4449444C076D7B6C01D880C6D007716C02CBAEB581017AB183E7F1077A6B028BEABFC2067F8EF1C1EE0D026E036C02EFCEE7800401C4FBF2DB05046C03D6FCA70200E1EDEB4A7184F7FEE80A0501060C4449444C00017104746F626905677265657402656E01011E000300",
   ),
   canister_id: Principal.fromHex("00000000006000FD0101"),
-  ingress_expiry: BigInt('1712666698482000000'),
+  ingress_expiry: BigInt("1712666698482000000"),
   method_name: "icrc21_canister_call_consent_message",
   nonce: hexStringToArrayBuffer("A3788C1805553FB69B20F08E87E23B13"),
   request_type: "call" as SubmitRequestType,

--- a/scripts/test-vectors/20240730-icrc21.ts
+++ b/scripts/test-vectors/20240730-icrc21.ts
@@ -1,6 +1,6 @@
-import { Expiry, SubmitRequestType } from "@dfinity/agent";
+import { Cbor } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
-import { _prepareCborForLedger, writeToJson } from "./utils";
+import { writeToJson } from "./utils";
 
 function hexStringToArrayBuffer(hexString: string): ArrayBuffer {
   // Remove any non-hexadecimal characters (e.g., spaces)
@@ -26,9 +26,9 @@ function hexStringToArrayBuffer(hexString: string): ArrayBuffer {
 const callRequest = {
   arg: hexStringToArrayBuffer("4449444C00017104746F6269"),
   canister_id: Principal.fromHex("00000000006000FD0101"),
-  ingress_expiry: new Expiry(1712667140606 - Date.now()),
+  ingress_expiry: BigInt("1712667140606000000"),
   method_name: "greet",
-  request_type: "query" as SubmitRequestType,
+  request_type: "query",
   sender: Principal.fromHex("04"),
 };
 
@@ -37,19 +37,19 @@ const consentMessageRequest = {
     "4449444C076D7B6C01D880C6D007716C02CBAEB581017AB183E7F1077A6B028BEABFC2067F8EF1C1EE0D026E036C02EFCEE7800401C4FBF2DB05046C03D6FCA70200E1EDEB4A7184F7FEE80A0501060C4449444C00017104746F626905677265657402656E01011E000300",
   ),
   canister_id: Principal.fromHex("00000000006000FD0101"),
-  ingress_expiry: new Expiry(1712666698482 - Date.now()),
+  ingress_expiry: BigInt("1712666698482000000"),
   method_name: "icrc21_canister_call_consent_message",
   nonce: hexStringToArrayBuffer("A3788C1805553FB69B20F08E87E23B13"),
-  request_type: "call" as SubmitRequestType,
+  request_type: "call",
   sender: Principal.fromHex("04"),
 };
 
 const createCandidBlobs = () => {
   const callRequestBlob = Buffer.from(
-    _prepareCborForLedger(callRequest),
+    Cbor.encode({ content: callRequest }),
   ).toString("hex");
   const consentMessageRequestBlob = Buffer.from(
-    _prepareCborForLedger(consentMessageRequest),
+    Cbor.encode({ content: consentMessageRequest }),
   ).toString("hex");
 
   writeToJson({

--- a/scripts/test-vectors/20240730-icrc21.ts
+++ b/scripts/test-vectors/20240730-icrc21.ts
@@ -1,4 +1,4 @@
-import { Expiry, SubmitRequestType } from "@dfinity/agent";
+import { SubmitRequestType } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { _prepareCborForLedger, writeToJson } from "./utils";
 
@@ -26,7 +26,7 @@ function hexStringToArrayBuffer(hexString: string): ArrayBuffer {
 const callRequest = {
   arg: hexStringToArrayBuffer("4449444C00017104746F6269"),
   canister_id: Principal.fromHex("00000000006000FD0101"),
-  ingress_expiry: new Expiry(1712667140606000000),
+  ingress_expiry: BigInt('1712667140606000000'),
   method_name: "greet",
   request_type: "query" as SubmitRequestType,
   sender: Principal.fromHex("04"),
@@ -37,7 +37,7 @@ const consentMessageRequest = {
     "4449444C076D7B6C01D880C6D007716C02CBAEB581017AB183E7F1077A6B028BEABFC2067F8EF1C1EE0D026E036C02EFCEE7800401C4FBF2DB05046C03D6FCA70200E1EDEB4A7184F7FEE80A0501060C4449444C00017104746F626905677265657402656E01011E000300",
   ),
   canister_id: Principal.fromHex("00000000006000FD0101"),
-  ingress_expiry: new Expiry(1712666698482000000),
+  ingress_expiry: BigInt('1712666698482000000'),
   method_name: "icrc21_canister_call_consent_message",
   nonce: hexStringToArrayBuffer("A3788C1805553FB69B20F08E87E23B13"),
   request_type: "call" as SubmitRequestType,
@@ -54,7 +54,7 @@ const createCandidBlobs = () => {
 
   writeToJson({
     data: { callRequestBlob, consentMessageRequestBlob },
-    fileName: "icrc29.json",
+    fileName: "icrc21.json",
   });
 };
 

--- a/scripts/test-vectors/20240730-icrc21.ts
+++ b/scripts/test-vectors/20240730-icrc21.ts
@@ -1,4 +1,4 @@
-import { SubmitRequestType } from "@dfinity/agent";
+import { Expiry, SubmitRequestType } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { _prepareCborForLedger, writeToJson } from "./utils";
 
@@ -26,7 +26,7 @@ function hexStringToArrayBuffer(hexString: string): ArrayBuffer {
 const callRequest = {
   arg: hexStringToArrayBuffer("4449444C00017104746F6269"),
   canister_id: Principal.fromHex("00000000006000FD0101"),
-  ingress_expiry: BigInt("1712667140606000000"),
+  ingress_expiry: new Expiry(1712667140606 - Date.now()),
   method_name: "greet",
   request_type: "query" as SubmitRequestType,
   sender: Principal.fromHex("04"),
@@ -37,7 +37,7 @@ const consentMessageRequest = {
     "4449444C076D7B6C01D880C6D007716C02CBAEB581017AB183E7F1077A6B028BEABFC2067F8EF1C1EE0D026E036C02EFCEE7800401C4FBF2DB05046C03D6FCA70200E1EDEB4A7184F7FEE80A0501060C4449444C00017104746F626905677265657402656E01011E000300",
   ),
   canister_id: Principal.fromHex("00000000006000FD0101"),
-  ingress_expiry: BigInt("1712666698482000000"),
+  ingress_expiry: new Expiry(1712666698482 - Date.now()),
   method_name: "icrc21_canister_call_consent_message",
   nonce: hexStringToArrayBuffer("A3788C1805553FB69B20F08E87E23B13"),
   request_type: "call" as SubmitRequestType,

--- a/scripts/test-vectors/date-utils.ts
+++ b/scripts/test-vectors/date-utils.ts
@@ -38,7 +38,7 @@ export const secondsToDissolveDelayDuration = (seconds: bigint): string => {
   const years = seconds / BigInt(SECONDS_IN_YEAR);
   const months = (seconds % BigInt(SECONDS_IN_YEAR)) / BigInt(SECONDS_IN_MONTH);
   const days = BigInt(
-    Math.ceil((Number(seconds) % SECONDS_IN_MONTH) / SECONDS_IN_DAY)
+    Math.ceil((Number(seconds) % SECONDS_IN_MONTH) / SECONDS_IN_DAY),
   );
   const periods = [
     createLabel("year", years),
@@ -54,7 +54,7 @@ export const secondsToDissolveDelayDuration = (seconds: bigint): string => {
           labelInfo.amount === 1
             ? labels[labelInfo.labelKey]
             : labels[`${labelInfo.labelKey}_plural`]
-        }`
+        }`,
     )
     .join(", ");
 };

--- a/scripts/test-vectors/sns-governance.idl.ts
+++ b/scripts/test-vectors/sns-governance.idl.ts
@@ -18,12 +18,12 @@ const NervousSystemFunction = IDL.Record({
 });
 const GovernanceCachedMetrics = IDL.Record({
   not_dissolving_neurons_e8s_buckets: IDL.Vec(
-    IDL.Tuple(IDL.Nat64, IDL.Float64)
+    IDL.Tuple(IDL.Nat64, IDL.Float64),
   ),
   garbage_collectable_neurons_count: IDL.Nat64,
   neurons_with_invalid_stake_count: IDL.Nat64,
   not_dissolving_neurons_count_buckets: IDL.Vec(
-    IDL.Tuple(IDL.Nat64, IDL.Nat64)
+    IDL.Tuple(IDL.Nat64, IDL.Nat64),
   ),
   neurons_with_less_than_6_months_dissolve_delay_count: IDL.Nat64,
   dissolved_neurons_count: IDL.Nat64,
@@ -273,7 +273,7 @@ const Neuron = IDL.Record({
 const Governance = IDL.Record({
   root_canister_id: IDL.Opt(IDL.Principal),
   id_to_nervous_system_functions: IDL.Vec(
-    IDL.Tuple(IDL.Nat64, NervousSystemFunction)
+    IDL.Tuple(IDL.Nat64, NervousSystemFunction),
   ),
   metrics: IDL.Opt(GovernanceCachedMetrics),
   mode: IDL.Int32,
@@ -431,7 +431,7 @@ const SetMode = IDL.Record({ mode: IDL.Int32 });
 export const ManageNeuronFn = IDL.Func(
   [ManageNeuron],
   [ManageNeuronResponse],
-  []
+  [],
 );
 
 // List of endpoints
@@ -439,14 +439,14 @@ IDL.Service({
   claim_swap_neurons: IDL.Func(
     [ClaimSwapNeuronsRequest],
     [ClaimSwapNeuronsResponse],
-    []
+    [],
   ),
   get_build_metadata: IDL.Func([], [IDL.Text], ["query"]),
   get_metadata: IDL.Func([IDL.Record({})], [GetMetadataResponse], ["query"]),
   get_nervous_system_parameters: IDL.Func(
     [IDL.Null],
     [NervousSystemParameters],
-    ["query"]
+    ["query"],
   ),
   get_neuron: IDL.Func([GetNeuron], [GetNeuronResponse], ["query"]),
   get_proposal: IDL.Func([GetProposal], [GetProposalResponse], ["query"]),
@@ -454,17 +454,17 @@ IDL.Service({
   get_running_sns_version: IDL.Func(
     [IDL.Record({})],
     [GetRunningSnsVersionResponse],
-    ["query"]
+    ["query"],
   ),
   get_sns_initialization_parameters: IDL.Func(
     [IDL.Record({})],
     [GetSnsInitializationParametersResponse],
-    ["query"]
+    ["query"],
   ),
   list_nervous_system_functions: IDL.Func(
     [],
     [ListNervousSystemFunctionsResponse],
-    ["query"]
+    ["query"],
   ),
   list_neurons: IDL.Func([ListNeurons], [ListNeuronsResponse], ["query"]),
   list_proposals: IDL.Func([ListProposals], [ListProposalsResponse], ["query"]),

--- a/scripts/test-vectors/sns-ledger.idl.ts
+++ b/scripts/test-vectors/sns-ledger.idl.ts
@@ -62,14 +62,14 @@ const service = IDL.Service({
   icrc1_metadata: IDL.Func(
     [],
     [IDL.Vec(IDL.Tuple(IDL.Text, Value))],
-    ["query"]
+    ["query"],
   ),
   icrc1_minting_account: IDL.Func([], [IDL.Opt(Account)], ["query"]),
   icrc1_name: IDL.Func([], [IDL.Text], ["query"]),
   icrc1_supported_standards: IDL.Func(
     [],
     [IDL.Vec(IDL.Record({ url: IDL.Text, name: IDL.Text }))],
-    ["query"]
+    ["query"],
   ),
   icrc1_symbol: IDL.Func([], [IDL.Text], ["query"]),
   icrc1_total_supply: IDL.Func([], [Tokens], ["query"]),


### PR DESCRIPTION
# Motivation

Expiry takes as a constructor argument the time _delta_ in millis. Supplied was the absolute timestamp as a number (but too large to use accurate integer representation).

This fixes the bug.

In addition, the test vector should be called ICRC-21 rather then ICRC-29.
