### PR TITLE
feat: bitcoin balance and getUtxos support for queries only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 - Rename values of enum Topic and NnsFunction to match the backend values.
 - Use different request/response types for NNS Governance proposals, and different fields for `InstallCode` proposals.
 - The `getUtxos` parameter `filter.min_confirmations` has been renamed to `filter.minConfirmations` for consistency with the general naming conventions used in `@dfinity/ckbtc`.
-- Only queries to `getUtxos` of the Bitcoin canister can be executed by external users — i.e., update calls can only be performed by the canister. This is why `getUtxos` now only supports non-certified calls.
+- Only queries to `getUtxos` of the Bitcoin canister can be executed by external users — i.e., update calls can only be performed by the canister. This is why `getUtxos` now only supports non-certified calls and has been renamed to `getUtxosQuery`.
 
 ## Features
 
 - Provide a new utility to convert Candid `Nat` to `BigInt`. This utility is useful for interpreting the fees provided by the SNS Aggregator.
 - Support conversion of `InstallCode`, `StopOrStartCanister` and `UpdateCanisterSettings` actions, `SetVisibility` neuron operation, and `Neuron::visibility` attribute.
-- Add function `getBalance` to `BitcoinCanister` object of package `@dfinity/ckbtc`, that implements the `bitcoin_get_balance_query` method of the IC Bitcoin API.
+- Add function `getBalanceQuery` to `BitcoinCanister` object of package `@dfinity/ckbtc`, that implements the `bitcoin_get_balance_query` method of the IC Bitcoin API.
 
 ## Build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@
 - Rename values of enum Topic and NnsFunction to match the backend values.
 - Use different request/response types for NNS Governance proposals, and different fields for `InstallCode` proposals.
 - The `getUtxos` parameter `filter.min_confirmations` has been renamed to `filter.minConfirmations` for consistency with the general naming conventions used in `@dfinity/ckbtc`.
+- Only queries to `getUtxos` of the Bitcoin canister can be executed by external users — i.e., update calls can only be performed by the canister. This is why `getUtxos` now only supports non-certified calls.
 
 ## Features
 
 - Provide a new utility to convert Candid `Nat` to `BigInt`. This utility is useful for interpreting the fees provided by the SNS Aggregator.
 - Support conversion of `InstallCode`, `StopOrStartCanister` and `UpdateCanisterSettings` actions, `SetVisibility` neuron operation, and `Neuron::visibility` attribute.
-- Add function `getBalance` to `BitcoinCanister` object of package `@dfinity/ckbtc`, that implements the `bitcoin_get_balance` method of the IC Bitcoin API.
+- Add function `getBalance` to `BitcoinCanister` object of package `@dfinity/ckbtc`, that implements the `bitcoin_get_balance_query` method of the IC Bitcoin API.
 
 ## Build
 

--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -281,8 +281,8 @@ Parameters:
 #### Methods
 
 - [create](#gear-create)
-- [getUtxos](#gear-getutxos)
-- [getBalance](#gear-getbalance)
+- [getUtxosQuery](#gear-getutxosquery)
+- [getBalanceQuery](#gear-getbalancequery)
 
 ##### :gear: create
 
@@ -292,15 +292,15 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/bitcoin.canister.ts#L18)
 
-##### :gear: getUtxos
+##### :gear: getUtxosQuery
 
 Given a `get_utxos_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet` or `testnet`), the function returns all unspent transaction outputs (UTXOs) associated with the provided address in the specified Bitcoin network based on the current view of the Bitcoin blockchain available to the Bitcoin component.
 
 ⚠️ Note that this method does not support certified calls because only canisters are allowed to get UTXOs via update calls.
 
-| Method     | Type                                                             |
-| ---------- | ---------------------------------------------------------------- |
-| `getUtxos` | `({ ...params }: GetUtxosParams) => Promise<get_utxos_response>` |
+| Method          | Type                                                             |
+| --------------- | ---------------------------------------------------------------- |
+| `getUtxosQuery` | `({ ...params }: GetUtxosParams) => Promise<get_utxos_response>` |
 
 Parameters:
 
@@ -310,15 +310,15 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/bitcoin.canister.ts#L42)
 
-##### :gear: getBalance
+##### :gear: getBalanceQuery
 
 Given a `get_balance_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet` or `testnet`), the function returns the current balance of this address in `Satoshi` (10^8 Satoshi = 1 Bitcoin) in the specified Bitcoin network.
 
 ⚠️ Note that this method does not support certified calls because only canisters are allowed to get Bitcoin balance via update calls.
 
-| Method       | Type                                                   |
-| ------------ | ------------------------------------------------------ |
-| `getBalance` | `({ ...params }: GetBalanceParams) => Promise<bigint>` |
+| Method            | Type                                                   |
+| ----------------- | ------------------------------------------------------ |
+| `getBalanceQuery` | `({ ...params }: GetBalanceParams) => Promise<bigint>` |
 
 Parameters:
 
@@ -326,7 +326,7 @@ Parameters:
 - `params.min_confirmations`: The optional filter parameter can be used to limit the set of considered UTXOs for the calculation of the balance to those with at least the provided number of confirmations in the same manner as for the `bitcoin_get_utxos` call.
 - `params.address`: A Bitcoin address.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/bitcoin.canister.ts#L62)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/bitcoin.canister.ts#L64)
 
 <!-- TSDOC_END -->
 

--- a/packages/ckbtc/src/bitcoin.canister.spec.ts
+++ b/packages/ckbtc/src/bitcoin.canister.spec.ts
@@ -20,7 +20,7 @@ describe("BitcoinCanister", () => {
       ...services,
     });
 
-  describe("bitcoinGetUtxos", () => {
+  describe("bitcoinGetUtxosQuery", () => {
     const params: Omit<GetUtxosParams, "certified"> = {
       network: "testnet",
       filter: { minConfirmations: 2 },
@@ -55,11 +55,11 @@ describe("BitcoinCanister", () => {
       const service = mock<ActorSubclass<BitcoinService>>();
       service.bitcoin_get_utxos_query.mockResolvedValue(response);
 
-      const { getUtxos } = createBitcoinCanister({
+      const { getUtxosQuery } = createBitcoinCanister({
         serviceOverride: service,
       });
 
-      const res = await getUtxos({
+      const res = await getUtxosQuery({
         ...params,
       });
 
@@ -76,11 +76,11 @@ describe("BitcoinCanister", () => {
       const service = mock<ActorSubclass<BitcoinService>>();
       service.bitcoin_get_utxos_query.mockResolvedValue(response);
 
-      const { getUtxos } = createBitcoinCanister({
+      const { getUtxosQuery } = createBitcoinCanister({
         serviceOverride: service,
       });
 
-      await getUtxos({
+      await getUtxosQuery({
         ...params,
       });
 
@@ -95,7 +95,7 @@ describe("BitcoinCanister", () => {
       const service = mock<ActorSubclass<BitcoinService>>();
       service.bitcoin_get_utxos_query.mockResolvedValue(response);
 
-      const { getUtxos } = createBitcoinCanister({
+      const { getUtxosQuery } = createBitcoinCanister({
         serviceOverride: service,
       });
 
@@ -107,7 +107,7 @@ describe("BitcoinCanister", () => {
         },
       };
 
-      await getUtxos({
+      await getUtxosQuery({
         ...pageParams,
       });
 
@@ -123,12 +123,12 @@ describe("BitcoinCanister", () => {
       const service = mock<ActorSubclass<BitcoinService>>();
       service.bitcoin_get_utxos_query.mockRejectedValue(error);
 
-      const { getUtxos } = createBitcoinCanister({
+      const { getUtxosQuery } = createBitcoinCanister({
         serviceOverride: service,
       });
 
       const call = () =>
-        getUtxos({
+        getUtxosQuery({
           ...params,
         });
 
@@ -139,11 +139,11 @@ describe("BitcoinCanister", () => {
       const service = mock<ActorSubclass<BitcoinService>>();
       service.bitcoin_get_utxos_query.mockResolvedValue(response);
 
-      const { getUtxos } = createBitcoinCanister({
+      const { getUtxosQuery } = createBitcoinCanister({
         serviceOverride: service,
       });
 
-      await getUtxos({
+      await getUtxosQuery({
         ...params,
       });
 
@@ -151,7 +151,7 @@ describe("BitcoinCanister", () => {
     });
   });
 
-  describe("bitcoinGetBalance", () => {
+  describe("bitcoinGetBalanceQuery", () => {
     const params: Omit<GetBalanceParams, "certified"> = {
       network: "testnet",
       minConfirmations: 2,
@@ -164,11 +164,11 @@ describe("BitcoinCanister", () => {
       const service = mock<ActorSubclass<BitcoinService>>();
       service.bitcoin_get_balance_query.mockResolvedValue(response);
 
-      const { getBalance } = createBitcoinCanister({
+      const { getBalanceQuery } = createBitcoinCanister({
         serviceOverride: service,
       });
 
-      const res = await getBalance({
+      const res = await getBalanceQuery({
         ...params,
       });
 
@@ -185,12 +185,12 @@ describe("BitcoinCanister", () => {
       const service = mock<ActorSubclass<BitcoinService>>();
       service.bitcoin_get_balance_query.mockRejectedValue(error);
 
-      const { getBalance } = createBitcoinCanister({
+      const { getBalanceQuery } = createBitcoinCanister({
         serviceOverride: service,
       });
 
       const call = () =>
-        getBalance({
+        getBalanceQuery({
           ...params,
         });
 
@@ -201,11 +201,11 @@ describe("BitcoinCanister", () => {
       const service = mock<ActorSubclass<BitcoinService>>();
       service.bitcoin_get_balance_query.mockResolvedValue(response);
 
-      const { getBalance } = createBitcoinCanister({
+      const { getBalanceQuery } = createBitcoinCanister({
         serviceOverride: service,
       });
 
-      await getBalance({
+      await getBalanceQuery({
         ...params,
       });
 

--- a/packages/ckbtc/src/bitcoin.canister.spec.ts
+++ b/packages/ckbtc/src/bitcoin.canister.spec.ts
@@ -13,10 +13,7 @@ import { GetBalanceParams, GetUtxosParams } from "./types/bitcoin.params";
 
 describe("BitcoinCanister", () => {
   const createBitcoinCanister = (
-    services: Pick<
-      CanisterOptions<BitcoinService>,
-      "serviceOverride" | "certifiedServiceOverride"
-    >,
+    services: Pick<CanisterOptions<BitcoinService>, "serviceOverride">,
   ): BitcoinCanister =>
     BitcoinCanister.create({
       canisterId: bitcoinCanisterIdMock,
@@ -54,142 +51,103 @@ describe("BitcoinCanister", () => {
       ],
     };
 
-    describe("certified", () => {
-      it("returns get utxos result when success", async () => {
-        const certifiedService = mock<ActorSubclass<BitcoinService>>();
-        certifiedService.bitcoin_get_utxos.mockResolvedValue(response);
+    it("returns get utxos result when success", async () => {
+      const service = mock<ActorSubclass<BitcoinService>>();
+      service.bitcoin_get_utxos_query.mockResolvedValue(response);
 
-        const service = mock<ActorSubclass<BitcoinService>>();
-
-        const { getUtxos } = await createBitcoinCanister({
-          certifiedServiceOverride: certifiedService,
-          serviceOverride: service,
-        });
-
-        const res = await getUtxos({
-          ...params,
-          certified: true,
-        });
-
-        expect(res).toEqual(response);
-        expect(certifiedService.bitcoin_get_utxos).toHaveBeenCalledWith({
-          network: { testnet: null },
-          filter: [{ min_confirmations: 2 }],
-          address: bitcoinAddressMock,
-        });
-        expect(service.bitcoin_get_utxos_query).not.toHaveBeenCalled();
+      const { getUtxos } = createBitcoinCanister({
+        serviceOverride: service,
       });
 
-      it("call get utxos with min_confirmations", async () => {
-        const certifiedService = mock<ActorSubclass<BitcoinService>>();
-        certifiedService.bitcoin_get_utxos.mockResolvedValue(response);
-
-        const { getUtxos } = await createBitcoinCanister({
-          certifiedServiceOverride: certifiedService,
-        });
-
-        await getUtxos({
-          ...params,
-          certified: true,
-        });
-
-        expect(certifiedService.bitcoin_get_utxos).toHaveBeenCalledWith({
-          network: { testnet: null },
-          filter: [{ min_confirmations: 2 }],
-          address: bitcoinAddressMock,
-        });
+      const res = await getUtxos({
+        ...params,
       });
 
-      it("call get utxos with page", async () => {
-        const certifiedService = mock<ActorSubclass<BitcoinService>>();
-        certifiedService.bitcoin_get_utxos.mockResolvedValue(response);
+      expect(res).toEqual(response);
+      expect(service.bitcoin_get_utxos_query).toHaveBeenCalledWith({
+        network: { testnet: null },
+        filter: [{ min_confirmations: 2 }],
+        address: bitcoinAddressMock,
+      });
+      expect(service.bitcoin_get_utxos).not.toHaveBeenCalled();
+    });
 
-        const { getUtxos } = await createBitcoinCanister({
-          certifiedServiceOverride: certifiedService,
-        });
+    it("call get utxos with min_confirmations", async () => {
+      const service = mock<ActorSubclass<BitcoinService>>();
+      service.bitcoin_get_utxos_query.mockResolvedValue(response);
 
-        const page = [1, 2, 3];
-        const pageParams: Omit<GetUtxosParams, "certified"> = {
-          ...params,
-          filter: {
-            page,
-          },
-        };
-
-        await getUtxos({
-          ...pageParams,
-          certified: true,
-        });
-
-        expect(certifiedService.bitcoin_get_utxos).toHaveBeenCalledWith({
-          network: { testnet: null },
-          filter: [{ page }],
-          address: bitcoinAddressMock,
-        });
+      const { getUtxos } = createBitcoinCanister({
+        serviceOverride: service,
       });
 
-      it("throws Error", async () => {
-        const error = new Error("Test");
-        const certifiedService = mock<ActorSubclass<BitcoinService>>();
-        certifiedService.bitcoin_get_utxos.mockRejectedValue(error);
+      await getUtxos({
+        ...params,
+      });
 
-        const { getUtxos } = await createBitcoinCanister({
-          certifiedServiceOverride: certifiedService,
-        });
-
-        const call = () =>
-          getUtxos({
-            ...params,
-            certified: true,
-          });
-
-        expect(call).rejects.toThrowError(Error);
+      expect(service.bitcoin_get_utxos_query).toHaveBeenCalledWith({
+        network: { testnet: null },
+        filter: [{ min_confirmations: 2 }],
+        address: bitcoinAddressMock,
       });
     });
 
-    describe("Not certified", () => {
-      it("returns get utxos query result when success", async () => {
-        const service = mock<ActorSubclass<BitcoinService>>();
-        service.bitcoin_get_utxos_query.mockResolvedValue(response);
+    it("call get utxos with page", async () => {
+      const service = mock<ActorSubclass<BitcoinService>>();
+      service.bitcoin_get_utxos_query.mockResolvedValue(response);
 
-        const certifiedService = mock<ActorSubclass<BitcoinService>>();
+      const { getUtxos } = createBitcoinCanister({
+        serviceOverride: service,
+      });
 
-        const { getUtxos } = await createBitcoinCanister({
-          certifiedServiceOverride: certifiedService,
-          serviceOverride: service,
-        });
+      const page = [1, 2, 3];
+      const pageParams: Omit<GetUtxosParams, "certified"> = {
+        ...params,
+        filter: {
+          page,
+        },
+      };
 
-        const res = await getUtxos({
+      await getUtxos({
+        ...pageParams,
+      });
+
+      expect(service.bitcoin_get_utxos_query).toHaveBeenCalledWith({
+        network: { testnet: null },
+        filter: [{ page }],
+        address: bitcoinAddressMock,
+      });
+    });
+
+    it("throws Error", async () => {
+      const error = new Error("Test");
+      const service = mock<ActorSubclass<BitcoinService>>();
+      service.bitcoin_get_utxos_query.mockRejectedValue(error);
+
+      const { getUtxos } = createBitcoinCanister({
+        serviceOverride: service,
+      });
+
+      const call = () =>
+        getUtxos({
           ...params,
-          certified: false,
         });
 
-        expect(res).toEqual(response);
-        expect(service.bitcoin_get_utxos_query).toHaveBeenCalledWith({
-          network: { testnet: null },
-          filter: [{ min_confirmations: 2 }],
-          address: bitcoinAddressMock,
-        });
-        expect(certifiedService.bitcoin_get_utxos).not.toHaveBeenCalled();
+      expect(call).rejects.toThrowError(Error);
+    });
+
+    it("should not call certified end point", async () => {
+      const service = mock<ActorSubclass<BitcoinService>>();
+      service.bitcoin_get_utxos_query.mockResolvedValue(response);
+
+      const { getUtxos } = createBitcoinCanister({
+        serviceOverride: service,
       });
 
-      it("throws Error", async () => {
-        const error = new Error("Test");
-        const service = mock<ActorSubclass<BitcoinService>>();
-        service.bitcoin_get_utxos_query.mockRejectedValue(error);
-
-        const { getUtxos } = await createBitcoinCanister({
-          serviceOverride: service,
-        });
-
-        const call = () =>
-          getUtxos({
-            ...params,
-            certified: false,
-          });
-
-        expect(call).rejects.toThrowError(Error);
+      await getUtxos({
+        ...params,
       });
+
+      expect(service.bitcoin_get_utxos).not.toHaveBeenCalled();
     });
   });
 
@@ -202,94 +160,56 @@ describe("BitcoinCanister", () => {
 
     const response: satoshi = 1000n;
 
-    describe("certified", () => {
-      it("returns balance result when success", async () => {
-        const certifiedService = mock<ActorSubclass<BitcoinService>>();
-        certifiedService.bitcoin_get_balance.mockResolvedValue(response);
+    it("returns balance result when success", async () => {
+      const service = mock<ActorSubclass<BitcoinService>>();
+      service.bitcoin_get_balance_query.mockResolvedValue(response);
 
-        const service = mock<ActorSubclass<BitcoinService>>();
-
-        const { getBalance } = await createBitcoinCanister({
-          certifiedServiceOverride: certifiedService,
-          serviceOverride: service,
-        });
-
-        const res = await getBalance({
-          ...params,
-          certified: true,
-        });
-
-        expect(res).toEqual(response);
-        expect(certifiedService.bitcoin_get_balance).toHaveBeenCalledWith({
-          network: { testnet: null },
-          min_confirmations: [2],
-          address: bitcoinAddressMock,
-        });
-        expect(service.bitcoin_get_balance_query).not.toHaveBeenCalled();
+      const { getBalance } = createBitcoinCanister({
+        serviceOverride: service,
       });
 
-      it("throws Error", async () => {
-        const error = new Error("Test");
-        const certifiedService = mock<ActorSubclass<BitcoinService>>();
-        certifiedService.bitcoin_get_balance.mockRejectedValue(error);
+      const res = await getBalance({
+        ...params,
+      });
 
-        const { getBalance } = await createBitcoinCanister({
-          certifiedServiceOverride: certifiedService,
-        });
-
-        const call = () =>
-          getBalance({
-            ...params,
-            certified: true,
-          });
-
-        expect(call).rejects.toThrowError(Error);
+      expect(res).toEqual(response);
+      expect(service.bitcoin_get_balance_query).toHaveBeenCalledWith({
+        network: { testnet: null },
+        min_confirmations: [2],
+        address: bitcoinAddressMock,
       });
     });
 
-    describe("Not certified", () => {
-      it("returns balance query result when success", async () => {
-        const service = mock<ActorSubclass<BitcoinService>>();
-        service.bitcoin_get_balance_query.mockResolvedValue(response);
+    it("throws Error", async () => {
+      const error = new Error("Test");
+      const service = mock<ActorSubclass<BitcoinService>>();
+      service.bitcoin_get_balance_query.mockRejectedValue(error);
 
-        const certifiedService = mock<ActorSubclass<BitcoinService>>();
+      const { getBalance } = createBitcoinCanister({
+        serviceOverride: service,
+      });
 
-        const { getBalance } = await createBitcoinCanister({
-          certifiedServiceOverride: certifiedService,
-          serviceOverride: service,
-        });
-
-        const res = await getBalance({
+      const call = () =>
+        getBalance({
           ...params,
-          certified: false,
         });
 
-        expect(res).toEqual(response);
-        expect(service.bitcoin_get_balance_query).toHaveBeenCalledWith({
-          network: { testnet: null },
-          min_confirmations: [2],
-          address: bitcoinAddressMock,
-        });
-        expect(certifiedService.bitcoin_get_balance).not.toHaveBeenCalled();
+      expect(call).rejects.toThrowError(Error);
+    });
+
+    it("should not call certified end point", async () => {
+      const service = mock<ActorSubclass<BitcoinService>>();
+      service.bitcoin_get_balance_query.mockResolvedValue(response);
+
+      const { getBalance } = createBitcoinCanister({
+        serviceOverride: service,
       });
 
-      it("throws Error", async () => {
-        const error = new Error("Test");
-        const service = mock<ActorSubclass<BitcoinService>>();
-        service.bitcoin_get_balance_query.mockRejectedValue(error);
-
-        const { getBalance } = await createBitcoinCanister({
-          serviceOverride: service,
-        });
-
-        const call = () =>
-          getBalance({
-            ...params,
-            certified: false,
-          });
-
-        expect(call).rejects.toThrowError(Error);
+      await getBalance({
+        ...params,
       });
+
+      expect(service.bitcoin_get_balance).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/ckbtc/src/bitcoin.canister.ts
+++ b/packages/ckbtc/src/bitcoin.canister.ts
@@ -29,28 +29,27 @@ export class BitcoinCanister extends Canister<BitcoinService> {
   /**
    * Given a `get_utxos_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet` or `testnet`), the function returns all unspent transaction outputs (UTXOs) associated with the provided address in the specified Bitcoin network based on the current view of the Bitcoin blockchain available to the Bitcoin component.
    *
+   * ⚠️ Note that this method does not support certified calls because only canisters are allowed to get UTXOs via update calls.
+   *
    * @link https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-bitcoin_get_utxos
    *
    * @param {Object} params
    * @param {BitcoinNetwork} params.network Tesnet or mainnet.
    * @param {Object} params.filter The optional filter parameter can be used to restrict the set of returned UTXOs, either providing a minimum number of confirmations or a page reference when pagination is used for addresses with many UTXOs.
    * @param {string} params.address A Bitcoin address.
-   * @param {boolean} params.certified query or update call
    * @returns {Promise<bitcoin_get_utxos_result>} The UTXOs are returned sorted by block height in descending order.
    */
-  getUtxos = ({
-    certified = true,
-    ...params
-  }: GetUtxosParams): Promise<get_utxos_response> => {
-    const { bitcoin_get_utxos, bitcoin_get_utxos_query } = this.caller({
-      certified,
+  getUtxos = ({ ...params }: GetUtxosParams): Promise<get_utxos_response> => {
+    const { bitcoin_get_utxos_query } = this.caller({
+      certified: false,
     });
-    const fn = certified ? bitcoin_get_utxos : bitcoin_get_utxos_query;
-    return fn(toGetUtxosParams(params));
+    return bitcoin_get_utxos_query(toGetUtxosParams(params));
   };
 
   /**
    * Given a `get_balance_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet` or `testnet`), the function returns the current balance of this address in `Satoshi` (10^8 Satoshi = 1 Bitcoin) in the specified Bitcoin network.
+   *
+   * ⚠️ Note that this method does not support certified calls because only canisters are allowed to get Bitcoin balance via update calls.
    *
    * @link https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-bitcoin_get_balance
    *
@@ -58,17 +57,12 @@ export class BitcoinCanister extends Canister<BitcoinService> {
    * @param {BitcoinNetwork} params.network Tesnet or mainnet.
    * @param {Object} params.min_confirmations The optional filter parameter can be used to limit the set of considered UTXOs for the calculation of the balance to those with at least the provided number of confirmations in the same manner as for the `bitcoin_get_utxos` call.
    * @param {string} params.address A Bitcoin address.
-   * @param {boolean} params.certified query or update call
    * @returns {Promise<satoshi>} The balance is returned in `Satoshi` (10^8 Satoshi = 1 Bitcoin).
    */
-  getBalance = ({
-    certified = true,
-    ...params
-  }: GetBalanceParams): Promise<satoshi> => {
-    const { bitcoin_get_balance, bitcoin_get_balance_query } = this.caller({
-      certified,
+  getBalance = ({ ...params }: GetBalanceParams): Promise<satoshi> => {
+    const { bitcoin_get_balance_query } = this.caller({
+      certified: false,
     });
-    const fn = certified ? bitcoin_get_balance : bitcoin_get_balance_query;
-    return fn(toGetBalanceParams(params));
+    return bitcoin_get_balance_query(toGetBalanceParams(params));
   };
 }

--- a/packages/ckbtc/src/bitcoin.canister.ts
+++ b/packages/ckbtc/src/bitcoin.canister.ts
@@ -39,7 +39,7 @@ export class BitcoinCanister extends Canister<BitcoinService> {
    * @param {string} params.address A Bitcoin address.
    * @returns {Promise<bitcoin_get_utxos_result>} The UTXOs are returned sorted by block height in descending order.
    */
-  getUtxos = ({ ...params }: GetUtxosParams): Promise<get_utxos_response> => {
+  getUtxosQuery = ({ ...params }: GetUtxosParams): Promise<get_utxos_response> => {
     const { bitcoin_get_utxos_query } = this.caller({
       certified: false,
     });
@@ -59,7 +59,7 @@ export class BitcoinCanister extends Canister<BitcoinService> {
    * @param {string} params.address A Bitcoin address.
    * @returns {Promise<satoshi>} The balance is returned in `Satoshi` (10^8 Satoshi = 1 Bitcoin).
    */
-  getBalance = ({ ...params }: GetBalanceParams): Promise<satoshi> => {
+  getBalanceQuery = ({ ...params }: GetBalanceParams): Promise<satoshi> => {
     const { bitcoin_get_balance_query } = this.caller({
       certified: false,
     });

--- a/packages/ckbtc/src/bitcoin.canister.ts
+++ b/packages/ckbtc/src/bitcoin.canister.ts
@@ -39,7 +39,9 @@ export class BitcoinCanister extends Canister<BitcoinService> {
    * @param {string} params.address A Bitcoin address.
    * @returns {Promise<bitcoin_get_utxos_result>} The UTXOs are returned sorted by block height in descending order.
    */
-  getUtxosQuery = ({ ...params }: GetUtxosParams): Promise<get_utxos_response> => {
+  getUtxosQuery = ({
+    ...params
+  }: GetUtxosParams): Promise<get_utxos_response> => {
     const { bitcoin_get_utxos_query } = this.caller({
       certified: false,
     });

--- a/packages/ckbtc/src/types/bitcoin.params.ts
+++ b/packages/ckbtc/src/types/bitcoin.params.ts
@@ -13,7 +13,7 @@ const mapBitcoinNetwork = (network: BitcoinNetwork): network =>
 export type GetUtxosParams = Omit<get_utxos_request, "network" | "filter"> & {
   network: BitcoinNetwork;
   filter?: { page: Uint8Array | number[] } | { minConfirmations: number };
-} & QueryParams;
+} & Omit<QueryParams, "certified">;
 
 export const toGetUtxosParams = ({
   network,
@@ -37,7 +37,7 @@ export type GetBalanceParams = Omit<
 > & {
   network: BitcoinNetwork;
   minConfirmations?: number;
-} & QueryParams;
+} & Omit<QueryParams, "certified">;
 
 export const toGetBalanceParams = ({
   network,


### PR DESCRIPTION
# Motivation

As we learned this week, update calls to the Bitcoin canister for `get_balance` and `get_utxos` are only possible when executed from a canister. Therefore, we remove the support for certified calls regarding those endpoints in `@dfinity/ckbtc`. In addition, to make the exception more obvious and to reflects the actual IC API naming, we also add the suffix `Query` to the functions.

# Documentation

https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_utxos

# Changes

- Remove `certified` option parameter for `getBalance` and `getUtxos`
- Rename `getBalance` and `getUtxos` to `getBalanceQuery` and `getUtxosQuery`
- Add a warning in the documentation
- Update code to use only endpoints `_query`
- Add breaking change in changelog
