### PR TITLE
refactor: Extract createAgent parameters and export them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Next
 
+
 ## Breaking Changes
 
 - For consistency, the `CMCCanister.create` function now requires the `canisterId` option to be provided exclusively as a `Principal`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Next
 
-
 ## Breaking Changes
 
-- For consistency, the `CMCCanister.create` function now requires the `canisterId` option to be provided exclusively as a `Principal`.
+- For consistency, the `CMCCanister.create` function now requires the `canisterId` option to be provided exclusively as
+  a `Principal`.
 
 ## Features
 
@@ -16,7 +16,7 @@
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status        |
-| ------------------------ | ------- | ------------- |
+|--------------------------|---------|---------------|
 | `@dfinity/ckbtc`         | v3.1.1  | Maintained ⚙️ |
 | `@dfinity/cketh`         | v3.3.2  | Maintained ⚙️ |
 | `@dfinity/cmc`           | v3.2.2  | Maintained ⚙️ |
@@ -39,7 +39,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-| ------------------------ | ------- | ------------------- |
+|--------------------------|---------|---------------------|
 | `@dfinity/ckbtc`         | v3.1.0  | Enhanced 🔧️        |
 | `@dfinity/cketh`         | v3.3.1  | Maintained ⚙️       |
 | `@dfinity/cmc`           | v3.2.1  | Maintained ⚙️       |
@@ -53,7 +53,8 @@ The current status of the libraries at the time of the release is as follows:
 
 ## Breaking changes
 
-- Removed deprecated `OpenSnsTokenSwap`, `SetSnsTokenSwapOpenTimeWindow`, and `SetDefaultFollowees` from `ProposalActionRequest`.
+- Removed deprecated `OpenSnsTokenSwap`, `SetSnsTokenSwapOpenTimeWindow`, and `SetDefaultFollowees` from
+  `ProposalActionRequest`.
 
 ## Features
 
@@ -72,7 +73,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-| ------------------------ | ------- | ------------------- |
+|--------------------------|---------|---------------------|
 | `@dfinity/ckbtc`         | v3.0.0  | Breaking Changes ⚠️ |
 | `@dfinity/cketh`         | v3.3.0  | Maintained ⚙️       |
 | `@dfinity/cmc`           | v3.2.0  | Maintained ⚙️       |
@@ -88,14 +89,20 @@ The current status of the libraries at the time of the release is as follows:
 
 - Rename values of enum Topic and NnsFunction to match the backend values.
 - Use different request/response types for NNS Governance proposals, and different fields for `InstallCode` proposals.
-- The `getUtxos` parameter `filter.min_confirmations` has been renamed to `filter.minConfirmations` for consistency with the general naming conventions used in `@dfinity/ckbtc`.
-- Only queries to `getUtxos` of the Bitcoin canister can be executed by external users — i.e., update calls can only be performed by the canister. This is why `getUtxos` now only supports non-certified calls and has been renamed to `getUtxosQuery`.
+- The `getUtxos` parameter `filter.min_confirmations` has been renamed to `filter.minConfirmations` for consistency with
+  the general naming conventions used in `@dfinity/ckbtc`.
+- Only queries to `getUtxos` of the Bitcoin canister can be executed by external users — i.e., update calls can only be
+  performed by the canister. This is why `getUtxos` now only supports non-certified calls and has been renamed to
+  `getUtxosQuery`.
 
 ## Features
 
-- Provide a new utility to convert Candid `Nat` to `BigInt`. This utility is useful for interpreting the fees provided by the SNS Aggregator.
-- Support conversion of `InstallCode`, `StopOrStartCanister` and `UpdateCanisterSettings` actions, `SetVisibility` neuron operation, and `Neuron::visibility` attribute.
-- Add function `getBalanceQuery` to `BitcoinCanister` object of package `@dfinity/ckbtc`, that implements the `bitcoin_get_balance_query` method of the IC Bitcoin API.
+- Provide a new utility to convert Candid `Nat` to `BigInt`. This utility is useful for interpreting the fees provided
+  by the SNS Aggregator.
+- Support conversion of `InstallCode`, `StopOrStartCanister` and `UpdateCanisterSettings` actions, `SetVisibility`
+  neuron operation, and `Neuron::visibility` attribute.
+- Add function `getBalanceQuery` to `BitcoinCanister` object of package `@dfinity/ckbtc`, that implements the
+  `bitcoin_get_balance_query` method of the IC Bitcoin API.
 
 ## Build
 
@@ -108,7 +115,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status         |
-| ------------------------ | ------- | -------------- |
+|--------------------------|---------|----------------|
 | `@dfinity/ckbtc`         | v2.5.0  | Maintained ⚙️  |
 | `@dfinity/cketh`         | v3.2.0  | Enhanced 🔧️   |
 | `@dfinity/cmc`           | v3.1.0  | Maintained ⚙️  |
@@ -144,7 +151,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status         |
-| ------------------------ | ------- | -------------- |
+|--------------------------|---------|----------------|
 | `@dfinity/ckbtc`         | v2.4.1  | Maintained ⚙️  |
 | `@dfinity/cketh`         | v3.1.1  | Maintained ⚙️  |
 | `@dfinity/cmc`           | v3.0.7  | Maintained ⚙️  |
@@ -171,7 +178,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-| ------------------------ | ------- | ------------------- |
+|--------------------------|---------|---------------------|
 | `@dfinity/ckbtc`         | v2.4.0  | Enhanced 🔧         |
 | `@dfinity/cketh`         | v3.1.0  | Enhanced 🔧         |
 | `@dfinity/cmc`           | v3.0.6  | Maintained ⚙️       |
@@ -185,7 +192,8 @@ The current status of the libraries at the time of the release is as follows:
 
 ## Breaking changes
 
-- `bitcoinGetUtxos` and `bitcoinGetUtxosQuery` have been removed from the `@dfinity/ic-management` library. Instead, use `getUtxos` from the new Bitcoin canister exposed in `@dfinity/ckbtc` to access similar data.
+- `bitcoinGetUtxos` and `bitcoinGetUtxosQuery` have been removed from the `@dfinity/ic-management` library. Instead, use
+  `getUtxos` from the new Bitcoin canister exposed in `@dfinity/ckbtc` to access similar data.
 
 ## Features
 
