### PR TITLE
Use different request/response types for NNS proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Breaking changes
 
 - Rename values of enum Topic and NnsFunction to match the backend values.
+- Use different request/response types for NNS Governance proposals, and different fields for `InstallCode` proposals.
 
 ## Features
 

--- a/packages/nns/candid/governance.certified.idl.js
+++ b/packages/nns/candid/governance.certified.idl.js
@@ -1,5 +1,6 @@
 /* Do not edit.  Compiled with ./scripts/compile-idl-js from packages/nns/candid/governance.did */
 export const idlFactory = ({ IDL }) => {
+  const ManageNeuronRequest = IDL.Rec();
   const Proposal = IDL.Rec();
   const NeuronId = IDL.Record({ 'id' : IDL.Nat64 });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
@@ -117,10 +118,10 @@ export const idlFactory = ({ IDL }) => {
     'settings' : IDL.Opt(CanisterSettings),
   });
   const InstallCode = IDL.Record({
-    'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
-    'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
+    'wasm_module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'arg_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'install_mode' : IDL.Opt(IDL.Int32),
   });
   const StopOrStartCanister = IDL.Record({
@@ -755,6 +756,58 @@ export const idlFactory = ({ IDL }) => {
   const ListProposalInfoResponse = IDL.Record({
     'proposal_info' : IDL.Vec(ProposalInfo),
   });
+  const InstallCodeRequest = IDL.Record({
+    'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'install_mode' : IDL.Opt(IDL.Int32),
+  });
+  const ProposalActionRequest = IDL.Variant({
+    'RegisterKnownNeuron' : KnownNeuron,
+    'ManageNeuron' : ManageNeuronRequest,
+    'UpdateCanisterSettings' : UpdateCanisterSettings,
+    'InstallCode' : InstallCodeRequest,
+    'StopOrStartCanister' : StopOrStartCanister,
+    'CreateServiceNervousSystem' : CreateServiceNervousSystem,
+    'ExecuteNnsFunction' : ExecuteNnsFunction,
+    'RewardNodeProvider' : RewardNodeProvider,
+    'OpenSnsTokenSwap' : OpenSnsTokenSwap,
+    'SetSnsTokenSwapOpenTimeWindow' : SetSnsTokenSwapOpenTimeWindow,
+    'SetDefaultFollowees' : SetDefaultFollowees,
+    'RewardNodeProviders' : RewardNodeProviders,
+    'ManageNetworkEconomics' : NetworkEconomics,
+    'ApproveGenesisKyc' : Principals,
+    'AddOrRemoveNodeProvider' : AddOrRemoveNodeProvider,
+    'Motion' : Motion,
+  });
+  const MakeProposalRequest = IDL.Record({
+    'url' : IDL.Text,
+    'title' : IDL.Opt(IDL.Text),
+    'action' : IDL.Opt(ProposalActionRequest),
+    'summary' : IDL.Text,
+  });
+  const ManageNeuronCommandRequest = IDL.Variant({
+    'Spawn' : Spawn,
+    'Split' : Split,
+    'Follow' : Follow,
+    'ClaimOrRefresh' : ClaimOrRefresh,
+    'Configure' : Configure,
+    'RegisterVote' : RegisterVote,
+    'Merge' : Merge,
+    'DisburseToNeuron' : DisburseToNeuron,
+    'MakeProposal' : MakeProposalRequest,
+    'StakeMaturity' : StakeMaturity,
+    'MergeMaturity' : MergeMaturity,
+    'Disburse' : Disburse,
+  });
+  ManageNeuronRequest.fill(
+    IDL.Record({
+      'id' : IDL.Opt(NeuronId),
+      'command' : IDL.Opt(ManageNeuronCommandRequest),
+      'neuron_id_or_subaccount' : IDL.Opt(NeuronIdOrSubaccount),
+    })
+  );
   const SpawnResponse = IDL.Record({ 'created_neuron_id' : IDL.Opt(NeuronId) });
   const ClaimOrRefreshResponse = IDL.Record({
     'refreshed_neuron_id' : IDL.Opt(NeuronId),
@@ -889,7 +942,11 @@ export const idlFactory = ({ IDL }) => {
         [ListProposalInfoResponse],
         [],
       ),
-    'manage_neuron' : IDL.Func([ManageNeuron], [ManageNeuronResponse], []),
+    'manage_neuron' : IDL.Func(
+        [ManageNeuronRequest],
+        [ManageNeuronResponse],
+        [],
+      ),
     'settle_community_fund_participation' : IDL.Func(
         [SettleCommunityFundParticipation],
         [Result],
@@ -901,7 +958,7 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'simulate_manage_neuron' : IDL.Func(
-        [ManageNeuron],
+        [ManageNeuronRequest],
         [ManageNeuronResponse],
         [],
       ),
@@ -1027,10 +1084,10 @@ export const init = ({ IDL }) => {
     'settings' : IDL.Opt(CanisterSettings),
   });
   const InstallCode = IDL.Record({
-    'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
-    'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
+    'wasm_module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'arg_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'install_mode' : IDL.Opt(IDL.Int32),
   });
   const StopOrStartCanister = IDL.Record({

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -323,6 +323,13 @@ export interface InitialTokenDistribution {
   swap_distribution: [] | [SwapDistribution];
 }
 export interface InstallCode {
+  skip_stopping_before_installing: [] | [boolean];
+  wasm_module_hash: [] | [Uint8Array | number[]];
+  canister_id: [] | [Principal];
+  arg_hash: [] | [Uint8Array | number[]];
+  install_mode: [] | [number];
+}
+export interface InstallCodeRequest {
   arg: [] | [Uint8Array | number[]];
   wasm_module: [] | [Uint8Array | number[]];
   skip_stopping_before_installing: [] | [boolean];
@@ -371,6 +378,12 @@ export interface ListProposalInfo {
 export interface ListProposalInfoResponse {
   proposal_info: Array<ProposalInfo>;
 }
+export interface MakeProposalRequest {
+  url: string;
+  title: [] | [string];
+  action: [] | [ProposalActionRequest];
+  summary: string;
+}
 export interface MakeProposalResponse {
   message: [] | [string];
   proposal_id: [] | [NeuronId];
@@ -383,6 +396,24 @@ export interface MakingSnsProposal {
 export interface ManageNeuron {
   id: [] | [NeuronId];
   command: [] | [Command];
+  neuron_id_or_subaccount: [] | [NeuronIdOrSubaccount];
+}
+export type ManageNeuronCommandRequest =
+  | { Spawn: Spawn }
+  | { Split: Split }
+  | { Follow: Follow }
+  | { ClaimOrRefresh: ClaimOrRefresh }
+  | { Configure: Configure }
+  | { RegisterVote: RegisterVote }
+  | { Merge: Merge }
+  | { DisburseToNeuron: DisburseToNeuron }
+  | { MakeProposal: MakeProposalRequest }
+  | { StakeMaturity: StakeMaturity }
+  | { MergeMaturity: MergeMaturity }
+  | { Disburse: Disburse };
+export interface ManageNeuronRequest {
+  id: [] | [NeuronId];
+  command: [] | [ManageNeuronCommandRequest];
   neuron_id_or_subaccount: [] | [NeuronIdOrSubaccount];
 }
 export interface ManageNeuronResponse {
@@ -629,6 +660,23 @@ export interface Proposal {
   action: [] | [Action];
   summary: string;
 }
+export type ProposalActionRequest =
+  | { RegisterKnownNeuron: KnownNeuron }
+  | { ManageNeuron: ManageNeuronRequest }
+  | { UpdateCanisterSettings: UpdateCanisterSettings }
+  | { InstallCode: InstallCodeRequest }
+  | { StopOrStartCanister: StopOrStartCanister }
+  | { CreateServiceNervousSystem: CreateServiceNervousSystem }
+  | { ExecuteNnsFunction: ExecuteNnsFunction }
+  | { RewardNodeProvider: RewardNodeProvider }
+  | { OpenSnsTokenSwap: OpenSnsTokenSwap }
+  | { SetSnsTokenSwapOpenTimeWindow: SetSnsTokenSwapOpenTimeWindow }
+  | { SetDefaultFollowees: SetDefaultFollowees }
+  | { RewardNodeProviders: RewardNodeProviders }
+  | { ManageNetworkEconomics: NetworkEconomics }
+  | { ApproveGenesisKyc: Principals }
+  | { AddOrRemoveNodeProvider: AddOrRemoveNodeProvider }
+  | { Motion: Motion };
 export interface ProposalData {
   id: [] | [NeuronId];
   failure_reason: [] | [GovernanceError];
@@ -881,7 +929,7 @@ export interface _SERVICE {
   list_neurons: ActorMethod<[ListNeurons], ListNeuronsResponse>;
   list_node_providers: ActorMethod<[], ListNodeProvidersResponse>;
   list_proposals: ActorMethod<[ListProposalInfo], ListProposalInfoResponse>;
-  manage_neuron: ActorMethod<[ManageNeuron], ManageNeuronResponse>;
+  manage_neuron: ActorMethod<[ManageNeuronRequest], ManageNeuronResponse>;
   settle_community_fund_participation: ActorMethod<
     [SettleCommunityFundParticipation],
     Result
@@ -890,7 +938,10 @@ export interface _SERVICE {
     [SettleNeuronsFundParticipationRequest],
     SettleNeuronsFundParticipationResponse
   >;
-  simulate_manage_neuron: ActorMethod<[ManageNeuron], ManageNeuronResponse>;
+  simulate_manage_neuron: ActorMethod<
+    [ManageNeuronRequest],
+    ManageNeuronResponse
+  >;
   transfer_gtc_neuron: ActorMethod<[NeuronId, NeuronId], Result>;
   update_node_provider: ActorMethod<[UpdateNodeProvider], Result>;
 }

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 3d0b3f1 (2024-08-02 tags: release-2024-08-02_01-30-base) 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 8e149ef621 (2024-08-16) 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
@@ -267,6 +267,13 @@ type InitialTokenDistribution = record {
   swap_distribution : opt SwapDistribution;
 };
 type InstallCode = record {
+  skip_stopping_before_installing : opt bool;
+  wasm_module_hash : opt blob;
+  canister_id : opt principal;
+  arg_hash : opt blob;
+  install_mode : opt int32;
+};
+type InstallCodeRequest = record {
   arg : opt blob;
   wasm_module : opt blob;
   skip_stopping_before_installing : opt bool;
@@ -306,6 +313,12 @@ type ListProposalInfo = record {
   include_status : vec int32;
 };
 type ListProposalInfoResponse = record { proposal_info : vec ProposalInfo };
+type MakeProposalRequest = record {
+  url : text;
+  title : opt text;
+  action : opt ProposalActionRequest;
+  summary : text;
+};
 type MakeProposalResponse = record {
   message : opt text;
   proposal_id : opt NeuronId;
@@ -318,6 +331,25 @@ type MakingSnsProposal = record {
 type ManageNeuron = record {
   id : opt NeuronId;
   command : opt Command;
+  neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
+};
+type ManageNeuronCommandRequest = variant {
+  Spawn : Spawn;
+  Split : Split;
+  Follow : Follow;
+  ClaimOrRefresh : ClaimOrRefresh;
+  Configure : Configure;
+  RegisterVote : RegisterVote;
+  Merge : Merge;
+  DisburseToNeuron : DisburseToNeuron;
+  MakeProposal : MakeProposalRequest;
+  StakeMaturity : StakeMaturity;
+  MergeMaturity : MergeMaturity;
+  Disburse : Disburse;
+};
+type ManageNeuronRequest = record {
+  id : opt NeuronId;
+  command : opt ManageNeuronCommandRequest;
   neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
 };
 type ManageNeuronResponse = record { command : opt Command_1 };
@@ -539,6 +571,24 @@ type Proposal = record {
   action : opt Action;
   summary : text;
 };
+type ProposalActionRequest = variant {
+  RegisterKnownNeuron : KnownNeuron;
+  ManageNeuron : ManageNeuronRequest;
+  UpdateCanisterSettings : UpdateCanisterSettings;
+  InstallCode : InstallCodeRequest;
+  StopOrStartCanister : StopOrStartCanister;
+  CreateServiceNervousSystem : CreateServiceNervousSystem;
+  ExecuteNnsFunction : ExecuteNnsFunction;
+  RewardNodeProvider : RewardNodeProvider;
+  OpenSnsTokenSwap : OpenSnsTokenSwap;
+  SetSnsTokenSwapOpenTimeWindow : SetSnsTokenSwapOpenTimeWindow;
+  SetDefaultFollowees : SetDefaultFollowees;
+  RewardNodeProviders : RewardNodeProviders;
+  ManageNetworkEconomics : NetworkEconomics;
+  ApproveGenesisKyc : Principals;
+  AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
+  Motion : Motion;
+};
 type ProposalData = record {
   id : opt NeuronId;
   failure_reason : opt GovernanceError;
@@ -752,14 +802,14 @@ service : (Governance) -> {
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
   list_node_providers : () -> (ListNodeProvidersResponse) query;
   list_proposals : (ListProposalInfo) -> (ListProposalInfoResponse) query;
-  manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
+  manage_neuron : (ManageNeuronRequest) -> (ManageNeuronResponse);
   settle_community_fund_participation : (SettleCommunityFundParticipation) -> (
       Result,
     );
   settle_neurons_fund_participation : (
       SettleNeuronsFundParticipationRequest,
     ) -> (SettleNeuronsFundParticipationResponse);
-  simulate_manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
+  simulate_manage_neuron : (ManageNeuronRequest) -> (ManageNeuronResponse);
   transfer_gtc_neuron : (NeuronId, NeuronId) -> (Result);
   update_node_provider : (UpdateNodeProvider) -> (Result);
 }

--- a/packages/nns/candid/governance.idl.js
+++ b/packages/nns/candid/governance.idl.js
@@ -1,5 +1,6 @@
 /* Do not edit.  Compiled with ./scripts/compile-idl-js from packages/nns/candid/governance.did */
 export const idlFactory = ({ IDL }) => {
+  const ManageNeuronRequest = IDL.Rec();
   const Proposal = IDL.Rec();
   const NeuronId = IDL.Record({ 'id' : IDL.Nat64 });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
@@ -117,10 +118,10 @@ export const idlFactory = ({ IDL }) => {
     'settings' : IDL.Opt(CanisterSettings),
   });
   const InstallCode = IDL.Record({
-    'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
-    'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
+    'wasm_module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'arg_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'install_mode' : IDL.Opt(IDL.Int32),
   });
   const StopOrStartCanister = IDL.Record({
@@ -755,6 +756,58 @@ export const idlFactory = ({ IDL }) => {
   const ListProposalInfoResponse = IDL.Record({
     'proposal_info' : IDL.Vec(ProposalInfo),
   });
+  const InstallCodeRequest = IDL.Record({
+    'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'install_mode' : IDL.Opt(IDL.Int32),
+  });
+  const ProposalActionRequest = IDL.Variant({
+    'RegisterKnownNeuron' : KnownNeuron,
+    'ManageNeuron' : ManageNeuronRequest,
+    'UpdateCanisterSettings' : UpdateCanisterSettings,
+    'InstallCode' : InstallCodeRequest,
+    'StopOrStartCanister' : StopOrStartCanister,
+    'CreateServiceNervousSystem' : CreateServiceNervousSystem,
+    'ExecuteNnsFunction' : ExecuteNnsFunction,
+    'RewardNodeProvider' : RewardNodeProvider,
+    'OpenSnsTokenSwap' : OpenSnsTokenSwap,
+    'SetSnsTokenSwapOpenTimeWindow' : SetSnsTokenSwapOpenTimeWindow,
+    'SetDefaultFollowees' : SetDefaultFollowees,
+    'RewardNodeProviders' : RewardNodeProviders,
+    'ManageNetworkEconomics' : NetworkEconomics,
+    'ApproveGenesisKyc' : Principals,
+    'AddOrRemoveNodeProvider' : AddOrRemoveNodeProvider,
+    'Motion' : Motion,
+  });
+  const MakeProposalRequest = IDL.Record({
+    'url' : IDL.Text,
+    'title' : IDL.Opt(IDL.Text),
+    'action' : IDL.Opt(ProposalActionRequest),
+    'summary' : IDL.Text,
+  });
+  const ManageNeuronCommandRequest = IDL.Variant({
+    'Spawn' : Spawn,
+    'Split' : Split,
+    'Follow' : Follow,
+    'ClaimOrRefresh' : ClaimOrRefresh,
+    'Configure' : Configure,
+    'RegisterVote' : RegisterVote,
+    'Merge' : Merge,
+    'DisburseToNeuron' : DisburseToNeuron,
+    'MakeProposal' : MakeProposalRequest,
+    'StakeMaturity' : StakeMaturity,
+    'MergeMaturity' : MergeMaturity,
+    'Disburse' : Disburse,
+  });
+  ManageNeuronRequest.fill(
+    IDL.Record({
+      'id' : IDL.Opt(NeuronId),
+      'command' : IDL.Opt(ManageNeuronCommandRequest),
+      'neuron_id_or_subaccount' : IDL.Opt(NeuronIdOrSubaccount),
+    })
+  );
   const SpawnResponse = IDL.Record({ 'created_neuron_id' : IDL.Opt(NeuronId) });
   const ClaimOrRefreshResponse = IDL.Record({
     'refreshed_neuron_id' : IDL.Opt(NeuronId),
@@ -905,7 +958,11 @@ export const idlFactory = ({ IDL }) => {
         [ListProposalInfoResponse],
         ['query'],
       ),
-    'manage_neuron' : IDL.Func([ManageNeuron], [ManageNeuronResponse], []),
+    'manage_neuron' : IDL.Func(
+        [ManageNeuronRequest],
+        [ManageNeuronResponse],
+        [],
+      ),
     'settle_community_fund_participation' : IDL.Func(
         [SettleCommunityFundParticipation],
         [Result],
@@ -917,7 +974,7 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'simulate_manage_neuron' : IDL.Func(
-        [ManageNeuron],
+        [ManageNeuronRequest],
         [ManageNeuronResponse],
         [],
       ),
@@ -1043,10 +1100,10 @@ export const init = ({ IDL }) => {
     'settings' : IDL.Opt(CanisterSettings),
   });
   const InstallCode = IDL.Record({
-    'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
-    'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
+    'wasm_module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'arg_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'install_mode' : IDL.Opt(IDL.Int32),
   });
   const StopOrStartCanister = IDL.Record({

--- a/packages/nns/candid/governance_test.certified.idl.js
+++ b/packages/nns/candid/governance_test.certified.idl.js
@@ -1,5 +1,6 @@
 /* Do not edit.  Compiled with ./scripts/compile-idl-js from packages/nns/candid/governance_test.did */
 export const idlFactory = ({ IDL }) => {
+  const ManageNeuronRequest = IDL.Rec();
   const Proposal = IDL.Rec();
   const NeuronId = IDL.Record({ 'id' : IDL.Nat64 });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
@@ -117,10 +118,10 @@ export const idlFactory = ({ IDL }) => {
     'settings' : IDL.Opt(CanisterSettings),
   });
   const InstallCode = IDL.Record({
-    'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
-    'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
+    'wasm_module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'arg_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'install_mode' : IDL.Opt(IDL.Int32),
   });
   const StopOrStartCanister = IDL.Record({
@@ -755,6 +756,58 @@ export const idlFactory = ({ IDL }) => {
   const ListProposalInfoResponse = IDL.Record({
     'proposal_info' : IDL.Vec(ProposalInfo),
   });
+  const InstallCodeRequest = IDL.Record({
+    'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'install_mode' : IDL.Opt(IDL.Int32),
+  });
+  const ProposalActionRequest = IDL.Variant({
+    'RegisterKnownNeuron' : KnownNeuron,
+    'ManageNeuron' : ManageNeuronRequest,
+    'UpdateCanisterSettings' : UpdateCanisterSettings,
+    'InstallCode' : InstallCodeRequest,
+    'StopOrStartCanister' : StopOrStartCanister,
+    'CreateServiceNervousSystem' : CreateServiceNervousSystem,
+    'ExecuteNnsFunction' : ExecuteNnsFunction,
+    'RewardNodeProvider' : RewardNodeProvider,
+    'OpenSnsTokenSwap' : OpenSnsTokenSwap,
+    'SetSnsTokenSwapOpenTimeWindow' : SetSnsTokenSwapOpenTimeWindow,
+    'SetDefaultFollowees' : SetDefaultFollowees,
+    'RewardNodeProviders' : RewardNodeProviders,
+    'ManageNetworkEconomics' : NetworkEconomics,
+    'ApproveGenesisKyc' : Principals,
+    'AddOrRemoveNodeProvider' : AddOrRemoveNodeProvider,
+    'Motion' : Motion,
+  });
+  const MakeProposalRequest = IDL.Record({
+    'url' : IDL.Text,
+    'title' : IDL.Opt(IDL.Text),
+    'action' : IDL.Opt(ProposalActionRequest),
+    'summary' : IDL.Text,
+  });
+  const ManageNeuronCommandRequest = IDL.Variant({
+    'Spawn' : Spawn,
+    'Split' : Split,
+    'Follow' : Follow,
+    'ClaimOrRefresh' : ClaimOrRefresh,
+    'Configure' : Configure,
+    'RegisterVote' : RegisterVote,
+    'Merge' : Merge,
+    'DisburseToNeuron' : DisburseToNeuron,
+    'MakeProposal' : MakeProposalRequest,
+    'StakeMaturity' : StakeMaturity,
+    'MergeMaturity' : MergeMaturity,
+    'Disburse' : Disburse,
+  });
+  ManageNeuronRequest.fill(
+    IDL.Record({
+      'id' : IDL.Opt(NeuronId),
+      'command' : IDL.Opt(ManageNeuronCommandRequest),
+      'neuron_id_or_subaccount' : IDL.Opt(NeuronIdOrSubaccount),
+    })
+  );
   const SpawnResponse = IDL.Record({ 'created_neuron_id' : IDL.Opt(NeuronId) });
   const ClaimOrRefreshResponse = IDL.Record({
     'refreshed_neuron_id' : IDL.Opt(NeuronId),
@@ -889,7 +942,11 @@ export const idlFactory = ({ IDL }) => {
         [ListProposalInfoResponse],
         [],
       ),
-    'manage_neuron' : IDL.Func([ManageNeuron], [ManageNeuronResponse], []),
+    'manage_neuron' : IDL.Func(
+        [ManageNeuronRequest],
+        [ManageNeuronResponse],
+        [],
+      ),
     'settle_community_fund_participation' : IDL.Func(
         [SettleCommunityFundParticipation],
         [Result],
@@ -901,7 +958,7 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'simulate_manage_neuron' : IDL.Func(
-        [ManageNeuron],
+        [ManageNeuronRequest],
         [ManageNeuronResponse],
         [],
       ),
@@ -1028,10 +1085,10 @@ export const init = ({ IDL }) => {
     'settings' : IDL.Opt(CanisterSettings),
   });
   const InstallCode = IDL.Record({
-    'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
-    'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
+    'wasm_module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'arg_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'install_mode' : IDL.Opt(IDL.Int32),
   });
   const StopOrStartCanister = IDL.Record({

--- a/packages/nns/candid/governance_test.d.ts
+++ b/packages/nns/candid/governance_test.d.ts
@@ -323,6 +323,13 @@ export interface InitialTokenDistribution {
   swap_distribution: [] | [SwapDistribution];
 }
 export interface InstallCode {
+  skip_stopping_before_installing: [] | [boolean];
+  wasm_module_hash: [] | [Uint8Array | number[]];
+  canister_id: [] | [Principal];
+  arg_hash: [] | [Uint8Array | number[]];
+  install_mode: [] | [number];
+}
+export interface InstallCodeRequest {
   arg: [] | [Uint8Array | number[]];
   wasm_module: [] | [Uint8Array | number[]];
   skip_stopping_before_installing: [] | [boolean];
@@ -371,6 +378,12 @@ export interface ListProposalInfo {
 export interface ListProposalInfoResponse {
   proposal_info: Array<ProposalInfo>;
 }
+export interface MakeProposalRequest {
+  url: string;
+  title: [] | [string];
+  action: [] | [ProposalActionRequest];
+  summary: string;
+}
 export interface MakeProposalResponse {
   message: [] | [string];
   proposal_id: [] | [NeuronId];
@@ -383,6 +396,24 @@ export interface MakingSnsProposal {
 export interface ManageNeuron {
   id: [] | [NeuronId];
   command: [] | [Command];
+  neuron_id_or_subaccount: [] | [NeuronIdOrSubaccount];
+}
+export type ManageNeuronCommandRequest =
+  | { Spawn: Spawn }
+  | { Split: Split }
+  | { Follow: Follow }
+  | { ClaimOrRefresh: ClaimOrRefresh }
+  | { Configure: Configure }
+  | { RegisterVote: RegisterVote }
+  | { Merge: Merge }
+  | { DisburseToNeuron: DisburseToNeuron }
+  | { MakeProposal: MakeProposalRequest }
+  | { StakeMaturity: StakeMaturity }
+  | { MergeMaturity: MergeMaturity }
+  | { Disburse: Disburse };
+export interface ManageNeuronRequest {
+  id: [] | [NeuronId];
+  command: [] | [ManageNeuronCommandRequest];
   neuron_id_or_subaccount: [] | [NeuronIdOrSubaccount];
 }
 export interface ManageNeuronResponse {
@@ -629,6 +660,23 @@ export interface Proposal {
   action: [] | [Action];
   summary: string;
 }
+export type ProposalActionRequest =
+  | { RegisterKnownNeuron: KnownNeuron }
+  | { ManageNeuron: ManageNeuronRequest }
+  | { UpdateCanisterSettings: UpdateCanisterSettings }
+  | { InstallCode: InstallCodeRequest }
+  | { StopOrStartCanister: StopOrStartCanister }
+  | { CreateServiceNervousSystem: CreateServiceNervousSystem }
+  | { ExecuteNnsFunction: ExecuteNnsFunction }
+  | { RewardNodeProvider: RewardNodeProvider }
+  | { OpenSnsTokenSwap: OpenSnsTokenSwap }
+  | { SetSnsTokenSwapOpenTimeWindow: SetSnsTokenSwapOpenTimeWindow }
+  | { SetDefaultFollowees: SetDefaultFollowees }
+  | { RewardNodeProviders: RewardNodeProviders }
+  | { ManageNetworkEconomics: NetworkEconomics }
+  | { ApproveGenesisKyc: Principals }
+  | { AddOrRemoveNodeProvider: AddOrRemoveNodeProvider }
+  | { Motion: Motion };
 export interface ProposalData {
   id: [] | [NeuronId];
   failure_reason: [] | [GovernanceError];
@@ -881,7 +929,7 @@ export interface _SERVICE {
   list_neurons: ActorMethod<[ListNeurons], ListNeuronsResponse>;
   list_node_providers: ActorMethod<[], ListNodeProvidersResponse>;
   list_proposals: ActorMethod<[ListProposalInfo], ListProposalInfoResponse>;
-  manage_neuron: ActorMethod<[ManageNeuron], ManageNeuronResponse>;
+  manage_neuron: ActorMethod<[ManageNeuronRequest], ManageNeuronResponse>;
   settle_community_fund_participation: ActorMethod<
     [SettleCommunityFundParticipation],
     Result
@@ -890,7 +938,10 @@ export interface _SERVICE {
     [SettleNeuronsFundParticipationRequest],
     SettleNeuronsFundParticipationResponse
   >;
-  simulate_manage_neuron: ActorMethod<[ManageNeuron], ManageNeuronResponse>;
+  simulate_manage_neuron: ActorMethod<
+    [ManageNeuronRequest],
+    ManageNeuronResponse
+  >;
   transfer_gtc_neuron: ActorMethod<[NeuronId, NeuronId], Result>;
   update_neuron: ActorMethod<[Neuron], [] | [GovernanceError]>;
   update_node_provider: ActorMethod<[UpdateNodeProvider], Result>;

--- a/packages/nns/candid/governance_test.did
+++ b/packages/nns/candid/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 3d0b3f1 (2024-08-02 tags: release-2024-08-02_01-30-base) 'rs/nns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 8e149ef621 (2024-08-16) 'rs/nns/governance/canister/governance_test.did' by import-candid
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
@@ -267,6 +267,13 @@ type InitialTokenDistribution = record {
   swap_distribution : opt SwapDistribution;
 };
 type InstallCode = record {
+  skip_stopping_before_installing : opt bool;
+  wasm_module_hash : opt blob;
+  canister_id : opt principal;
+  arg_hash : opt blob;
+  install_mode : opt int32;
+};
+type InstallCodeRequest = record {
   arg : opt blob;
   wasm_module : opt blob;
   skip_stopping_before_installing : opt bool;
@@ -306,6 +313,12 @@ type ListProposalInfo = record {
   include_status : vec int32;
 };
 type ListProposalInfoResponse = record { proposal_info : vec ProposalInfo };
+type MakeProposalRequest = record {
+  url : text;
+  title : opt text;
+  action : opt ProposalActionRequest;
+  summary : text;
+};
 type MakeProposalResponse = record {
   message : opt text;
   proposal_id : opt NeuronId;
@@ -318,6 +331,25 @@ type MakingSnsProposal = record {
 type ManageNeuron = record {
   id : opt NeuronId;
   command : opt Command;
+  neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
+};
+type ManageNeuronCommandRequest = variant {
+  Spawn : Spawn;
+  Split : Split;
+  Follow : Follow;
+  ClaimOrRefresh : ClaimOrRefresh;
+  Configure : Configure;
+  RegisterVote : RegisterVote;
+  Merge : Merge;
+  DisburseToNeuron : DisburseToNeuron;
+  MakeProposal : MakeProposalRequest;
+  StakeMaturity : StakeMaturity;
+  MergeMaturity : MergeMaturity;
+  Disburse : Disburse;
+};
+type ManageNeuronRequest = record {
+  id : opt NeuronId;
+  command : opt ManageNeuronCommandRequest;
   neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
 };
 type ManageNeuronResponse = record { command : opt Command_1 };
@@ -539,6 +571,24 @@ type Proposal = record {
   action : opt Action;
   summary : text;
 };
+type ProposalActionRequest = variant {
+  RegisterKnownNeuron : KnownNeuron;
+  ManageNeuron : ManageNeuronRequest;
+  UpdateCanisterSettings : UpdateCanisterSettings;
+  InstallCode : InstallCodeRequest;
+  StopOrStartCanister : StopOrStartCanister;
+  CreateServiceNervousSystem : CreateServiceNervousSystem;
+  ExecuteNnsFunction : ExecuteNnsFunction;
+  RewardNodeProvider : RewardNodeProvider;
+  OpenSnsTokenSwap : OpenSnsTokenSwap;
+  SetSnsTokenSwapOpenTimeWindow : SetSnsTokenSwapOpenTimeWindow;
+  SetDefaultFollowees : SetDefaultFollowees;
+  RewardNodeProviders : RewardNodeProviders;
+  ManageNetworkEconomics : NetworkEconomics;
+  ApproveGenesisKyc : Principals;
+  AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
+  Motion : Motion;
+};
 type ProposalData = record {
   id : opt NeuronId;
   failure_reason : opt GovernanceError;
@@ -752,14 +802,14 @@ service : (Governance) -> {
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
   list_node_providers : () -> (ListNodeProvidersResponse) query;
   list_proposals : (ListProposalInfo) -> (ListProposalInfoResponse) query;
-  manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
+  manage_neuron : (ManageNeuronRequest) -> (ManageNeuronResponse);
   settle_community_fund_participation : (SettleCommunityFundParticipation) -> (
       Result,
     );
   settle_neurons_fund_participation : (
       SettleNeuronsFundParticipationRequest,
     ) -> (SettleNeuronsFundParticipationResponse);
-  simulate_manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
+  simulate_manage_neuron : (ManageNeuronRequest) -> (ManageNeuronResponse);
   transfer_gtc_neuron : (NeuronId, NeuronId) -> (Result);
   update_neuron : (Neuron) -> (opt GovernanceError);
   update_node_provider : (UpdateNodeProvider) -> (Result);

--- a/packages/nns/candid/governance_test.idl.js
+++ b/packages/nns/candid/governance_test.idl.js
@@ -1,5 +1,6 @@
 /* Do not edit.  Compiled with ./scripts/compile-idl-js from packages/nns/candid/governance_test.did */
 export const idlFactory = ({ IDL }) => {
+  const ManageNeuronRequest = IDL.Rec();
   const Proposal = IDL.Rec();
   const NeuronId = IDL.Record({ 'id' : IDL.Nat64 });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
@@ -117,10 +118,10 @@ export const idlFactory = ({ IDL }) => {
     'settings' : IDL.Opt(CanisterSettings),
   });
   const InstallCode = IDL.Record({
-    'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
-    'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
+    'wasm_module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'arg_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'install_mode' : IDL.Opt(IDL.Int32),
   });
   const StopOrStartCanister = IDL.Record({
@@ -755,6 +756,58 @@ export const idlFactory = ({ IDL }) => {
   const ListProposalInfoResponse = IDL.Record({
     'proposal_info' : IDL.Vec(ProposalInfo),
   });
+  const InstallCodeRequest = IDL.Record({
+    'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
+    'canister_id' : IDL.Opt(IDL.Principal),
+    'install_mode' : IDL.Opt(IDL.Int32),
+  });
+  const ProposalActionRequest = IDL.Variant({
+    'RegisterKnownNeuron' : KnownNeuron,
+    'ManageNeuron' : ManageNeuronRequest,
+    'UpdateCanisterSettings' : UpdateCanisterSettings,
+    'InstallCode' : InstallCodeRequest,
+    'StopOrStartCanister' : StopOrStartCanister,
+    'CreateServiceNervousSystem' : CreateServiceNervousSystem,
+    'ExecuteNnsFunction' : ExecuteNnsFunction,
+    'RewardNodeProvider' : RewardNodeProvider,
+    'OpenSnsTokenSwap' : OpenSnsTokenSwap,
+    'SetSnsTokenSwapOpenTimeWindow' : SetSnsTokenSwapOpenTimeWindow,
+    'SetDefaultFollowees' : SetDefaultFollowees,
+    'RewardNodeProviders' : RewardNodeProviders,
+    'ManageNetworkEconomics' : NetworkEconomics,
+    'ApproveGenesisKyc' : Principals,
+    'AddOrRemoveNodeProvider' : AddOrRemoveNodeProvider,
+    'Motion' : Motion,
+  });
+  const MakeProposalRequest = IDL.Record({
+    'url' : IDL.Text,
+    'title' : IDL.Opt(IDL.Text),
+    'action' : IDL.Opt(ProposalActionRequest),
+    'summary' : IDL.Text,
+  });
+  const ManageNeuronCommandRequest = IDL.Variant({
+    'Spawn' : Spawn,
+    'Split' : Split,
+    'Follow' : Follow,
+    'ClaimOrRefresh' : ClaimOrRefresh,
+    'Configure' : Configure,
+    'RegisterVote' : RegisterVote,
+    'Merge' : Merge,
+    'DisburseToNeuron' : DisburseToNeuron,
+    'MakeProposal' : MakeProposalRequest,
+    'StakeMaturity' : StakeMaturity,
+    'MergeMaturity' : MergeMaturity,
+    'Disburse' : Disburse,
+  });
+  ManageNeuronRequest.fill(
+    IDL.Record({
+      'id' : IDL.Opt(NeuronId),
+      'command' : IDL.Opt(ManageNeuronCommandRequest),
+      'neuron_id_or_subaccount' : IDL.Opt(NeuronIdOrSubaccount),
+    })
+  );
   const SpawnResponse = IDL.Record({ 'created_neuron_id' : IDL.Opt(NeuronId) });
   const ClaimOrRefreshResponse = IDL.Record({
     'refreshed_neuron_id' : IDL.Opt(NeuronId),
@@ -905,7 +958,11 @@ export const idlFactory = ({ IDL }) => {
         [ListProposalInfoResponse],
         ['query'],
       ),
-    'manage_neuron' : IDL.Func([ManageNeuron], [ManageNeuronResponse], []),
+    'manage_neuron' : IDL.Func(
+        [ManageNeuronRequest],
+        [ManageNeuronResponse],
+        [],
+      ),
     'settle_community_fund_participation' : IDL.Func(
         [SettleCommunityFundParticipation],
         [Result],
@@ -917,7 +974,7 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'simulate_manage_neuron' : IDL.Func(
-        [ManageNeuron],
+        [ManageNeuronRequest],
         [ManageNeuronResponse],
         [],
       ),
@@ -1044,10 +1101,10 @@ export const init = ({ IDL }) => {
     'settings' : IDL.Opt(CanisterSettings),
   });
   const InstallCode = IDL.Record({
-    'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
-    'wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'skip_stopping_before_installing' : IDL.Opt(IDL.Bool),
+    'wasm_module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'arg_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'install_mode' : IDL.Opt(IDL.Int32),
   });
   const StopOrStartCanister = IDL.Record({

--- a/packages/nns/src/canisters/governance/request.converters.spec.ts
+++ b/packages/nns/src/canisters/governance/request.converters.spec.ts
@@ -1,6 +1,6 @@
 import { Principal } from "@dfinity/principal";
 import { arrayBufferToUint8Array, toNullable } from "@dfinity/utils";
-import type { ManageNeuron as RawManageNeuron } from "../../../candid/governance";
+import type { ManageNeuronRequest as RawManageNeuron } from "../../../candid/governance";
 import {
   CanisterAction,
   CanisterInstallMode,

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -14,11 +14,11 @@ import type {
   Amount,
   ListProposalInfo,
   AccountIdentifier as RawAccountIdentifier,
-  Action as RawAction,
+  ProposalActionRequest as RawAction,
   By as RawBy,
   CanisterSettings as RawCanisterSettings,
   Change as RawChange,
-  Command as RawCommand,
+  ManageNeuronCommandRequest as RawCommand,
   Countries as RawCountries,
   CreateServiceNervousSystem as RawCreateServiceNervousSystem,
   Decimal as RawDecimal,
@@ -29,10 +29,10 @@ import type {
   GovernanceParameters as RawGovernanceParameters,
   Image as RawImage,
   InitialTokenDistribution as RawInitialTokenDistribution,
-  InstallCode as RawInstallCode,
+  InstallCodeRequest as RawInstallCode,
   LedgerParameters as RawLedgerParameters,
   ListNeurons as RawListNeurons,
-  ManageNeuron as RawManageNeuron,
+  ManageNeuronRequest as RawManageNeuron,
   NeuronBasketConstructionParameters as RawNeuronBasketConstructionParameters,
   NeuronDistribution as RawNeuronDistribution,
   NeuronId as RawNeuronId,
@@ -52,12 +52,10 @@ import type { NeuronVisibility, Vote } from "../../enums/governance.enums";
 import { UnsupportedValueError } from "../../errors/governance.errors";
 import type { E8s, NeuronId, Option } from "../../types/common";
 import type {
-  Action,
   By,
   CanisterSettings,
   Change,
   ClaimOrRefreshNeuronRequest,
-  Command,
   Countries,
   CreateServiceNervousSystem,
   Decimal,
@@ -69,11 +67,12 @@ import type {
   GovernanceParameters,
   Image,
   InitialTokenDistribution,
-  InstallCode,
+  InstallCodeRequest,
   LedgerParameters,
   ListProposalsRequest,
   MakeProposalRequest,
-  ManageNeuron,
+  ManageNeuronCommandRequest,
+  ManageNeuronRequest,
   NeuronBasketConstructionParameters,
   NeuronDistribution,
   NeuronIdOrSubaccount,
@@ -82,6 +81,7 @@ import type {
   NodeProvider,
   Operation,
   Percentage,
+  ProposalActionRequest,
   ProposalId,
   RewardMode,
   SwapDistribution,
@@ -423,7 +423,7 @@ const fromCreateServiceNervousSystem = (
       : [],
 });
 
-const fromInstallCode = (installCode: InstallCode): RawInstallCode => {
+const fromInstallCode = (installCode: InstallCodeRequest): RawInstallCode => {
   if (installCode.wasmModule === undefined) {
     throw new Error("wasmModule not found");
   }
@@ -470,7 +470,7 @@ const fromCanisterSettings = (
       ];
 };
 
-const fromAction = (action: Action): RawAction => {
+const fromAction = (action: ProposalActionRequest): RawAction => {
   if ("ExecuteNnsFunction" in action) {
     const executeNnsFunction = action.ExecuteNnsFunction;
 
@@ -716,7 +716,7 @@ const fromAction = (action: Action): RawAction => {
   throw new UnsupportedValueError(action);
 };
 
-const fromCommand = (command: Command): RawCommand => {
+const fromCommand = (command: ManageNeuronCommandRequest): RawCommand => {
   if ("Split" in command) {
     const split = command.Split;
     return {
@@ -1091,7 +1091,7 @@ export const fromManageNeuron = ({
   id,
   command,
   neuronIdOrSubaccount,
-}: ManageNeuron): RawManageNeuron => ({
+}: ManageNeuronRequest): RawManageNeuron => ({
   id: id ? [fromNeuronId(id)] : [],
   command: command ? [fromCommand(command)] : [],
   neuron_id_or_subaccount: neuronIdOrSubaccount

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -11,6 +11,7 @@ import {
   nonNullish,
   toNullable,
   uint8ArrayToArrayOfNumber,
+  uint8ArrayToHexString,
 } from "@dfinity/utils";
 import type {
   Params,
@@ -551,6 +552,12 @@ const toAction = (action: RawAction): Action => {
         installMode: fromNullable(installCode.install_mode) as
           | CanisterInstallMode
           | undefined,
+        wasmModuleHash: uint8ArrayToHexString(
+          fromDefinedNullable(installCode.wasm_module_hash),
+        ),
+        argHash: uint8ArrayToHexString(
+          fromDefinedNullable(installCode.arg_hash),
+        ),
       },
     };
   }

--- a/packages/nns/src/canisters/governance/services.ts
+++ b/packages/nns/src/canisters/governance/services.ts
@@ -1,7 +1,7 @@
 import type {
   Command_1,
   _SERVICE as GovernanceService,
-  ManageNeuron,
+  ManageNeuronRequest,
   ManageNeuronResponse,
 } from "../../../candid/governance";
 import { GovernanceError } from "../../errors/governance.errors";
@@ -36,7 +36,7 @@ export const manageNeuron = async ({
   request,
   service,
 }: {
-  request: ManageNeuron;
+  request: ManageNeuronRequest;
   service: GovernanceService;
 }): Promise<Command_1> => {
   const response = await service.manage_neuron(request);
@@ -51,7 +51,7 @@ export const simulateManageNeuron = async ({
   request,
   service,
 }: {
-  request: ManageNeuron;
+  request: ManageNeuronRequest;
   service: GovernanceService;
 }): Promise<Command_1> => {
   const response = await service.simulate_manage_neuron(request);

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -858,8 +858,8 @@ describe("GovernanceCanister", () => {
       });
 
       const rawInstallCode: RawInstallCode = {
-        arg: [Uint8Array.from([1, 2, 3])],
-        wasm_module: [Uint8Array.from([4, 5, 6])],
+        arg_hash: [Uint8Array.from([1, 2, 3])],
+        wasm_module_hash: [Uint8Array.from([4, 5, 6])],
         skip_stopping_before_installing: [true],
         canister_id: [Principal.fromText("miw6j-knlcl-xq")],
         install_mode: [3],
@@ -869,6 +869,8 @@ describe("GovernanceCanister", () => {
         skipStoppingBeforeInstalling: true,
         canisterId: "miw6j-knlcl-xq",
         installMode: CanisterInstallMode.Upgrade,
+        argHash: "010203",
+        wasmModuleHash: "040506",
       };
 
       const rawProposal = {

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -40,6 +40,25 @@ export type Action =
   | { Motion: Motion }
   | { SetSnsTokenSwapOpenTimeWindow: SetSnsTokenSwapOpenTimeWindow }
   | { OpenSnsTokenSwap: OpenSnsTokenSwap };
+export type ProposalActionRequest =
+  | { RegisterKnownNeuron: KnownNeuron }
+  | {
+      ExecuteNnsFunction: ExecuteNnsFunction;
+    }
+  | { CreateServiceNervousSystem: CreateServiceNervousSystem }
+  | { ManageNeuron: ManageNeuronRequest }
+  | { InstallCode: InstallCodeRequest }
+  | { StopOrStartCanister: StopOrStartCanister }
+  | { UpdateCanisterSettings: UpdateCanisterSettings }
+  | { ApproveGenesisKyc: ApproveGenesisKyc }
+  | { ManageNetworkEconomics: NetworkEconomics }
+  | { RewardNodeProvider: RewardNodeProvider }
+  | { RewardNodeProviders: RewardNodeProviders }
+  | { AddOrRemoveNodeProvider: AddOrRemoveNodeProvider }
+  | { SetDefaultFollowees: SetDefaultFollowees }
+  | { Motion: Motion }
+  | { SetSnsTokenSwapOpenTimeWindow: SetSnsTokenSwapOpenTimeWindow }
+  | { OpenSnsTokenSwap: OpenSnsTokenSwap };
 export interface AddHotKey {
   newHotKey: Option<PrincipalString>;
 }
@@ -90,6 +109,19 @@ export type Command =
   | { MergeMaturity: MergeMaturity }
   | { StakeMaturity: StakeMaturity }
   | { MakeProposal: Proposal }
+  | { Disburse: Disburse };
+export type ManageNeuronCommandRequest =
+  | { Spawn: Spawn }
+  | { Split: Split }
+  | { Follow: Follow }
+  | { ClaimOrRefresh: ClaimOrRefresh }
+  | { Configure: Configure }
+  | { RegisterVote: RegisterVote }
+  | { Merge: Merge }
+  | { DisburseToNeuron: DisburseToNeuron }
+  | { MergeMaturity: MergeMaturity }
+  | { StakeMaturity: StakeMaturity }
+  | { MakeProposal: MakeProposalRequest }
   | { Disburse: Disburse };
 export interface Configure {
   operation: Option<Operation>;
@@ -193,9 +225,21 @@ export interface ManageNeuron {
   command: Option<Command>;
   neuronIdOrSubaccount: Option<NeuronIdOrSubaccount>;
 }
+export interface ManageNeuronRequest {
+  id: Option<NeuronId>;
+  command: Option<ManageNeuronCommandRequest>;
+  neuronIdOrSubaccount: Option<NeuronIdOrSubaccount>;
+}
 export interface InstallCode {
-  arg?: ArrayBuffer;
-  wasmModule?: ArrayBuffer;
+  argHash: string;
+  wasmModuleHash: string;
+  skipStoppingBeforeInstalling: Option<boolean>;
+  canisterId: Option<PrincipalString>;
+  installMode: Option<CanisterInstallMode>;
+}
+export interface InstallCodeRequest {
+  arg: ArrayBuffer;
+  wasmModule: ArrayBuffer;
   skipStoppingBeforeInstalling: Option<boolean>;
   canisterId: Option<PrincipalString>;
   installMode: Option<CanisterInstallMode>;
@@ -506,7 +550,7 @@ export interface MakeProposalRequest {
   title: Option<string>;
   url: string;
   summary: string;
-  action: Action;
+  action: ProposalActionRequest;
 }
 
 export interface MakeMotionProposalRequest {


### PR DESCRIPTION
# Motivation

NNS Governance now has different types for proposals depending on request/response (related [PR](https://github.com/dfinity/ic/pull/937)), mainly because we want the `InstallCode` proposal type to have full wasm/arg blobs for requests, but hashes of the blobs for responses. We need to update the ic-js according to the new candid interface.

# Changes

* Run `import_candid` on the latest ic repo and `compile-idl-js`
* Revert everything other than `packages/nns/governance*`
* Use separate types for request/response types related to proposals
* Change converters for `InstallCode` proposals.

# Tests

Unit tests

# Todos

- [x] Add entry to changelog (if necessary).
