### PR TITLE
build: bump size-limit for ledger-icrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     {
       "name": "@dfinity/ledger-icrc",
       "path": "./packages/ledger-icrc/dist/index.js",
-      "limit": "4 kB",
+      "limit": "5 kB",
       "gzip": true,
       "ignore": [
         "@dfinity/agent",


### PR DESCRIPTION
# Motivation

The `@dfinity/ledger-icrc` gained weight (just a bit) in #710. Given that we are really precaucious, it makes the test fails.

# Changes

- Add 1kb to the limit (5 instead of 4)