### PR TITLE
feat: icrc21_canister_call_consent_message for ledger-icrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-- Add support for `icrc21_canister_call_consent_message` to `@dfinity/ledger-icp`.
+- Add support for `icrc21_canister_call_consent_message` to `@dfinity/ledger-icp` and `@dfinity/ledger-icrc`.
 
 # 2024.09.02-0830Z
 

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -145,7 +145,7 @@ Parameters:
 
 ### :factory: IcrcLedgerCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L27)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L33)
 
 #### Methods
 
@@ -158,6 +158,7 @@ Parameters:
 - [transferFrom](#gear-transferfrom)
 - [approve](#gear-approve)
 - [allowance](#gear-allowance)
+- [consentMessage](#gear-consentmessage)
 
 ##### :gear: create
 
@@ -165,7 +166,7 @@ Parameters:
 | -------- | ---------------------------------------------------------------------- |
 | `create` | `(options: IcrcLedgerCanisterOptions<_SERVICE>) => IcrcLedgerCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L28)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L34)
 
 ##### :gear: metadata
 
@@ -175,7 +176,7 @@ The token metadata (name, symbol, etc.).
 | ---------- | ------------------------------------------------------------- |
 | `metadata` | `(params: QueryParams) => Promise<IcrcTokenMetadataResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L42)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L48)
 
 ##### :gear: transactionFee
 
@@ -185,7 +186,7 @@ The ledger transaction fees.
 | ---------------- | ------------------------------------------ |
 | `transactionFee` | `(params: QueryParams) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L50)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L56)
 
 ##### :gear: balance
 
@@ -199,7 +200,7 @@ Parameters:
 
 - `params`: The parameters to get the balance of an account.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L59)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L65)
 
 ##### :gear: transfer
 
@@ -213,7 +214,7 @@ Parameters:
 
 - `params`: The parameters to transfer tokens.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L72)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L78)
 
 ##### :gear: totalTokensSupply
 
@@ -223,7 +224,7 @@ Returns the total supply of tokens.
 | ------------------- | ------------------------------------------ |
 | `totalTokensSupply` | `(params: QueryParams) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L88)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L94)
 
 ##### :gear: transferFrom
 
@@ -239,7 +240,7 @@ Parameters:
 
 - `params`: The parameters to transfer tokens from to.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L101)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L107)
 
 ##### :gear: approve
 
@@ -255,7 +256,7 @@ Parameters:
 
 - `params`: The parameters to approve.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L123)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L129)
 
 ##### :gear: allowance
 
@@ -271,7 +272,21 @@ Parameters:
 
 - `params`: The parameters to call the allowance.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L145)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L151)
+
+##### :gear: consentMessage
+
+Fetches the consent message for a specified canister call, intended to provide a human-readable message that helps users make informed decisions.
+
+| Method           | Type                                                                   |
+| ---------------- | ---------------------------------------------------------------------- |
+| `consentMessage` | `(params: Icrc21ConsentMessageParams) => Promise<icrc21_consent_info>` |
+
+Parameters:
+
+- `params`: - The request parameters containing the method name, arguments, and consent preferences (e.g., language).
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L169)
 
 ### :factory: IcrcIndexCanister
 

--- a/packages/ledger-icrc/src/converters/ledger.converters.ts
+++ b/packages/ledger-icrc/src/converters/ledger.converters.ts
@@ -1,11 +1,13 @@
-import { toNullable } from "@dfinity/utils";
+import { isNullish, toNullable } from "@dfinity/utils";
 import type {
   ApproveArgs,
+  icrc21_consent_message_request as ConsentMessageArgs,
   TransferArg,
   TransferFromArgs,
 } from "../../candid/icrc_ledger";
 import type {
   ApproveParams,
+  Icrc21ConsentMessageParams,
   TransferFromParams,
   TransferParams,
 } from "../types/ledger.params";
@@ -59,4 +61,32 @@ export const toApproveArgs = ({
   created_at_time: toNullable(created_at_time),
   expected_allowance: toNullable(expected_allowance),
   expires_at: toNullable(expires_at),
+});
+
+export const toIcrc21ConsentMessageArgs = ({
+  userPreferences: {
+    metadata: { utcOffsetMinutes, language },
+    deriveSpec,
+  },
+  ...rest
+}: Icrc21ConsentMessageParams): ConsentMessageArgs => ({
+  ...rest,
+  user_preferences: {
+    metadata: {
+      language,
+      utc_offset_minutes: toNullable(utcOffsetMinutes),
+    },
+    device_spec: isNullish(deriveSpec)
+      ? toNullable()
+      : toNullable(
+          "GenericDisplay" in deriveSpec
+            ? { GenericDisplay: null }
+            : {
+                LineDisplay: {
+                  characters_per_line: deriveSpec.LineDisplay.charactersPerLine,
+                  lines_per_page: deriveSpec.LineDisplay.linesPerPage,
+                },
+              },
+        ),
+  },
 });

