### PR TITLE
Update old_list_neurons_service.certified.idl.js

### DIFF
--- a/packages/nns/candid/old_list_neurons_service.certified.idl.js
+++ b/packages/nns/candid/old_list_neurons_service.certified.idl.js
@@ -5,74 +5,76 @@
 // `include_empty_neurons_readable_by_caller` field, even when it's not set, so
 // we use this service for compatibility with the hardware wallet.
 export const idlFactory = ({ IDL }) => {
-  const NeuronId = IDL.Record({ id: IDL.Nat64 });
-  const Followees = IDL.Record({ followees: IDL.Vec(NeuronId) });
+  const NeuronId = IDL.Record({ 'id' : IDL.Nat64 });
+  const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
   const KnownNeuronData = IDL.Record({
-    name: IDL.Text,
-    description: IDL.Opt(IDL.Text),
+    'name' : IDL.Text,
+    'description' : IDL.Opt(IDL.Text),
   });
   const NeuronStakeTransfer = IDL.Record({
-    to_subaccount: IDL.Vec(IDL.Nat8),
-    neuron_stake_e8s: IDL.Nat64,
-    from: IDL.Opt(IDL.Principal),
-    memo: IDL.Nat64,
-    from_subaccount: IDL.Vec(IDL.Nat8),
-    transfer_timestamp: IDL.Nat64,
-    block_height: IDL.Nat64,
+    'to_subaccount' : IDL.Vec(IDL.Nat8),
+    'neuron_stake_e8s' : IDL.Nat64,
+    'from' : IDL.Opt(IDL.Principal),
+    'memo' : IDL.Nat64,
+    'from_subaccount' : IDL.Vec(IDL.Nat8),
+    'transfer_timestamp' : IDL.Nat64,
+    'block_height' : IDL.Nat64,
   });
   const BallotInfo = IDL.Record({
-    vote: IDL.Int32,
-    proposal_id: IDL.Opt(NeuronId),
+    'vote' : IDL.Int32,
+    'proposal_id' : IDL.Opt(NeuronId),
   });
   const DissolveState = IDL.Variant({
-    DissolveDelaySeconds: IDL.Nat64,
-    WhenDissolvedTimestampSeconds: IDL.Nat64,
+    'DissolveDelaySeconds' : IDL.Nat64,
+    'WhenDissolvedTimestampSeconds' : IDL.Nat64,
   });
   const Neuron = IDL.Record({
-    id: IDL.Opt(NeuronId),
-    staked_maturity_e8s_equivalent: IDL.Opt(IDL.Nat64),
-    controller: IDL.Opt(IDL.Principal),
-    recent_ballots: IDL.Vec(BallotInfo),
-    kyc_verified: IDL.Bool,
-    neuron_type: IDL.Opt(IDL.Int32),
-    not_for_profit: IDL.Bool,
-    maturity_e8s_equivalent: IDL.Nat64,
-    cached_neuron_stake_e8s: IDL.Nat64,
-    created_timestamp_seconds: IDL.Nat64,
-    auto_stake_maturity: IDL.Opt(IDL.Bool),
-    aging_since_timestamp_seconds: IDL.Nat64,
-    hot_keys: IDL.Vec(IDL.Principal),
-    account: IDL.Vec(IDL.Nat8),
-    joined_community_fund_timestamp_seconds: IDL.Opt(IDL.Nat64),
-    dissolve_state: IDL.Opt(DissolveState),
-    followees: IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
-    neuron_fees_e8s: IDL.Nat64,
-    transfer: IDL.Opt(NeuronStakeTransfer),
-    known_neuron_data: IDL.Opt(KnownNeuronData),
-    spawn_at_timestamp_seconds: IDL.Opt(IDL.Nat64),
+    'id' : IDL.Opt(NeuronId),
+    'staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
+    'controller' : IDL.Opt(IDL.Principal),
+    'recent_ballots' : IDL.Vec(BallotInfo),
+    'kyc_verified' : IDL.Bool,
+    'neuron_type' : IDL.Opt(IDL.Int32),
+    'not_for_profit' : IDL.Bool,
+    'maturity_e8s_equivalent' : IDL.Nat64,
+    'cached_neuron_stake_e8s' : IDL.Nat64,
+    'created_timestamp_seconds' : IDL.Nat64,
+    'auto_stake_maturity' : IDL.Opt(IDL.Bool),
+    'aging_since_timestamp_seconds' : IDL.Nat64,
+    'hot_keys' : IDL.Vec(IDL.Principal),
+    'account' : IDL.Vec(IDL.Nat8),
+    'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'dissolve_state' : IDL.Opt(DissolveState),
+    'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
+    'neuron_fees_e8s' : IDL.Nat64,
+    'visibility' : IDL.Opt(IDL.Int32),
+    'transfer' : IDL.Opt(NeuronStakeTransfer),
+    'known_neuron_data' : IDL.Opt(KnownNeuronData),
+    'spawn_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
   const NeuronInfo = IDL.Record({
-    dissolve_delay_seconds: IDL.Nat64,
-    recent_ballots: IDL.Vec(BallotInfo),
-    neuron_type: IDL.Opt(IDL.Int32),
-    created_timestamp_seconds: IDL.Nat64,
-    state: IDL.Int32,
-    stake_e8s: IDL.Nat64,
-    joined_community_fund_timestamp_seconds: IDL.Opt(IDL.Nat64),
-    retrieved_at_timestamp_seconds: IDL.Nat64,
-    known_neuron_data: IDL.Opt(KnownNeuronData),
-    voting_power: IDL.Nat64,
-    age_seconds: IDL.Nat64,
+    'dissolve_delay_seconds' : IDL.Nat64,
+    'recent_ballots' : IDL.Vec(BallotInfo),
+    'neuron_type' : IDL.Opt(IDL.Int32),
+    'created_timestamp_seconds' : IDL.Nat64,
+    'state' : IDL.Int32,
+    'stake_e8s' : IDL.Nat64,
+    'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'retrieved_at_timestamp_seconds' : IDL.Nat64,
+    'visibility' : IDL.Opt(IDL.Int32),
+    'known_neuron_data' : IDL.Opt(KnownNeuronData),
+    'voting_power' : IDL.Nat64,
+    'age_seconds' : IDL.Nat64,
   });
   const ListNeurons = IDL.Record({
-    neuron_ids: IDL.Vec(IDL.Nat64),
-    include_neurons_readable_by_caller: IDL.Bool,
+    'neuron_ids' : IDL.Vec(IDL.Nat64),
+    'include_neurons_readable_by_caller' : IDL.Bool,
   });
   const ListNeuronsResponse = IDL.Record({
-    neuron_infos: IDL.Vec(IDL.Tuple(IDL.Nat64, NeuronInfo)),
-    full_neurons: IDL.Vec(Neuron),
+    'neuron_infos' : IDL.Vec(IDL.Tuple(IDL.Nat64, NeuronInfo)),
+    'full_neurons' : IDL.Vec(Neuron),
   });
   return IDL.Service({
-    list_neurons: IDL.Func([ListNeurons], [ListNeuronsResponse], []),
+    'list_neurons' : IDL.Func([ListNeurons], [ListNeuronsResponse], []),
   });
 };


### PR DESCRIPTION
# Motivation

The purpose of `old_list_neurons_service.certified.idl.js` is to have the request type be supported by Ledger HW ICP app version 2.4.9.
The hardware wallet does care about the response type so it is safe to update.
We want to include `visibility` specifically.

# Changes

Recreate `old_list_neurons_service.certified.idl.js` the same way it was created the first time as documented by the comment at the top:
```
// This file was created manually by taking governance.certified.idl.js and
// removing everything that isn't needed for `list_neurons` and then removing
// all fields except `neuron_ids` and `include_neurons_readable_by_caller` from
// `ListNeurons`.
// The Ledger hardware wallet app verion 2.4.9 doesn't support the newer fields,
// even when they are optional and not set, so we use this service for
// compatibility with the hardware wallet.
```
The result is that the `visibility` field was added in addition to field names now being wrapped in `''`.

# Tests

Used manually with nns-dapp and was able to
1. show neurons from a hardware wallet,
2. see `visibility` in the response.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary