### PR TITLE
fix: ic.did source

### DIFF
--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -117,5 +117,5 @@ import_did "rs/ethereum/cketh/minter/cketh_minter.did" "minter.did" "cketh"
 import_did "rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did" "orchestrator.did" "cketh"
 
 mkdir -p packages/ic-management/candid
-download_did https://raw.githubusercontent.com/dfinity/interface-spec/master/spec/_attachments/ic.did "ic-management.did" "ic-management"
+download_did https://raw.githubusercontent.com/dfinity/portal/master/docs/references/_attachments/ic.did "ic-management.did" "ic-management"
 : Fin


### PR DESCRIPTION
# Motivation

The `ic.did` file we use to generate the bindings for `@dfinity/ic-management` has been moved to the [portal](https://github.com/dfinity/portal/blob/master/docs/references/_attachments/ic.did) and will now be handled there (confirmed by the team) instead of the deprecated [interface-spec](https://github.com/dfinity/interface-spec/) repo.

# Changes

- Update source for `ic.did` in `import-candid` script.

# Todos

- [ ] Add entry to changelog (if necessary).
