### PR TITLE
Add support for "Regtest" BTC network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - Add support for `icrc21_canister_call_consent_message` to `@dfinity/ledger-icp` and `@dfinity/ledger-icrc`.
+- Add support for `"regtest"` in `BitcoinNetwork`.
 
 # 2024.09.02-0830Z
 

--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -294,7 +294,7 @@ Parameters:
 
 ##### :gear: getUtxosQuery
 
-Given a `get_utxos_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet` or `testnet`), the function returns all unspent transaction outputs (UTXOs) associated with the provided address in the specified Bitcoin network based on the current view of the Bitcoin blockchain available to the Bitcoin component.
+Given a `get_utxos_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet`, `testnet` or `regtest`), the function returns all unspent transaction outputs (UTXOs) associated with the provided address in the specified Bitcoin network based on the current view of the Bitcoin blockchain available to the Bitcoin component.
 
 ⚠️ Note that this method does not support certified calls because only canisters are allowed to get UTXOs via update calls.
 
@@ -312,7 +312,7 @@ Parameters:
 
 ##### :gear: getBalanceQuery
 
-Given a `get_balance_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet` or `testnet`), the function returns the current balance of this address in `Satoshi` (10^8 Satoshi = 1 Bitcoin) in the specified Bitcoin network.
+Given a `get_balance_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet`, `testnet` or `regtest`), the function returns the current balance of this address in `Satoshi` (10^8 Satoshi = 1 Bitcoin) in the specified Bitcoin network.
 
 ⚠️ Note that this method does not support certified calls because only canisters are allowed to get Bitcoin balance via update calls.
 

--- a/packages/ckbtc/src/bitcoin.canister.ts
+++ b/packages/ckbtc/src/bitcoin.canister.ts
@@ -27,7 +27,7 @@ export class BitcoinCanister extends Canister<BitcoinService> {
   }
 
   /**
-   * Given a `get_utxos_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet` or `testnet`), the function returns all unspent transaction outputs (UTXOs) associated with the provided address in the specified Bitcoin network based on the current view of the Bitcoin blockchain available to the Bitcoin component.
+   * Given a `get_utxos_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet`, `testnet` or `regtest`), the function returns all unspent transaction outputs (UTXOs) associated with the provided address in the specified Bitcoin network based on the current view of the Bitcoin blockchain available to the Bitcoin component.
    *
    * ⚠️ Note that this method does not support certified calls because only canisters are allowed to get UTXOs via update calls.
    *
@@ -49,7 +49,7 @@ export class BitcoinCanister extends Canister<BitcoinService> {
   };
 
   /**
-   * Given a `get_balance_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet` or `testnet`), the function returns the current balance of this address in `Satoshi` (10^8 Satoshi = 1 Bitcoin) in the specified Bitcoin network.
+   * Given a `get_balance_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet`, `testnet` or `regtest`), the function returns the current balance of this address in `Satoshi` (10^8 Satoshi = 1 Bitcoin) in the specified Bitcoin network.
    *
    * ⚠️ Note that this method does not support certified calls because only canisters are allowed to get Bitcoin balance via update calls.
    *

--- a/packages/ckbtc/src/types/bitcoin.params.ts
+++ b/packages/ckbtc/src/types/bitcoin.params.ts
@@ -5,10 +5,13 @@ import type {
   network,
 } from "../../candid/bitcoin";
 
-export type BitcoinNetwork = "testnet" | "mainnet";
+export type BitcoinNetwork = "testnet" | "mainnet" | "regtest";
 
-const mapBitcoinNetwork = (network: BitcoinNetwork): network =>
-  network === "testnet" ? { testnet: null } : { mainnet: null };
+const mapBitcoinNetwork: Record<BitcoinNetwork, network> = {
+  mainnet: { mainnet: null },
+  testnet: { testnet: null },
+  regtest: { regtest: null },
+};
 
 export type GetUtxosParams = Omit<get_utxos_request, "network" | "filter"> & {
   network: BitcoinNetwork;
@@ -45,6 +48,6 @@ export const toGetBalanceParams = ({
   ...rest
 }: GetBalanceParams): get_balance_request => ({
   min_confirmations: toNullable(minConfirmations),
-  network: mapBitcoinNetwork(network),
+  network: mapBitcoinNetwork[network],
   ...rest,
 });


### PR DESCRIPTION
# Motivation

We want to use Regtest for local development in Oisy, but at the moment, this network is not supported in the `BitcoinNetwork`.

# Changes

* Add `"regtest"` as supported BitcoinNetwork and change the mapper to support the new value.

# Tests

No new functionality.

# Todos

- [ ] Add entry to changelog (if necessary).
