### PR TITLE
build: downgrade agent-js ^2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next
+
+## Build
+
+- Downgrade Agent-js to `^2.0.0` to let consumers pick the compatible version they wish to use.
+
 # 2024.09.30-1100Z
 
 ## Overview

--- a/package-lock.json
+++ b/package-lock.json
@@ -717,10 +717,9 @@
       "dev": true
     },
     "node_modules/@dfinity/agent": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.2.tgz",
-      "integrity": "sha512-UAXf6uXovhBlSp245RWlA21zcCavy+vVUvKVQUpesk1gLJpJlvsCE6hYOwTeFZAP+bjmPi0Tl7cx8DT2KM4eDQ==",
-      "license": "Apache-2.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.0.0.tgz",
+      "integrity": "sha512-Cc2VDAMfxCNIQoaEeKPf0rbS/Y21HAF+eEFj6GfijNnUxS42i4zwUF2PUvEJZqaB2FQwA9SC7MDyuwL8BR2oJA==",
       "peer": true,
       "dependencies": {
         "@noble/curves": "^1.4.0",
@@ -731,18 +730,17 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^2.1.2",
-        "@dfinity/principal": "^2.1.2"
+        "@dfinity/candid": "^2.0.0",
+        "@dfinity/principal": "^2.0.0"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.2.tgz",
-      "integrity": "sha512-do69J9iahW2tlmbPdbmc8MDhi5cfIQyTcAlYqaSOOAyg+Kp8beCnW7mletXVfx30dyVlpkyCrYOXhbpQuSCKtw==",
-      "license": "Apache-2.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.0.0.tgz",
+      "integrity": "sha512-poxIEnzErcKBM5yroabQ3VqQpiYZnqYZdLJWFuIQZzioGdP1mlnVLHx7IbgHN4HBlqVXYPFmEzMU02FnyYUA1Q==",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "^2.1.2"
+        "@dfinity/principal": "^2.0.0"
       }
     },
     "node_modules/@dfinity/ckbtc": {
@@ -778,10 +776,9 @@
       "link": true
     },
     "node_modules/@dfinity/principal": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.2.tgz",
-      "integrity": "sha512-L3Y0nDjquqNFseM2Gx5fI4GOUKjjezFr9/6ZjSwAFeDeb4Ubqld4ZKL3FEzv4QKNbfZgCx19b7UXi+OdmLhi4w==",
-      "license": "Apache-2.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.0.0.tgz",
+      "integrity": "sha512-cqJ5kOrPpxco+wvJC4TFBhdr4lkw9mnwKGAYunesyqdzSYi8lnFB4dShNqlHFWdwoxNAw6OZkt/B+0nLa+7Yqw==",
       "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.3.1"
@@ -1659,7 +1656,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
       "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@noble/hashes": "1.5.0"
@@ -2772,7 +2768,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "peer": true
     },
     "node_modules/bech32": {
@@ -2784,7 +2779,6 @@
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
       "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": "*"
@@ -2806,7 +2800,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
       "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "bignumber.js": "^9.0.0",
@@ -2839,7 +2832,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
@@ -2935,7 +2927,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
@@ -3139,7 +3130,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT",
       "peer": true
     },
     "node_modules/concat-map": {
@@ -3282,7 +3272,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
       "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ==",
-      "license": "BSD-2-Clause",
       "peer": true
     },
     "node_modules/detect-newline": {
@@ -4591,7 +4580,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
       "peer": true
     },
     "node_modules/ignore": {
@@ -4972,7 +4960,6 @@
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
       "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -5673,7 +5660,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
       "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "delimit-stream": "0.1.0"
@@ -6404,7 +6390,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -6680,7 +6665,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
       "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
-      "license": "ISC",
       "peer": true
     },
     "node_modules/sisteransi": {
@@ -6813,7 +6797,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -6837,7 +6820,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "peer": true
     },
     "node_modules/string-length": {
@@ -7336,7 +7318,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT",
       "peer": true
     },
     "node_modules/v8-to-istanbul": {
@@ -7521,9 +7502,9 @@
         "bech32": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.2",
-        "@dfinity/candid": "^2.1.2",
-        "@dfinity/principal": "^2.1.2",
+        "@dfinity/agent": "^2.0.0",
+        "@dfinity/candid": "^2.0.0",
+        "@dfinity/principal": "^2.0.0",
         "@dfinity/utils": "^2.5.1"
       }
     },
@@ -7532,9 +7513,9 @@
       "version": "3.3.1",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.2",
