### PR TITLE
feat: add Agent Manager to utils package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## Features
 
 - Add support for `get_default_subnets` to `@dfinity/cmc`.
-- Add class `AgentManager` in `@dfinity/utils` which scope is to manages HttpAgent instances for different identities.
+- Add class `AgentManager` in `@dfinity/utils` which caches `HttpAgent` instances for different identities.
 
 # 2024.10.09-1140Z
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next
+
+## Features
+
+- Add class `AgentManager` in `@dfinity/utils` which scope is to manages HttpAgent instances for different identities.
+
 # 2024.10.09-1140Z
 
 ## Overview

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -597,7 +597,7 @@ Parameters:
 - `config.fetchRootKey`: - Whether to fetch the root key for certificate validation.
 - `config.host`: - The host to connect to.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L71)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L69)
 
 ##### :gear: getAgent
 
@@ -614,7 +614,7 @@ Parameters:
 
 - `identity`: - The identity to be used to create the agent.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L84)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L82)
 
 ##### :gear: clearAgents
 
@@ -627,7 +627,7 @@ Useful when identities have changed or if you want to reset all active connectio
 | ------------- | ------------ |
 | `clearAgents` | `() => void` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L116)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L114)
 
 ### :factory: InvalidPercentageError
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -577,7 +577,6 @@ Provides functionality to create new agents, retrieve cached agents, and clear t
 
 - [create](#gear-create)
 - [getAgent](#gear-getagent)
-- [createAgent](#gear-createagent)
 - [clearAgents](#gear-clearagents)
 
 ##### :gear: create
@@ -616,24 +615,6 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L88)
 
-##### :gear: createAgent
-
-Create a new HTTP agent for a given identity.
-
-This method does not check the cache. It always creates a new agent.
-The agent is configured with the specified identity, fetchRootKey option, and the host.
-
-| Method        | Type                                                                                                                                  |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `createAgent` | `({ identity, verifyQuerySignatures, }: { identity: Identity; verifyQuerySignatures?: boolean or undefined; }) => Promise<HttpAgent>` |
-
-Parameters:
-
-- `identity`: - The identity to use for the agent.
-- `verifyQuerySignatures`: - Whether to verify query signatures for query calls.
-
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L119)
-
 ##### :gear: clearAgents
 
 Clear the cache of HTTP agents.
@@ -645,7 +626,7 @@ Useful when identities have changed or if you want to reset all active connectio
 | ------------- | ------------ |
 | `clearAgents` | `() => void` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L140)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L120)
 
 ### :factory: InvalidPercentageError
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -564,6 +564,89 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/services/canister.ts#L4)
 
+### :factory: AgentManager
+
+AgentManager class manages HttpAgent instances for different identities.
+
+It caches agents by identity to optimise resource usage and avoid unnecessary agent creation.
+Provides functionality to create new agents, retrieve cached agents, and clear the cache when needed.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L57)
+
+#### Methods
+
+- [create](#gear-create)
+- [getAgent](#gear-getagent)
+- [createAgent](#gear-createagent)
+- [clearAgents](#gear-clearagents)
+
+##### :gear: create
+
+Static factory method to create a new AgentManager instance.
+
+This method serves as an alternative to directly using the private constructor,
+making it more convenient to create instances of `AgentManager` using a simple and clear method.
+
+| Method   | Type                                           |
+| -------- | ---------------------------------------------- |
+| `create` | `(config: AgentManagerConfig) => AgentManager` |
+
+Parameters:
+
+- `config`: - Configuration options for the AgentManager instance.
+- `config.fetchRootKey`: - Whether to fetch the root key for certificate validation.
+- `config.host`: - The host to connect to.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L75)
+
+##### :gear: getAgent
+
+Get or create an HTTP agent for a given identity.
+
+If the agent for the specified identity has been created and cached, it is retrieved from the cache.
+If no agent exists for the identity, a new one is created, cached, and then returned.
+
+| Method     | Type                                                             |
+| ---------- | ---------------------------------------------------------------- |
+| `getAgent` | `({ identity, }: { identity: Identity; }) => Promise<HttpAgent>` |
+
+Parameters:
+
+- `identity`: - The identity to be used to create the agent.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L88)
+
+##### :gear: createAgent
+
+Create a new HTTP agent for a given identity.
+
+This method does not check the cache. It always creates a new agent.
+The agent is configured with the specified identity, fetchRootKey option, and the host.
+
+| Method        | Type                                                                                                                                  |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `createAgent` | `({ identity, verifyQuerySignatures, }: { identity: Identity; verifyQuerySignatures?: boolean or undefined; }) => Promise<HttpAgent>` |
+
+Parameters:
+
+- `identity`: - The identity to use for the agent.
+- `verifyQuerySignatures`: - Whether to verify query signatures for query calls.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L119)
+
+##### :gear: clearAgents
+
+Clear the cache of HTTP agents.
+
+This method removes all cached agents, forcing new agent creation on the next request for any identity.
+Useful when identities have changed or if you want to reset all active connections.
+
+| Method        | Type         |
+| ------------- | ------------ |
+| `clearAgents` | `() => void` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L140)
+
 ### :factory: InvalidPercentageError
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/asserts.utils.ts#L1)

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -572,7 +572,7 @@ AgentManager class manages HttpAgent instances for different identities.
 It caches agents by identity to optimise resource usage and avoid unnecessary agent creation.
 Provides functionality to create new agents, retrieve cached agents, and clear the cache when needed.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L57)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L53)
 
 #### Methods
 
