### PR TITLE
build: bump agent-js v2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -717,9 +717,9 @@
       "dev": true
     },
     "node_modules/@dfinity/agent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.0.0.tgz",
-      "integrity": "sha512-Cc2VDAMfxCNIQoaEeKPf0rbS/Y21HAF+eEFj6GfijNnUxS42i4zwUF2PUvEJZqaB2FQwA9SC7MDyuwL8BR2oJA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.1.tgz",
+      "integrity": "sha512-9+XPFc9PrXM0kmaqZOOVW3eXBGaWzOjnnbEa55J1NBuDA6+X2jAyE51I62zXr1oFwMeKj7ykOEFd5MOmnMEijA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -731,18 +731,18 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^2.0.0",
-        "@dfinity/principal": "^2.0.0"
+        "@dfinity/candid": "^2.1.1",
+        "@dfinity/principal": "^2.1.1"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.0.0.tgz",
-      "integrity": "sha512-poxIEnzErcKBM5yroabQ3VqQpiYZnqYZdLJWFuIQZzioGdP1mlnVLHx7IbgHN4HBlqVXYPFmEzMU02FnyYUA1Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.1.tgz",
+      "integrity": "sha512-RVcTKko8wLys2yW84e9Fu/AcJkZOdH7U/Rlm3Pgcx81fnfm74hxKCoecTYD+awbD2HSlVJRB/Uo7NoAoE/N+gQ==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "^2.0.0"
+        "@dfinity/principal": "^2.1.1"
       }
     },
     "node_modules/@dfinity/ckbtc": {
@@ -778,9 +778,9 @@
       "link": true
     },
     "node_modules/@dfinity/principal": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.0.0.tgz",
-      "integrity": "sha512-cqJ5kOrPpxco+wvJC4TFBhdr4lkw9mnwKGAYunesyqdzSYi8lnFB4dShNqlHFWdwoxNAw6OZkt/B+0nLa+7Yqw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.1.tgz",
+      "integrity": "sha512-XKoQRgL7S7MRPwabY6z2wJ1Mn0WQqe9ZQIMK2wtRq48f5nL1m0rZejf8kR9JsZCNCYK6ss4b09FCRNGC20J8Bg==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -1656,24 +1656,28 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/hashes": "1.5.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -7517,9 +7521,9 @@
         "bech32": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.0.0",
-        "@dfinity/candid": "^2.0.0",
-        "@dfinity/principal": "^2.0.0",
+        "@dfinity/agent": "^2.1.1",
+        "@dfinity/candid": "^2.1.1",
+        "@dfinity/principal": "^2.1.1",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7528,9 +7532,9 @@
       "version": "3.3.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.0.0",
-        "@dfinity/candid": "^2.0.0",
-        "@dfinity/principal": "^2.0.0",
+        "@dfinity/agent": "^2.1.1",
+        "@dfinity/candid": "^2.1.1",
+        "@dfinity/principal": "^2.1.1",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7539,9 +7543,9 @@
       "version": "3.2.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.0.0",
-        "@dfinity/candid": "^2.0.0",
-        "@dfinity/principal": "^2.0.0",
+        "@dfinity/agent": "^2.1.1",
+        "@dfinity/candid": "^2.1.1",
+        "@dfinity/principal": "^2.1.1",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7550,9 +7554,9 @@
       "version": "5.2.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.0.0",
-        "@dfinity/candid": "^2.0.0",
-        "@dfinity/principal": "^2.0.0",
+        "@dfinity/agent": "^2.1.1",
+        "@dfinity/candid": "^2.1.1",
+        "@dfinity/principal": "^2.1.1",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7561,9 +7565,9 @@
       "version": "2.5.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.0.0",
-        "@dfinity/candid": "^2.0.0",
-        "@dfinity/principal": "^2.0.0",
+        "@dfinity/agent": "^2.1.1",
+        "@dfinity/candid": "^2.1.1",
+        "@dfinity/principal": "^2.1.1",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7572,9 +7576,9 @@
       "version": "2.5.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.0.0",
