### PR TITLE
ci: Bump checkout action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install didc
         run: |
           mkdir -p .bin
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check the protoc installer
         run: ./scripts/install-protoc --help
       - name: Install protoc
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: npm ci
       - name: Build
@@ -120,7 +120,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: npm ci
       - name: Lint
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: npm ci
       - name: Build
@@ -146,7 +146,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Size check
         uses: andresz1/size-limit-action@v1
         with:

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build next version
         run: ./scripts/build-next
       - name: Set up npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ic-js
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Choose IC ref
         id: choose_ic_ref
         run: |
@@ -32,7 +32,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Checkout ic repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: dfinity/ic
           ref: ${{ steps.choose_ic_ref.outputs.ic_ref }}


### PR DESCRIPTION
# Motivation

During CI checks, we receive [a few warnings](https://github.com/dfinity/ic-js/actions/runs/11493801539) about an old version of `actions/checkout`, so we bump all the current instances to version `actions/checkout@v4`.

![Screenshot 2024-10-24 at 08 28 23](https://github.com/user-attachments/assets/55458497-bdf5-4b54-ae8a-c5ca5914289f)