@@ -597,7 +597,7 @@ Parameters:
 - `config.fetchRootKey`: - Whether to fetch the root key for certificate validation.
 - `config.host`: - The host to connect to.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L75)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L71)
 
 ##### :gear: getAgent
 
@@ -614,7 +614,7 @@ Parameters:
 
 - `identity`: - The identity to be used to create the agent.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L88)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L84)
 
 ##### :gear: clearAgents
 
@@ -627,7 +627,7 @@ Useful when identities have changed or if you want to reset all active connectio
 | ------------- | ------------ |
 | `clearAgents` | `() => void` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L120)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L116)
 
 ### :factory: InvalidPercentageError
 

--- a/packages/utils/src/mocks/agent.mock.ts
+++ b/packages/utils/src/mocks/agent.mock.ts
@@ -1,0 +1,23 @@
+import type { HttpAgent } from "@dfinity/agent";
+import { AgentManagerConfig } from "../utils/agent.utils";
+
+export const mockHttpAgent = {
+  call: jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({ data: "mocked call result" }),
+  }),
+  query: jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({ data: "mocked query result" }),
+  }),
+  fetchRootKey: jest.fn().mockResolvedValue(undefined),
+} as unknown as HttpAgent;
+
+export const mockAgentManagerConfig: AgentManagerConfig = {
+  fetchRootKey: false,
+  host: "https://icp-api.io",
+};

--- a/packages/utils/src/mocks/agent.mock.ts
+++ b/packages/utils/src/mocks/agent.mock.ts
@@ -17,6 +17,22 @@ export const mockHttpAgent = {
   fetchRootKey: jest.fn().mockResolvedValue(undefined),
 } as unknown as HttpAgent;
 
+export const mockHttpAgent2 = {
+  call: jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({ data: "mocked call result" }),
+  }),
+  query: jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({ data: "mocked query result" }),
+  }),
+  fetchRootKey: jest.fn().mockResolvedValue(undefined),
+} as unknown as HttpAgent;
+
 export const mockAgentManagerConfig: AgentManagerConfig = {
   fetchRootKey: false,
   host: "https://icp-api.io",

--- a/packages/utils/src/mocks/identity.mock.ts
+++ b/packages/utils/src/mocks/identity.mock.ts
@@ -1,0 +1,11 @@
+import type { Identity } from "@dfinity/agent";
+import { Principal } from "@dfinity/principal";
+
+export const mockPrincipalText =
+  "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe";
+
+export const mockPrincipal = Principal.fromText(mockPrincipalText);
+
+export const mockIdentity = {
+  getPrincipal: () => mockPrincipal,
+} as unknown as Identity;

--- a/packages/utils/src/mocks/identity.mock.ts
+++ b/packages/utils/src/mocks/identity.mock.ts
@@ -9,3 +9,12 @@ export const mockPrincipal = Principal.fromText(mockPrincipalText);
 export const mockIdentity = {
   getPrincipal: () => mockPrincipal,
 } as unknown as Identity;
+
+export const mockPrincipalText2 =
+  "5uuwe-ggtgm-fonrs-rblmx-cfc23-pb3dg-iyfk2-dle5w-j5uev-ggmep-6ae";
+
+export const mockPrincipal2 = Principal.fromText(mockPrincipalText2);
+
+export const mockIdentity2 = {
+  getPrincipal: () => mockPrincipal2,
+} as unknown as Identity;

--- a/packages/utils/src/utils/agent.utils.spec.ts
+++ b/packages/utils/src/utils/agent.utils.spec.ts
@@ -14,11 +14,6 @@ jest.mock("@dfinity/agent", () => ({
   },
 }));
 