-        "@dfinity/candid": "^2.0.0",
-        "@dfinity/principal": "^2.0.0",
+        "@dfinity/agent": "^2.1.1",
+        "@dfinity/candid": "^2.1.1",
+        "@dfinity/principal": "^2.1.1",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7590,10 +7594,10 @@
         "@types/randombytes": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.0.0",
-        "@dfinity/candid": "^2.0.0",
+        "@dfinity/agent": "^2.1.1",
+        "@dfinity/candid": "^2.1.1",
         "@dfinity/ledger-icp": "^2.5.0",
-        "@dfinity/principal": "^2.0.0",
+        "@dfinity/principal": "^2.1.1",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7616,10 +7620,10 @@
         "@noble/hashes": "^1.3.2"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.0.0",
-        "@dfinity/candid": "^2.0.0",
+        "@dfinity/agent": "^2.1.1",
+        "@dfinity/candid": "^2.1.1",
         "@dfinity/ledger-icrc": "^2.5.0",
-        "@dfinity/principal": "^2.0.0",
+        "@dfinity/principal": "^2.1.1",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7628,9 +7632,9 @@
       "version": "2.5.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.0.0",
-        "@dfinity/candid": "^2.0.0",
-        "@dfinity/principal": "^2.0.0"
+        "@dfinity/agent": "^2.1.1",
+        "@dfinity/candid": "^2.1.1",
+        "@dfinity/principal": "^2.1.1"
       }
     }
   },
@@ -8144,9 +8148,9 @@
       "dev": true
     },
     "@dfinity/agent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.0.0.tgz",
-      "integrity": "sha512-Cc2VDAMfxCNIQoaEeKPf0rbS/Y21HAF+eEFj6GfijNnUxS42i4zwUF2PUvEJZqaB2FQwA9SC7MDyuwL8BR2oJA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.1.tgz",
+      "integrity": "sha512-9+XPFc9PrXM0kmaqZOOVW3eXBGaWzOjnnbEa55J1NBuDA6+X2jAyE51I62zXr1oFwMeKj7ykOEFd5MOmnMEijA==",
       "peer": true,
       "requires": {
         "@noble/curves": "^1.4.0",
@@ -8158,9 +8162,9 @@
       }
     },
     "@dfinity/candid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.0.0.tgz",
-      "integrity": "sha512-poxIEnzErcKBM5yroabQ3VqQpiYZnqYZdLJWFuIQZzioGdP1mlnVLHx7IbgHN4HBlqVXYPFmEzMU02FnyYUA1Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.1.tgz",
+      "integrity": "sha512-RVcTKko8wLys2yW84e9Fu/AcJkZOdH7U/Rlm3Pgcx81fnfm74hxKCoecTYD+awbD2HSlVJRB/Uo7NoAoE/N+gQ==",
       "peer": true,
       "requires": {}
     },
@@ -8208,9 +8212,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.0.0.tgz",
-      "integrity": "sha512-cqJ5kOrPpxco+wvJC4TFBhdr4lkw9mnwKGAYunesyqdzSYi8lnFB4dShNqlHFWdwoxNAw6OZkt/B+0nLa+7Yqw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.1.tgz",
+      "integrity": "sha512-XKoQRgL7S7MRPwabY6z2wJ1Mn0WQqe9ZQIMK2wtRq48f5nL1m0rZejf8kR9JsZCNCYK6ss4b09FCRNGC20J8Bg==",
       "peer": true,
       "requires": {
         "@noble/hashes": "^1.3.1"
@@ -8776,18 +8780,18 @@
       }
     },
     "@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
       "peer": true,
       "requires": {
-        "@noble/hashes": "1.4.0"
+        "@noble/hashes": "1.5.0"
       }
     },
     "@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.0.0",