--- a/packages/ledger-icrc/src/errors/ledger.errors.ts
+++ b/packages/ledger-icrc/src/errors/ledger.errors.ts
@@ -1,3 +1,5 @@
+import type { icrc21_error as Icrc21RawError } from "../../candid/icrc_ledger";
+
 export class IcrcTransferError<T> extends Error {
   public errorType: T;
   constructor({ msg, errorType }: { msg?: string; errorType: T }) {
@@ -5,3 +7,51 @@ export class IcrcTransferError<T> extends Error {
     this.errorType = errorType;
   }
 }
+
+export class GenericError extends Error {
+  constructor(
+    public readonly message: string,
+    public readonly error_code: bigint,
+  ) {
+    super();
+  }
+}
+
+export class ConsentMessageError extends Error {}
+
+export class InsufficientPaymentError extends ConsentMessageError {}
+export class UnsupportedCanisterCallError extends ConsentMessageError {}
+export class ConsentMessageUnavailableError extends ConsentMessageError {}
+
+export const mapIcrc21ConsentMessageError = (
+  rawError: Icrc21RawError,
+): ConsentMessageError => {
+  if ("GenericError" in rawError) {
+    return new GenericError(
+      rawError.GenericError.description,
+      rawError.GenericError.error_code,
+    );
+  }
+
+  if ("InsufficientPayment" in rawError) {
+    return new InsufficientPaymentError(
+      rawError.InsufficientPayment.description,
+    );
+  }
+
+  if ("UnsupportedCanisterCall" in rawError) {
+    return new UnsupportedCanisterCallError(
+      rawError.UnsupportedCanisterCall.description,
+    );
+  }
+  if ("ConsentMessageUnavailable" in rawError) {
+    return new ConsentMessageUnavailableError(
+      rawError.ConsentMessageUnavailable.description,
+    );
+  }
+
+  // Edge case
+  return new ConsentMessageError(
+    `Unknown error type ${JSON.stringify(rawError)}`,
+  );
+};

--- a/packages/ledger-icrc/src/types/ledger.params.ts
+++ b/packages/ledger-icrc/src/types/ledger.params.ts
@@ -2,6 +2,7 @@ import type { QueryParams } from "@dfinity/utils";
 import type {
   Account,
   AllowanceArgs,
+  icrc21_consent_message_request as ConsentMessageArgs,
   Subaccount,
   Timestamp,
   Tokens,
@@ -77,3 +78,55 @@ export type ApproveParams = Omit<TransferParams, "to"> & {
  * Params to get the token allowance that the spender account can transfer from the specified account
  */
 export type AllowanceParams = AllowanceArgs & QueryParams;
+
+/**
+ * Metadata for the consent message in ICRC-21 specification.
+ * @param {number} [utcOffsetMinutes] - The user's local timezone offset in minutes from UTC. If absent, the default is UTC.
+ * @param {string} language - BCP-47 language tag. See https://www.rfc-editor.org/rfc/bcp/bcp47.txt
+ */
+export type Icrc21ConsentMessageMetadata = {
+  utcOffsetMinutes?: number;
+  language: string;
+};
+
+/**
+ * Device specification for displaying the consent message.
+ *
+ * @param {null} [GenericDisplay] -  A generic display able to handle large documents and do line wrapping and pagination / scrolling.  Text must be Markdown formatted, no external resources (e.g. images) are allowed.
+ * @param {Object} [LineDisplay] - Simple display able to handle lines of text with a maximum number of characters per line.
+ * @param {number} LineDisplay.charactersPerLine - Maximum number of characters that can be displayed per line.
+ * @param {number} LineDisplay.linesPerPage - Maximum number of lines that can be displayed at once on a single page.
+ */
+export type Icrc21ConsentMessageDeviceSpec =
+  | { GenericDisplay: null }
+  | {
+      LineDisplay: {
+        charactersPerLine: number;
+        linesPerPage: number;
+      };
+    };
+
+/**
+ * Specification for the consent message, including metadata and device preferences.
+ *
+ * @param {Icrc21ConsentMessageMetadata} metadata - Metadata of the consent message.
+ * @param {Icrc21ConsentMessageDeviceSpec} [deviceSpec] - Information about the device responsible for presenting the consent message to the user.
+ */
+export type Icrc21ConsentMessageSpec = {
+  metadata: Icrc21ConsentMessageMetadata;
+  deriveSpec?: Icrc21ConsentMessageDeviceSpec;
+};
+
+/**
+ * Parameters for the consent message request.
+ *
+ * @param {string} method - Method name of the canister call.
+ * @param {Uint8Array} arg - Argument of the canister call.
+ * @param {Icrc21ConsentMessageSpec} userPreferences - User preferences with regards to the consent message presented to the end-user.
+ */
+export type Icrc21ConsentMessageParams = Omit<
+  ConsentMessageArgs,
+  "user_preferences"
+> & {
+  userPreferences: Icrc21ConsentMessageSpec;
+};


### PR DESCRIPTION
# Motivation

Add support for `icrc21_canister_call_consent_message` to `@dfinity/ledger-icrc`.

# Notes

It annoys me a bit that the close basically duplicates the code of ICP but, not sure it is worth the effort at this point to create a util or even lib for that particular topic. We might do so if more canisters starts implementing consent message but, happy to hear any thoughts about it.

# Changes

- Expose and implement new function `consentMessage`.
- Add a new parameter for the request.
- Map the potential error.
