### PR TITLE
Update ledger candid path

### DIFF
--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -100,13 +100,13 @@ mkdir -p packages/cmc/candid
 import_did "rs/nns/cmc/cmc.did" "cmc.did" "cmc"
 
 mkdir -p packages/ledger-icp/candid
-import_did "rs/rosetta-api/icp_ledger/ledger.did" "ledger.did" "ledger-icp"
-import_did "rs/rosetta-api/icp_ledger/index/index.did" "index.did" "ledger-icp"
+import_did "rs/ledger_suite/icp/ledger.did" "ledger.did" "ledger-icp"
+import_did "rs/ledger_suite/icp/index/index.did" "index.did" "ledger-icp"
 
 mkdir -p packages/ledger-icrc/candid
-import_did "rs/rosetta-api/icrc1/ledger/ledger.did" "icrc_ledger.did" "ledger-icrc"
-import_did "rs/rosetta-api/icrc1/index/index.did" "icrc_index.did" "ledger-icrc"
-import_did "rs/rosetta-api/icrc1/index-ng/index-ng.did" "icrc_index-ng.did" "ledger-icrc"
+import_did "rs/ledger_suite/icrc1/ledger/ledger.did" "icrc_ledger.did" "ledger-icrc"
+import_did "rs/ledger_suite/icrc1/index/index.did" "icrc_index.did" "ledger-icrc"
+import_did "rs/ledger_suite/icrc1/index-ng/index-ng.did" "icrc_index-ng.did" "ledger-icrc"
 
 mkdir -p packages/ckbtc/candid
 import_did "rs/bitcoin/ckbtc/minter/ckbtc_minter.did" "minter.did" "ckbtc"


### PR DESCRIPTION
# Motivation

The "Update IC" workflow [failed](https://github.com/dfinity/ic-js/actions/runs/11432725940/job/31803642725) because ledger and Index Candid files were moved to a different directory in https://github.com/dfinity/ic/pull/1682

# Changes

Updated `scripts/import-candid` to copy the ledger candid files from the new path.

# Tests

Manually ran `./scripts/import-candid ../../ic` to see that it works again.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary