### PR TITLE
build: patch agent-js v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Add support for `icrc21_canister_call_consent_message` to `@dfinity/ledger-icp` and `@dfinity/ledger-icrc`.
 - Add support for `"regtest"` in `BitcoinNetwork`.
 
+## Build
+
+- Incorporate Agent-js patch `v2.1.2`.
+
 # 2024.09.02-0830Z
 
 ## Overview

--- a/package-lock.json
+++ b/package-lock.json
@@ -717,9 +717,9 @@
       "dev": true
     },
     "node_modules/@dfinity/agent": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.1.tgz",
-      "integrity": "sha512-9+XPFc9PrXM0kmaqZOOVW3eXBGaWzOjnnbEa55J1NBuDA6+X2jAyE51I62zXr1oFwMeKj7ykOEFd5MOmnMEijA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.2.tgz",
+      "integrity": "sha512-UAXf6uXovhBlSp245RWlA21zcCavy+vVUvKVQUpesk1gLJpJlvsCE6hYOwTeFZAP+bjmPi0Tl7cx8DT2KM4eDQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -731,18 +731,18 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^2.1.1",
-        "@dfinity/principal": "^2.1.1"
+        "@dfinity/candid": "^2.1.2",
+        "@dfinity/principal": "^2.1.2"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.1.tgz",
-      "integrity": "sha512-RVcTKko8wLys2yW84e9Fu/AcJkZOdH7U/Rlm3Pgcx81fnfm74hxKCoecTYD+awbD2HSlVJRB/Uo7NoAoE/N+gQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.2.tgz",
+      "integrity": "sha512-do69J9iahW2tlmbPdbmc8MDhi5cfIQyTcAlYqaSOOAyg+Kp8beCnW7mletXVfx30dyVlpkyCrYOXhbpQuSCKtw==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "^2.1.1"
+        "@dfinity/principal": "^2.1.2"
       }
     },
     "node_modules/@dfinity/ckbtc": {
@@ -778,9 +778,9 @@
       "link": true
     },
     "node_modules/@dfinity/principal": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.1.tgz",
-      "integrity": "sha512-XKoQRgL7S7MRPwabY6z2wJ1Mn0WQqe9ZQIMK2wtRq48f5nL1m0rZejf8kR9JsZCNCYK6ss4b09FCRNGC20J8Bg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.2.tgz",
+      "integrity": "sha512-L3Y0nDjquqNFseM2Gx5fI4GOUKjjezFr9/6ZjSwAFeDeb4Ubqld4ZKL3FEzv4QKNbfZgCx19b7UXi+OdmLhi4w==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -7521,9 +7521,9 @@
         "bech32": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.1",
-        "@dfinity/candid": "^2.1.1",
-        "@dfinity/principal": "^2.1.1",
+        "@dfinity/agent": "^2.1.2",
+        "@dfinity/candid": "^2.1.2",
+        "@dfinity/principal": "^2.1.2",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7532,9 +7532,9 @@
       "version": "3.3.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.1",
-        "@dfinity/candid": "^2.1.1",
-        "@dfinity/principal": "^2.1.1",
+        "@dfinity/agent": "^2.1.2",
+        "@dfinity/candid": "^2.1.2",
+        "@dfinity/principal": "^2.1.2",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7543,9 +7543,9 @@
       "version": "3.2.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.1",
-        "@dfinity/candid": "^2.1.1",
-        "@dfinity/principal": "^2.1.1",
+        "@dfinity/agent": "^2.1.2",
+        "@dfinity/candid": "^2.1.2",
+        "@dfinity/principal": "^2.1.2",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7554,9 +7554,9 @@
       "version": "5.2.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.1",
-        "@dfinity/candid": "^2.1.1",
-        "@dfinity/principal": "^2.1.1",
+        "@dfinity/agent": "^2.1.2",
+        "@dfinity/candid": "^2.1.2",
+        "@dfinity/principal": "^2.1.2",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7565,9 +7565,9 @@
       "version": "2.5.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.1",
