### PR TITLE
feat: ckBTC min_confirmations renamed to minConfirmations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Rename values of enum Topic and NnsFunction to match the backend values.
 - Use different request/response types for NNS Governance proposals, and different fields for `InstallCode` proposals.
+- The `getUtxos` parameter `filter.min_confirmations` has been renamed to `filter.minConfirmations` for consistency with the general naming conventions used in `@dfinity/ckbtc`.
 
 ## Features
 

--- a/packages/ckbtc/src/bitcoin.canister.spec.ts
+++ b/packages/ckbtc/src/bitcoin.canister.spec.ts
@@ -107,10 +107,9 @@ describe("BitcoinCanister", () => {
           certifiedServiceOverride: certifiedService,
         });
 
-        const { filter, ...rest } = params;
         const page = [1, 2, 3];
         const pageParams: Omit<GetUtxosParams, "certified"> = {
-          ...rest,
+          ...params,
           filter: {
             page,
           },

--- a/packages/ckbtc/src/types/bitcoin.params.ts
+++ b/packages/ckbtc/src/types/bitcoin.params.ts
@@ -1,11 +1,11 @@
-import { toNullable, type QueryParams } from "@dfinity/utils";
+import { nonNullish, toNullable, type QueryParams } from "@dfinity/utils";
 import type { get_utxos_request } from "../../candid/bitcoin";
 
 export type BitcoinNetwork = "testnet" | "mainnet";
 
 export type GetUtxosParams = Omit<get_utxos_request, "network" | "filter"> & {
   network: BitcoinNetwork;
-  filter?: { page: Uint8Array | number[] } | { min_confirmations: number };
+  filter?: { page: Uint8Array | number[] } | { minConfirmations: number };
 } & QueryParams;
 
 export const toGetUtxosParams = ({
@@ -13,7 +13,13 @@ export const toGetUtxosParams = ({
   filter,
   ...rest
 }: GetUtxosParams): get_utxos_request => ({
-  filter: toNullable(filter),
+  filter: nonNullish(filter)
+    ? toNullable(
+        "minConfirmations" in filter
+          ? { min_confirmations: filter.minConfirmations }
+          : { page: filter.page },
+      )
+    : toNullable(),
   network: network === "testnet" ? { testnet: null } : { mainnet: null },
   ...rest,
 });


### PR DESCRIPTION
# Motivation

As discussed in #701, let's rename `min_confirmations` parameter of `getUtxos` in ckBTC library to `minConfirmations`.

# Changes

- Parameter and mapping updated accordingly.
