### PR TITLE
Update nns-js Candid Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+## Breaking changes
+
+- Removed deprecated `OpenSnsTokenSwap`, `SetSnsTokenSwapOpenTimeWindow`, and `SetDefaultFollowees` from `ProposalActionRequest`.
+
 ## Features
 
 - Add support for `icrc21_canister_call_consent_message` to `@dfinity/ledger-icp` and `@dfinity/ledger-icrc`.

--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 35bfcad (2024-08-29 tags: release-2024-08-29_01-30-base) 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit 20321d1029 (2024-09-07) 'rs/nns/gtc/canister/gtc.did' by import-candid
 type AccountState = record {
   authenticated_principal_id : opt principal;
   successfully_transferred_neurons : vec TransferredNeuron;

--- a/packages/nns/candid/governance.certified.idl.js
+++ b/packages/nns/candid/governance.certified.idl.js
@@ -485,7 +485,6 @@ export const idlFactory = ({ IDL }) => {
   });
   const NeuronsFundNeuronPortion = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
     'hotkeys' : IDL.Vec(IDL.Principal),
     'is_capped' : IDL.Opt(IDL.Bool),
     'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
@@ -770,9 +769,6 @@ export const idlFactory = ({ IDL }) => {
     'CreateServiceNervousSystem' : CreateServiceNervousSystem,
     'ExecuteNnsFunction' : ExecuteNnsFunction,
     'RewardNodeProvider' : RewardNodeProvider,
-    'OpenSnsTokenSwap' : OpenSnsTokenSwap,
-    'SetSnsTokenSwapOpenTimeWindow' : SetSnsTokenSwapOpenTimeWindow,
-    'SetDefaultFollowees' : SetDefaultFollowees,
     'RewardNodeProviders' : RewardNodeProviders,
     'ManageNetworkEconomics' : NetworkEconomics,
     'ApproveGenesisKyc' : Principals,
@@ -873,7 +869,6 @@ export const idlFactory = ({ IDL }) => {
   });
   const NeuronsFundNeuron = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
-    'hotkey_principal' : IDL.Opt(IDL.Text),
     'hotkeys' : IDL.Opt(Principals),
     'is_capped' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Opt(IDL.Nat64),
