### PR TITLE
Support more than 2 parts in candidNumberArrayToBigInt

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -242,9 +242,9 @@ Parameters:
 
 #### :gear: candidNumberArrayToBigInt
 
-| Function                    | Type                                                                |
-| --------------------------- | ------------------------------------------------------------------- |
-| `candidNumberArrayToBigInt` | `([lowPart, highPart]: [number, (number or undefined)?]) => bigint` |
+| Function                    | Type                          |
+| --------------------------- | ----------------------------- |
+| `candidNumberArrayToBigInt` | `(array: number[]) => bigint` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/arrays.utils.ts#L70)
 

--- a/packages/utils/src/utils/arrays.utils.spec.ts
+++ b/packages/utils/src/utils/arrays.utils.spec.ts
@@ -91,5 +91,14 @@ describe("arrays-utils", () => {
     expect(candidNumberArrayToBigInt([20000])).toBe(20_000n);
     expect(candidNumberArrayToBigInt([100000])).toBe(100_000n);
     expect(candidNumberArrayToBigInt([1000000])).toBe(1_000_000n);
+
+    // More than 2 parts:
+    expect(candidNumberArrayToBigInt([0, 0, 1])).toBe(1n << 64n);
+    expect(
+      candidNumberArrayToBigInt([
+        3735344374, 914506646, 1139096947, 3625449072, 77510495, 1540130702,
+        55083,
+      ]),
+    ).toBe(345763845793847239482739482739482739482739482374928374234928374n);
   });
 });

--- a/packages/utils/src/utils/arrays.utils.ts
+++ b/packages/utils/src/utils/arrays.utils.ts
@@ -67,12 +67,10 @@ export const uint8ArrayToHexString = (bytes: Uint8Array | number[]) => {
   );
 };
 
-export const candidNumberArrayToBigInt = ([lowPart, highPart]: [
-  number,
-  number?,
-]): bigint => {
-  const low = BigInt(lowPart);
-  const high = BigInt(highPart ?? 0);
-
-  return (high << 32n) + low;
+export const candidNumberArrayToBigInt = (array: number[]): bigint => {
+  let result = 0n;
+  for (let i = array.length - 1; i >= 0; i--) {
+    result = (result << 32n) + BigInt(array[i]);
+  }
+  return result;
 };


### PR DESCRIPTION
# Motivation

When very large Candid Nat numbers are converted to JSON, the array will have more than 2 elements if the number needs more than 64 bits.

# Changes

Change `candidNumberArrayToBigInt` to allow more than 2 elements in the input array.

# Tests

Unit test updated.

Also made the following test in Rust (not committed) to make sure the encoding matches:
```
#[test]
fn test_nat() {
  let i : candid::Nat = candid::Nat::from_str(
    "345763845793847239482739482739482739482739482374928374234928374"
  ).unwrap();
  let s = serde_json::to_string(&i).unwrap();
  assert_eq!(s, "[3735344374,914506646,1139096947,3625449072,77510495,1540130702,55083]");
}
```

# Todos

- [ ] Add entry to changelog (if necessary).
covered by existing entry