-        "@dfinity/candid": "^2.1.1",
-        "@dfinity/principal": "^2.1.1",
+        "@dfinity/agent": "^2.1.2",
+        "@dfinity/candid": "^2.1.2",
+        "@dfinity/principal": "^2.1.2",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7576,9 +7576,9 @@
       "version": "2.5.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.1",
-        "@dfinity/candid": "^2.1.1",
-        "@dfinity/principal": "^2.1.1",
+        "@dfinity/agent": "^2.1.2",
+        "@dfinity/candid": "^2.1.2",
+        "@dfinity/principal": "^2.1.2",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7594,10 +7594,10 @@
         "@types/randombytes": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.1",
-        "@dfinity/candid": "^2.1.1",
+        "@dfinity/agent": "^2.1.2",
+        "@dfinity/candid": "^2.1.2",
         "@dfinity/ledger-icp": "^2.5.0",
-        "@dfinity/principal": "^2.1.1",
+        "@dfinity/principal": "^2.1.2",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7620,10 +7620,10 @@
         "@noble/hashes": "^1.3.2"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.1",
-        "@dfinity/candid": "^2.1.1",
+        "@dfinity/agent": "^2.1.2",
+        "@dfinity/candid": "^2.1.2",
         "@dfinity/ledger-icrc": "^2.5.0",
-        "@dfinity/principal": "^2.1.1",
+        "@dfinity/principal": "^2.1.2",
         "@dfinity/utils": "^2.5.0"
       }
     },
@@ -7632,9 +7632,9 @@
       "version": "2.5.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.1",
-        "@dfinity/candid": "^2.1.1",
-        "@dfinity/principal": "^2.1.1"
+        "@dfinity/agent": "^2.1.2",
+        "@dfinity/candid": "^2.1.2",
+        "@dfinity/principal": "^2.1.2"
       }
     }
   },
@@ -8148,9 +8148,9 @@
       "dev": true
     },
     "@dfinity/agent": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.1.tgz",
-      "integrity": "sha512-9+XPFc9PrXM0kmaqZOOVW3eXBGaWzOjnnbEa55J1NBuDA6+X2jAyE51I62zXr1oFwMeKj7ykOEFd5MOmnMEijA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.2.tgz",
+      "integrity": "sha512-UAXf6uXovhBlSp245RWlA21zcCavy+vVUvKVQUpesk1gLJpJlvsCE6hYOwTeFZAP+bjmPi0Tl7cx8DT2KM4eDQ==",
       "peer": true,
       "requires": {
         "@noble/curves": "^1.4.0",
@@ -8162,9 +8162,9 @@
       }
     },
     "@dfinity/candid": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.1.tgz",
-      "integrity": "sha512-RVcTKko8wLys2yW84e9Fu/AcJkZOdH7U/Rlm3Pgcx81fnfm74hxKCoecTYD+awbD2HSlVJRB/Uo7NoAoE/N+gQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.2.tgz",
+      "integrity": "sha512-do69J9iahW2tlmbPdbmc8MDhi5cfIQyTcAlYqaSOOAyg+Kp8beCnW7mletXVfx30dyVlpkyCrYOXhbpQuSCKtw==",
       "peer": true,
       "requires": {}
     },
@@ -8212,9 +8212,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.1.tgz",
-      "integrity": "sha512-XKoQRgL7S7MRPwabY6z2wJ1Mn0WQqe9ZQIMK2wtRq48f5nL1m0rZejf8kR9JsZCNCYK6ss4b09FCRNGC20J8Bg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.2.tgz",
+      "integrity": "sha512-L3Y0nDjquqNFseM2Gx5fI4GOUKjjezFr9/6ZjSwAFeDeb4Ubqld4ZKL3FEzv4QKNbfZgCx19b7UXi+OdmLhi4w==",
       "peer": true,
       "requires": {
         "@noble/hashes": "^1.3.1"

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.1",
-    "@dfinity/candid": "^2.1.1",
-    "@dfinity/principal": "^2.1.1",
+    "@dfinity/agent": "^2.1.2",
+    "@dfinity/candid": "^2.1.2",
+    "@dfinity/principal": "^2.1.2",
     "@dfinity/utils": "^2.5.0"
   },
   "dependencies": {

--- a/packages/cketh/package.json
+++ b/packages/cketh/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.1",
-    "@dfinity/candid": "^2.1.1",
-    "@dfinity/principal": "^2.1.1",
+    "@dfinity/agent": "^2.1.2",
+    "@dfinity/candid": "^2.1.2",
+    "@dfinity/principal": "^2.1.2",
     "@dfinity/utils": "^2.5.0"
   }
 }