-        "@dfinity/candid": "^2.1.2",
-        "@dfinity/principal": "^2.1.2",
+        "@dfinity/agent": "^2.0.0",
+        "@dfinity/candid": "^2.0.0",
+        "@dfinity/principal": "^2.0.0",
         "@dfinity/utils": "^2.5.1"
       }
     },
@@ -7543,9 +7524,9 @@
       "version": "3.2.1",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.2",
-        "@dfinity/candid": "^2.1.2",
-        "@dfinity/principal": "^2.1.2",
+        "@dfinity/agent": "^2.0.0",
+        "@dfinity/candid": "^2.0.0",
+        "@dfinity/principal": "^2.0.0",
         "@dfinity/utils": "^2.5.1"
       }
     },
@@ -7554,9 +7535,9 @@
       "version": "5.2.1",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.2",
-        "@dfinity/candid": "^2.1.2",
-        "@dfinity/principal": "^2.1.2",
+        "@dfinity/agent": "^2.0.0",
+        "@dfinity/candid": "^2.0.0",
+        "@dfinity/principal": "^2.0.0",
         "@dfinity/utils": "^2.5.1"
       }
     },
@@ -7565,9 +7546,9 @@
       "version": "2.6.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.2",
-        "@dfinity/candid": "^2.1.2",
-        "@dfinity/principal": "^2.1.2",
+        "@dfinity/agent": "^2.0.0",
+        "@dfinity/candid": "^2.0.0",
+        "@dfinity/principal": "^2.0.0",
         "@dfinity/utils": "^2.5.1"
       }
     },
@@ -7576,9 +7557,9 @@
       "version": "2.6.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.2",
-        "@dfinity/candid": "^2.1.2",
-        "@dfinity/principal": "^2.1.2",
+        "@dfinity/agent": "^2.0.0",
+        "@dfinity/candid": "^2.0.0",
+        "@dfinity/principal": "^2.0.0",
         "@dfinity/utils": "^2.5.1"
       }
     },
@@ -7594,10 +7575,10 @@
         "@types/randombytes": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.2",
-        "@dfinity/candid": "^2.1.2",
+        "@dfinity/agent": "^2.0.0",
+        "@dfinity/candid": "^2.0.0",
         "@dfinity/ledger-icp": "^2.6.0",
-        "@dfinity/principal": "^2.1.2",
+        "@dfinity/principal": "^2.0.0",
         "@dfinity/utils": "^2.5.1"
       }
     },
@@ -7620,10 +7601,10 @@
         "@noble/hashes": "^1.3.2"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.2",
-        "@dfinity/candid": "^2.1.2",
+        "@dfinity/agent": "^2.0.0",
+        "@dfinity/candid": "^2.0.0",
         "@dfinity/ledger-icrc": "^2.6.0",
-        "@dfinity/principal": "^2.1.2",
+        "@dfinity/principal": "^2.0.0",
         "@dfinity/utils": "^2.5.1"
       }
     },
@@ -7632,9 +7613,9 @@
       "version": "2.5.1",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.2",
-        "@dfinity/candid": "^2.1.2",
-        "@dfinity/principal": "^2.1.2"
+        "@dfinity/agent": "^2.0.0",
+        "@dfinity/candid": "^2.0.0",
+        "@dfinity/principal": "^2.0.0"
       }
     }
   },
@@ -8148,9 +8129,9 @@
       "dev": true
     },
     "@dfinity/agent": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.2.tgz",
-      "integrity": "sha512-UAXf6uXovhBlSp245RWlA21zcCavy+vVUvKVQUpesk1gLJpJlvsCE6hYOwTeFZAP+bjmPi0Tl7cx8DT2KM4eDQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.0.0.tgz",
+      "integrity": "sha512-Cc2VDAMfxCNIQoaEeKPf0rbS/Y21HAF+eEFj6GfijNnUxS42i4zwUF2PUvEJZqaB2FQwA9SC7MDyuwL8BR2oJA==",
       "peer": true,
       "requires": {
         "@noble/curves": "^1.4.0",
@@ -8162,9 +8143,9 @@
       }
     },
     "@dfinity/candid": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.2.tgz",
-      "integrity": "sha512-do69J9iahW2tlmbPdbmc8MDhi5cfIQyTcAlYqaSOOAyg+Kp8beCnW7mletXVfx30dyVlpkyCrYOXhbpQuSCKtw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.0.0.tgz",
+      "integrity": "sha512-poxIEnzErcKBM5yroabQ3VqQpiYZnqYZdLJWFuIQZzioGdP1mlnVLHx7IbgHN4HBlqVXYPFmEzMU02FnyYUA1Q==",
       "peer": true,
       "requires": {}
     },
