### PR TITLE
feat: CMC create standardized to support query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next
+
+## Breaking Changes
+
+- For consistency, the `CMCCanister.create` function now requires the `canisterId` option to be provided exclusively as a `Principal`.
+
 # 2024.10.09-1140Z
 
 ## Overview

--- a/packages/cmc/README.md
+++ b/packages/cmc/README.md
@@ -55,7 +55,7 @@ const rate = await getIcpToCyclesConversionRate();
 
 ### :factory: CMCCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L13)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L14)
 
 #### Methods
 
@@ -70,7 +70,7 @@ const rate = await getIcpToCyclesConversionRate();
 | -------- | ---------------------------------------------- |
 | `create` | `(options: CMCCanisterOptions) => CMCCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L18)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L15)
 
 ##### :gear: getIcpToCyclesConversionRate
 
@@ -80,7 +80,7 @@ Returns conversion rate of ICP to Cycles
 | ------------------------------ | ----------------------- |
 | `getIcpToCyclesConversionRate` | `() => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L37)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L31)
 
 ##### :gear: notifyCreateCanister
 
@@ -91,7 +91,7 @@ It returns the new canister principal.
 | ---------------------- | ---------------------------------------------------------- |
 | `notifyCreateCanister` | `(request: NotifyCreateCanisterArg) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L54)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L48)
 
 ##### :gear: notifyTopUp
 
@@ -102,6 +102,6 @@ It returns the new Cycles of the canister.
 | ------------- | ---------------------------------------------- |
 | `notifyTopUp` | `(request: NotifyTopUpArg) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L82)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L76)
 
 <!-- TSDOC_END -->

--- a/packages/cmc/src/cmc.canister.ts
+++ b/packages/cmc/src/cmc.canister.ts
@@ -1,32 +1,26 @@
-import { Actor } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
+import { Canister, createServices } from "@dfinity/utils";
 import type {
+  _SERVICE as CMCCanisterService,
   Cycles,
   NotifyCreateCanisterArg,
   NotifyTopUpArg,
-  _SERVICE,
 } from "../candid/cmc";
+import { idlFactory as certifiedIdlFactory } from "../candid/cmc.certified.idl";
 import { idlFactory } from "../candid/cmc.idl";
 import { throwNotifyError } from "./cmc.errors";
 import type { CMCCanisterOptions } from "./cmc.options";
 
-export class CMCCanister {
-  private constructor(private readonly service: _SERVICE) {
-    this.service = service;
-  }
-
-  public static create(options: CMCCanisterOptions) {
-    const agent = options.agent;
-    const canisterId = options.canisterId;
-
-    const service =
-      options.serviceOverride ??
-      Actor.createActor<_SERVICE>(idlFactory, {
-        agent,
-        canisterId,
+export class CMCCanister extends Canister<CMCCanisterService> {
+  static create(options: CMCCanisterOptions): CMCCanister {
+    const { service, certifiedService, canisterId } =
+      createServices<CMCCanisterService>({
+        options,
+        idlFactory,
+        certifiedIdlFactory,
       });
 
-    return new CMCCanister(service);
+    return new CMCCanister(canisterId, service, certifiedService);
   }
 
   /**

--- a/packages/cmc/src/cmc.options.ts
+++ b/packages/cmc/src/cmc.options.ts
@@ -4,5 +4,5 @@ import type { _SERVICE as CanisterService } from "../candid/cmc";
 
 export interface CMCCanisterOptions
   extends Omit<CanisterOptions<CanisterService>, "canisterId"> {
-  canisterId: string | Principal;
+  canisterId: Principal;
 }


### PR DESCRIPTION
# Motivation

In PR  #733 I would like to implement a function for the CMC canister that can be called as `query` or `update` call. The `CMCCanister` does not yet support the service binding for query and it's `create` implementation differs from the standards.

That's why this PR update the create function to use the standard utility `createServices`.

# Changes

- Update `CMCCanister.create` to use the standardized function.
- Deprecate the use of `string` as creation option for consistency reasons.

# Tests

The tests were already using a `canisterId` set as `Principal`.