--- a/packages/cmc/package.json
+++ b/packages/cmc/package.json
@@ -36,9 +36,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.1",
-    "@dfinity/candid": "^2.1.1",
-    "@dfinity/principal": "^2.1.1",
+    "@dfinity/agent": "^2.1.2",
+    "@dfinity/candid": "^2.1.2",
+    "@dfinity/principal": "^2.1.2",
     "@dfinity/utils": "^2.5.0"
   }
 }

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -34,9 +34,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.1",
-    "@dfinity/candid": "^2.1.1",
-    "@dfinity/principal": "^2.1.1",
+    "@dfinity/agent": "^2.1.2",
+    "@dfinity/candid": "^2.1.2",
+    "@dfinity/principal": "^2.1.2",
     "@dfinity/utils": "^2.5.0"
   }
 }

--- a/packages/ledger-icp/package.json
+++ b/packages/ledger-icp/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.1",
-    "@dfinity/candid": "^2.1.1",
-    "@dfinity/principal": "^2.1.1",
+    "@dfinity/agent": "^2.1.2",
+    "@dfinity/candid": "^2.1.2",
+    "@dfinity/principal": "^2.1.2",
     "@dfinity/utils": "^2.5.0"
   }
 }

--- a/packages/ledger-icrc/package.json
+++ b/packages/ledger-icrc/package.json
@@ -37,9 +37,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.1",
-    "@dfinity/candid": "^2.1.1",
-    "@dfinity/principal": "^2.1.1",
+    "@dfinity/agent": "^2.1.2",
+    "@dfinity/candid": "^2.1.2",
+    "@dfinity/principal": "^2.1.2",
     "@dfinity/utils": "^2.5.0"
   }
 }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -51,10 +51,10 @@
     "network-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.1",
-    "@dfinity/candid": "^2.1.1",
+    "@dfinity/agent": "^2.1.2",
+    "@dfinity/candid": "^2.1.2",
     "@dfinity/ledger-icp": "^2.5.0",
-    "@dfinity/principal": "^2.1.1",
+    "@dfinity/principal": "^2.1.2",
     "@dfinity/utils": "^2.5.0"
   }
 }

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -36,10 +36,10 @@
     "sns"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.1",
-    "@dfinity/candid": "^2.1.1",
+    "@dfinity/agent": "^2.1.2",
+    "@dfinity/candid": "^2.1.2",
     "@dfinity/ledger-icrc": "^2.5.0",
-    "@dfinity/principal": "^2.1.1",
+    "@dfinity/principal": "^2.1.2",
     "@dfinity/utils": "^2.5.0"
   },
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -47,8 +47,8 @@
     "service-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.1",
-    "@dfinity/candid": "^2.1.1",
-    "@dfinity/principal": "^2.1.1"
+    "@dfinity/agent": "^2.1.2",
+    "@dfinity/candid": "^2.1.2",
+    "@dfinity/principal": "^2.1.2"
   }
 }


### PR DESCRIPTION
# Motivation

Agent-js has been patched because the community has started frequently encountered issues with "ingress expiry time" error messages. To help the community adopt this version, we need to incorporate it into ic-js.

# Notes

- Currently the ic-js released version use v2.0.0.

- The patch of Agent-js consists of reverting a PR https://github.com/dfinity/agent-js/pull/935. A suggested them to add a description. Meanwhile conversation on [Slack](https://dfinity.slack.com/archives/C020G13AS4F/p1727430471252989).

# Changes

- `npm run update:agent`