-jest.mock("./nullish.utils", () => ({
-  isNullish: jest.requireActual("./nullish.utils").isNullish,
-  nonNullish: jest.requireActual("./nullish.utils").nonNullish,
-}));
-
 describe("AgentManager", () => {
   let agentManager: AgentManager;
   const mockHttpAgentCreate = HttpAgent.create as jest.Mock;
@@ -28,30 +23,6 @@ describe("AgentManager", () => {
     jest.clearAllMocks();
 
     mockHttpAgentCreate.mockResolvedValueOnce(mockHttpAgent);
-  });
-
-  describe("createAgent", () => {
-    it("should create a new agent", async () => {
-      const agent = await agentManager.createAgent({ identity: mockIdentity });
-
-      expect(mockHttpAgentCreate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          identity: mockIdentity,
-          host: mockAgentManagerConfig.host,
-          shouldFetchRootKey: mockAgentManagerConfig.fetchRootKey,
-        }),
-      );
-      expect(agent).toBe(mockHttpAgent);
-    });
-
-    it("should not cache agent", async () => {
-      await agentManager.createAgent({ identity: mockIdentity });
-
-      const agent = await agentManager.getAgent({ identity: mockIdentity });
-
-      expect(mockHttpAgentCreate).toHaveBeenCalledTimes(2);
-      expect(agent).toBeUndefined();
-    });
   });
 
   describe("getAgent", () => {

--- a/packages/utils/src/utils/agent.utils.spec.ts
+++ b/packages/utils/src/utils/agent.utils.spec.ts
@@ -1,0 +1,102 @@
+import { HttpAgent } from "@dfinity/agent";
+import { describe, expect } from "@jest/globals";
+import { mockAgentManagerConfig, mockHttpAgent } from "../mocks/agent.mock";
+import { mockIdentity } from "../mocks/identity.mock";
+import { AgentManager } from "./agent.utils";
+
+jest.mock("@dfinity/agent", () => ({
+  HttpAgent: {
+    create: jest.fn(),
+  },
+}));
+
+jest.mock("./nullish.utils", () => ({
+  isNullish: jest.requireActual("./nullish.utils").isNullish,
+  nonNullish: jest.requireActual("./nullish.utils").nonNullish,
+}));
+
+describe("AgentManager", () => {
+  let agentManager: AgentManager;
+  const mockHttpAgentCreate = HttpAgent.create as jest.Mock;
+
+  beforeEach(() => {
+    agentManager = AgentManager.create(mockAgentManagerConfig);
+    jest.clearAllMocks();
+  });
+
+  describe("createAgent", () => {
+    it("should create a new agent", async () => {
+      mockHttpAgentCreate.mockResolvedValueOnce(mockHttpAgent);
+
+      const agent = await agentManager.createAgent({ identity: mockIdentity });
+
+      expect(mockHttpAgentCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          identity: mockIdentity,
+          host: mockAgentManagerConfig.host,
+          shouldFetchRootKey: mockAgentManagerConfig.fetchRootKey,
+        }),
+      );
+      expect(agent).toBe(mockHttpAgent);
+    });
+
+    it("should not cache agent", async () => {
+      mockHttpAgentCreate.mockResolvedValueOnce(mockHttpAgent);
+
+      await agentManager.createAgent({ identity: mockIdentity });
+
+      const agent = await agentManager.getAgent({ identity: mockIdentity });
+
+      expect(mockHttpAgentCreate).toHaveBeenCalledTimes(2);
+      expect(agent).toBeUndefined();
+    });
+  });
+
+  describe("getAgent", () => {
+    it("should create a new agent when there is none", async () => {
+      mockHttpAgentCreate.mockResolvedValueOnce(mockHttpAgent);
+
+      const agent = await agentManager.getAgent({ identity: mockIdentity });
+
+      expect(mockHttpAgentCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ identity: mockIdentity }),
+      );
+      expect(agent).toBe(mockHttpAgent);
+    });
+
+    it("should return cached agent if already created", async () => {
+      mockHttpAgentCreate.mockResolvedValueOnce(mockHttpAgent);
+
+      await agentManager.getAgent({ identity: mockIdentity });
+
+      const agent = await agentManager.getAgent({ identity: mockIdentity });
+
+      expect(mockHttpAgentCreate).toHaveBeenCalledTimes(1);
+      expect(agent).toBe(mockHttpAgent);
+    });
+  });
+
+  describe("clearAgents", () => {
+    it("should clear cached agents", async () => {
+      mockHttpAgentCreate.mockResolvedValueOnce(mockHttpAgent);
+
+      await agentManager.getAgent({ identity: mockIdentity });
+
+      const agentBefore = await agentManager.getAgent({
+        identity: mockIdentity,
+      });
+
+      expect(agentBefore).toBe(mockHttpAgent);
+
+      agentManager.clearAgents();
+
+      const agentAfter = await agentManager.getAgent({
+        identity: mockIdentity,
+      });
+
+      expect(mockHttpAgentCreate).toHaveBeenCalledTimes(2);
+      expect(agentAfter).not.toBe(mockHttpAgent);
+      expect(agentAfter).toBeUndefined();
+    });
+  });
+});

--- a/packages/utils/src/utils/agent.utils.ts
+++ b/packages/utils/src/utils/agent.utils.ts
@@ -107,6 +107,16 @@ export class AgentManager {
   }
 
   /**
+   * Clear the cache of HTTP agents.
+   *
+   * This method removes all cached agents, forcing new agent creation on the next request for any identity.
+   * Useful when identities have changed or if you want to reset all active connections.
+   */
+  public clearAgents(): void {
+    this.agents = undefined;
+  }
+
+  /**
    * Create a new HTTP agent for a given identity.
    *
    * This method does not check the cache. It always creates a new agent.
@@ -116,7 +126,7 @@ export class AgentManager {
    * @param {boolean} [verifyQuerySignatures=true] - Whether to verify query signatures for query calls.
    * @returns {Promise<HttpAgent>} The newly created HttpAgent instance.
    */
-  public createAgent({
+  private createAgent({
     identity,
     verifyQuerySignatures = true,
   }: {
@@ -129,15 +139,5 @@ export class AgentManager {
       host: this.config.host,
       verifyQuerySignatures,
     });
-  }
-
-  /**
-   * Clear the cache of HTTP agents.
-   *
-   * This method removes all cached agents, forcing new agent creation on the next request for any identity.
-   * Useful when identities have changed or if you want to reset all active connections.
-   */
-  public clearAgents(): void {
-    this.agents = undefined;
   }
 }

--- a/packages/utils/src/utils/agent.utils.ts
+++ b/packages/utils/src/utils/agent.utils.ts
@@ -93,7 +93,12 @@ export class AgentManager {
     const key = identity.getPrincipal().toText();
 
     if (isNullish(this.agents) || isNullish(this.agents[key])) {
-      const agent = await this.createAgent({ identity });
+      const agent = await createAgent({
+        identity,
+        fetchRootKey: this.config.fetchRootKey,
+        host: this.config.host,
+        verifyQuerySignatures: true,
+      });
 
       this.agents = {
         ...(this.agents ?? {}),
@@ -114,30 +119,5 @@ export class AgentManager {
    */
   public clearAgents(): void {
     this.agents = undefined;
-  }
-
-  /**
-   * Create a new HTTP agent for a given identity.
-   *
-   * This method does not check the cache. It always creates a new agent.
-   * The agent is configured with the specified identity, fetchRootKey option, and the host.
-   *
-   * @param {Identity} identity - The identity to use for the agent.
-   * @param {boolean} [verifyQuerySignatures=true] - Whether to verify query signatures for query calls.
-   * @returns {Promise<HttpAgent>} The newly created HttpAgent instance.
-   */
-  private createAgent({
-    identity,
-    verifyQuerySignatures = true,
-  }: {
-    identity: Identity;
-    verifyQuerySignatures?: boolean;
-  }): Promise<HttpAgent> {
-    return createAgent({
-      identity,
-      fetchRootKey: this.config.fetchRootKey,
-      host: this.config.host,
-      verifyQuerySignatures,
-    });
   }
 }

--- a/packages/utils/src/utils/agent.utils.ts
+++ b/packages/utils/src/utils/agent.utils.ts
@@ -1,6 +1,6 @@
 import type { Agent, Identity } from "@dfinity/agent";
 import { AnonymousIdentity, HttpAgent } from "@dfinity/agent";
-import { nonNullish } from "./nullish.utils";
+import { isNullish, nonNullish } from "./nullish.utils";
 
 /**
  * Get a default agent that connects to mainnet with the anonymous identity.
@@ -42,3 +42,102 @@ export const createAgent = async ({
     shouldFetchRootKey: fetchRootKey,
   });
 };
+
+export interface AgentManagerConfig {
+  fetchRootKey: boolean;
+  host: string;
+}
+
+/**
+ * AgentManager class manages HttpAgent instances for different identities.
+ *
+ * It caches agents by identity to optimise resource usage and avoid unnecessary agent creation.
+ * Provides functionality to create new agents, retrieve cached agents, and clear the cache when needed.
+ */
+export class AgentManager {
+  private agents: Record<string, HttpAgent> | undefined = undefined;
+
+  private constructor(private readonly config: AgentManagerConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Static factory method to create a new AgentManager instance.
+   *
+   * This method serves as an alternative to directly using the private constructor,
+   * making it more convenient to create instances of `AgentManager` using a simple and clear method.
+   *
+   * @param {AgentManagerConfig} config - Configuration options for the AgentManager instance.
+   * @param {boolean} config.fetchRootKey - Whether to fetch the root key for certificate validation.
+   * @param {string} config.host - The host to connect to.
+   * @returns {AgentManager} A new instance of `AgentManager`.
+   */
+  public static create(config: AgentManagerConfig): AgentManager {
+    return new AgentManager(config);
+  }
+
+  /**
+   * Get or create an HTTP agent for a given identity.
+   *
+   * If the agent for the specified identity has been created and cached, it is retrieved from the cache.
+   * If no agent exists for the identity, a new one is created, cached, and then returned.
+   *
+   * @param {Identity} identity - The identity to be used to create the agent.
+   * @returns {Promise<HttpAgent>} The HttpAgent associated with the given identity.
+   */
+  public async getAgent({
+    identity,
+  }: {
+    identity: Identity;
+  }): Promise<HttpAgent> {
+    const key = identity.getPrincipal().toText();
+
+    if (isNullish(this.agents) || isNullish(this.agents[key])) {
+      const agent = await this.createAgent({ identity });
+
+      this.agents = {
+        ...(this.agents ?? {}),
+        [key]: agent,
+      };
+
+      return agent;
+    }
+
+    return this.agents[key];
+  }
+
+  /**
+   * Create a new HTTP agent for a given identity.
+   *
+   * This method does not check the cache. It always creates a new agent.
+   * The agent is configured with the specified identity, fetchRootKey option, and the host.
+   *
+   * @param {Identity} identity - The identity to use for the agent.
+   * @param {boolean} [verifyQuerySignatures=true] - Whether to verify query signatures for query calls.
+   * @returns {Promise<HttpAgent>} The newly created HttpAgent instance.
+   */
+  public createAgent({
+    identity,
+    verifyQuerySignatures = true,
+  }: {
+    identity: Identity;
+    verifyQuerySignatures?: boolean;
+  }): Promise<HttpAgent> {
+    return createAgent({
+      identity,
+      fetchRootKey: this.config.fetchRootKey,
+      host: this.config.host,
+      verifyQuerySignatures,
+    });
+  }
+
+  /**
+   * Clear the cache of HTTP agents.
+   *
+   * This method removes all cached agents, forcing new agent creation on the next request for any identity.
+   * Useful when identities have changed or if you want to reset all active connections.
+   */
+  public clearAgents(): void {
+    this.agents = undefined;
+  }
+}

--- a/packages/utils/src/utils/agent.utils.ts
+++ b/packages/utils/src/utils/agent.utils.ts
@@ -1,7 +1,7 @@
 import type { Agent } from "@dfinity/agent";
 import { AnonymousIdentity, HttpAgent } from "@dfinity/agent";
-import { isNullish, nonNullish } from "./nullish.utils";
 import type { CreateAgentParams } from "../types/agent.utils";
+import { isNullish, nonNullish } from "./nullish.utils";
 
 /**
  * Get a default agent that connects to mainnet with the anonymous identity.

--- a/packages/utils/src/utils/agent.utils.ts
+++ b/packages/utils/src/utils/agent.utils.ts
@@ -1,4 +1,4 @@
-import type { Agent } from "@dfinity/agent";
+import type { Agent, Identity } from "@dfinity/agent";
 import { AnonymousIdentity, HttpAgent } from "@dfinity/agent";
 import type { CreateAgentParams } from "../types/agent.utils";
 import { isNullish, nonNullish } from "./nullish.utils";
@@ -39,10 +39,10 @@ export const createAgent = async ({
   });
 };
 
-export interface AgentManagerConfig {
-  fetchRootKey: boolean;
-  host: string;
-}
+export type AgentManagerConfig = Pick<
+  CreateAgentParams,
+  "fetchRootKey" | "host"
+>;
 
 /**
  * AgentManager class manages HttpAgent instances for different identities.

--- a/packages/utils/src/utils/agent.utils.ts
+++ b/packages/utils/src/utils/agent.utils.ts
@@ -53,9 +53,7 @@ export type AgentManagerConfig = Pick<
 export class AgentManager {
   private agents: Record<string, HttpAgent> | undefined | null = undefined;
 
-  private constructor(private readonly config: AgentManagerConfig) {
-    this.config = config;
-  }
+  private constructor(private readonly config: AgentManagerConfig) {}
 
   /**
    * Static factory method to create a new AgentManager instance.

--- a/packages/utils/src/utils/agent.utils.ts
+++ b/packages/utils/src/utils/agent.utils.ts
@@ -9,7 +9,7 @@ import { isNullish, nonNullish } from "./nullish.utils";
 export const defaultAgent = (): Agent =>
   HttpAgent.createSync({
     host: "https://icp-api.io",
-    identity: new AnonymousIdentity(),
+    identity: new AnonymousIdentity()
   });
 
 /**
@@ -21,12 +21,12 @@ export const defaultAgent = (): Agent =>
  * @param retryTimes Set the number of retries the agent should perform before errorring.
  */
 export const createAgent = async ({
-  identity,
-  host,
-  fetchRootKey = false,
-  verifyQuerySignatures = false,
-  retryTimes,
-}: {
+                                    identity,
+                                    host,
+                                    fetchRootKey = false,
+                                    verifyQuerySignatures = false,
+                                    retryTimes
+                                  }: {
   identity: Identity;
   host?: string;
   fetchRootKey?: boolean;
@@ -39,7 +39,7 @@ export const createAgent = async ({
     ...(nonNullish(host) && { host }),
     verifyQuerySignatures,
     ...(nonNullish(retryTimes) && { retryTimes }),
-    shouldFetchRootKey: fetchRootKey,
+    shouldFetchRootKey: fetchRootKey
   });
 };
 
@@ -55,7 +55,7 @@ export interface AgentManagerConfig {
  * Provides functionality to create new agents, retrieve cached agents, and clear the cache when needed.
  */
 export class AgentManager {
-  private agents: Record<string, HttpAgent> | undefined = undefined;
+  private agents: Record<string, HttpAgent> | undefined | null = undefined;
 
   private constructor(private readonly config: AgentManagerConfig) {
     this.config = config;
@@ -86,8 +86,8 @@ export class AgentManager {
    * @returns {Promise<HttpAgent>} The HttpAgent associated with the given identity.
    */
   public async getAgent({
-    identity,
-  }: {
+                          identity
+                        }: {
     identity: Identity;
   }): Promise<HttpAgent> {
     const key = identity.getPrincipal().toText();
@@ -97,12 +97,12 @@ export class AgentManager {
         identity,
         fetchRootKey: this.config.fetchRootKey,
         host: this.config.host,
-        verifyQuerySignatures: true,
+        verifyQuerySignatures: true
       });
 
       this.agents = {
         ...(this.agents ?? {}),
-        [key]: agent,
+        [key]: agent
       };
 
       return agent;
@@ -118,6 +118,6 @@ export class AgentManager {
    * Useful when identities have changed or if you want to reset all active connections.
    */
   public clearAgents(): void {
-    this.agents = undefined;
+    this.agents = null;
   }
 }

--- a/packages/utils/src/utils/agent.utils.ts
+++ b/packages/utils/src/utils/agent.utils.ts
@@ -9,7 +9,7 @@ import { isNullish, nonNullish } from "./nullish.utils";
 export const defaultAgent = (): Agent =>
   HttpAgent.createSync({
     host: "https://icp-api.io",
-    identity: new AnonymousIdentity()
+    identity: new AnonymousIdentity(),
   });
 
 /**
@@ -21,12 +21,12 @@ export const defaultAgent = (): Agent =>
  * @param retryTimes Set the number of retries the agent should perform before errorring.
  */
 export const createAgent = async ({
-                                    identity,
-                                    host,
-                                    fetchRootKey = false,
-                                    verifyQuerySignatures = false,
-                                    retryTimes
-                                  }: {
+  identity,
+  host,
+  fetchRootKey = false,
+  verifyQuerySignatures = false,
+  retryTimes,
+}: {
   identity: Identity;
   host?: string;
   fetchRootKey?: boolean;
@@ -39,7 +39,7 @@ export const createAgent = async ({
     ...(nonNullish(host) && { host }),
     verifyQuerySignatures,
     ...(nonNullish(retryTimes) && { retryTimes }),
-    shouldFetchRootKey: fetchRootKey
+    shouldFetchRootKey: fetchRootKey,
   });
 };
 
@@ -86,8 +86,8 @@ export class AgentManager {
    * @returns {Promise<HttpAgent>} The HttpAgent associated with the given identity.
    */
   public async getAgent({
-                          identity
-                        }: {
+    identity,
+  }: {
     identity: Identity;
   }): Promise<HttpAgent> {
     const key = identity.getPrincipal().toText();
@@ -97,12 +97,12 @@ export class AgentManager {
         identity,
         fetchRootKey: this.config.fetchRootKey,
         host: this.config.host,
-        verifyQuerySignatures: true
+        verifyQuerySignatures: true,
       });
 
       this.agents = {
         ...(this.agents ?? {}),
-        [key]: agent
+        [key]: agent,
       };
 
       return agent;


### PR DESCRIPTION
# Motivation

It is a simple but useful class to manage multiple HTTP agents associated with identities.

# Credits

The original scripts were created by @peterpeterparker in the [OISY repo](https://github.com/dfinity/oisy-wallet). This is just a transposition to a re-usable utility.

# Changes

New `AgentManager` class with:
- `create` method: static constructor.
- `createAgent` method: as the name suggests, it creates a new HTTP but do not cache it.
- `getAgent` method: it fetches the HTTP agent among the cached, and if does note exists, it creates it and cache it.
- `clearAgents` method: clean slate.

# Tests

I created a few tests for the few usecases.

# Todos

- [x] Maybe add more mocked identity, to check for concurrent multiple agents.