@@ -1454,7 +1449,6 @@ export const init = ({ IDL }) => {
   });
   const NeuronsFundNeuronPortion = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
     'hotkeys' : IDL.Vec(IDL.Principal),
     'is_capped' : IDL.Opt(IDL.Bool),
     'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -575,7 +575,6 @@ export interface NeuronsFundMatchedFundingCurveCoefficients {
 }
 export interface NeuronsFundNeuron {
   controller: [] | [Principal];
-  hotkey_principal: [] | [string];
   hotkeys: [] | [Principals];
   is_capped: [] | [boolean];
   nns_neuron_id: [] | [bigint];
@@ -583,7 +582,6 @@ export interface NeuronsFundNeuron {
 }
 export interface NeuronsFundNeuronPortion {
   controller: [] | [Principal];
-  hotkey_principal: [] | [Principal];
   hotkeys: Array<Principal>;
   is_capped: [] | [boolean];
   maturity_equivalent_icp_e8s: [] | [bigint];
@@ -668,9 +666,6 @@ export type ProposalActionRequest =
   | { CreateServiceNervousSystem: CreateServiceNervousSystem }
   | { ExecuteNnsFunction: ExecuteNnsFunction }
   | { RewardNodeProvider: RewardNodeProvider }
-  | { OpenSnsTokenSwap: OpenSnsTokenSwap }
-  | { SetSnsTokenSwapOpenTimeWindow: SetSnsTokenSwapOpenTimeWindow }
-  | { SetDefaultFollowees: SetDefaultFollowees }
   | { RewardNodeProviders: RewardNodeProviders }
   | { ManageNetworkEconomics: NetworkEconomics }
   | { ApproveGenesisKyc: Principals }

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 35bfcad (2024-08-29 tags: release-2024-08-29_01-30-base) 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 20321d1029 (2024-09-07) 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -677,7 +677,6 @@ type NeuronsFundMatchedFundingCurveCoefficients = record {
 
 type NeuronsFundNeuron = record {
   controller : opt principal;
-  hotkey_principal : opt text;
   hotkeys : opt Principals;
   is_capped : opt bool;
   nns_neuron_id : opt nat64;
@@ -686,7 +685,6 @@ type NeuronsFundNeuron = record {
 
 type NeuronsFundNeuronPortion = record {
   controller : opt principal;
-  hotkey_principal : opt principal;
   hotkeys : vec principal;
   is_capped : opt bool;
   maturity_equivalent_icp_e8s : opt nat64;
@@ -783,9 +781,6 @@ type ProposalActionRequest = variant {
   CreateServiceNervousSystem : CreateServiceNervousSystem;
   ExecuteNnsFunction : ExecuteNnsFunction;
   RewardNodeProvider : RewardNodeProvider;
-  OpenSnsTokenSwap : OpenSnsTokenSwap;
-  SetSnsTokenSwapOpenTimeWindow : SetSnsTokenSwapOpenTimeWindow;
-  SetDefaultFollowees : SetDefaultFollowees;
   RewardNodeProviders : RewardNodeProviders;
   ManageNetworkEconomics : NetworkEconomics;
   ApproveGenesisKyc : Principals;

--- a/packages/nns/candid/governance.idl.js
+++ b/packages/nns/candid/governance.idl.js
@@ -485,7 +485,6 @@ export const idlFactory = ({ IDL }) => {
   });
   const NeuronsFundNeuronPortion = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
     'hotkeys' : IDL.Vec(IDL.Principal),
     'is_capped' : IDL.Opt(IDL.Bool),
     'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
@@ -770,9 +769,6 @@ export const idlFactory = ({ IDL }) => {
     'CreateServiceNervousSystem' : CreateServiceNervousSystem,
     'ExecuteNnsFunction' : ExecuteNnsFunction,
     'RewardNodeProvider' : RewardNodeProvider,
-    'OpenSnsTokenSwap' : OpenSnsTokenSwap,
-    'SetSnsTokenSwapOpenTimeWindow' : SetSnsTokenSwapOpenTimeWindow,
-    'SetDefaultFollowees' : SetDefaultFollowees,
     'RewardNodeProviders' : RewardNodeProviders,
     'ManageNetworkEconomics' : NetworkEconomics,
     'ApproveGenesisKyc' : Principals,
@@ -873,7 +869,6 @@ export const idlFactory = ({ IDL }) => {
   });
   const NeuronsFundNeuron = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
-    'hotkey_principal' : IDL.Opt(IDL.Text),
     'hotkeys' : IDL.Opt(Principals),
     'is_capped' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Opt(IDL.Nat64),
@@ -1470,7 +1465,6 @@ export const init = ({ IDL }) => {
   });
   const NeuronsFundNeuronPortion = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
     'hotkeys' : IDL.Vec(IDL.Principal),
     'is_capped' : IDL.Opt(IDL.Bool),
     'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/candid/governance_test.certified.idl.js
+++ b/packages/nns/candid/governance_test.certified.idl.js
@@ -485,7 +485,6 @@ export const idlFactory = ({ IDL }) => {
   });
   const NeuronsFundNeuronPortion = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
     'hotkeys' : IDL.Vec(IDL.Principal),
     'is_capped' : IDL.Opt(IDL.Bool),
     'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
@@ -770,9 +769,6 @@ export const idlFactory = ({ IDL }) => {
     'CreateServiceNervousSystem' : CreateServiceNervousSystem,
     'ExecuteNnsFunction' : ExecuteNnsFunction,
     'RewardNodeProvider' : RewardNodeProvider,
-    'OpenSnsTokenSwap' : OpenSnsTokenSwap,
-    'SetSnsTokenSwapOpenTimeWindow' : SetSnsTokenSwapOpenTimeWindow,
-    'SetDefaultFollowees' : SetDefaultFollowees,
     'RewardNodeProviders' : RewardNodeProviders,
     'ManageNetworkEconomics' : NetworkEconomics,
     'ApproveGenesisKyc' : Principals,
@@ -873,7 +869,6 @@ export const idlFactory = ({ IDL }) => {
   });
   const NeuronsFundNeuron = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
-    'hotkey_principal' : IDL.Opt(IDL.Text),
     'hotkeys' : IDL.Opt(Principals),
     'is_capped' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Opt(IDL.Nat64),
@@ -1455,7 +1450,6 @@ export const init = ({ IDL }) => {
   });
   const NeuronsFundNeuronPortion = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
     'hotkeys' : IDL.Vec(IDL.Principal),
     'is_capped' : IDL.Opt(IDL.Bool),
     'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/candid/governance_test.d.ts
+++ b/packages/nns/candid/governance_test.d.ts
@@ -575,7 +575,6 @@ export interface NeuronsFundMatchedFundingCurveCoefficients {
 }
 export interface NeuronsFundNeuron {
   controller: [] | [Principal];
-  hotkey_principal: [] | [string];
   hotkeys: [] | [Principals];
   is_capped: [] | [boolean];
   nns_neuron_id: [] | [bigint];
@@ -583,7 +582,6 @@ export interface NeuronsFundNeuron {
 }
 export interface NeuronsFundNeuronPortion {
   controller: [] | [Principal];
-  hotkey_principal: [] | [Principal];
   hotkeys: Array<Principal>;
   is_capped: [] | [boolean];
   maturity_equivalent_icp_e8s: [] | [bigint];
@@ -668,9 +666,6 @@ export type ProposalActionRequest =
   | { CreateServiceNervousSystem: CreateServiceNervousSystem }
   | { ExecuteNnsFunction: ExecuteNnsFunction }
   | { RewardNodeProvider: RewardNodeProvider }
-  | { OpenSnsTokenSwap: OpenSnsTokenSwap }
-  | { SetSnsTokenSwapOpenTimeWindow: SetSnsTokenSwapOpenTimeWindow }
-  | { SetDefaultFollowees: SetDefaultFollowees }
   | { RewardNodeProviders: RewardNodeProviders }
   | { ManageNetworkEconomics: NetworkEconomics }
   | { ApproveGenesisKyc: Principals }

--- a/packages/nns/candid/governance_test.did
+++ b/packages/nns/candid/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 35bfcad (2024-08-29 tags: release-2024-08-29_01-30-base) 'rs/nns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 20321d1029 (2024-09-07) 'rs/nns/governance/canister/governance_test.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -679,7 +679,6 @@ type NeuronsFundMatchedFundingCurveCoefficients = record {
 
 type NeuronsFundNeuron = record {
   controller : opt principal;
-  hotkey_principal : opt text;
   hotkeys : opt Principals;
   is_capped : opt bool;
   nns_neuron_id : opt nat64;
@@ -688,7 +687,6 @@ type NeuronsFundNeuron = record {
 
 type NeuronsFundNeuronPortion = record {
   controller : opt principal;
-  hotkey_principal : opt principal;
   hotkeys : vec principal;
   is_capped : opt bool;
   maturity_equivalent_icp_e8s : opt nat64;
@@ -785,9 +783,6 @@ type ProposalActionRequest = variant {
   CreateServiceNervousSystem : CreateServiceNervousSystem;
   ExecuteNnsFunction : ExecuteNnsFunction;
   RewardNodeProvider : RewardNodeProvider;
-  OpenSnsTokenSwap : OpenSnsTokenSwap;
-  SetSnsTokenSwapOpenTimeWindow : SetSnsTokenSwapOpenTimeWindow;
-  SetDefaultFollowees : SetDefaultFollowees;
   RewardNodeProviders : RewardNodeProviders;
   ManageNetworkEconomics : NetworkEconomics;
   ApproveGenesisKyc : Principals;

--- a/packages/nns/candid/governance_test.idl.js
+++ b/packages/nns/candid/governance_test.idl.js
@@ -485,7 +485,6 @@ export const idlFactory = ({ IDL }) => {
   });
   const NeuronsFundNeuronPortion = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
     'hotkeys' : IDL.Vec(IDL.Principal),
     'is_capped' : IDL.Opt(IDL.Bool),
     'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),
@@ -770,9 +769,6 @@ export const idlFactory = ({ IDL }) => {
     'CreateServiceNervousSystem' : CreateServiceNervousSystem,
     'ExecuteNnsFunction' : ExecuteNnsFunction,
     'RewardNodeProvider' : RewardNodeProvider,
-    'OpenSnsTokenSwap' : OpenSnsTokenSwap,
-    'SetSnsTokenSwapOpenTimeWindow' : SetSnsTokenSwapOpenTimeWindow,
-    'SetDefaultFollowees' : SetDefaultFollowees,
     'RewardNodeProviders' : RewardNodeProviders,
     'ManageNetworkEconomics' : NetworkEconomics,
     'ApproveGenesisKyc' : Principals,
@@ -873,7 +869,6 @@ export const idlFactory = ({ IDL }) => {
   });
   const NeuronsFundNeuron = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
-    'hotkey_principal' : IDL.Opt(IDL.Text),
     'hotkeys' : IDL.Opt(Principals),
     'is_capped' : IDL.Opt(IDL.Bool),
     'nns_neuron_id' : IDL.Opt(IDL.Nat64),
@@ -1471,7 +1466,6 @@ export const init = ({ IDL }) => {
   });
   const NeuronsFundNeuronPortion = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
-    'hotkey_principal' : IDL.Opt(IDL.Principal),
     'hotkeys' : IDL.Vec(IDL.Principal),
     'is_capped' : IDL.Opt(IDL.Bool),
     'maturity_equivalent_icp_e8s' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/candid/sns_wasm.did
+++ b/packages/nns/candid/sns_wasm.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 35bfcad (2024-08-29 tags: release-2024-08-29_01-30-base) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit 20321d1029 (2024-09-07) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -574,18 +574,6 @@ const fromAction = (action: ProposalActionRequest): RawAction => {
     };
   }
 
-  if ("SetDefaultFollowees" in action) {
-    const setDefaultFollowees = action.SetDefaultFollowees;
-    return {
-      SetDefaultFollowees: {
-        default_followees: setDefaultFollowees.defaultFollowees.map((f) => [
-          f.topic as number,
-          fromFollowees(f.followees),
-        ]),
-      },
-    };
-  }
-
   if ("RegisterKnownNeuron" in action) {
     const knownNeuron = action.RegisterKnownNeuron;
     return {
@@ -600,74 +588,6 @@ const fromAction = (action: ProposalActionRequest): RawAction => {
                 : [],
           },
         ],
-      },
-    };
-  }
-
-  if ("SetSnsTokenSwapOpenTimeWindow" in action) {
-    const { request, swapCanisterId } = action.SetSnsTokenSwapOpenTimeWindow;
-
-    return {
-      SetSnsTokenSwapOpenTimeWindow: {
-        request:
-          request === undefined
-            ? []
-            : [
-                {
-                  open_time_window:
-                    request.openTimeWindow === undefined
-                      ? []
-                      : [
-                          {
-                            start_timestamp_seconds:
-                              request.openTimeWindow.startTimestampSeconds,
-                            end_timestamp_seconds:
-                              request.openTimeWindow.endTimestampSeconds,
-                          },
-                        ],
-                },
-              ],
-
-        swap_canister_id:
-          swapCanisterId === undefined
-            ? []
-            : [Principal.fromText(swapCanisterId)],
-      },
-    };
-  }
-
-  if ("OpenSnsTokenSwap" in action) {
-    const { communityFundInvestmentE8s, targetSwapCanisterId, params } =
-      action.OpenSnsTokenSwap;
-
-    return {
-      OpenSnsTokenSwap: {
-        community_fund_investment_e8s: toNullable(communityFundInvestmentE8s),
-        target_swap_canister_id: toNullable(targetSwapCanisterId),
-        params:
-          params === undefined
-            ? []
-            : [
-                {
-                  min_participant_icp_e8s: params.minParticipantIcpE8s,
-                  max_icp_e8s: params.maxIcpE8s,
-                  swap_due_timestamp_seconds: params.swapDueTimestampSeconds,
-                  min_participants: params.minParticipants,
-                  sns_token_e8s: params.snsTokenE8s,
-                  max_participant_icp_e8s: params.maxParticipantIcpE8s,
-                  min_icp_e8s: params.minIcpE8s,
-                  sale_delay_seconds: toNullable(params.saleDelaySeconds),
-                  neuron_basket_construction_parameters: toNullable(
-                    params.neuronBasketConstructionParameters,
-                  ),
-                  max_direct_participation_icp_e8s: toNullable(
-                    params.maxDirectParticipationIcpE8s,
-                  ),
-                  min_direct_participation_icp_e8s: toNullable(
-                    params.minDirectParticipationIcpE8s,
-                  ),
-                },
-              ],
       },
     };
   }

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -24,7 +24,6 @@ import type {
   Decimal as RawDecimal,
   DeveloperDistribution as RawDeveloperDistribution,
   Duration as RawDuration,
-  Followees as RawFollowees,
   GlobalTimeOfDay as RawGlobalTimeOfDay,
   GovernanceParameters as RawGovernanceParameters,
   Image as RawImage,
@@ -96,10 +95,6 @@ const fromProposalId = (proposalId: ProposalId): RawNeuronId => ({
 
 const fromNeuronId = (neuronId: NeuronId): RawNeuronId => ({
   id: neuronId,
-});
-
-const fromFollowees = (followees: Array<NeuronId>): RawFollowees => ({
-  followees: followees.map(fromNeuronId),
 });
 
 const fromNeuronIdOrSubaccount = (

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -55,10 +55,7 @@ export type ProposalActionRequest =
   | { RewardNodeProvider: RewardNodeProvider }
   | { RewardNodeProviders: RewardNodeProviders }
   | { AddOrRemoveNodeProvider: AddOrRemoveNodeProvider }
-  | { SetDefaultFollowees: SetDefaultFollowees }
-  | { Motion: Motion }
-  | { SetSnsTokenSwapOpenTimeWindow: SetSnsTokenSwapOpenTimeWindow }
-  | { OpenSnsTokenSwap: OpenSnsTokenSwap };
+  | { Motion: Motion };
 export interface AddHotKey {
   newHotKey: Option<PrincipalString>;
 }


### PR DESCRIPTION
# Motivation

We want to keep Candid files in ic-js in sync with the IC repo.
This is normally done by automated jobs, but the changes from https://github.com/dfinity/ic/pull/1157 caused tests to break in the [latest automated update](https://github.com/dfinity/ic-js/pull/714).

# Changes

1. Ran `git pull` in `../../ic`
2. Ran `scripts/import-candid ../../ic`
3. Ran `scripts/compile-idl-js`
4. Removed `OpenSnsTokenSwap`, `SetSnsTokenSwapOpenTimeWindow`, and `SetDefaultFollowees` from `ProposalActionRequest` in `packages/nns/src/canisters/governance/request.converters.ts`.
5. Remove `OpenSnsTokenSwap`, `SetSnsTokenSwapOpenTimeWindow`, and `SetDefaultFollowees` from `Action` in `packages/nns/src/types/governance_converters.ts`.
6. Reverted the changes in packages other than `nns`.

# Tests

1. Tests pass.
2. Tested that tests pass in NNS dapp after updating to ic-js with the new changes.


# Todos

- [x] Add entry to changelog (if necessary).
