### PR TITLE
refactor: destruct candid service in ic-mgmt

### DIFF
--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -100,7 +100,7 @@ Update canister settings
 | ---------------- | ------------------------------------------------------------------------------------------- |
 | `updateSettings` | `({ canisterId, senderCanisterVersion, settings, }: UpdateSettingsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L99)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L101)
 
 ##### :gear: installCode
 
@@ -110,7 +110,7 @@ Install code to a canister
 | ------------- | ----------------------------------------------------------------------------------------------------- |
 | `installCode` | `({ mode, canisterId, wasmModule, arg, senderCanisterVersion, }: InstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L121)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L126)
 
 ##### :gear: uploadChunk
 
@@ -125,7 +125,7 @@ Parameters:
 - `params.canisterId`: The canister in which the chunks will be stored.
 - `params.chunk`: A chunk of Wasm module.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L146)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L154)
 
 ##### :gear: clearChunkStore
 
@@ -139,7 +139,7 @@ Parameters:
 
 - `params.canisterId`: The canister in which the chunks are stored.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L166)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L174)
 
 ##### :gear: storedChunks
 
@@ -153,7 +153,7 @@ Parameters:
 
 - `params.canisterId`: The canister in which the chunks are stored.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L185)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L193)
 
 ##### :gear: installChunkedCode
 
@@ -173,7 +173,7 @@ Parameters:
 - `params.storeCanisterId`: Specifies the canister in whose chunk storage the chunks are stored (this parameter defaults to target_canister if not specified).
 - `params.wasmModuleHash`: The Wasm module hash as hex string. Used to check that the SHA-256 hash of wasm_module is equal to the wasm_module_hash parameter and can calls install_code with parameters.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L210)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L218)
 
 ##### :gear: uninstallCode
 
@@ -183,7 +183,7 @@ Uninstall code from a canister
 | --------------- | -------------------------------------------------------------------------------- |
 | `uninstallCode` | `({ canisterId, senderCanisterVersion, }: UninstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L243)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L251)
 
 ##### :gear: startCanister
 
@@ -193,7 +193,7 @@ Start a canister
 | --------------- | ------------------------------------------ |
 | `startCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L258)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L269)
 
 ##### :gear: stopCanister
 
@@ -203,7 +203,7 @@ Stop a canister
 | -------------- | ------------------------------------------ |
 | `stopCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L267)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L281)
 
 ##### :gear: canisterStatus
 
@@ -213,7 +213,7 @@ Get canister details (memory size, status, etc.)
 | ---------------- | ------------------------------------------------------------ |
 | `canisterStatus` | `(canisterId: Principal) => Promise<canister_status_result>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L276)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L292)
 
 ##### :gear: deleteCanister
 
@@ -223,7 +223,7 @@ Deletes a canister
 | ---------------- | ------------------------------------------ |
 | `deleteCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L287)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L306)
 
 ##### :gear: provisionalCreateCanisterWithCycles
 
@@ -233,7 +233,7 @@ Creates a canister. Only available on development instances.
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `provisionalCreateCanisterWithCycles` | `({ settings, amount, canisterId, }?: ProvisionalCreateCanisterWithCyclesParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L299)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L321)
 
 ##### :gear: fetchCanisterLogs
 