@@ -8212,9 +8193,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.2.tgz",
-      "integrity": "sha512-L3Y0nDjquqNFseM2Gx5fI4GOUKjjezFr9/6ZjSwAFeDeb4Ubqld4ZKL3FEzv4QKNbfZgCx19b7UXi+OdmLhi4w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.0.0.tgz",
+      "integrity": "sha512-cqJ5kOrPpxco+wvJC4TFBhdr4lkw9mnwKGAYunesyqdzSYi8lnFB4dShNqlHFWdwoxNAw6OZkt/B+0nLa+7Yqw==",
       "peer": true,
       "requires": {
         "@noble/hashes": "^1.3.1"

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.2",
-    "@dfinity/candid": "^2.1.2",
-    "@dfinity/principal": "^2.1.2",
+    "@dfinity/agent": "^2.0.0",
+    "@dfinity/candid": "^2.0.0",
+    "@dfinity/principal": "^2.0.0",
     "@dfinity/utils": "^2.5.1"
   },
   "dependencies": {

--- a/packages/cketh/package.json
+++ b/packages/cketh/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.2",
-    "@dfinity/candid": "^2.1.2",
-    "@dfinity/principal": "^2.1.2",
+    "@dfinity/agent": "^2.0.0",
+    "@dfinity/candid": "^2.0.0",
+    "@dfinity/principal": "^2.0.0",
     "@dfinity/utils": "^2.5.1"
   }
 }

--- a/packages/cmc/package.json
+++ b/packages/cmc/package.json
@@ -36,9 +36,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.2",
-    "@dfinity/candid": "^2.1.2",
-    "@dfinity/principal": "^2.1.2",
+    "@dfinity/agent": "^2.0.0",
+    "@dfinity/candid": "^2.0.0",
+    "@dfinity/principal": "^2.0.0",
     "@dfinity/utils": "^2.5.1"
   }
 }

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -34,9 +34,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.2",
-    "@dfinity/candid": "^2.1.2",
-    "@dfinity/principal": "^2.1.2",
+    "@dfinity/agent": "^2.0.0",
+    "@dfinity/candid": "^2.0.0",
+    "@dfinity/principal": "^2.0.0",
     "@dfinity/utils": "^2.5.1"
   }
 }

--- a/packages/ledger-icp/package.json
+++ b/packages/ledger-icp/package.json
@@ -38,9 +38,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.2",
-    "@dfinity/candid": "^2.1.2",
-    "@dfinity/principal": "^2.1.2",
+    "@dfinity/agent": "^2.0.0",
+    "@dfinity/candid": "^2.0.0",
+    "@dfinity/principal": "^2.0.0",
     "@dfinity/utils": "^2.5.1"
   }
 }

--- a/packages/ledger-icrc/package.json
+++ b/packages/ledger-icrc/package.json
@@ -37,9 +37,9 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.2",
-    "@dfinity/candid": "^2.1.2",
-    "@dfinity/principal": "^2.1.2",
+    "@dfinity/agent": "^2.0.0",
+    "@dfinity/candid": "^2.0.0",
+    "@dfinity/principal": "^2.0.0",
     "@dfinity/utils": "^2.5.1"
   }
 }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -51,10 +51,10 @@
     "network-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.2",
-    "@dfinity/candid": "^2.1.2",
+    "@dfinity/agent": "^2.0.0",
+    "@dfinity/candid": "^2.0.0",
     "@dfinity/ledger-icp": "^2.6.0",
-    "@dfinity/principal": "^2.1.2",
+    "@dfinity/principal": "^2.0.0",
     "@dfinity/utils": "^2.5.1"
   }
 }

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -36,10 +36,10 @@
     "sns"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.2",
-    "@dfinity/candid": "^2.1.2",
+    "@dfinity/agent": "^2.0.0",
+    "@dfinity/candid": "^2.0.0",
     "@dfinity/ledger-icrc": "^2.6.0",
-    "@dfinity/principal": "^2.1.2",
+    "@dfinity/principal": "^2.0.0",
     "@dfinity/utils": "^2.5.1"
   },
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -47,8 +47,8 @@
     "service-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.2",
-    "@dfinity/candid": "^2.1.2",
-    "@dfinity/principal": "^2.1.2"
+    "@dfinity/agent": "^2.0.0",
+    "@dfinity/candid": "^2.0.0",
+    "@dfinity/principal": "^2.0.0"
   }
 }


### PR DESCRIPTION
# Motivation

We want to allow the consumers to decide what compatible version of agent-js v2 they wish to use. 

# Notes

We also need to downgrade agent-js in NNS dapp.
https://github.com/dfinity/nns-dapp/pull/5584

# Changes

- Downgrade to `^2.0.0`