-    "@dfinity/candid": "^2.0.0",
-    "@dfinity/principal": "^2.0.0",
+    "@dfinity/agent": "^2.1.1",
+    "@dfinity/candid": "^2.1.1",
+    "@dfinity/principal": "^2.1.1",
     "@dfinity/utils": "^2.5.0"
   },
   "dependencies": {

--- a/packages/cketh/package.json
+++ b/packages/cketh/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.0.0",
-    "@dfinity/candid": "^2.0.0",
-    "@dfinity/principal": "^2.0.0",
+    "@dfinity/agent": "^2.1.1",
+    "@dfinity/candid": "^2.1.1",
+    "@dfinity/principal": "^2.1.1",
     "@dfinity/utils": "^2.5.0"
   }
 }

--- a/packages/cmc/package.json
+++ b/packages/cmc/package.json
@@ -36,9 +36,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.0.0",
-    "@dfinity/candid": "^2.0.0",
-    "@dfinity/principal": "^2.0.0",
+    "@dfinity/agent": "^2.1.1",
+    "@dfinity/candid": "^2.1.1",
+    "@dfinity/principal": "^2.1.1",
     "@dfinity/utils": "^2.5.0"
   }
 }

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -34,9 +34,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.0.0",
-    "@dfinity/candid": "^2.0.0",
-    "@dfinity/principal": "^2.0.0",
+    "@dfinity/agent": "^2.1.1",
+    "@dfinity/candid": "^2.1.1",
+    "@dfinity/principal": "^2.1.1",
     "@dfinity/utils": "^2.5.0"
   }
 }

--- a/packages/ledger-icp/package.json
+++ b/packages/ledger-icp/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.0.0",
-    "@dfinity/candid": "^2.0.0",
-    "@dfinity/principal": "^2.0.0",
+    "@dfinity/agent": "^2.1.1",
+    "@dfinity/candid": "^2.1.1",
+    "@dfinity/principal": "^2.1.1",
     "@dfinity/utils": "^2.5.0"
   }
 }

--- a/packages/ledger-icrc/package.json
+++ b/packages/ledger-icrc/package.json
@@ -37,9 +37,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.0.0",
-    "@dfinity/candid": "^2.0.0",
-    "@dfinity/principal": "^2.0.0",
+    "@dfinity/agent": "^2.1.1",
+    "@dfinity/candid": "^2.1.1",
+    "@dfinity/principal": "^2.1.1",
     "@dfinity/utils": "^2.5.0"
   }
 }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -51,10 +51,10 @@
     "network-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^2.0.0",
-    "@dfinity/candid": "^2.0.0",
+    "@dfinity/agent": "^2.1.1",
+    "@dfinity/candid": "^2.1.1",
     "@dfinity/ledger-icp": "^2.5.0",
-    "@dfinity/principal": "^2.0.0",
+    "@dfinity/principal": "^2.1.1",
     "@dfinity/utils": "^2.5.0"
   }
 }

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -36,10 +36,10 @@
     "sns"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^2.0.0",
-    "@dfinity/candid": "^2.0.0",
+    "@dfinity/agent": "^2.1.1",
+    "@dfinity/candid": "^2.1.1",
     "@dfinity/ledger-icrc": "^2.5.0",
-    "@dfinity/principal": "^2.0.0",
+    "@dfinity/principal": "^2.1.1",
     "@dfinity/utils": "^2.5.0"
   },
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -47,8 +47,8 @@
     "service-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^2.0.0",
-    "@dfinity/candid": "^2.0.0",
-    "@dfinity/principal": "^2.0.0"
+    "@dfinity/agent": "^2.1.1",
+    "@dfinity/candid": "^2.1.1",
+    "@dfinity/principal": "^2.1.1"
   }
 }


### PR DESCRIPTION
# Motivation

We need fixes for the Signer Standards that have been patched in agent-js v2.1.0.
Bumped to latest 2.1.1 which contains an additional feature unused by ourselves but, maybe for the community.

# Changes

- `npm run update:agent`
