### PR TITLE
Enable getNeuron to use the new service

### DIFF
--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -539,9 +539,9 @@ Uses query call only.
 
 Return the data of the neuron provided as id.
 
-| Method      | Type                                                                                                        |
-| ----------- | ----------------------------------------------------------------------------------------------------------- |
-| `getNeuron` | `({ certified, neuronId, }: { certified: boolean; neuronId: bigint; }) => Promise<NeuronInfo or undefined>` |
+| Method      | Type                                                                                                                                                                         |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getNeuron` | `({ certified, neuronId, includeEmptyNeurons, }: { certified: boolean; neuronId: bigint; includeEmptyNeurons?: boolean or undefined; }) => Promise<NeuronInfo or undefined>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L976)
 

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -740,7 +740,7 @@ describe("GovernanceCanister", () => {
       expect(service.list_neurons).not.toBeCalled();
       expect(oldService.list_neurons).toBeCalledTimes(1);
     });
-    it("should fetch and convert a neuron with new service when includeEmptyNeurons is set to false", async () => {
+    it("should fetch and convert a neuron with certified service when includeEmptyNeurons is set to false", async () => {
       const service = mock<ActorSubclass<GovernanceService>>();
       const certifiedService = mock<ActorSubclass<GovernanceService>>();
       const oldService = mock<ActorSubclass<GovernanceService>>();

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -740,7 +740,7 @@ describe("GovernanceCanister", () => {
       expect(service.list_neurons).not.toBeCalled();
       expect(oldService.list_neurons).toBeCalledTimes(1);
     });
-    it("should fetch and convert a neuron with new service when includeEmptyNeurons is set to true", async () => {
+    it("should fetch and convert a neuron with new service when includeEmptyNeurons is set to false", async () => {
       const service = mock<ActorSubclass<GovernanceService>>();
       const certifiedService = mock<ActorSubclass<GovernanceService>>();
       const oldService = mock<ActorSubclass<GovernanceService>>();
@@ -756,13 +756,13 @@ describe("GovernanceCanister", () => {
       const response = await governance.getNeuron({
         certified: true,
         neuronId,
-        includeEmptyNeurons: true,
+        includeEmptyNeurons: false,
       });
 
       expect(certifiedService.list_neurons).toBeCalledWith({
         neuron_ids: new BigUint64Array([neuronId]),
         include_neurons_readable_by_caller: false,
-        include_empty_neurons_readable_by_caller: [true],
+        include_empty_neurons_readable_by_caller: [false],
         include_public_neurons_in_full_neurons: [],
       });
 

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -976,16 +976,22 @@ export class GovernanceCanister {
   public getNeuron = async ({
     certified = true,
     neuronId,
+    includeEmptyNeurons = false,
   }: {
     certified: boolean;
     neuronId: NeuronId;
+    includeEmptyNeurons?: boolean;
   }): Promise<NeuronInfo | undefined> => {
     // The governance canister exposes two functions "get_neuron_info" and "get_full_neuron" that could probably be used to fetch the neuron details too.
     // However historically this function has been resolved with a single call "list_neurons".
 
+    //Visibility is not provided by old oldListNeuronsCertifiedService, and we pass include empty neurons to get correct visibility
     const [neuron]: NeuronInfo[] = await this.listNeurons({
       certified,
       neuronIds: [neuronId],
+      includeEmptyNeurons: includeEmptyNeurons
+        ? includeEmptyNeurons
+        : undefined,
     });
 
     return neuron;

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -976,7 +976,7 @@ export class GovernanceCanister {
   public getNeuron = async ({
     certified = true,
     neuronId,
-    includeEmptyNeurons = false,
+    includeEmptyNeurons,
   }: {
     certified: boolean;
     neuronId: NeuronId;
@@ -985,13 +985,11 @@ export class GovernanceCanister {
     // The governance canister exposes two functions "get_neuron_info" and "get_full_neuron" that could probably be used to fetch the neuron details too.
     // However historically this function has been resolved with a single call "list_neurons".
 
-    //Visibility is not provided by old oldListNeuronsCertifiedService, and we pass include empty neurons to get correct visibility
+    //Visibility is not provided by oldListNeuronsCertifiedService, and we pass include empty neurons to have option to use the certifiedService
     const [neuron]: NeuronInfo[] = await this.listNeurons({
       certified,
       neuronIds: [neuronId],
-      includeEmptyNeurons: includeEmptyNeurons
-        ? includeEmptyNeurons
-        : undefined,
+      includeEmptyNeurons,
     });
 
     return neuron;


### PR DESCRIPTION
# Motivation

I need to fetch visibility with getNeuron and it looks like old service doesn't provide that

# Changes

includeEmptyNeurons props is added to getNeuron to use the new service

# Tests

Add and updates tests to include when includeEmptyNeurons not provided it uses old service and includeEmptyNeurons provided it uses certified service

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary
