### PR TITLE
Adjust ingress expiry to not be more than 5 min after the consent message

### DIFF
--- a/scripts/test-vectors/20240730-icrc21.ts
+++ b/scripts/test-vectors/20240730-icrc21.ts
@@ -26,7 +26,7 @@ function hexStringToArrayBuffer(hexString: string): ArrayBuffer {
 const callRequest = {
   arg: hexStringToArrayBuffer("4449444C00017104746F6269"),
   canister_id: Principal.fromHex("00000000006000FD0101"),
-  ingress_expiry: BigInt("1712667140606000000"),
+  ingress_expiry: BigInt("1712666798482000000"),
   method_name: "greet",
   request_type: "query",
   sender: Principal.fromHex("04"),


### PR DESCRIPTION
The previous value was too far into the future, such that the consent message would be considered stale.
