### PR TITLE
refactor: rename optional param of getBalance

### DIFF
--- a/packages/ckbtc/src/bitcoin.canister.spec.ts
+++ b/packages/ckbtc/src/bitcoin.canister.spec.ts
@@ -196,7 +196,7 @@ describe("BitcoinCanister", () => {
   describe("bitcoinGetBalance", () => {
     const params: Omit<GetBalanceParams, "certified"> = {
       network: "testnet",
-      min_confirmations: 2,
+      minConfirmations: 2,
       address: bitcoinAddressMock,
     };
 

--- a/packages/ckbtc/src/types/bitcoin.params.ts
+++ b/packages/ckbtc/src/types/bitcoin.params.ts
@@ -36,15 +36,15 @@ export type GetBalanceParams = Omit<
   "network" | "min_confirmations"
 > & {
   network: BitcoinNetwork;
-  min_confirmations?: number;
+  minConfirmations?: number;
 } & QueryParams;
 
 export const toGetBalanceParams = ({
   network,
-  min_confirmations,
+  minConfirmations,
   ...rest
 }: GetBalanceParams): get_balance_request => ({
-  min_confirmations: toNullable(min_confirmations),
+  min_confirmations: toNullable(minConfirmations),
   network: mapBitcoinNetwork(network),
   ...rest,
 });


### PR DESCRIPTION
# Motivation

As discussed in #701, let's rename `min_confirmations` parameter of `getBalance` in ckBTC library to `minConfirmations`.

# Changes

- Parameter and mapping updated accordingly.