@@ -243,7 +243,7 @@ Given a canister ID as input, this method returns a vector of logs of that canis
 | ------------------- | ---------------------------------------------------------------- |
 | `fetchCanisterLogs` | `(canisterId: Principal) => Promise<fetch_canister_logs_result>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L321)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L344)
 
 <!-- TSDOC_END -->
 

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -79,7 +79,9 @@ export class ICManagementCanister {
     settings,
     senderCanisterVersion,
   }: CreateCanisterParams = {}): Promise<Principal> => {
-    const { canister_id } = await this.service.create_canister({
+    const { create_canister } = this.service;
+
+    const { canister_id } = await create_canister({
       settings: toNullable(toCanisterSettings(settings)),
       sender_canister_version: toNullable(senderCanisterVersion),
     });
@@ -100,12 +102,15 @@ export class ICManagementCanister {
     canisterId,
     senderCanisterVersion,
     settings,
-  }: UpdateSettingsParams): Promise<void> =>
-    this.service.update_settings({
+  }: UpdateSettingsParams): Promise<void> => {
+    const { update_settings } = this.service;
+
+    return update_settings({
       canister_id: canisterId,
       sender_canister_version: toNullable(senderCanisterVersion),
       settings: toCanisterSettings(settings),
     });
+  };
 
   /**
    * Install code to a canister
@@ -124,14 +129,17 @@ export class ICManagementCanister {
     wasmModule,
     arg,
     senderCanisterVersion,
-  }: InstallCodeParams): Promise<void> =>
-    this.service.install_code({
+  }: InstallCodeParams): Promise<void> => {
+    const { install_code } = this.service;
+
+    return install_code({
       mode: toInstallMode(mode),
       canister_id: canisterId,
       wasm_module: wasmModule,
       arg,
       sender_canister_version: toNullable(senderCanisterVersion),
     });
+  };
 
   /**
    * Upload chunks of Wasm modules that are too large to fit in a single message for installation purposes.
@@ -243,11 +251,14 @@ export class ICManagementCanister {
   uninstallCode = ({
     canisterId,
     senderCanisterVersion,
-  }: UninstallCodeParams): Promise<void> =>
-    this.service.uninstall_code({
+  }: UninstallCodeParams): Promise<void> => {
+    const { uninstall_code } = this.service;
+
+    return uninstall_code({
       canister_id: canisterId,
       sender_canister_version: toNullable(senderCanisterVersion),
     });
+  };
 
   /**
    * Start a canister
@@ -255,8 +266,11 @@ export class ICManagementCanister {
    * @param {Principal} canisterId
    * @returns {Promise<void>}
    */
-  startCanister = (canisterId: Principal): Promise<void> =>
-    this.service.start_canister({ canister_id: canisterId });
+  startCanister = (canisterId: Principal): Promise<void> => {
+    const { start_canister } = this.service;
+
+    return start_canister({ canister_id: canisterId });
+  };
 
   /**
    * Stop a canister
@@ -264,8 +278,10 @@ export class ICManagementCanister {
    * @param {Principal} canisterId
    * @returns {Promise<void>}
    */
-  stopCanister = (canisterId: Principal): Promise<void> =>
-    this.service.stop_canister({ canister_id: canisterId });
+  stopCanister = (canisterId: Principal): Promise<void> => {
+    const { stop_canister } = this.service;
+    return stop_canister({ canister_id: canisterId });
+  };
 
   /**
    * Get canister details (memory size, status, etc.)
@@ -273,10 +289,13 @@ export class ICManagementCanister {
    * @param {Principal} canisterId
    * @returns {Promise<CanisterStatusResponse>}
    */
-  canisterStatus = (canisterId: Principal): Promise<CanisterStatusResponse> =>
-    this.service.canister_status({
+  canisterStatus = (canisterId: Principal): Promise<CanisterStatusResponse> => {
+    const { canister_status } = this.service;
+
+    return canister_status({
       canister_id: canisterId,
     });
+  };
 
   /**
    * Deletes a canister
@@ -284,8 +303,11 @@ export class ICManagementCanister {
    * @param {Principal} canisterId
    * @returns {Promise<void>}
    */
-  deleteCanister = (canisterId: Principal): Promise<void> =>
-    this.service.delete_canister({ canister_id: canisterId });
+  deleteCanister = (canisterId: Principal): Promise<void> => {
+    const { delete_canister } = this.service;
+
+    return delete_canister({ canister_id: canisterId });
+  };
 
   /**
    * Creates a canister. Only available on development instances.
@@ -301,13 +323,14 @@ export class ICManagementCanister {
     amount,
     canisterId,
   }: ProvisionalCreateCanisterWithCyclesParams = {}): Promise<Principal> => {
-    const { canister_id } =
-      await this.service.provisional_create_canister_with_cycles({
-        settings: toNullable(toCanisterSettings(settings)),
-        amount: toNullable(amount),
-        specified_id: toNullable(canisterId),
-        sender_canister_version: [],
-      });
+    const { provisional_create_canister_with_cycles } = this.service;
+
+    const { canister_id } = await provisional_create_canister_with_cycles({
+      settings: toNullable(toCanisterSettings(settings)),
+      amount: toNullable(amount),
+      specified_id: toNullable(canisterId),
+      sender_canister_version: [],
+    });
 
     return canister_id;
   };
@@ -320,8 +343,11 @@ export class ICManagementCanister {
    */
   fetchCanisterLogs = (
     canisterId: Principal,
-  ): Promise<FetchCanisterLogsResponse> =>
-    this.service.fetch_canister_logs({
+  ): Promise<FetchCanisterLogsResponse> => {
+    const { fetch_canister_logs } = this.service;
+
+    return fetch_canister_logs({
       canister_id: canisterId,
     });
+  };
 }


### PR DESCRIPTION
# Motivation

IDE, or at least Webstorm, cannot resolves the definition of Candid services when those function are not destructed.

# Changes

- Destruct `const {something} = this.service` in ic-mgmt instead of use `this.service.something`

# Screenshots

<img width="1536" alt="Capture d’écran 2024-11-20 à 13 09 10" src="https://github.com/user-attachments/assets/3af257f2-5a23-43c1-a6db-614eb1f24032">

<img width="1536" alt="Capture d’écran 2024-11-20 à 13 09 51" src="https://github.com/user-attachments/assets/505638d4-dc76-4b41-86c0-45eafa155274">

Opening function's definition if destructed:

<img width="1536" alt="Capture d’écran 2024-11-20 à 13 17 34" src="https://github.com/user-attachments/assets/5f6f7552-212c-47bb-85c8-f3a4ab741af9">

