### PR TITLE
Update IC commit with voting_power_refreshed_timestamp_seconds

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Size check
-        # The limits are defined in packages.json.
+        # The limits are defined in package.json.
         uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -148,6 +148,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Size check
+        # The limits are defined in packages.json.
         uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Features
 
 - Added `memoToNeuronSubaccount` and `memoToNeuronAccountIdentifier`.
+- Support new neuron field `voting_power_refreshed_timestamp_seconds`.
 
 # 2024.10.29-1130Z
 

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     {
       "name": "@dfinity/sns",
       "path": "./packages/sns/dist/index.js",
-      "limit": "17 kB",
+      "limit": "18 kB",
       "gzip": true,
       "ignore": [
         "@dfinity/agent",

--- a/packages/ckbtc/candid/minter.did
+++ b/packages/ckbtc/candid/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
 // Represents an account on the ckBTC ledger.
 type Account = record { owner : principal; subaccount : opt blob };
 

--- a/packages/cketh/candid/minter.certified.idl.js
+++ b/packages/cketh/candid/minter.certified.idl.js
@@ -83,6 +83,7 @@ export const idlFactory = ({ IDL }) => {
     'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'reserved_cycles' : IDL.Nat,
   });
+  const Subaccount = IDL.Vec(IDL.Nat8);
   const EventSource = IDL.Record({
     'transaction_hash' : IDL.Text,
     'log_index' : IDL.Nat,
@@ -131,6 +132,7 @@ export const idlFactory = ({ IDL }) => {
         'transaction_hash' : IDL.Text,
         'value' : IDL.Nat,
         'log_index' : IDL.Nat,
+        'subaccount' : IDL.Opt(Subaccount),
         'block_number' : IDL.Nat,
         'erc20_contract_address' : IDL.Text,
         'from_address' : IDL.Text,
@@ -154,6 +156,7 @@ export const idlFactory = ({ IDL }) => {
         'transaction_hash' : IDL.Text,
         'value' : IDL.Nat,
         'log_index' : IDL.Nat,
+        'subaccount' : IDL.Opt(Subaccount),
         'block_number' : IDL.Nat,
         'from_address' : IDL.Text,
       }),

--- a/packages/cketh/candid/minter.d.ts
+++ b/packages/cketh/candid/minter.d.ts
@@ -70,6 +70,7 @@ export interface Event {
           transaction_hash: string;
           value: bigint;
           log_index: bigint;
+          subaccount: [] | [Subaccount];
           block_number: bigint;
           erc20_contract_address: string;
           from_address: string;
@@ -99,6 +100,7 @@ export interface Event {
           transaction_hash: string;
           value: bigint;
           log_index: bigint;
+          subaccount: [] | [Subaccount];
           block_number: bigint;
           from_address: string;
         };
@@ -283,6 +285,7 @@ export type RetrieveEthStatus =
   | { TxSent: EthTransaction }
   | { TxCreated: null }
   | { Pending: null };
+export type Subaccount = Uint8Array | number[];
 export interface TransactionReceipt {
   effective_gas_price: bigint;
   status: { Success: null } | { Failure: null };

--- a/packages/cketh/candid/minter.did
+++ b/packages/cketh/candid/minter.did
@@ -1,10 +1,12 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
 type EthereumNetwork = variant {
     // The public Ethereum mainnet.
     Mainnet;
     // The public Ethereum Sepolia testnet.
     Sepolia;
 };
+
+type Subaccount = blob;
 
 type CanisterStatusResponse = record {
   query_stats : QueryStats;
@@ -432,6 +434,7 @@ type Event = record {
             from_address : text;
             value : nat;
             "principal" : principal;
+            subaccount : opt Subaccount;
         };
         InvalidDeposit : record {
             event_source : EventSource;
@@ -503,6 +506,7 @@ type Event = record {
             value : nat;
             "principal" : principal;
             erc20_contract_address : text;
+            subaccount : opt Subaccount;
         };
         AcceptedErc20WithdrawalRequest : record {
             max_transaction_fee : nat;

--- a/packages/cketh/candid/minter.idl.js
+++ b/packages/cketh/candid/minter.idl.js
@@ -83,6 +83,7 @@ export const idlFactory = ({ IDL }) => {
     'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'reserved_cycles' : IDL.Nat,
   });
+  const Subaccount = IDL.Vec(IDL.Nat8);
   const EventSource = IDL.Record({
     'transaction_hash' : IDL.Text,
     'log_index' : IDL.Nat,
@@ -131,6 +132,7 @@ export const idlFactory = ({ IDL }) => {
         'transaction_hash' : IDL.Text,
         'value' : IDL.Nat,
         'log_index' : IDL.Nat,
+        'subaccount' : IDL.Opt(Subaccount),
         'block_number' : IDL.Nat,
         'erc20_contract_address' : IDL.Text,
         'from_address' : IDL.Text,
@@ -154,6 +156,7 @@ export const idlFactory = ({ IDL }) => {
         'transaction_hash' : IDL.Text,
         'value' : IDL.Nat,
         'log_index' : IDL.Nat,
+        'subaccount' : IDL.Opt(Subaccount),
         'block_number' : IDL.Nat,
         'from_address' : IDL.Text,
       }),

--- a/packages/cketh/candid/orchestrator.did
+++ b/packages/cketh/candid/orchestrator.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did' by import-candid
 type OrchestratorArg = variant {
     UpgradeArg : UpgradeArg;
     InitArg : InitArg;

--- a/packages/cmc/candid/cmc.did
+++ b/packages/cmc/candid/cmc.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/nns/cmc/cmc.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/nns/cmc/cmc.did' by import-candid
 type Cycles = nat;
 type BlockIndex = nat64;
 type log_visibility = variant {

--- a/packages/ic-management/candid/ic-management.certified.idl.js
+++ b/packages/ic-management/candid/ic-management.certified.idl.js
@@ -109,6 +109,7 @@ export const idlFactory = ({ IDL }) => {
   const log_visibility = IDL.Variant({
     'controllers' : IDL.Null,
     'public' : IDL.Null,
+    'allowed_viewers' : IDL.Vec(IDL.Principal),
   });
   const definite_canister_settings = IDL.Record({
     'freezing_threshold' : IDL.Nat,

--- a/packages/ic-management/candid/ic-management.d.ts
+++ b/packages/ic-management/candid/ic-management.d.ts
@@ -228,7 +228,10 @@ export interface load_canister_snapshot_args {
   sender_canister_version: [] | [bigint];
   snapshot_id: snapshot_id;
 }
-export type log_visibility = { controllers: null } | { public: null };
+export type log_visibility =
+  | { controllers: null }
+  | { public: null }
+  | { allowed_viewers: Array<Principal> };
 export type millisatoshi_per_byte = bigint;
 export interface node_metrics {
   num_block_failures_total: bigint;

--- a/packages/ic-management/candid/ic-management.did
+++ b/packages/ic-management/candid/ic-management.did
@@ -1,4 +1,4 @@
-// Generated from dfinity/interface-spec commit ac416ec82cd9fae4825824fea639f7ae32aec594 for file 'spec/_attachments/ic.did'
+// Generated from dfinity/interface-spec commit 9a5077e7f90f06a5c45e83bcdbec73a6e5427537 for file 'spec/_attachments/ic.did'
 type canister_id = principal;
 type wasm_module = blob;
 type snapshot_id = blob;
@@ -6,6 +6,7 @@ type snapshot_id = blob;
 type log_visibility = variant {
     controllers;
     public;
+    allowed_viewers : vec principal;
 };
 
 type canister_settings = record {

--- a/packages/ic-management/candid/ic-management.idl.js
+++ b/packages/ic-management/candid/ic-management.idl.js
@@ -109,6 +109,7 @@ export const idlFactory = ({ IDL }) => {
   const log_visibility = IDL.Variant({
     'controllers' : IDL.Null,
     'public' : IDL.Null,
+    'allowed_viewers' : IDL.Vec(IDL.Principal),
   });
   const definite_canister_settings = IDL.Record({
     'freezing_threshold' : IDL.Nat,

--- a/packages/ledger-icp/candid/index.did
+++ b/packages/ledger-icp/candid/index.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/ledger_suite/icp/index/index.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/ledger_suite/icp/index/index.did' by import-candid
 type Account = record { owner : principal; subaccount : opt vec nat8 };
 type GetAccountIdentifierTransactionsArgs = record {
   max_results : nat64;

--- a/packages/ledger-icp/candid/ledger.did
+++ b/packages/ledger-icp/candid/ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/ledger_suite/icp/ledger.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/ledger_suite/icp/ledger.did' by import-candid
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.

--- a/packages/ledger-icrc/candid/icrc_index-ng.did
+++ b/packages/ledger-icrc/candid/icrc_index-ng.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/ledger_suite/icrc1/index-ng/index-ng.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/ledger_suite/icrc1/index-ng/index-ng.did' by import-candid
 type Tokens = nat;
 
 type InitArg = record {

--- a/packages/ledger-icrc/candid/icrc_index.did
+++ b/packages/ledger-icrc/candid/icrc_index.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/ledger_suite/icrc1/index/index.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/ledger_suite/icrc1/index/index.did' by import-candid
 type TxId = nat;
 
 type Account = record { owner : principal; subaccount : opt blob };

--- a/packages/ledger-icrc/candid/icrc_ledger.did
+++ b/packages/ledger-icrc/candid/icrc_ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/ledger_suite/icrc1/ledger/ledger.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/ledger_suite/icrc1/ledger/ledger.did' by import-candid
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.

--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/nns/gtc/canister/gtc.did' by import-candid
 type AccountState = record {
   authenticated_principal_id : opt principal;
   successfully_transferred_neurons : vec TransferredNeuron;

--- a/packages/nns/candid/governance.certified.idl.js
+++ b/packages/nns/candid/governance.certified.idl.js
@@ -599,6 +599,7 @@ export const idlFactory = ({ IDL }) => {
     'staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'controller' : IDL.Opt(IDL.Principal),
     'recent_ballots' : IDL.Vec(BallotInfo),
+    'voting_power_refreshed_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'kyc_verified' : IDL.Bool,
     'neuron_type' : IDL.Opt(IDL.Int32),
     'not_for_profit' : IDL.Bool,
@@ -666,6 +667,7 @@ export const idlFactory = ({ IDL }) => {
   const NeuronInfo = IDL.Record({
     'dissolve_delay_seconds' : IDL.Nat64,
     'recent_ballots' : IDL.Vec(BallotInfo),
+    'voting_power_refreshed_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'neuron_type' : IDL.Opt(IDL.Int32),
     'created_timestamp_seconds' : IDL.Nat64,
     'state' : IDL.Int32,
@@ -1564,6 +1566,7 @@ export const init = ({ IDL }) => {
     'staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'controller' : IDL.Opt(IDL.Principal),
     'recent_ballots' : IDL.Vec(BallotInfo),
+    'voting_power_refreshed_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'kyc_verified' : IDL.Bool,
     'neuron_type' : IDL.Opt(IDL.Int32),
     'not_for_profit' : IDL.Bool,

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -471,6 +471,7 @@ export interface Neuron {
   staked_maturity_e8s_equivalent: [] | [bigint];
   controller: [] | [Principal];
   recent_ballots: Array<BallotInfo>;
+  voting_power_refreshed_timestamp_seconds: [] | [bigint];
   kyc_verified: boolean;
   neuron_type: [] | [number];
   not_for_profit: boolean;
@@ -518,6 +519,7 @@ export interface NeuronInFlightCommand {
 export interface NeuronInfo {
   dissolve_delay_seconds: bigint;
   recent_ballots: Array<BallotInfo>;
+  voting_power_refreshed_timestamp_seconds: [] | [bigint];
   neuron_type: [] | [number];
   created_timestamp_seconds: bigint;
   state: number;

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -578,6 +578,7 @@ type Neuron = record {
   transfer : opt NeuronStakeTransfer;
   known_neuron_data : opt KnownNeuronData;
   spawn_at_timestamp_seconds : opt nat64;
+  voting_power_refreshed_timestamp_seconds : opt nat64;
 };
 
 type NeuronBasketConstructionParameters = record {
@@ -629,6 +630,7 @@ type NeuronInfo = record {
   known_neuron_data : opt KnownNeuronData;
   voting_power : nat64;
   age_seconds : nat64;
+  voting_power_refreshed_timestamp_seconds : opt nat64;
 };
 
 type NeuronStakeTransfer = record {

--- a/packages/nns/candid/governance.idl.js
+++ b/packages/nns/candid/governance.idl.js
@@ -599,6 +599,7 @@ export const idlFactory = ({ IDL }) => {
     'staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'controller' : IDL.Opt(IDL.Principal),
     'recent_ballots' : IDL.Vec(BallotInfo),
+    'voting_power_refreshed_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'kyc_verified' : IDL.Bool,
     'neuron_type' : IDL.Opt(IDL.Int32),
     'not_for_profit' : IDL.Bool,
@@ -666,6 +667,7 @@ export const idlFactory = ({ IDL }) => {
   const NeuronInfo = IDL.Record({
     'dissolve_delay_seconds' : IDL.Nat64,
     'recent_ballots' : IDL.Vec(BallotInfo),
+    'voting_power_refreshed_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'neuron_type' : IDL.Opt(IDL.Int32),
     'created_timestamp_seconds' : IDL.Nat64,
     'state' : IDL.Int32,
@@ -1580,6 +1582,7 @@ export const init = ({ IDL }) => {
     'staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'controller' : IDL.Opt(IDL.Principal),
     'recent_ballots' : IDL.Vec(BallotInfo),
+    'voting_power_refreshed_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'kyc_verified' : IDL.Bool,
     'neuron_type' : IDL.Opt(IDL.Int32),
     'not_for_profit' : IDL.Bool,

--- a/packages/nns/candid/governance_test.certified.idl.js
+++ b/packages/nns/candid/governance_test.certified.idl.js
@@ -599,6 +599,7 @@ export const idlFactory = ({ IDL }) => {
     'staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'controller' : IDL.Opt(IDL.Principal),
     'recent_ballots' : IDL.Vec(BallotInfo),
+    'voting_power_refreshed_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'kyc_verified' : IDL.Bool,
     'neuron_type' : IDL.Opt(IDL.Int32),
     'not_for_profit' : IDL.Bool,
@@ -666,6 +667,7 @@ export const idlFactory = ({ IDL }) => {
   const NeuronInfo = IDL.Record({
     'dissolve_delay_seconds' : IDL.Nat64,
     'recent_ballots' : IDL.Vec(BallotInfo),
+    'voting_power_refreshed_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'neuron_type' : IDL.Opt(IDL.Int32),
     'created_timestamp_seconds' : IDL.Nat64,
     'state' : IDL.Int32,
@@ -1565,6 +1567,7 @@ export const init = ({ IDL }) => {
     'staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'controller' : IDL.Opt(IDL.Principal),
     'recent_ballots' : IDL.Vec(BallotInfo),
+    'voting_power_refreshed_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'kyc_verified' : IDL.Bool,
     'neuron_type' : IDL.Opt(IDL.Int32),
     'not_for_profit' : IDL.Bool,

--- a/packages/nns/candid/governance_test.d.ts
+++ b/packages/nns/candid/governance_test.d.ts
@@ -471,6 +471,7 @@ export interface Neuron {
   staked_maturity_e8s_equivalent: [] | [bigint];
   controller: [] | [Principal];
   recent_ballots: Array<BallotInfo>;
+  voting_power_refreshed_timestamp_seconds: [] | [bigint];
   kyc_verified: boolean;
   neuron_type: [] | [number];
   not_for_profit: boolean;
@@ -518,6 +519,7 @@ export interface NeuronInFlightCommand {
 export interface NeuronInfo {
   dissolve_delay_seconds: bigint;
   recent_ballots: Array<BallotInfo>;
+  voting_power_refreshed_timestamp_seconds: [] | [bigint];
   neuron_type: [] | [number];
   created_timestamp_seconds: bigint;
   state: number;

--- a/packages/nns/candid/governance_test.did
+++ b/packages/nns/candid/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/nns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/nns/governance/canister/governance_test.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -580,6 +580,7 @@ type Neuron = record {
   transfer : opt NeuronStakeTransfer;
   known_neuron_data : opt KnownNeuronData;
   spawn_at_timestamp_seconds : opt nat64;
+  voting_power_refreshed_timestamp_seconds : opt nat64;
 };
 
 type NeuronBasketConstructionParameters = record {
@@ -631,6 +632,7 @@ type NeuronInfo = record {
   known_neuron_data : opt KnownNeuronData;
   voting_power : nat64;
   age_seconds : nat64;
+  voting_power_refreshed_timestamp_seconds : opt nat64;
 };
 
 type NeuronStakeTransfer = record {

--- a/packages/nns/candid/governance_test.idl.js
+++ b/packages/nns/candid/governance_test.idl.js
@@ -599,6 +599,7 @@ export const idlFactory = ({ IDL }) => {
     'staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'controller' : IDL.Opt(IDL.Principal),
     'recent_ballots' : IDL.Vec(BallotInfo),
+    'voting_power_refreshed_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'kyc_verified' : IDL.Bool,
     'neuron_type' : IDL.Opt(IDL.Int32),
     'not_for_profit' : IDL.Bool,
@@ -666,6 +667,7 @@ export const idlFactory = ({ IDL }) => {
   const NeuronInfo = IDL.Record({
     'dissolve_delay_seconds' : IDL.Nat64,
     'recent_ballots' : IDL.Vec(BallotInfo),
+    'voting_power_refreshed_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'neuron_type' : IDL.Opt(IDL.Int32),
     'created_timestamp_seconds' : IDL.Nat64,
     'state' : IDL.Int32,
@@ -1581,6 +1583,7 @@ export const init = ({ IDL }) => {
     'staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
     'controller' : IDL.Opt(IDL.Principal),
     'recent_ballots' : IDL.Vec(BallotInfo),
+    'voting_power_refreshed_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'kyc_verified' : IDL.Bool,
     'neuron_type' : IDL.Opt(IDL.Int32),
     'not_for_profit' : IDL.Bool,

--- a/packages/nns/candid/sns_wasm.did
+++ b/packages/nns/candid/sns_wasm.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/packages/nns/src/canisters/governance/response.converters.spec.ts
+++ b/packages/nns/src/canisters/governance/response.converters.spec.ts
@@ -1,0 +1,118 @@
+import { Principal } from "@dfinity/principal";
+import type { Neuron as RawNeuron } from "../../../candid/governance";
+import { MAINNET_GOVERNANCE_CANISTER_ID } from "../../constants/canister_ids";
+import type { Neuron } from "../../types/governance_converters";
+import { toNeuron, toRawNeuron } from "./response.converters";
+
+describe("response.converters", () => {
+  const neuronId = 123n;
+  const neuronStake = 100_000_000n;
+  const controlledIdText = "souto-grxij-jbijj-tmr3q";
+  const createdTimestampSeconds = 1_234_567_000n;
+  const dissolveDelaySeconds = 8_640_000n;
+
+  const defaultCandidNeuron: RawNeuron = {
+    id: [{ id: neuronId }],
+    staked_maturity_e8s_equivalent: [0n],
+    controller: [Principal.fromText(controlledIdText)],
+    recent_ballots: [],
+    kyc_verified: false,
+    neuron_type: [],
+    not_for_profit: false,
+    cached_neuron_stake_e8s: neuronStake,
+    created_timestamp_seconds: createdTimestampSeconds,
+    auto_stake_maturity: [false],
+    maturity_e8s_equivalent: 0n,
+    aging_since_timestamp_seconds: createdTimestampSeconds,
+    neuron_fees_e8s: 0n,
+    hot_keys: [],
+    account: new Uint8Array(),
+    joined_community_fund_timestamp_seconds: [],
+    dissolve_state: [{ DissolveDelaySeconds: dissolveDelaySeconds }],
+    spawn_at_timestamp_seconds: [],
+    followees: [],
+    visibility: [],
+    transfer: [],
+    known_neuron_data: [],
+    voting_power_refreshed_timestamp_seconds: [],
+  };
+
+  const defaultNeuron: Neuron = {
+    id: neuronId,
+    stakedMaturityE8sEquivalent: 0n,
+    controller: controlledIdText,
+    recentBallots: [],
+    neuronType: undefined,
+    kycVerified: false,
+    notForProfit: false,
+    cachedNeuronStake: neuronStake,
+    createdTimestampSeconds,
+    autoStakeMaturity: false,
+    maturityE8sEquivalent: 0n,
+    agingSinceTimestampSeconds: createdTimestampSeconds,
+    neuronFees: 0n,
+    hotKeys: [],
+    accountIdentifier:
+      "5608e9e28e45cb752c31464abe8edfca5fca00971942a882989613c20848da6f",
+    joinedCommunityFundTimestampSeconds: undefined,
+    dissolveState: { DissolveDelaySeconds: dissolveDelaySeconds },
+    spawnAtTimesSeconds: undefined,
+    followees: [],
+    visibility: undefined,
+    votingPowerRefreshedTimestampSeconds: undefined,
+  };
+
+  describe("toNeuron", () => {
+    it("should convert a default candid Neuron to ic-js Neuron", () => {
+      expect(
+        toNeuron({
+          neuron: defaultCandidNeuron,
+          canisterId: MAINNET_GOVERNANCE_CANISTER_ID,
+        }),
+      ).toEqual(defaultNeuron);
+    });
+
+    it("should convert a voting power refreshed timestamp", () => {
+      const timestamp = 1_333_444_999n;
+      expect(
+        toNeuron({
+          neuron: {
+            ...defaultCandidNeuron,
+            voting_power_refreshed_timestamp_seconds: [timestamp],
+          },
+          canisterId: MAINNET_GOVERNANCE_CANISTER_ID,
+        }),
+      ).toEqual({
+        ...defaultNeuron,
+        votingPowerRefreshedTimestampSeconds: timestamp,
+      });
+    });
+  });
+
+  describe("toRawNeuron", () => {
+    it("should convert a default ic-js Neuron to candid Neuron", () => {
+      expect(
+        toRawNeuron({
+          neuron: defaultNeuron,
+          account: new Uint8Array(),
+        }),
+      ).toEqual(defaultCandidNeuron);
+    });
+
+    it("should convert a voting power refreshed timestamp", () => {
+      const timestamp = 1_333_444_998n;
+      expect(
+        toRawNeuron({
+          neuron: {
+            ...defaultNeuron,
+            votingPowerRefreshedTimestampSeconds: timestamp,
+          },
+          account: new Uint8Array(),
+        }),
+      ).toEqual({
+        ...defaultCandidNeuron,
+        voting_power_refreshed_timestamp_seconds: [timestamp],
+      });
+    });
+  });
+});

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -190,6 +190,9 @@ export const toNeuron = ({
     toFollowees({ topic, followees }),
   ),
   visibility: fromNullable(neuron.visibility) as NeuronVisibility | undefined,
+  votingPowerRefreshedTimestampSeconds: fromNullable(
+    neuron.voting_power_refreshed_timestamp_seconds,
+  ),
 });
 
 export const toRawNeuron = ({
@@ -241,6 +244,9 @@ export const toRawNeuron = ({
   transfer: [],
   // Not kept when converted to Neuron.
   known_neuron_data: [],
+  voting_power_refreshed_timestamp_seconds: toNullable(
+    neuron.votingPowerRefreshedTimestampSeconds,
+  ),
 });
 
 const toBallotInfo = ({ vote, proposal_id }: RawBallotInfo): BallotInfo => ({

--- a/packages/nns/src/mocks/governance.mock.ts
+++ b/packages/nns/src/mocks/governance.mock.ts
@@ -20,6 +20,7 @@ export const mockNeuronInfo: NeuronInfo = {
   voting_power: one,
   age_seconds: one,
   visibility: [1],
+  voting_power_refreshed_timestamp_seconds: [],
 };
 export const mockNeuron: Neuron = {
   id: [{ id: mockNeuronId }],
@@ -44,6 +45,7 @@ export const mockNeuron: Neuron = {
   known_neuron_data: [],
   spawn_at_timestamp_seconds: [],
   visibility: [1],
+  voting_power_refreshed_timestamp_seconds: [],
 };
 export const mockListNeuronsResponse: ListNeuronsResponse = {
   neuron_infos: [[mockNeuronId, mockNeuronInfo]],

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -367,6 +367,7 @@ export interface Neuron {
   dissolveState: Option<DissolveState>;
   followees: Array<Followees>;
   visibility: Option<NeuronVisibility>;
+  votingPowerRefreshedTimestampSeconds: Option<bigint>;
 }
 export type NeuronIdOrSubaccount =
   | { Subaccount: Array<number> }

--- a/packages/sns/candid/sns_governance.certified.idl.js
+++ b/packages/sns/candid/sns_governance.certified.idl.js
@@ -3,6 +3,7 @@ export const idlFactory = ({ IDL }) => {
   const Timers = IDL.Record({
     'last_spawned_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'last_reset_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'requires_periodic_tasks' : IDL.Opt(IDL.Bool),
   });
   const Version = IDL.Record({
     'archive_wasm_hash' : IDL.Vec(IDL.Nat8),
@@ -63,6 +64,50 @@ export const idlFactory = ({ IDL }) => {
     'current_basis_points' : IDL.Opt(IDL.Int32),
     'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const TargetVersionSet = IDL.Record({
+    'old_target_version' : IDL.Opt(Version),
+    'new_target_version' : IDL.Opt(Version),
+  });
+  const UpgradeOutcome = IDL.Record({
+    'status' : IDL.Opt(
+      IDL.Variant({
+        'Success' : IDL.Record({}),
+        'Timeout' : IDL.Record({}),
+        'ExternalFailure' : IDL.Record({}),
+        'InvalidState' : IDL.Record({ 'version' : IDL.Opt(Version) }),
+      })
+    ),
+    'human_readable' : IDL.Opt(IDL.Text),
+  });
+  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
+  const UpgradeStarted = IDL.Record({
+    'current_version' : IDL.Opt(Version),
+    'expected_version' : IDL.Opt(Version),
+    'reason' : IDL.Opt(
+      IDL.Variant({
+        'UpgradeSnsToNextVersionProposal' : ProposalId,
+        'BehindTargetVersion' : IDL.Record({}),
+      })
+    ),
+  });
+  const UpgradeStepsRefreshed = IDL.Record({
+    'upgrade_steps' : IDL.Opt(Versions),
+  });
+  const UpgradeJournalEntry = IDL.Record({
+    'event' : IDL.Opt(
+      IDL.Variant({
+        'TargetVersionSet' : TargetVersionSet,
+        'UpgradeOutcome' : UpgradeOutcome,
+        'UpgradeStarted' : UpgradeStarted,
+        'UpgradeStepsRefreshed' : UpgradeStepsRefreshed,
+        'TargetVersionReset' : TargetVersionSet,
+      })
+    ),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const UpgradeJournal = IDL.Record({
+    'entries' : IDL.Vec(UpgradeJournalEntry),
+  });
   const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
   const DefaultFollowees = IDL.Record({
@@ -99,7 +144,6 @@ export const idlFactory = ({ IDL }) => {
     'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
     'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
   });
-  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
   const RewardEvent = IDL.Record({
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
@@ -374,6 +418,7 @@ export const idlFactory = ({ IDL }) => {
     ),
     'metrics' : IDL.Opt(GovernanceCachedMetrics),
     'maturity_modulation' : IDL.Opt(MaturityModulation),
+    'upgrade_journal' : IDL.Opt(UpgradeJournal),
     'mode' : IDL.Int32,
     'parameters' : IDL.Opt(NervousSystemParameters),
     'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),
@@ -478,6 +523,7 @@ export const idlFactory = ({ IDL }) => {
   const GetTimersResponse = IDL.Record({ 'timers' : IDL.Opt(Timers) });
   const GetUpgradeJournalRequest = IDL.Record({});
   const GetUpgradeJournalResponse = IDL.Record({
+    'upgrade_journal' : IDL.Opt(UpgradeJournal),
     'upgrade_steps' : IDL.Opt(Versions),
     'response_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'target_version' : IDL.Opt(Version),
@@ -622,6 +668,7 @@ export const init = ({ IDL }) => {
   const Timers = IDL.Record({
     'last_spawned_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'last_reset_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'requires_periodic_tasks' : IDL.Opt(IDL.Bool),
   });
   const Version = IDL.Record({
     'archive_wasm_hash' : IDL.Vec(IDL.Nat8),
@@ -682,6 +729,50 @@ export const init = ({ IDL }) => {
     'current_basis_points' : IDL.Opt(IDL.Int32),
     'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const TargetVersionSet = IDL.Record({
+    'old_target_version' : IDL.Opt(Version),
+    'new_target_version' : IDL.Opt(Version),
+  });
+  const UpgradeOutcome = IDL.Record({
+    'status' : IDL.Opt(
+      IDL.Variant({
+        'Success' : IDL.Record({}),
+        'Timeout' : IDL.Record({}),
+        'ExternalFailure' : IDL.Record({}),
+        'InvalidState' : IDL.Record({ 'version' : IDL.Opt(Version) }),
+      })
+    ),
+    'human_readable' : IDL.Opt(IDL.Text),
+  });
+  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
+  const UpgradeStarted = IDL.Record({
+    'current_version' : IDL.Opt(Version),
+    'expected_version' : IDL.Opt(Version),
+    'reason' : IDL.Opt(
+      IDL.Variant({
+        'UpgradeSnsToNextVersionProposal' : ProposalId,
+        'BehindTargetVersion' : IDL.Record({}),
+      })
+    ),
+  });
+  const UpgradeStepsRefreshed = IDL.Record({
+    'upgrade_steps' : IDL.Opt(Versions),
+  });
+  const UpgradeJournalEntry = IDL.Record({
+    'event' : IDL.Opt(
+      IDL.Variant({
+        'TargetVersionSet' : TargetVersionSet,
+        'UpgradeOutcome' : UpgradeOutcome,
+        'UpgradeStarted' : UpgradeStarted,
+        'UpgradeStepsRefreshed' : UpgradeStepsRefreshed,
+        'TargetVersionReset' : TargetVersionSet,
+      })
+    ),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const UpgradeJournal = IDL.Record({
+    'entries' : IDL.Vec(UpgradeJournalEntry),
+  });
   const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
   const DefaultFollowees = IDL.Record({
@@ -718,7 +809,6 @@ export const init = ({ IDL }) => {
     'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
     'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
   });
-  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
   const RewardEvent = IDL.Record({
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
@@ -993,6 +1083,7 @@ export const init = ({ IDL }) => {
     ),
     'metrics' : IDL.Opt(GovernanceCachedMetrics),
     'maturity_modulation' : IDL.Opt(MaturityModulation),
+    'upgrade_journal' : IDL.Opt(UpgradeJournal),
     'mode' : IDL.Int32,
     'parameters' : IDL.Opt(NervousSystemParameters),
     'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -227,6 +227,7 @@ export interface GetTimersResponse {
 }
 export type GetUpgradeJournalRequest = {};
 export interface GetUpgradeJournalResponse {
+  upgrade_journal: [] | [UpgradeJournal];
   upgrade_steps: [] | [Versions];
   response_timestamp_seconds: [] | [bigint];
   target_version: [] | [Version];
@@ -238,6 +239,7 @@ export interface Governance {
   id_to_nervous_system_functions: Array<[bigint, NervousSystemFunction]>;
   metrics: [] | [GovernanceCachedMetrics];
   maturity_modulation: [] | [MaturityModulation];
+  upgrade_journal: [] | [UpgradeJournal];
   mode: number;
   parameters: [] | [NervousSystemParameters];
   is_finalizing_disburse_maturity: [] | [boolean];
@@ -546,9 +548,14 @@ export interface Tally {
   total: bigint;
   timestamp_seconds: bigint;
 }
+export interface TargetVersionSet {
+  old_target_version: [] | [Version];
+  new_target_version: [] | [Version];
+}
 export interface Timers {
   last_spawned_timestamp_seconds: [] | [bigint];
   last_reset_timestamp_seconds: [] | [bigint];
+  requires_periodic_tasks: [] | [boolean];
 }
 export interface Tokens {
   e8s: [] | [bigint];
@@ -566,11 +573,50 @@ export interface UpgradeInProgress {
   proposal_id: bigint;
   target_version: [] | [Version];
 }
+export interface UpgradeJournal {
+  entries: Array<UpgradeJournalEntry>;
+}
+export interface UpgradeJournalEntry {
+  event:
+    | []
+    | [
+        | { TargetVersionSet: TargetVersionSet }
+        | { UpgradeOutcome: UpgradeOutcome }
+        | { UpgradeStarted: UpgradeStarted }
+        | { UpgradeStepsRefreshed: UpgradeStepsRefreshed }
+        | { TargetVersionReset: TargetVersionSet },
+      ];
+  timestamp_seconds: [] | [bigint];
+}
+export interface UpgradeOutcome {
+  status:
+    | []
+    | [
+        | { Success: {} }
+        | { Timeout: {} }
+        | { ExternalFailure: {} }
+        | { InvalidState: { version: [] | [Version] } },
+      ];
+  human_readable: [] | [string];
+}
 export interface UpgradeSnsControlledCanister {
   new_canister_wasm: Uint8Array | number[];
   mode: [] | [number];
   canister_id: [] | [Principal];
   canister_upgrade_arg: [] | [Uint8Array | number[]];
+}
+export interface UpgradeStarted {
+  current_version: [] | [Version];
+  expected_version: [] | [Version];
+  reason:
+    | []
+    | [
+        | { UpgradeSnsToNextVersionProposal: ProposalId }
+        | { BehindTargetVersion: {} },
+      ];
+}
+export interface UpgradeStepsRefreshed {
+  upgrade_steps: [] | [Versions];
 }
 export interface Valuation {
   token: [] | [number];

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -291,11 +291,13 @@ type Governance = record {
   sns_metadata : opt ManageSnsMetadata;
   neurons : vec record { text; Neuron };
   genesis_timestamp_seconds : nat64;
-  target_version: opt Version;
+  target_version : opt Version;
   timers : opt Timers;
+  upgrade_journal : opt UpgradeJournal;
 };
 
 type Timers = record {
+  requires_periodic_tasks : opt bool;
   last_reset_timestamp_seconds : opt nat64;
   last_spawned_timestamp_seconds : opt nat64;
 };
@@ -719,12 +721,56 @@ type WaitForQuietState = record {
   current_deadline_timestamp_seconds : nat64;
 };
 
+type UpgradeJournalEntry = record {
+  event : opt variant {
+    UpgradeStepsRefreshed : UpgradeStepsRefreshed;
+    TargetVersionSet : TargetVersionSet;
+    TargetVersionReset : TargetVersionSet;
+    UpgradeStarted : UpgradeStarted;
+    UpgradeOutcome : UpgradeOutcome;
+  };
+  timestamp_seconds : opt nat64;
+};
+
+type UpgradeStepsRefreshed = record {
+  upgrade_steps : opt Versions;
+};
+
+type TargetVersionSet = record {
+  new_target_version : opt Version;
+  old_target_version : opt Version;
+};
+
+type UpgradeStarted = record {
+  current_version : opt Version;
+  expected_version : opt Version;
+  reason : opt variant {
+    UpgradeSnsToNextVersionProposal : ProposalId;
+    BehindTargetVersion : record {};
+  }
+};
+
+type UpgradeOutcome = record {
+  human_readable : opt text;
+  status : opt variant {
+    Success : record {};
+    Timeout : record {};
+    InvalidState : record { version : opt Version };
+    ExternalFailure : record {};
+  };
+};
+
+type UpgradeJournal = record {
+  entries : vec UpgradeJournalEntry;
+};
+
 type GetUpgradeJournalRequest = record {};
 
 type GetUpgradeJournalResponse = record {
   upgrade_steps : opt Versions;
   response_timestamp_seconds : opt nat64;
   target_version : opt Version;
+  upgrade_journal : opt UpgradeJournal;
 };
 
 service : (Governance) -> {
@@ -740,13 +786,9 @@ service : (Governance) -> {
   get_proposal : (GetProposal) -> (GetProposalResponse) query;
   get_root_canister_status : (null) -> (CanisterStatusResultV2);
   get_running_sns_version : (record {}) -> (GetRunningSnsVersionResponse) query;
-  get_sns_initialization_parameters : (record {}) -> (
-      GetSnsInitializationParametersResponse,
-    ) query;
+  get_sns_initialization_parameters : (record {}) -> (GetSnsInitializationParametersResponse) query;
   get_upgrade_journal : (GetUpgradeJournalRequest) -> (GetUpgradeJournalResponse) query;
-  list_nervous_system_functions : () -> (
-      ListNervousSystemFunctionsResponse,
-    ) query;
+  list_nervous_system_functions : () -> (ListNervousSystemFunctionsResponse) query;
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
   list_proposals : (ListProposals) -> (ListProposalsResponse) query;
   manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -3,6 +3,7 @@ export const idlFactory = ({ IDL }) => {
   const Timers = IDL.Record({
     'last_spawned_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'last_reset_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'requires_periodic_tasks' : IDL.Opt(IDL.Bool),
   });
   const Version = IDL.Record({
     'archive_wasm_hash' : IDL.Vec(IDL.Nat8),
@@ -63,6 +64,50 @@ export const idlFactory = ({ IDL }) => {
     'current_basis_points' : IDL.Opt(IDL.Int32),
     'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const TargetVersionSet = IDL.Record({
+    'old_target_version' : IDL.Opt(Version),
+    'new_target_version' : IDL.Opt(Version),
+  });
+  const UpgradeOutcome = IDL.Record({
+    'status' : IDL.Opt(
+      IDL.Variant({
+        'Success' : IDL.Record({}),
+        'Timeout' : IDL.Record({}),
+        'ExternalFailure' : IDL.Record({}),
+        'InvalidState' : IDL.Record({ 'version' : IDL.Opt(Version) }),
+      })
+    ),
+    'human_readable' : IDL.Opt(IDL.Text),
+  });
+  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
+  const UpgradeStarted = IDL.Record({
+    'current_version' : IDL.Opt(Version),
+    'expected_version' : IDL.Opt(Version),
+    'reason' : IDL.Opt(
+      IDL.Variant({
+        'UpgradeSnsToNextVersionProposal' : ProposalId,
+        'BehindTargetVersion' : IDL.Record({}),
+      })
+    ),
+  });
+  const UpgradeStepsRefreshed = IDL.Record({
+    'upgrade_steps' : IDL.Opt(Versions),
+  });
+  const UpgradeJournalEntry = IDL.Record({
+    'event' : IDL.Opt(
+      IDL.Variant({
+        'TargetVersionSet' : TargetVersionSet,
+        'UpgradeOutcome' : UpgradeOutcome,
+        'UpgradeStarted' : UpgradeStarted,
+        'UpgradeStepsRefreshed' : UpgradeStepsRefreshed,
+        'TargetVersionReset' : TargetVersionSet,
+      })
+    ),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const UpgradeJournal = IDL.Record({
+    'entries' : IDL.Vec(UpgradeJournalEntry),
+  });
   const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
   const DefaultFollowees = IDL.Record({
@@ -99,7 +144,6 @@ export const idlFactory = ({ IDL }) => {
     'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
     'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
   });
-  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
   const RewardEvent = IDL.Record({
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
@@ -374,6 +418,7 @@ export const idlFactory = ({ IDL }) => {
     ),
     'metrics' : IDL.Opt(GovernanceCachedMetrics),
     'maturity_modulation' : IDL.Opt(MaturityModulation),
+    'upgrade_journal' : IDL.Opt(UpgradeJournal),
     'mode' : IDL.Int32,
     'parameters' : IDL.Opt(NervousSystemParameters),
     'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),
@@ -478,6 +523,7 @@ export const idlFactory = ({ IDL }) => {
   const GetTimersResponse = IDL.Record({ 'timers' : IDL.Opt(Timers) });
   const GetUpgradeJournalRequest = IDL.Record({});
   const GetUpgradeJournalResponse = IDL.Record({
+    'upgrade_journal' : IDL.Opt(UpgradeJournal),
     'upgrade_steps' : IDL.Opt(Versions),
     'response_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'target_version' : IDL.Opt(Version),
@@ -630,6 +676,7 @@ export const init = ({ IDL }) => {
   const Timers = IDL.Record({
     'last_spawned_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'last_reset_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'requires_periodic_tasks' : IDL.Opt(IDL.Bool),
   });
   const Version = IDL.Record({
     'archive_wasm_hash' : IDL.Vec(IDL.Nat8),
@@ -690,6 +737,50 @@ export const init = ({ IDL }) => {
     'current_basis_points' : IDL.Opt(IDL.Int32),
     'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const TargetVersionSet = IDL.Record({
+    'old_target_version' : IDL.Opt(Version),
+    'new_target_version' : IDL.Opt(Version),
+  });
+  const UpgradeOutcome = IDL.Record({
+    'status' : IDL.Opt(
+      IDL.Variant({
+        'Success' : IDL.Record({}),
+        'Timeout' : IDL.Record({}),
+        'ExternalFailure' : IDL.Record({}),
+        'InvalidState' : IDL.Record({ 'version' : IDL.Opt(Version) }),
+      })
+    ),
+    'human_readable' : IDL.Opt(IDL.Text),
+  });
+  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
+  const UpgradeStarted = IDL.Record({
+    'current_version' : IDL.Opt(Version),
+    'expected_version' : IDL.Opt(Version),
+    'reason' : IDL.Opt(
+      IDL.Variant({
+        'UpgradeSnsToNextVersionProposal' : ProposalId,
+        'BehindTargetVersion' : IDL.Record({}),
+      })
+    ),
+  });
+  const UpgradeStepsRefreshed = IDL.Record({
+    'upgrade_steps' : IDL.Opt(Versions),
+  });
+  const UpgradeJournalEntry = IDL.Record({
+    'event' : IDL.Opt(
+      IDL.Variant({
+        'TargetVersionSet' : TargetVersionSet,
+        'UpgradeOutcome' : UpgradeOutcome,
+        'UpgradeStarted' : UpgradeStarted,
+        'UpgradeStepsRefreshed' : UpgradeStepsRefreshed,
+        'TargetVersionReset' : TargetVersionSet,
+      })
+    ),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const UpgradeJournal = IDL.Record({
+    'entries' : IDL.Vec(UpgradeJournalEntry),
+  });
   const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
   const DefaultFollowees = IDL.Record({
@@ -726,7 +817,6 @@ export const init = ({ IDL }) => {
     'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
     'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
   });
-  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
   const RewardEvent = IDL.Record({
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
@@ -1001,6 +1091,7 @@ export const init = ({ IDL }) => {
     ),
     'metrics' : IDL.Opt(GovernanceCachedMetrics),
     'maturity_modulation' : IDL.Opt(MaturityModulation),
+    'upgrade_journal' : IDL.Opt(UpgradeJournal),
     'mode' : IDL.Int32,
     'parameters' : IDL.Opt(NervousSystemParameters),
     'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),

--- a/packages/sns/candid/sns_governance_test.certified.idl.js
+++ b/packages/sns/candid/sns_governance_test.certified.idl.js
@@ -3,6 +3,7 @@ export const idlFactory = ({ IDL }) => {
   const Timers = IDL.Record({
     'last_spawned_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'last_reset_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'requires_periodic_tasks' : IDL.Opt(IDL.Bool),
   });
   const Version = IDL.Record({
     'archive_wasm_hash' : IDL.Vec(IDL.Nat8),
@@ -63,6 +64,50 @@ export const idlFactory = ({ IDL }) => {
     'current_basis_points' : IDL.Opt(IDL.Int32),
     'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const TargetVersionSet = IDL.Record({
+    'old_target_version' : IDL.Opt(Version),
+    'new_target_version' : IDL.Opt(Version),
+  });
+  const UpgradeOutcome = IDL.Record({
+    'status' : IDL.Opt(
+      IDL.Variant({
+        'Success' : IDL.Record({}),
+        'Timeout' : IDL.Record({}),
+        'ExternalFailure' : IDL.Record({}),
+        'InvalidState' : IDL.Record({ 'version' : IDL.Opt(Version) }),
+      })
+    ),
+    'human_readable' : IDL.Opt(IDL.Text),
+  });
+  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
+  const UpgradeStarted = IDL.Record({
+    'current_version' : IDL.Opt(Version),
+    'expected_version' : IDL.Opt(Version),
+    'reason' : IDL.Opt(
+      IDL.Variant({
+        'UpgradeSnsToNextVersionProposal' : ProposalId,
+        'BehindTargetVersion' : IDL.Record({}),
+      })
+    ),
+  });
+  const UpgradeStepsRefreshed = IDL.Record({
+    'upgrade_steps' : IDL.Opt(Versions),
+  });
+  const UpgradeJournalEntry = IDL.Record({
+    'event' : IDL.Opt(
+      IDL.Variant({
+        'TargetVersionSet' : TargetVersionSet,
+        'UpgradeOutcome' : UpgradeOutcome,
+        'UpgradeStarted' : UpgradeStarted,
+        'UpgradeStepsRefreshed' : UpgradeStepsRefreshed,
+        'TargetVersionReset' : TargetVersionSet,
+      })
+    ),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const UpgradeJournal = IDL.Record({
+    'entries' : IDL.Vec(UpgradeJournalEntry),
+  });
   const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
   const DefaultFollowees = IDL.Record({
@@ -99,7 +144,6 @@ export const idlFactory = ({ IDL }) => {
     'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
     'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
   });
-  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
   const RewardEvent = IDL.Record({
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
@@ -374,6 +418,7 @@ export const idlFactory = ({ IDL }) => {
     ),
     'metrics' : IDL.Opt(GovernanceCachedMetrics),
     'maturity_modulation' : IDL.Opt(MaturityModulation),
+    'upgrade_journal' : IDL.Opt(UpgradeJournal),
     'mode' : IDL.Int32,
     'parameters' : IDL.Opt(NervousSystemParameters),
     'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),
@@ -489,6 +534,7 @@ export const idlFactory = ({ IDL }) => {
   const GetTimersResponse = IDL.Record({ 'timers' : IDL.Opt(Timers) });
   const GetUpgradeJournalRequest = IDL.Record({});
   const GetUpgradeJournalResponse = IDL.Record({
+    'upgrade_journal' : IDL.Opt(UpgradeJournal),
     'upgrade_steps' : IDL.Opt(Versions),
     'response_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'target_version' : IDL.Opt(Version),
@@ -645,6 +691,7 @@ export const init = ({ IDL }) => {
   const Timers = IDL.Record({
     'last_spawned_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'last_reset_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'requires_periodic_tasks' : IDL.Opt(IDL.Bool),
   });
   const Version = IDL.Record({
     'archive_wasm_hash' : IDL.Vec(IDL.Nat8),
@@ -705,6 +752,50 @@ export const init = ({ IDL }) => {
     'current_basis_points' : IDL.Opt(IDL.Int32),
     'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const TargetVersionSet = IDL.Record({
+    'old_target_version' : IDL.Opt(Version),
+    'new_target_version' : IDL.Opt(Version),
+  });
+  const UpgradeOutcome = IDL.Record({
+    'status' : IDL.Opt(
+      IDL.Variant({
+        'Success' : IDL.Record({}),
+        'Timeout' : IDL.Record({}),
+        'ExternalFailure' : IDL.Record({}),
+        'InvalidState' : IDL.Record({ 'version' : IDL.Opt(Version) }),
+      })
+    ),
+    'human_readable' : IDL.Opt(IDL.Text),
+  });
+  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
+  const UpgradeStarted = IDL.Record({
+    'current_version' : IDL.Opt(Version),
+    'expected_version' : IDL.Opt(Version),
+    'reason' : IDL.Opt(
+      IDL.Variant({
+        'UpgradeSnsToNextVersionProposal' : ProposalId,
+        'BehindTargetVersion' : IDL.Record({}),
+      })
+    ),
+  });
+  const UpgradeStepsRefreshed = IDL.Record({
+    'upgrade_steps' : IDL.Opt(Versions),
+  });
+  const UpgradeJournalEntry = IDL.Record({
+    'event' : IDL.Opt(
+      IDL.Variant({
+        'TargetVersionSet' : TargetVersionSet,
+        'UpgradeOutcome' : UpgradeOutcome,
+        'UpgradeStarted' : UpgradeStarted,
+        'UpgradeStepsRefreshed' : UpgradeStepsRefreshed,
+        'TargetVersionReset' : TargetVersionSet,
+      })
+    ),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const UpgradeJournal = IDL.Record({
+    'entries' : IDL.Vec(UpgradeJournalEntry),
+  });
   const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
   const DefaultFollowees = IDL.Record({
@@ -741,7 +832,6 @@ export const init = ({ IDL }) => {
     'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
     'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
   });
-  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
   const RewardEvent = IDL.Record({
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
@@ -1016,6 +1106,7 @@ export const init = ({ IDL }) => {
     ),
     'metrics' : IDL.Opt(GovernanceCachedMetrics),
     'maturity_modulation' : IDL.Opt(MaturityModulation),
+    'upgrade_journal' : IDL.Opt(UpgradeJournal),
     'mode' : IDL.Int32,
     'parameters' : IDL.Opt(NervousSystemParameters),
     'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),

--- a/packages/sns/candid/sns_governance_test.d.ts
+++ b/packages/sns/candid/sns_governance_test.d.ts
@@ -238,6 +238,7 @@ export interface GetTimersResponse {
 }
 export type GetUpgradeJournalRequest = {};
 export interface GetUpgradeJournalResponse {
+  upgrade_journal: [] | [UpgradeJournal];
   upgrade_steps: [] | [Versions];
   response_timestamp_seconds: [] | [bigint];
   target_version: [] | [Version];
@@ -249,6 +250,7 @@ export interface Governance {
   id_to_nervous_system_functions: Array<[bigint, NervousSystemFunction]>;
   metrics: [] | [GovernanceCachedMetrics];
   maturity_modulation: [] | [MaturityModulation];
+  upgrade_journal: [] | [UpgradeJournal];
   mode: number;
   parameters: [] | [NervousSystemParameters];
   is_finalizing_disburse_maturity: [] | [boolean];
@@ -561,9 +563,14 @@ export interface Tally {
   total: bigint;
   timestamp_seconds: bigint;
 }
+export interface TargetVersionSet {
+  old_target_version: [] | [Version];
+  new_target_version: [] | [Version];
+}
 export interface Timers {
   last_spawned_timestamp_seconds: [] | [bigint];
   last_reset_timestamp_seconds: [] | [bigint];
+  requires_periodic_tasks: [] | [boolean];
 }
 export interface Tokens {
   e8s: [] | [bigint];
@@ -581,11 +588,50 @@ export interface UpgradeInProgress {
   proposal_id: bigint;
   target_version: [] | [Version];
 }
+export interface UpgradeJournal {
+  entries: Array<UpgradeJournalEntry>;
+}
+export interface UpgradeJournalEntry {
+  event:
+    | []
+    | [
+        | { TargetVersionSet: TargetVersionSet }
+        | { UpgradeOutcome: UpgradeOutcome }
+        | { UpgradeStarted: UpgradeStarted }
+        | { UpgradeStepsRefreshed: UpgradeStepsRefreshed }
+        | { TargetVersionReset: TargetVersionSet },
+      ];
+  timestamp_seconds: [] | [bigint];
+}
+export interface UpgradeOutcome {
+  status:
+    | []
+    | [
+        | { Success: {} }
+        | { Timeout: {} }
+        | { ExternalFailure: {} }
+        | { InvalidState: { version: [] | [Version] } },
+      ];
+  human_readable: [] | [string];
+}
 export interface UpgradeSnsControlledCanister {
   new_canister_wasm: Uint8Array | number[];
   mode: [] | [number];
   canister_id: [] | [Principal];
   canister_upgrade_arg: [] | [Uint8Array | number[]];
+}
+export interface UpgradeStarted {
+  current_version: [] | [Version];
+  expected_version: [] | [Version];
+  reason:
+    | []
+    | [
+        | { UpgradeSnsToNextVersionProposal: ProposalId }
+        | { BehindTargetVersion: {} },
+      ];
+}
+export interface UpgradeStepsRefreshed {
+  upgrade_steps: [] | [Versions];
 }
 export interface Valuation {
   token: [] | [number];

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -302,9 +302,11 @@ type Governance = record {
   genesis_timestamp_seconds : nat64;
   target_version: opt Version;
   timers : opt Timers;
+  upgrade_journal : opt UpgradeJournal;
 };
 
 type Timers = record {
+  requires_periodic_tasks : opt bool;
   last_reset_timestamp_seconds : opt nat64;
   last_spawned_timestamp_seconds : opt nat64;
 };
@@ -733,12 +735,56 @@ type WaitForQuietState = record {
   current_deadline_timestamp_seconds : nat64;
 };
 
+type UpgradeJournalEntry = record {
+  event : opt variant {
+    UpgradeStepsRefreshed : UpgradeStepsRefreshed;
+    TargetVersionSet : TargetVersionSet;
+    TargetVersionReset : TargetVersionSet;
+    UpgradeStarted : UpgradeStarted;
+    UpgradeOutcome : UpgradeOutcome;
+  };
+  timestamp_seconds : opt nat64;
+};
+
+type UpgradeStepsRefreshed = record {
+  upgrade_steps : opt Versions;
+};
+
+type TargetVersionSet = record {
+  new_target_version : opt Version;
+  old_target_version : opt Version;
+};
+
+type UpgradeStarted = record {
+  current_version : opt Version;
+  expected_version : opt Version;
+  reason : opt variant {
+    UpgradeSnsToNextVersionProposal : ProposalId;
+    BehindTargetVersion : record {};
+  }
+};
+
+type UpgradeOutcome = record {
+  human_readable : opt text;
+  status : opt variant {
+    Success : record {};
+    Timeout : record {};
+    InvalidState : record { version : opt Version };
+    ExternalFailure : record {};
+  };
+};
+
+type UpgradeJournal = record {
+  entries : vec UpgradeJournalEntry;
+};
+
 type GetUpgradeJournalRequest = record {};
 
 type GetUpgradeJournalResponse = record {
   upgrade_steps : opt Versions;
   response_timestamp_seconds : opt nat64;
   target_version : opt Version;
+  upgrade_journal : opt UpgradeJournal;
 };
 
 type AdvanceTargetVersionRequest = record { target_version : opt Version; };

--- a/packages/sns/candid/sns_governance_test.idl.js
+++ b/packages/sns/candid/sns_governance_test.idl.js
@@ -3,6 +3,7 @@ export const idlFactory = ({ IDL }) => {
   const Timers = IDL.Record({
     'last_spawned_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'last_reset_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'requires_periodic_tasks' : IDL.Opt(IDL.Bool),
   });
   const Version = IDL.Record({
     'archive_wasm_hash' : IDL.Vec(IDL.Nat8),
@@ -63,6 +64,50 @@ export const idlFactory = ({ IDL }) => {
     'current_basis_points' : IDL.Opt(IDL.Int32),
     'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const TargetVersionSet = IDL.Record({
+    'old_target_version' : IDL.Opt(Version),
+    'new_target_version' : IDL.Opt(Version),
+  });
+  const UpgradeOutcome = IDL.Record({
+    'status' : IDL.Opt(
+      IDL.Variant({
+        'Success' : IDL.Record({}),
+        'Timeout' : IDL.Record({}),
+        'ExternalFailure' : IDL.Record({}),
+        'InvalidState' : IDL.Record({ 'version' : IDL.Opt(Version) }),
+      })
+    ),
+    'human_readable' : IDL.Opt(IDL.Text),
+  });
+  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
+  const UpgradeStarted = IDL.Record({
+    'current_version' : IDL.Opt(Version),
+    'expected_version' : IDL.Opt(Version),
+    'reason' : IDL.Opt(
+      IDL.Variant({
+        'UpgradeSnsToNextVersionProposal' : ProposalId,
+        'BehindTargetVersion' : IDL.Record({}),
+      })
+    ),
+  });
+  const UpgradeStepsRefreshed = IDL.Record({
+    'upgrade_steps' : IDL.Opt(Versions),
+  });
+  const UpgradeJournalEntry = IDL.Record({
+    'event' : IDL.Opt(
+      IDL.Variant({
+        'TargetVersionSet' : TargetVersionSet,
+        'UpgradeOutcome' : UpgradeOutcome,
+        'UpgradeStarted' : UpgradeStarted,
+        'UpgradeStepsRefreshed' : UpgradeStepsRefreshed,
+        'TargetVersionReset' : TargetVersionSet,
+      })
+    ),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const UpgradeJournal = IDL.Record({
+    'entries' : IDL.Vec(UpgradeJournalEntry),
+  });
   const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
   const DefaultFollowees = IDL.Record({
@@ -99,7 +144,6 @@ export const idlFactory = ({ IDL }) => {
     'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
     'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
   });
-  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
   const RewardEvent = IDL.Record({
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
@@ -374,6 +418,7 @@ export const idlFactory = ({ IDL }) => {
     ),
     'metrics' : IDL.Opt(GovernanceCachedMetrics),
     'maturity_modulation' : IDL.Opt(MaturityModulation),
+    'upgrade_journal' : IDL.Opt(UpgradeJournal),
     'mode' : IDL.Int32,
     'parameters' : IDL.Opt(NervousSystemParameters),
     'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),
@@ -489,6 +534,7 @@ export const idlFactory = ({ IDL }) => {
   const GetTimersResponse = IDL.Record({ 'timers' : IDL.Opt(Timers) });
   const GetUpgradeJournalRequest = IDL.Record({});
   const GetUpgradeJournalResponse = IDL.Record({
+    'upgrade_journal' : IDL.Opt(UpgradeJournal),
     'upgrade_steps' : IDL.Opt(Versions),
     'response_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'target_version' : IDL.Opt(Version),
@@ -653,6 +699,7 @@ export const init = ({ IDL }) => {
   const Timers = IDL.Record({
     'last_spawned_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'last_reset_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'requires_periodic_tasks' : IDL.Opt(IDL.Bool),
   });
   const Version = IDL.Record({
     'archive_wasm_hash' : IDL.Vec(IDL.Nat8),
@@ -713,6 +760,50 @@ export const init = ({ IDL }) => {
     'current_basis_points' : IDL.Opt(IDL.Int32),
     'updated_at_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const TargetVersionSet = IDL.Record({
+    'old_target_version' : IDL.Opt(Version),
+    'new_target_version' : IDL.Opt(Version),
+  });
+  const UpgradeOutcome = IDL.Record({
+    'status' : IDL.Opt(
+      IDL.Variant({
+        'Success' : IDL.Record({}),
+        'Timeout' : IDL.Record({}),
+        'ExternalFailure' : IDL.Record({}),
+        'InvalidState' : IDL.Record({ 'version' : IDL.Opt(Version) }),
+      })
+    ),
+    'human_readable' : IDL.Opt(IDL.Text),
+  });
+  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
+  const UpgradeStarted = IDL.Record({
+    'current_version' : IDL.Opt(Version),
+    'expected_version' : IDL.Opt(Version),
+    'reason' : IDL.Opt(
+      IDL.Variant({
+        'UpgradeSnsToNextVersionProposal' : ProposalId,
+        'BehindTargetVersion' : IDL.Record({}),
+      })
+    ),
+  });
+  const UpgradeStepsRefreshed = IDL.Record({
+    'upgrade_steps' : IDL.Opt(Versions),
+  });
+  const UpgradeJournalEntry = IDL.Record({
+    'event' : IDL.Opt(
+      IDL.Variant({
+        'TargetVersionSet' : TargetVersionSet,
+        'UpgradeOutcome' : UpgradeOutcome,
+        'UpgradeStarted' : UpgradeStarted,
+        'UpgradeStepsRefreshed' : UpgradeStepsRefreshed,
+        'TargetVersionReset' : TargetVersionSet,
+      })
+    ),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const UpgradeJournal = IDL.Record({
+    'entries' : IDL.Vec(UpgradeJournalEntry),
+  });
   const NeuronId = IDL.Record({ 'id' : IDL.Vec(IDL.Nat8) });
   const Followees = IDL.Record({ 'followees' : IDL.Vec(NeuronId) });
   const DefaultFollowees = IDL.Record({
@@ -749,7 +840,6 @@ export const init = ({ IDL }) => {
     'maturity_modulation_disabled' : IDL.Opt(IDL.Bool),
     'max_number_of_principals_per_neuron' : IDL.Opt(IDL.Nat64),
   });
-  const ProposalId = IDL.Record({ 'id' : IDL.Nat64 });
   const RewardEvent = IDL.Record({
     'rounds_since_last_distribution' : IDL.Opt(IDL.Nat64),
     'actual_timestamp_seconds' : IDL.Nat64,
@@ -1024,6 +1114,7 @@ export const init = ({ IDL }) => {
     ),
     'metrics' : IDL.Opt(GovernanceCachedMetrics),
     'maturity_modulation' : IDL.Opt(MaturityModulation),
+    'upgrade_journal' : IDL.Opt(UpgradeJournal),
     'mode' : IDL.Int32,
     'parameters' : IDL.Opt(NervousSystemParameters),
     'is_finalizing_disburse_maturity' : IDL.Opt(IDL.Bool),

--- a/packages/sns/candid/sns_root.certified.idl.js
+++ b/packages/sns/candid/sns_root.certified.idl.js
@@ -1,7 +1,13 @@
 /* Do not edit.  Compiled with ./scripts/compile-idl-js from packages/sns/candid/sns_root.did */
 export const idlFactory = ({ IDL }) => {
+  const Timers = IDL.Record({
+    'last_spawned_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'last_reset_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'requires_periodic_tasks' : IDL.Opt(IDL.Bool),
+  });
   const SnsRootCanister = IDL.Record({
     'dapp_canister_ids' : IDL.Vec(IDL.Principal),
+    'timers' : IDL.Opt(Timers),
     'testflight' : IDL.Bool,
     'archive_canister_ids' : IDL.Vec(IDL.Principal),
     'governance_canister_id' : IDL.Opt(IDL.Principal),
@@ -82,6 +88,7 @@ export const idlFactory = ({ IDL }) => {
     'dapps' : IDL.Vec(CanisterSummary),
     'archives' : IDL.Vec(CanisterSummary),
   });
+  const GetTimersResponse = IDL.Record({ 'timers' : IDL.Opt(Timers) });
   const ListSnsCanistersResponse = IDL.Record({
     'root' : IDL.Opt(IDL.Principal),
     'swap' : IDL.Opt(IDL.Principal),
@@ -137,6 +144,7 @@ export const idlFactory = ({ IDL }) => {
         [GetSnsCanistersSummaryResponse],
         [],
       ),
+    'get_timers' : IDL.Func([IDL.Record({})], [GetTimersResponse], []),
     'list_sns_canisters' : IDL.Func(
         [IDL.Record({})],
         [ListSnsCanistersResponse],
@@ -157,6 +165,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Record({})],
         [],
       ),
+    'reset_timers' : IDL.Func([IDL.Record({})], [IDL.Record({})], []),
     'set_dapp_controllers' : IDL.Func(
         [SetDappControllersRequest],
         [SetDappControllersResponse],
@@ -165,8 +174,14 @@ export const idlFactory = ({ IDL }) => {
   });
 };
 export const init = ({ IDL }) => {
+  const Timers = IDL.Record({
+    'last_spawned_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'last_reset_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'requires_periodic_tasks' : IDL.Opt(IDL.Bool),
+  });
   const SnsRootCanister = IDL.Record({
     'dapp_canister_ids' : IDL.Vec(IDL.Principal),
+    'timers' : IDL.Opt(Timers),
     'testflight' : IDL.Bool,
     'archive_canister_ids' : IDL.Vec(IDL.Principal),
     'governance_canister_id' : IDL.Opt(IDL.Principal),

--- a/packages/sns/candid/sns_root.d.ts
+++ b/packages/sns/candid/sns_root.d.ts
@@ -79,6 +79,9 @@ export interface GetSnsCanistersSummaryResponse {
   dapps: Array<CanisterSummary>;
   archives: Array<CanisterSummary>;
 }
+export interface GetTimersResponse {
+  timers: [] | [Timers];
+}
 export interface ListSnsCanistersResponse {
   root: [] | [Principal];
   swap: [] | [Principal];
@@ -116,12 +119,18 @@ export interface SetDappControllersResponse {
 }
 export interface SnsRootCanister {
   dapp_canister_ids: Array<Principal>;
+  timers: [] | [Timers];
   testflight: boolean;
   archive_canister_ids: Array<Principal>;
   governance_canister_id: [] | [Principal];
   index_canister_id: [] | [Principal];
   swap_canister_id: [] | [Principal];
   ledger_canister_id: [] | [Principal];
+}
+export interface Timers {
+  last_spawned_timestamp_seconds: [] | [bigint];
+  last_reset_timestamp_seconds: [] | [bigint];
+  requires_periodic_tasks: [] | [boolean];
 }
 export interface _SERVICE {
   canister_status: ActorMethod<[CanisterIdRecord], CanisterStatusResult>;
@@ -131,6 +140,7 @@ export interface _SERVICE {
     [GetSnsCanistersSummaryRequest],
     GetSnsCanistersSummaryResponse
   >;
+  get_timers: ActorMethod<[{}], GetTimersResponse>;
   list_sns_canisters: ActorMethod<[{}], ListSnsCanistersResponse>;
   manage_dapp_canister_settings: ActorMethod<
     [ManageDappCanisterSettingsRequest],
@@ -138,6 +148,7 @@ export interface _SERVICE {
   >;
   register_dapp_canister: ActorMethod<[RegisterDappCanisterRequest], {}>;
   register_dapp_canisters: ActorMethod<[RegisterDappCanistersRequest], {}>;
+  reset_timers: ActorMethod<[{}], {}>;
   set_dapp_controllers: ActorMethod<
     [SetDappControllersRequest],
     SetDappControllersResponse

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/sns/root/canister/root.did' by import-candid
 type CanisterCallError = record {
   code : opt int32;
   description : text;
@@ -145,6 +145,17 @@ type SnsRootCanister = record {
   index_canister_id : opt principal;
   swap_canister_id : opt principal;
   ledger_canister_id : opt principal;
+  timers : opt Timers;
+};
+
+type Timers = record {
+  requires_periodic_tasks : opt bool;
+  last_reset_timestamp_seconds : opt nat64;
+  last_spawned_timestamp_seconds : opt nat64;
+};
+
+type GetTimersResponse = record {
+  timers : opt Timers;
 };
 
 service : (SnsRootCanister) -> {
@@ -163,4 +174,6 @@ service : (SnsRootCanister) -> {
   set_dapp_controllers : (SetDappControllersRequest) -> (
       SetDappControllersResponse,
     );
+  reset_timers : (record {}) -> (record {});
+  get_timers : (record {}) -> (GetTimersResponse) query;
 }

--- a/packages/sns/candid/sns_root.idl.js
+++ b/packages/sns/candid/sns_root.idl.js
@@ -1,7 +1,13 @@
 /* Do not edit.  Compiled with ./scripts/compile-idl-js from packages/sns/candid/sns_root.did */
 export const idlFactory = ({ IDL }) => {
+  const Timers = IDL.Record({
+    'last_spawned_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'last_reset_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'requires_periodic_tasks' : IDL.Opt(IDL.Bool),
+  });
   const SnsRootCanister = IDL.Record({
     'dapp_canister_ids' : IDL.Vec(IDL.Principal),
+    'timers' : IDL.Opt(Timers),
     'testflight' : IDL.Bool,
     'archive_canister_ids' : IDL.Vec(IDL.Principal),
     'governance_canister_id' : IDL.Opt(IDL.Principal),
@@ -82,6 +88,7 @@ export const idlFactory = ({ IDL }) => {
     'dapps' : IDL.Vec(CanisterSummary),
     'archives' : IDL.Vec(CanisterSummary),
   });
+  const GetTimersResponse = IDL.Record({ 'timers' : IDL.Opt(Timers) });
   const ListSnsCanistersResponse = IDL.Record({
     'root' : IDL.Opt(IDL.Principal),
     'swap' : IDL.Opt(IDL.Principal),
@@ -137,6 +144,7 @@ export const idlFactory = ({ IDL }) => {
         [GetSnsCanistersSummaryResponse],
         [],
       ),
+    'get_timers' : IDL.Func([IDL.Record({})], [GetTimersResponse], ['query']),
     'list_sns_canisters' : IDL.Func(
         [IDL.Record({})],
         [ListSnsCanistersResponse],
@@ -157,6 +165,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Record({})],
         [],
       ),
+    'reset_timers' : IDL.Func([IDL.Record({})], [IDL.Record({})], []),
     'set_dapp_controllers' : IDL.Func(
         [SetDappControllersRequest],
         [SetDappControllersResponse],
@@ -165,8 +174,14 @@ export const idlFactory = ({ IDL }) => {
   });
 };
 export const init = ({ IDL }) => {
+  const Timers = IDL.Record({
+    'last_spawned_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'last_reset_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'requires_periodic_tasks' : IDL.Opt(IDL.Bool),
+  });
   const SnsRootCanister = IDL.Record({
     'dapp_canister_ids' : IDL.Vec(IDL.Principal),
+    'timers' : IDL.Opt(Timers),
     'testflight' : IDL.Bool,
     'archive_canister_ids' : IDL.Vec(IDL.Principal),
     'governance_canister_id' : IDL.Opt(IDL.Principal),

--- a/packages/sns/candid/sns_swap.certified.idl.js
+++ b/packages/sns/candid/sns_swap.certified.idl.js
@@ -297,6 +297,7 @@ export const idlFactory = ({ IDL }) => {
     'swap' : IDL.Opt(Swap),
     'derived' : IDL.Opt(DerivedState),
   });
+  const GetTimersResponse = IDL.Record({ 'timers' : IDL.Opt(Timers) });
   const ListCommunityFundParticipantsRequest = IDL.Record({
     'offset' : IDL.Opt(IDL.Nat64),
     'limit' : IDL.Opt(IDL.Nat32),
@@ -386,6 +387,7 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'get_state' : IDL.Func([IDL.Record({})], [GetStateResponse], []),
+    'get_timers' : IDL.Func([IDL.Record({})], [GetTimersResponse], []),
     'list_community_fund_participants' : IDL.Func(
         [ListCommunityFundParticipantsRequest],
         [ListCommunityFundParticipantsResponse],

--- a/packages/sns/candid/sns_swap.d.ts
+++ b/packages/sns/candid/sns_swap.d.ts
@@ -142,6 +142,9 @@ export interface GetStateResponse {
   swap: [] | [Swap];
   derived: [] | [DerivedState];
 }
+export interface GetTimersResponse {
+  timers: [] | [Timers];
+}
 export interface GovernanceError {
   error_message: string;
   error_type: number;
@@ -383,6 +386,7 @@ export interface _SERVICE {
   get_open_ticket: ActorMethod<[{}], GetOpenTicketResponse>;
   get_sale_parameters: ActorMethod<[{}], GetSaleParametersResponse>;
   get_state: ActorMethod<[{}], GetStateResponse>;
+  get_timers: ActorMethod<[{}], GetTimersResponse>;
   list_community_fund_participants: ActorMethod<
     [ListCommunityFundParticipantsRequest],
     ListCommunityFundParticipantsResponse

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit a6ef593 (2024-10-24 tags: release-2024-10-23_03-07-ubuntu20.04) 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 51f6f4e4ab (2024-10-31 tags: release-2024-10-31_03-09-ubuntu20.04) 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;
@@ -422,6 +422,10 @@ type Timers = record {
   last_spawned_timestamp_seconds : opt nat64;
 };
 
+type GetTimersResponse = record {
+  timers : opt Timers;
+};
+
 type SweepResult = record {
   failure : nat32;
   skipped : nat32;
@@ -475,4 +479,5 @@ service : (Init) -> {
       RefreshBuyerTokensResponse,
     );
   reset_timers : (record {}) -> (record {});
+  get_timers : (record {}) -> (GetTimersResponse) query;
 }

--- a/packages/sns/candid/sns_swap.idl.js
+++ b/packages/sns/candid/sns_swap.idl.js
@@ -297,6 +297,7 @@ export const idlFactory = ({ IDL }) => {
     'swap' : IDL.Opt(Swap),
     'derived' : IDL.Opt(DerivedState),
   });
+  const GetTimersResponse = IDL.Record({ 'timers' : IDL.Opt(Timers) });
   const ListCommunityFundParticipantsRequest = IDL.Record({
     'offset' : IDL.Opt(IDL.Nat64),
     'limit' : IDL.Opt(IDL.Nat32),
@@ -394,6 +395,7 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_state' : IDL.Func([IDL.Record({})], [GetStateResponse], ['query']),
+    'get_timers' : IDL.Func([IDL.Record({})], [GetTimersResponse], ['query']),
     'list_community_fund_participants' : IDL.Func(
         [ListCommunityFundParticipantsRequest],
         [ListCommunityFundParticipantsResponse],


### PR DESCRIPTION
# Motivation

The [automatic candid update](https://github.com/dfinity/ic-js/pull/746) failed because of a new neuron field: `voting_power_refreshed_timestamp_seconds`.

# Changes

1. Ran `./scripts/import-candid ../../ic` and `./scripts/compile-idl-js`.
2. Added conversions for `voting_power_refreshed_timestamp_seconds`.
3. Added empty mock values for `voting_power_refreshed_timestamp_seconds`.

# Tests

Added unit tests for converting `voting_power_refreshed_timestamp_seconds`.

# Todos

- [x] Add entry to changelog (if necessary).