@@ -202,7 +210,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-| ------------------------ | ------- | ------------------- |
+|--------------------------|---------|---------------------|
 | `@dfinity/ckbtc`         | v2.3.3  | Maintained ⚙️       |
 | `@dfinity/cketh`         | v3.0.1  | Maintained ⚙️       |
 | `@dfinity/cmc`           | v3.0.5  | Maintained ⚙️       |
@@ -216,9 +224,11 @@ The current status of the libraries at the time of the release is as follows:
 
 ## Breaking changes
 
-- `@dfinity/ic-management` function `canisterInfo` removed because users cannot call this method (see [documentation](https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-canister-info)).
+- `@dfinity/ic-management` function `canisterInfo` removed because users cannot call this method (
+  see [documentation](https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-canister-info)).
 - `@dfinity/nns-proto` was updated with the most recent proto types, some of which were not backwards compatible.
-- The size of the nns-proto-js library has noticeably increased, as it now exposes all types instead of just a manually picked subset.
+- The size of the nns-proto-js library has noticeably increased, as it now exposes all types instead of just a manually
+  picked subset.
 
 ## Features
 
@@ -231,7 +241,8 @@ The current status of the libraries at the time of the release is as follows:
 
 ## Build
 
-- Upgrade `agent-js` dependencies to `v1.3.0` and revert the default retry times value to 10, given that the issue is fixed.
+- Upgrade `agent-js` dependencies to `v1.3.0` and revert the default retry times value to 10, given that the issue is
+  fixed.
 
 # 2024.04.29-0930Z
 
@@ -240,7 +251,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-| ------------------------ | ------- | ------------------- |
+|--------------------------|---------|---------------------|
 | `@dfinity/ckbtc`         | v2.3.2  | Maintained ⚙️       |
 | `@dfinity/cketh`         | v3.0.0  | Breaking Changes ⚠️ |
 | `@dfinity/cmc`           | v3.0.4  | Maintained ⚙️       |
@@ -254,14 +265,17 @@ The current status of the libraries at the time of the release is as follows:
 
 ## Breaking changes
 
-- Protocol buffers for hardware wallet transactions are no longer supported. Internet Computer Ledger app 2.4.9 or later is now required.
-- GovernanceCanister.listNeurons no longer throws an error when called with `certified: false` for hardware wallet transactions.
+- Protocol buffers for hardware wallet transactions are no longer supported. Internet Computer Ledger app 2.4.9 or later
+  is now required.
+- GovernanceCanister.listNeurons no longer throws an error when called with `certified: false` for hardware wallet
+  transactions.
 - Potential errors thrown by `withdrawEth` provide now unparsed details.
 
 ## Features
 
 - ICP transactions, as provided by the Index canister, have been extended to include their block timestamp information.
-- When no fee is specified when making an ICP transaction, use the mandatory fee of 10000 e8s (0.0001 ICP) instead of fetching the fee from the network.
+- When no fee is specified when making an ICP transaction, use the mandatory fee of 10000 e8s (0.0001 ICP) instead of
+  fetching the fee from the network.
 - Remove hardware wallet specific code paths from `@dfinity/ledger-icp`.
 - Remove hardware wallet specific options from LedgerCanister.
 - Remove dependency on `@dfinity/nns-proto` from `@dfinity/ledger-icp`.
@@ -269,11 +283,16 @@ The current status of the libraries at the time of the release is as follows:
 - Add support for `withdrawErc20`.
 - Additional fields related to ERC20 have been added to ckETH `minterInfo`.
 - Expose the function `ledger_id` for Index canister in the `ledger-icrc` library.
-- Set number of retries to 10 (as opposed to default 3) in `createAgent` utility to make the agent more resilient against watermark check failures.
+- Set number of retries to 10 (as opposed to default 3) in `createAgent` utility to make the agent more resilient
+  against watermark check failures.
 
 ## Build
 
-- Upgrade `agent-js` dependencies to `v1.2.1`. Note that it is advised to set the number of retries of the agent to 10 to prevent the potential issue `Timestamp failed to pass the watermark after retrying the configured 3 times. We cannot guarantee the integrity of the response since it could be a replay attack.` (see thread on the [forum](https://forum.dfinity.org/t/timestamp-failed-to-pass-the-watermark-after-retrying-the-configured-3-times/29180/3?u=peterparker)).
+- Upgrade `agent-js` dependencies to `v1.2.1`. Note that it is advised to set the number of retries of the agent to 10
+  to prevent the potential issue
+  `Timestamp failed to pass the watermark after retrying the configured 3 times. We cannot guarantee the integrity of the response since it could be a replay attack.` (
+  see thread on
+  the [forum](https://forum.dfinity.org/t/timestamp-failed-to-pass-the-watermark-after-retrying-the-configured-3-times/29180/3?u=peterparker)).
 - Upgrade `didc` to `0.3.7` that converts candid files into JS and TS.
 
 # 2024.03.25-1430Z
@@ -283,7 +302,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status      |
-| ------------------------ | ------- | ----------- |
+|--------------------------|---------|-------------|
 | `@dfinity/ckbtc`         | v2.3.1  | Unchanged️️ |
 | `@dfinity/cketh`         | v2.0.1  | Unchanged️  |
 | `@dfinity/cmc`           | v3.0.3  | Unchanged️  |
@@ -306,7 +325,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status        |
-| ------------------------ | ------- | ------------- |
+|--------------------------|---------|---------------|
 | `@dfinity/ckbtc`         | v2.3.1  | Maintained ⚙️ |
 | `@dfinity/cketh`         | v2.0.1  | Maintained ⚙️ |
 | `@dfinity/cmc`           | v3.0.3  | Maintained ⚙️ |
@@ -321,7 +340,8 @@ The current status of the libraries at the time of the release is as follows:
 ## Features
 
 - Support for the installation of large canisters with chunked code of the Wasm module in `@dfinity/ic-management`.
-- Update most recent did files for ledgers (new optional field for initialization) and ckETH (new optional field in event).
+- Update most recent did files for ledgers (new optional field for initialization) and ckETH (new optional field in
+  event).
 - Expose Utxo types in `@dfinity/ckbtc`.
 
 ## Build
@@ -339,7 +359,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-| ------------------------ | ------- | ------------------- |
+|--------------------------|---------|---------------------|
 | `@dfinity/ckbtc`         | v2.3.0  | Enhanced 🔧️        |
 | `@dfinity/cketh`         | v2.0.0  | Breaking Changes ⚠️ |
 | `@dfinity/cmc`           | v3.0.2  | Unchanged️          |
@@ -348,20 +368,23 @@ The current status of the libraries at the time of the release is as follows:
 | `@dfinity/ledger-icrc`   | v2.1.3  | Enhanced 🔧         |
 | `@dfinity/nns`           | v4.0.1  | Unchanged️          |
 | `@dfinity/nns-proto`     | v1.0.1  | Unchanged️          |
-| `@dfinity/sns`           | v3.0.1  | Maintained ⚙       |
+| `@dfinity/sns`           | v3.0.1  | Maintained ⚙        |
 | `@dfinity/utils`         | v2.1.2  | Unchanged️          |
 
 ## Breaking Changes
 
 - Fix typo in `ic-management` interfaces (`senderCanisterVerion` -> `senderCanisterVersion`).
-- ckETH `eip1559TransactionPrice` expect a parameters which can optionally be set to execute a query (new) or update call.
+- ckETH `eip1559TransactionPrice` expect a parameters which can optionally be set to execute a query (new) or update
+  call.
 
 ## Features
 
-- Support for new ckETH endpoint `get_minter_info` which returns internal minter parameters such as the minimal withdrawal amount, the last observed block number, etc.
+- Support for new ckETH endpoint `get_minter_info` which returns internal minter parameters such as the minimal
+  withdrawal amount, the last observed block number, etc.
 - Add support for `bitcoin_get_utxos` and `bitcoin_get_utxos_query` features to `@dfinity/ic-management` library.
 - Support for new ckBTC endpoint `get_known_utxos` which returns UTXOs of the given account known by the minter.
-- New `IndexNgCanister` in `@dfinity/ledger-icrc`, which can be used to interact with the newer version of the ICRC Index canister, notably exposing `getTransactions` as a `query` function.
+- New `IndexNgCanister` in `@dfinity/ledger-icrc`, which can be used to interact with the newer version of the ICRC
+  Index canister, notably exposing `getTransactions` as a `query` function.
 
 # 2024.02.21-0835Z
 
@@ -370,7 +393,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-| ------------------------ | ------- | ------------------- |
+|--------------------------|---------|---------------------|
 | `@dfinity/ckbtc`         | v2.2.1  | Maintained ⚙️       |
 | `@dfinity/cketh`         | v1.0.2  | Maintained ⚙️       |
 | `@dfinity/cmc`           | v3.0.2  | Maintained ⚙️       |
@@ -388,7 +411,8 @@ The current status of the libraries at the time of the release is as follows:
 
 ## Build
 
-- Bump agent-js `v1.0.1` to hook on their semantic versioning, adopt last improvements and rollout a [security patch](https://github.com/dfinity/agent-js/security/advisories/GHSA-c9vv-fhgv-cjc3)
+- Bump agent-js `v1.0.1` to hook on their semantic versioning, adopt last improvements and rollout
+  a [security patch](https://github.com/dfinity/agent-js/security/advisories/GHSA-c9vv-fhgv-cjc3)
 
 # 2024.02.14-1600Z
 
@@ -397,7 +421,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-| ------------------------ | ------- | ------------------- |
+|--------------------------|---------|---------------------|
 | `@dfinity/ckbtc`         | v2.2.0  | Enhanced 🔧         |
 | `@dfinity/cketh`         | v1.0.1  | Maintained ⚙️       |
 | `@dfinity/cmc`           | v3.0.1  | Maintained ⚙️       |
@@ -411,13 +435,15 @@ The current status of the libraries at the time of the release is as follows:
 
 ## Breaking changes
 
-- Replace duplicate string type `AccountIdentifier` in `@dfinity/nns` with `AccountIdentifierHex` of `@dfinity/ledger-icp`.
+- Replace duplicate string type `AccountIdentifier` in `@dfinity/nns` with `AccountIdentifierHex` of
+  `@dfinity/ledger-icp`.
 
 ## Features
 
 - Extend ckBTC `retrieveBtcStatusV2ByAccount` with optional `account` parameter.
 - Remove unused Uint8Array type `SubAccount` in `@dfinity/nns`.
-- Modify the `@dfinity/ledger-icp` package's `SubAccount.formID` function to support more than 256 subaccounts, enabling it to handle larger numbers.
+- Modify the `@dfinity/ledger-icp` package's `SubAccount.formID` function to support more than 256 subaccounts, enabling
+  it to handle larger numbers.
 
 ## Build
 
@@ -430,7 +456,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-| ------------------------ | ------- | ------------------- |
+|--------------------------|---------|---------------------|
 | `@dfinity/ckbtc`         | v2.1.1  | Patched 🩹          |
 | `@dfinity/cketh`         | v1.0.0  | Launched 🚀         |
 | `@dfinity/cmc`           | v3.0.0  | Breaking Changes ⚠️ |
@@ -448,7 +474,8 @@ The current status of the libraries at the time of the release is as follows:
 
 ## Features
 
-- Add support for converting ckETH to ETH through the `withdrawEth` function and integrate useful features such as `eip1559TransactionPrice`, `encodePrincipalToEthAddress`, and `retrieve_eth_status`.
+- Add support for converting ckETH to ETH through the `withdrawEth` function and integrate useful features such as
+  `eip1559TransactionPrice`, `encodePrincipalToEthAddress`, and `retrieve_eth_status`.
 - Upgrade candid files for `ic-management` canister and support new field `reserved_cycles_limit`.
 - Add "API Boundary Node Management" topic support.
 - Add optional field `logo` to `Token` type.
@@ -470,7 +497,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status     |
-| ------------------------ | ------- | ---------- |
+|--------------------------|---------|------------|
 | `@dfinity/ckbtc`         | v2.1.0  | Unchanged  |
 | `@dfinity/cketh`         | v0.0.1  | Unchanged  |
 | `@dfinity/cmc`           | v2.1.0  | Unchanged  |
@@ -493,7 +520,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status     |
-| ------------------------ | ------- | ---------- |
+|--------------------------|---------|------------|
 | `@dfinity/ckbtc`         | v2.1.0  | Unchanged  |
 | `@dfinity/cketh`         | v0.0.1  | New 🚀     |
 | `@dfinity/cmc`           | v2.1.0  | Unchanged  |
@@ -507,7 +534,9 @@ The current status of the libraries at the time of the release is as follows:
 
 ## Features
 
-- Introduces an early first version of `@dfinity/cketh`, which is meant to provide functions for interfacing with ckETH. The library doesn't do much at the moment, but we're releasing it to integrate it into our pipelines, and features will be added iteratively as required.
+- Introduces an early first version of `@dfinity/cketh`, which is meant to provide functions for interfacing with ckETH.
+  The library doesn't do much at the moment, but we're releasing it to integrate it into our pipelines, and features
+  will be added iteratively as required.
 
 # 2023.12.20-1000Z
 
@@ -516,7 +545,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-| ------------------------ | ------- | ------------------- |
+|--------------------------|---------|---------------------|
 | `@dfinity/ckbtc`         | v2.1.0  | Enhanced 🔧         |
 | `@dfinity/cmc`           | v2.1.0  | Enhanced 🔧         |
 | `@dfinity/ic-management` | v2.1.0  | Enhanced 🔧         |
@@ -540,12 +569,15 @@ The current status of the libraries at the time of the release is as follows:
 - Make uint8ArrayToHexString also accept `number[]` as input.
 - Add a new type TokenAmountV2 which supports `decimals !== 8`.
 - Fix issue when converting token amount from small numbers with `TokenAmountV2`.
-- Bump agent-js to v0.20.2 in a non-breaking manner by introducing `verifyQuerySignatures` as an opt-in feature (for the time being).
-- Replace `https://ic0.app` by `https://icp-api.io` as the default host for the default anonymous agent provided by `defaultAgent`.
+- Bump agent-js to v0.20.2 in a non-breaking manner by introducing `verifyQuerySignatures` as an opt-in feature (for the
+  time being).
+- Replace `https://ic0.app` by `https://icp-api.io` as the default host for the default anonymous agent provided by
+  `defaultAgent`.
 
 ## Fix
 
-- Utilize ICP Index `accountBalance` and `getTransactions` with account identifier hex directly, eliminating the need for conversion with Buffer and resolving usage in non-polyfilled environments.
+- Utilize ICP Index `accountBalance` and `getTransactions` with account identifier hex directly, eliminating the need
+  for conversion with Buffer and resolving usage in non-polyfilled environments.
 
 ## Operations
 
@@ -558,7 +590,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status      |
-| ------------------------ | ------- | ----------- |
+|--------------------------|---------|-------------|
 | `@dfinity/ckbtc`         | v2.0.0  | Enhanced 🔧 |
 | `@dfinity/cmc`           | v2.0.0  | Enhanced 🔧 |
 | `@dfinity/ic-management` | v2.0.0  | Enhanced 🔧 |
@@ -583,7 +615,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status      |
-| ------------------------ | ------- | ----------- |
+|--------------------------|---------|-------------|
 | `@dfinity/ckbtc`         | v1.1.0  | Enhanced 🔧 |
 | `@dfinity/cmc`           | v1.0.0  | Unchanged   |
 | `@dfinity/ic-management` | v1.0.0  | Unchanged   |
@@ -596,10 +628,13 @@ The current status of the libraries at the time of the release is as follows:
 
 ## Features
 
-- add support for ICP Index canister to library `@dfinity/ledger-icp`. New `IndexCanister` functions: `accountBalance` and `getTransactions`
+- add support for ICP Index canister to library `@dfinity/ledger-icp`. New `IndexCanister` functions: `accountBalance`
+  and `getTransactions`
 - expose few types - notably `BlockHeight` - for library `@dfinity/ledger-icp`
-- support new fields from swap canister response types: `min_direct_participation_icp_e8s`, `max_direct_participation_icp_e8s` and `neurons_fund_participation`
-- support new fields in the `CreateServiceNervousSystem` proposal action: `maximum_direct_participation_icp`, `minimum_direct_participation_icp` and `neurons_fund_participation`
+- support new fields from swap canister response types: `min_direct_participation_icp_e8s`,
+  `max_direct_participation_icp_e8s` and `neurons_fund_participation`
+- support new fields in the `CreateServiceNervousSystem` proposal action: `maximum_direct_participation_icp`,
+  `minimum_direct_participation_icp` and `neurons_fund_participation`
 - support new filter field `omit_large_fields` in `list_proposals`
 - add support for `retrieve_btc_with_approval` in `@dfinity/ckbtc`
 - new utility to convert seconds to a human-readable duration
@@ -613,11 +648,11 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-| ------------------------ | ------- | ------------------- |
+|--------------------------|---------|---------------------|
 | `@dfinity/ckbtc`         | v1.0.1  | Patched             |
 | `@dfinity/cmc`           | v1.0.0  | Unchanged           |
 | `@dfinity/ic-management` | v1.0.0  | Unchanged           |
-| `@dfinity/ledger`        | v1.0.0  | Deprecated ❌       |
+| `@dfinity/ledger`        | v1.0.0  | Deprecated ❌        |
 | `@dfinity/ledger-icp`    | v1.0.0  | New 🚀              |
 | `@dfinity/ledger-icrc`   | v1.0.0  | New 🚀              |
 | `@dfinity/nns`           | v2.0.0  | Breaking Changes ⚠️ |
@@ -635,9 +670,12 @@ The current status of the libraries at the time of the release is as follows:
 
 ## Breaking Changes ⚠️
 
-- **ICP** ledger-related features have been relocated from `@dfinity/nns` to a new dedicated library called `@dfinity/ledger-icp`
-- **ICRC** ledger-related features have been moved as well. The library `@dfinity/ledger` has been deprecated, renamed, and replaced by `@dfinity/ledger-icrc`
-- remove the `ICP` class, which was deprecated a long time ago, from `@dfinity/nns`. Instead, utilize the token parsers from `@dfinity/utils`
+- **ICP** ledger-related features have been relocated from `@dfinity/nns` to a new dedicated library called
+  `@dfinity/ledger-icp`
+- **ICRC** ledger-related features have been moved as well. The library `@dfinity/ledger` has been deprecated, renamed,
+  and replaced by `@dfinity/ledger-icrc`
+- remove the `ICP` class, which was deprecated a long time ago, from `@dfinity/nns`. Instead, utilize the token parsers
+  from `@dfinity/utils`
 
 ## Build
 
@@ -670,7 +708,8 @@ The current status of the libraries at the time of the release is as follows:
 ## Build
 
 - bump did files in Cmc
-- starting from this version, we commit to adhering to [semantic versioning](https://semver.org/) for any libraries published in ic-js
+- starting from this version, we commit to adhering to [semantic versioning](https://semver.org/) for any libraries
+  published in ic-js
 
 # 0.18.4 (2023-09-05)
 
@@ -779,7 +818,8 @@ The current status of the libraries at the time of the release is as follows:
 
 ## Features
 
-- add a new utils function `decodePayment` to the `@dfinity/ledger` library. Useful to decode payment through QR code that contains target address and amount
+- add a new utils function `decodePayment` to the `@dfinity/ledger` library. Useful to decode payment through QR code
+  that contains target address and amount
 - add provisional create canister with cycles method
 - `CreateServiceNervousSystem` <-> `RawCreateServiceNervousSystem` transformations for Nns proposal
 - decode payment code (early support and not yet specified. see ICRC-22)
@@ -844,7 +884,8 @@ No particular changes. Resolve a version conflicts in npmjs.
 ## Features
 
 - introducing `@dfinity/ic-management` — a new library for interfacing with IC management canister
-- add `getMinterInfo` for ckBTC which returns internal minter parameters such as the minimal amount to retrieve BTC, minimal number of confirmations or KYT fee
+- add `getMinterInfo` for ckBTC which returns internal minter parameters such as the minimal amount to retrieve BTC,
+  minimal number of confirmations or KYT fee
 - add fee to nns stake neuron method
 - expose Sns index canister id in wrapper
 - add `simulateMergeNeurons` to Nns governance
@@ -878,7 +919,9 @@ No particular changes. Resolve a version conflicts in npmjs.
 
 ## Breaking Changes
 
-- the protobuf dependencies of `@dfinity/nns` have been extracted to a new peer dependency called `@dfinity/nns-proto`. In the NNS-dapp, we manually chunk the libraries. This change enables the dapp to load the required code of the hardware wallet only when necessary.
+- the protobuf dependencies of `@dfinity/nns` have been extracted to a new peer dependency called `@dfinity/nns-proto`.
+  In the NNS-dapp, we manually chunk the libraries. This change enables the dapp to load the required code of the
+  hardware wallet only when necessary.
 
 ## Features
 
@@ -924,7 +967,8 @@ No particular changes. Resolve a version conflicts in npmjs.
 ## Features
 
 - new utils moved from NNS-dapp: `isNullish`, `nonNullish`, `notEmptyString` and `debounce`
-- added ckBTC `updateBalance`, `getWithdrawalAccount`, `retrieveBtc`, `estimateWithdrawalFee` and `getDepositFee` functions
+- added ckBTC `updateBalance`, `getWithdrawalAccount`, `retrieveBtc`, `estimateWithdrawalFee` and `getDepositFee`
+  functions
 - parse and validate bitcoin address
 - review textual encoding for ICRC-1 account as in [dfinity/ICRC-1#98](https://github.com/dfinity/ICRC-1/pull/98)
 - add SNS action converters
@@ -1017,9 +1061,11 @@ No particular changes. Resolve a version conflicts in npmjs.
 
 Introducing `@dfinity/ledger` — A library for interfacing with ICRC ledgers on the Internet Computer.
 
-An ICRC-1 ledger is not only used in Sns projects but, in ckBTC too. It can also be integrated in various other scenario need by developers on the IC.
+An ICRC-1 ledger is not only used in Sns projects but, in ckBTC too. It can also be integrated in various other scenario
+need by developers on the IC.
 
-That's why we are launching this new library and why we refactored Sns ledger related features to create this new library.
+That's why we are launching this new library and why we refactored Sns ledger related features to create this new
+library.
 
 De facto, `@dfinity/ledger` becomes a peer dependency of `@dfinity/sns`.
 
@@ -1111,13 +1157,15 @@ De facto, `@dfinity/ledger` becomes a peer dependency of `@dfinity/sns`.
 
 ### Breaking changes
 
-- the development dependency `didc` has been bumped which leads to some types having to be converted from `number[]` to `Uint8Array`
+- the development dependency `didc` has been bumped which leads to some types having to be converted from `number[]` to
+  `Uint8Array`
 - new fields `stakedMaturityE8sEquivalent` and `autoStakeMaturity` in `Neuron`
 
 ### Features
 
 - new library `@dfinity/cmc`
-- new nns governance commands and actions: `ChangeAutoStakeMaturity`, `SetSnsTokenSwapOpenTimeWindow` and `OpenSnsTokenSwap`
+- new nns governance commands and actions: `ChangeAutoStakeMaturity`, `SetSnsTokenSwapOpenTimeWindow` and
+  `OpenSnsTokenSwap`
 - some new utilities added to transform arrays from various format to `Uint8Array`
 - new Sns utilities to encode and decode accounts to and from strings
 - `disburse` Sns neurons
@@ -1140,7 +1188,8 @@ De facto, `@dfinity/ledger` becomes a peer dependency of `@dfinity/sns`.
 ### Features
 
 - new library `@dfinity/utils`
-- more Sns related features: `notifyParticipation`, `getUserCommitment`, some Sns neurons related features and governance `metadata`
+- more Sns related features: `notifyParticipation`, `getUserCommitment`, some Sns neurons related features and
+  governance `metadata`
 - new nns governance features: `setDissolveDelay` and `setNodeProviderAccount`
 - new generic interface `Token` and class `TokenAmount`
 - class `ICP` set as deprecated
@@ -1190,7 +1239,8 @@ De facto, `@dfinity/ledger` becomes a peer dependency of `@dfinity/sns`.
 
 ## Features
 
-- Remove payload, payloadBytes and nnsFunctionName fields from proposal of type ExecuteNnsFunction action (moved to nns-dapp)
+- Remove payload, payloadBytes and nnsFunctionName fields from proposal of type ExecuteNnsFunction action (moved to
+  nns-dapp)
 - Use Candid interface by default for ledger canister and proto for hardware wallet
 - New function transactionFee to query the current transaction fee
 
@@ -1248,12 +1298,12 @@ De facto, `@dfinity/ledger` becomes a peer dependency of `@dfinity/sns`.
 ### Features
 
 - governance new functions:
-  - `getProposal`
-  - `stakeNeuron`
-  - `registerVote`
-  - `increaseDissolveDelay`
-  - `getNeuron`
-  - `setFollowees`
+    - `getProposal`
+    - `stakeNeuron`
+    - `registerVote`
+    - `increaseDissolveDelay`
+    - `getNeuron`
+    - `setFollowees`
 - ledger `transfer` enhanced with support for subaccount
 - new utils to filter voted neurons and proposals
 - export `common` types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status        |
-|--------------------------|---------|---------------|
+| ------------------------ | ------- | ------------- |
 | `@dfinity/ckbtc`         | v3.1.1  | Maintained ⚙️ |
 | `@dfinity/cketh`         | v3.3.2  | Maintained ⚙️ |
 | `@dfinity/cmc`           | v3.2.2  | Maintained ⚙️ |
@@ -39,7 +39,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-|--------------------------|---------|---------------------|
+| ------------------------ | ------- | ------------------- |
 | `@dfinity/ckbtc`         | v3.1.0  | Enhanced 🔧️        |
 | `@dfinity/cketh`         | v3.3.1  | Maintained ⚙️       |
 | `@dfinity/cmc`           | v3.2.1  | Maintained ⚙️       |
@@ -73,7 +73,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-|--------------------------|---------|---------------------|
+| ------------------------ | ------- | ------------------- |
 | `@dfinity/ckbtc`         | v3.0.0  | Breaking Changes ⚠️ |
 | `@dfinity/cketh`         | v3.3.0  | Maintained ⚙️       |
 | `@dfinity/cmc`           | v3.2.0  | Maintained ⚙️       |
@@ -115,7 +115,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status         |
-|--------------------------|---------|----------------|
+| ------------------------ | ------- | -------------- |
 | `@dfinity/ckbtc`         | v2.5.0  | Maintained ⚙️  |
 | `@dfinity/cketh`         | v3.2.0  | Enhanced 🔧️   |
 | `@dfinity/cmc`           | v3.1.0  | Maintained ⚙️  |
@@ -151,7 +151,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status         |
-|--------------------------|---------|----------------|
+| ------------------------ | ------- | -------------- |
 | `@dfinity/ckbtc`         | v2.4.1  | Maintained ⚙️  |
 | `@dfinity/cketh`         | v3.1.1  | Maintained ⚙️  |
 | `@dfinity/cmc`           | v3.0.7  | Maintained ⚙️  |
@@ -178,7 +178,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-|--------------------------|---------|---------------------|
+| ------------------------ | ------- | ------------------- |
 | `@dfinity/ckbtc`         | v2.4.0  | Enhanced 🔧         |
 | `@dfinity/cketh`         | v3.1.0  | Enhanced 🔧         |
 | `@dfinity/cmc`           | v3.0.6  | Maintained ⚙️       |
@@ -210,7 +210,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-|--------------------------|---------|---------------------|
+| ------------------------ | ------- | ------------------- |
 | `@dfinity/ckbtc`         | v2.3.3  | Maintained ⚙️       |
 | `@dfinity/cketh`         | v3.0.1  | Maintained ⚙️       |
 | `@dfinity/cmc`           | v3.0.5  | Maintained ⚙️       |
@@ -251,7 +251,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-|--------------------------|---------|---------------------|
+| ------------------------ | ------- | ------------------- |
 | `@dfinity/ckbtc`         | v2.3.2  | Maintained ⚙️       |
 | `@dfinity/cketh`         | v3.0.0  | Breaking Changes ⚠️ |
 | `@dfinity/cmc`           | v3.0.4  | Maintained ⚙️       |
@@ -302,7 +302,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status      |
-|--------------------------|---------|-------------|
+| ------------------------ | ------- | ----------- |
 | `@dfinity/ckbtc`         | v2.3.1  | Unchanged️️ |
 | `@dfinity/cketh`         | v2.0.1  | Unchanged️  |
 | `@dfinity/cmc`           | v3.0.3  | Unchanged️  |
@@ -325,7 +325,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status        |
-|--------------------------|---------|---------------|
+| ------------------------ | ------- | ------------- |
 | `@dfinity/ckbtc`         | v2.3.1  | Maintained ⚙️ |
 | `@dfinity/cketh`         | v2.0.1  | Maintained ⚙️ |
 | `@dfinity/cmc`           | v3.0.3  | Maintained ⚙️ |
@@ -359,7 +359,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-|--------------------------|---------|---------------------|
+| ------------------------ | ------- | ------------------- |
 | `@dfinity/ckbtc`         | v2.3.0  | Enhanced 🔧️        |
 | `@dfinity/cketh`         | v2.0.0  | Breaking Changes ⚠️ |
 | `@dfinity/cmc`           | v3.0.2  | Unchanged️          |
@@ -368,7 +368,7 @@ The current status of the libraries at the time of the release is as follows:
 | `@dfinity/ledger-icrc`   | v2.1.3  | Enhanced 🔧         |
 | `@dfinity/nns`           | v4.0.1  | Unchanged️          |
 | `@dfinity/nns-proto`     | v1.0.1  | Unchanged️          |
-| `@dfinity/sns`           | v3.0.1  | Maintained ⚙        |
+| `@dfinity/sns`           | v3.0.1  | Maintained ⚙       |
 | `@dfinity/utils`         | v2.1.2  | Unchanged️          |
 
 ## Breaking Changes
@@ -393,7 +393,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-|--------------------------|---------|---------------------|
+| ------------------------ | ------- | ------------------- |
 | `@dfinity/ckbtc`         | v2.2.1  | Maintained ⚙️       |
 | `@dfinity/cketh`         | v1.0.2  | Maintained ⚙️       |
 | `@dfinity/cmc`           | v3.0.2  | Maintained ⚙️       |
@@ -421,7 +421,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-|--------------------------|---------|---------------------|
+| ------------------------ | ------- | ------------------- |
 | `@dfinity/ckbtc`         | v2.2.0  | Enhanced 🔧         |
 | `@dfinity/cketh`         | v1.0.1  | Maintained ⚙️       |
 | `@dfinity/cmc`           | v3.0.1  | Maintained ⚙️       |
@@ -456,7 +456,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-|--------------------------|---------|---------------------|
+| ------------------------ | ------- | ------------------- |
 | `@dfinity/ckbtc`         | v2.1.1  | Patched 🩹          |
 | `@dfinity/cketh`         | v1.0.0  | Launched 🚀         |
 | `@dfinity/cmc`           | v3.0.0  | Breaking Changes ⚠️ |
@@ -497,7 +497,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status     |
-|--------------------------|---------|------------|
+| ------------------------ | ------- | ---------- |
 | `@dfinity/ckbtc`         | v2.1.0  | Unchanged  |
 | `@dfinity/cketh`         | v0.0.1  | Unchanged  |
 | `@dfinity/cmc`           | v2.1.0  | Unchanged  |
@@ -520,7 +520,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status     |
-|--------------------------|---------|------------|
+| ------------------------ | ------- | ---------- |
 | `@dfinity/ckbtc`         | v2.1.0  | Unchanged  |
 | `@dfinity/cketh`         | v0.0.1  | New 🚀     |
 | `@dfinity/cmc`           | v2.1.0  | Unchanged  |
@@ -545,7 +545,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-|--------------------------|---------|---------------------|
+| ------------------------ | ------- | ------------------- |
 | `@dfinity/ckbtc`         | v2.1.0  | Enhanced 🔧         |
 | `@dfinity/cmc`           | v2.1.0  | Enhanced 🔧         |
 | `@dfinity/ic-management` | v2.1.0  | Enhanced 🔧         |
@@ -590,7 +590,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status      |
-|--------------------------|---------|-------------|
+| ------------------------ | ------- | ----------- |
 | `@dfinity/ckbtc`         | v2.0.0  | Enhanced 🔧 |
 | `@dfinity/cmc`           | v2.0.0  | Enhanced 🔧 |
 | `@dfinity/ic-management` | v2.0.0  | Enhanced 🔧 |
@@ -615,7 +615,7 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status      |
-|--------------------------|---------|-------------|
+| ------------------------ | ------- | ----------- |
 | `@dfinity/ckbtc`         | v1.1.0  | Enhanced 🔧 |
 | `@dfinity/cmc`           | v1.0.0  | Unchanged   |
 | `@dfinity/ic-management` | v1.0.0  | Unchanged   |
@@ -648,11 +648,11 @@ The current status of the libraries at the time of the release is as follows:
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status              |
-|--------------------------|---------|---------------------|
+| ------------------------ | ------- | ------------------- |
 | `@dfinity/ckbtc`         | v1.0.1  | Patched             |
 | `@dfinity/cmc`           | v1.0.0  | Unchanged           |
 | `@dfinity/ic-management` | v1.0.0  | Unchanged           |
-| `@dfinity/ledger`        | v1.0.0  | Deprecated ❌        |
+| `@dfinity/ledger`        | v1.0.0  | Deprecated ❌       |
 | `@dfinity/ledger-icp`    | v1.0.0  | New 🚀              |
 | `@dfinity/ledger-icrc`   | v1.0.0  | New 🚀              |
 | `@dfinity/nns`           | v2.0.0  | Breaking Changes ⚠️ |
@@ -1298,12 +1298,12 @@ De facto, `@dfinity/ledger` becomes a peer dependency of `@dfinity/sns`.
 ### Features
 
 - governance new functions:
-    - `getProposal`
-    - `stakeNeuron`
-    - `registerVote`
-    - `increaseDissolveDelay`
-    - `getNeuron`
-    - `setFollowees`
+  - `getProposal`
+  - `stakeNeuron`
+  - `registerVote`
+  - `increaseDissolveDelay`
+  - `getNeuron`
+  - `setFollowees`
 - ledger `transfer` enhanced with support for subaccount
 - new utils to filter voted neurons and proposals
 - export `common` types

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -130,10 +130,10 @@ Parameters:
 
 - `params`: The parameters to create a new HTTP agent
 - `params.identity`: A mandatory identity to use for the agent
-- `params.host`: An optional host to connect to
+- `params.host`: An optional host to connect to, particularly useful for local development
 - `params.fetchRootKey`: Fetch root key for certificate validation during local development or on testnet
 - `params.verifyQuerySignatures`: Check for signatures in the state tree signed by the node that replies to queries - i.e. certify responses.
-- `params.retryTimes`: Set the number of retries the agent should perform before errorring.
+- `params.retryTimes`: Set the number of retries the agent should perform before error.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L26)
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -128,13 +128,14 @@ Create an agent for a given identity
 
 Parameters:
 
-- `identity`: A mandatory identity to use for the agent
-- `host`: An optional host to connect to
-- `fetchRootKey`: Fetch root key for certificate validation during local development or on testnet
-- `verifyQuerySignatures`: Check for signatures in the state tree signed by the node that replies to queries - i.e. certify responses.
-- `retryTimes`: Set the number of retries the agent should perform before errorring.
+- `params`: The parameters to create a new HTTP agent
+- `params.identity`: A mandatory identity to use for the agent
+- `params.host`: An optional host to connect to
+- `params.fetchRootKey`: Fetch root key for certificate validation during local development or on testnet
+- `params.verifyQuerySignatures`: Check for signatures in the state tree signed by the node that replies to queries - i.e. certify responses.
+- `params.retryTimes`: Set the number of retries the agent should perform before errorring.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L24)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L26)
 
 #### :gear: createServices
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -116,15 +116,15 @@ Get a default agent that connects to mainnet with the anonymous identity.
 | -------------- | ------------- |
 | `defaultAgent` | `() => Agent` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L9)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L10)
 
 #### :gear: createAgent
 
 Create an agent for a given identity
 
-| Function      | Type                                                                                                                                                                                                                                                               |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `createAgent` | `({ identity, host, fetchRootKey, verifyQuerySignatures, retryTimes, }: { identity: Identity; host?: string or undefined; fetchRootKey?: boolean or undefined; verifyQuerySignatures?: boolean or undefined; retryTimes?: number or undefined; }) => Promise<...>` |
+| Function      | Type                                                                                                              |
+| ------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `createAgent` | `({ identity, host, fetchRootKey, verifyQuerySignatures, retryTimes, }: CreateAgentParams) => Promise<HttpAgent>` |
 
 Parameters:
 
@@ -134,7 +134,7 @@ Parameters:
 - `verifyQuerySignatures`: Check for signatures in the state tree signed by the node that replies to queries - i.e. certify responses.
 - `retryTimes`: Set the number of retries the agent should perform before errorring.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L23)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L24)
 
 #### :gear: createServices
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,6 +2,7 @@ export * from "./enums/token.enums";
 export * from "./parser/token";
 export * from "./services/canister";
 export * from "./types/actor-type.utils";
+export type { CreateAgentParams } from "./types/agent.utils";
 export type { CanisterOptions } from "./types/canister.options";
 export type { QueryParams } from "./types/query.params";
 export * from "./utils/actor.utils";

--- a/packages/utils/src/types/agent.utils.ts
+++ b/packages/utils/src/types/agent.utils.ts
@@ -1,10 +1,9 @@
-import type { Identity } from "@dfinity/agent";
+import type { HttpAgentOptions, Identity } from "@dfinity/agent";
 
-export interface CreateAgentParams {
+export type CreateAgentParams = Pick<
+  HttpAgentOptions,
+  "host" | "retryTimes" | "verifyQuerySignatures"
+> & {
   identity: Identity;
-  host?: string;
   fetchRootKey?: boolean;
-  // @deprecated Shipped as an opt-in feature but, will become the default in next major version
-  verifyQuerySignatures?: boolean;
-  retryTimes?: number;
-}
+};

--- a/packages/utils/src/types/agent.utils.ts
+++ b/packages/utils/src/types/agent.utils.ts
@@ -1,0 +1,10 @@
+import type { Identity } from "@dfinity/agent";
+
+export interface CreateAgentParams {
+  identity: Identity;
+  host?: string;
+  fetchRootKey?: boolean;
+  // @deprecated Shipped as an opt-in feature but, will become the default in next major version
+  verifyQuerySignatures?: boolean;
+  retryTimes?: number;
+}

--- a/packages/utils/src/utils/agent.utils.ts
+++ b/packages/utils/src/utils/agent.utils.ts
@@ -15,11 +15,13 @@ export const defaultAgent = (): Agent =>
 
 /**
  * Create an agent for a given identity
- * @param identity A mandatory identity to use for the agent
- * @param host An optional host to connect to
- * @param fetchRootKey Fetch root key for certificate validation during local development or on testnet
- * @param verifyQuerySignatures Check for signatures in the state tree signed by the node that replies to queries - i.e. certify responses.
- * @param retryTimes Set the number of retries the agent should perform before errorring.
+ *
+ * @param {CreateAgentParams} params The parameters to create a new HTTP agent
+ * @param {Identity} params.identity A mandatory identity to use for the agent
+ * @param {string} params.host An optional host to connect to
+ * @param {boolean} params.fetchRootKey Fetch root key for certificate validation during local development or on testnet
+ * @param {boolean} params.verifyQuerySignatures Check for signatures in the state tree signed by the node that replies to queries - i.e. certify responses.
+ * @param {number} params.retryTimes Set the number of retries the agent should perform before errorring.
  */
 export const createAgent = async ({
   identity,

--- a/packages/utils/src/utils/agent.utils.ts
+++ b/packages/utils/src/utils/agent.utils.ts
@@ -18,10 +18,10 @@ export const defaultAgent = (): Agent =>
  *
  * @param {CreateAgentParams} params The parameters to create a new HTTP agent
  * @param {Identity} params.identity A mandatory identity to use for the agent
- * @param {string} params.host An optional host to connect to
+ * @param {string} params.host An optional host to connect to, particularly useful for local development
  * @param {boolean} params.fetchRootKey Fetch root key for certificate validation during local development or on testnet
  * @param {boolean} params.verifyQuerySignatures Check for signatures in the state tree signed by the node that replies to queries - i.e. certify responses.
- * @param {number} params.retryTimes Set the number of retries the agent should perform before errorring.
+ * @param {number} params.retryTimes Set the number of retries the agent should perform before error.
  */
 export const createAgent = async ({
   identity,

--- a/packages/utils/src/utils/agent.utils.ts
+++ b/packages/utils/src/utils/agent.utils.ts
@@ -1,5 +1,6 @@
-import type { Agent, Identity } from "@dfinity/agent";
+import type { Agent } from "@dfinity/agent";
 import { AnonymousIdentity, HttpAgent } from "@dfinity/agent";
+import type { CreateAgentParams } from "../types/agent.utils";
 import { nonNullish } from "./nullish.utils";
 
 /**
@@ -26,14 +27,7 @@ export const createAgent = async ({
   fetchRootKey = false,
   verifyQuerySignatures = false,
   retryTimes,
-}: {
-  identity: Identity;
-  host?: string;
-  fetchRootKey?: boolean;
-  // @deprecated Shipped as an opt-in feature but, will become the default in next major version
-  verifyQuerySignatures?: boolean;
-  retryTimes?: number;
-}): Promise<HttpAgent> => {
+}: CreateAgentParams): Promise<HttpAgent> => {
   return await HttpAgent.create({
     identity,
     ...(nonNullish(host) && { host }),


### PR DESCRIPTION
# Motivation

This small refactoring provides a new interface to the user: the one used by the `createAgent` function.