### PR TITLE
feat: add takeCanisterSnapshot to ic-mgmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `memoToNeuronSubaccount` and `memoToNeuronAccountIdentifier`.
 - Support new neuron field `voting_power_refreshed_timestamp_seconds`.
 - Add support for fetching the canister logs in `@dfinity@ic-management`.
+- Add support for snapshot features in `@dfinity@ic-management`.
 - Add `nowInBigIntNanoSeconds` to `@dfinity/utils`, a trivial function that is actually used across all our dapps.
 
 ## Build

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -100,7 +100,7 @@ Update canister settings
 | ---------------- | ------------------------------------------------------------------------------------------- |
 | `updateSettings` | `({ canisterId, senderCanisterVersion, settings, }: UpdateSettingsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L99)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L101)
 
 ##### :gear: installCode
 
@@ -110,7 +110,7 @@ Install code to a canister
 | ------------- | ----------------------------------------------------------------------------------------------------- |
 | `installCode` | `({ mode, canisterId, wasmModule, arg, senderCanisterVersion, }: InstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L121)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L126)
 
 ##### :gear: uploadChunk
 
@@ -125,7 +125,7 @@ Parameters:
 - `params.canisterId`: The canister in which the chunks will be stored.
 - `params.chunk`: A chunk of Wasm module.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L146)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L154)
 
 ##### :gear: clearChunkStore
 
@@ -139,7 +139,7 @@ Parameters:
 
 - `params.canisterId`: The canister in which the chunks are stored.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L166)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L174)
 
 ##### :gear: storedChunks
 
@@ -153,7 +153,7 @@ Parameters:
 
 - `params.canisterId`: The canister in which the chunks are stored.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L185)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L193)
 
 ##### :gear: installChunkedCode
 
@@ -173,7 +173,7 @@ Parameters:
 - `params.storeCanisterId`: Specifies the canister in whose chunk storage the chunks are stored (this parameter defaults to target_canister if not specified).
 - `params.wasmModuleHash`: The Wasm module hash as hex string. Used to check that the SHA-256 hash of wasm_module is equal to the wasm_module_hash parameter and can calls install_code with parameters.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L210)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L218)
 
 ##### :gear: uninstallCode
 
@@ -183,7 +183,7 @@ Uninstall code from a canister
 | --------------- | -------------------------------------------------------------------------------- |
 | `uninstallCode` | `({ canisterId, senderCanisterVersion, }: UninstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L243)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L251)
 
 ##### :gear: startCanister
 
@@ -193,7 +193,7 @@ Start a canister
 | --------------- | ------------------------------------------ |
 | `startCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L258)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L269)
 
 ##### :gear: stopCanister
 
@@ -203,7 +203,7 @@ Stop a canister
 | -------------- | ------------------------------------------ |
 | `stopCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L267)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L281)
 
 ##### :gear: canisterStatus
 
@@ -213,7 +213,7 @@ Get canister details (memory size, status, etc.)
 | ---------------- | ------------------------------------------------------------ |
 | `canisterStatus` | `(canisterId: Principal) => Promise<canister_status_result>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L276)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L292)
 
 ##### :gear: deleteCanister
 
@@ -223,7 +223,7 @@ Deletes a canister
 | ---------------- | ------------------------------------------ |
 | `deleteCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L287)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L306)
 
 ##### :gear: provisionalCreateCanisterWithCycles
 
@@ -233,7 +233,7 @@ Creates a canister. Only available on development instances.
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `provisionalCreateCanisterWithCycles` | `({ settings, amount, canisterId, }?: ProvisionalCreateCanisterWithCyclesParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L299)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L321)
 
 ##### :gear: fetchCanisterLogs
 
@@ -243,7 +243,7 @@ Given a canister ID as input, this method returns a vector of logs of that canis
 | ------------------- | ---------------------------------------------------------------- |
 | `fetchCanisterLogs` | `(canisterId: Principal) => Promise<fetch_canister_logs_result>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L321)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L344)
 
 <!-- TSDOC_END -->
 

--- a/packages/ic-management/src/ic-management.canister.spec.ts
+++ b/packages/ic-management/src/ic-management.canister.spec.ts
@@ -4,6 +4,7 @@ import { mock } from "jest-mock-extended";
 import type {
   _SERVICE as IcManagementService,
   chunk_hash,
+  take_canister_snapshot_result,
 } from "../candid/ic-management";
 import { ICManagementCanister } from "./ic-management.canister";
 import {
@@ -29,6 +30,7 @@ import {
   CanisterStatusResponse,
   type FetchCanisterLogsResponse,
 } from "./types/ic-management.responses";
+import { decodeSnapshotId } from "./utils/ic-management.utils";
 
 describe("ICManagementCanister", () => {
   const mockAgent: HttpAgent = mock<HttpAgent>();
@@ -716,6 +718,91 @@ describe("ICManagementCanister", () => {
       const call = () => icManagement.fetchCanisterLogs(mockCanisterId);
 
       expect(call).rejects.toThrowError(Error);
+    });
+  });
+
+  describe("takeCanisterSnapshot", () => {
+    const mockResponse: take_canister_snapshot_result = {
+      id: Uint8Array.from([1, 2, 3, 4]),
+      total_size: BigInt(5000),
+      taken_at_timestamp: BigInt(1680000000000),
+    };
+
+    it("should call take_canister_snapshot without snapshotId", async () => {
+      const service = mock<IcManagementService>();
+      service.take_canister_snapshot.mockResolvedValue(mockResponse);
+
+      const icManagement = await createICManagement(service);
+
+      const params = {
+        canisterId: mockCanisterId,
+      };
+
+      const res = await icManagement.takeCanisterSnapshot(params);
+
+      expect(res).toEqual(mockResponse);
+
+      expect(service.take_canister_snapshot).toHaveBeenCalledWith({
+        canister_id: params.canisterId,
+        replace_snapshot: [],
+      });
+    });
+
+    it("should call take_canister_snapshot with Uint8Array snapshotId", async () => {
+      const service = mock<IcManagementService>();
+      service.take_canister_snapshot.mockResolvedValue(mockResponse);
+
+      const icManagement = await createICManagement(service);
+
+      const params = {
+        canisterId: mockCanisterId,
+        snapshotId: Uint8Array.from([1, 2, 3, 4]),
+      };
+
+      const res = await icManagement.takeCanisterSnapshot(params);
+
+      expect(res).toEqual(mockResponse);
+
+      expect(service.take_canister_snapshot).toHaveBeenCalledWith({
+        canister_id: params.canisterId,
+        replace_snapshot: [params.snapshotId],
+      });
+    });
+
+    it("calls take_canister_snapshot with string snapshotId", async () => {
+      const service = mock<IcManagementService>();
+      service.take_canister_snapshot.mockResolvedValue(mockResponse);
+
+      const icManagement = await createICManagement(service);
+
+      const params = {
+        canisterId: mockCanisterId,
+        snapshotId: "000000000000000201010000000000000001",
+      };
+
+      const res = await icManagement.takeCanisterSnapshot(params);
+
+      expect(res).toEqual(mockResponse);
+
+      expect(service.take_canister_snapshot).toHaveBeenCalledWith({
+        canister_id: params.canisterId,
+        replace_snapshot: [decodeSnapshotId(params.snapshotId)],
+      });
+    });
+
+    it("should throws Error", async () => {
+      const error = new Error("Test");
+      const service = mock<IcManagementService>();
+      service.take_canister_snapshot.mockRejectedValue(error);
+
+      const icManagement = await createICManagement(service);
+
+      const call = () =>
+        icManagement.takeCanisterSnapshot({
+          canisterId: mockCanisterId,
+        });
+
+      await expect(call).rejects.toThrow(error);
     });
   });
 });

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -79,7 +79,9 @@ export class ICManagementCanister {
     settings,
     senderCanisterVersion,
   }: CreateCanisterParams = {}): Promise<Principal> => {
-    const { canister_id } = await this.service.create_canister({
+    const { create_canister } = this.service;
+
+    const { canister_id } = await create_canister({
       settings: toNullable(toCanisterSettings(settings)),
       sender_canister_version: toNullable(senderCanisterVersion),
     });
@@ -100,12 +102,15 @@ export class ICManagementCanister {
     canisterId,
     senderCanisterVersion,
     settings,
-  }: UpdateSettingsParams): Promise<void> =>
-    this.service.update_settings({
+  }: UpdateSettingsParams): Promise<void> => {
+    const { update_settings } = this.service;
+
+    return update_settings({
       canister_id: canisterId,
       sender_canister_version: toNullable(senderCanisterVersion),
       settings: toCanisterSettings(settings),
     });
+  };
 
   /**
    * Install code to a canister
@@ -124,14 +129,17 @@ export class ICManagementCanister {
     wasmModule,
     arg,
     senderCanisterVersion,
-  }: InstallCodeParams): Promise<void> =>
-    this.service.install_code({
+  }: InstallCodeParams): Promise<void> => {
+    const { install_code } = this.service;
+
+    return install_code({
       mode: toInstallMode(mode),
       canister_id: canisterId,
       wasm_module: wasmModule,
       arg,
       sender_canister_version: toNullable(senderCanisterVersion),
     });
+  };
 
   /**
    * Upload chunks of Wasm modules that are too large to fit in a single message for installation purposes.
@@ -243,11 +251,14 @@ export class ICManagementCanister {
   uninstallCode = ({
     canisterId,
     senderCanisterVersion,
-  }: UninstallCodeParams): Promise<void> =>
-    this.service.uninstall_code({
+  }: UninstallCodeParams): Promise<void> => {
+    const { uninstall_code } = this.service;
+
+    return uninstall_code({
       canister_id: canisterId,
       sender_canister_version: toNullable(senderCanisterVersion),
     });
+  };
 
   /**
    * Start a canister
@@ -255,8 +266,11 @@ export class ICManagementCanister {
    * @param {Principal} canisterId
    * @returns {Promise<void>}
    */
-  startCanister = (canisterId: Principal): Promise<void> =>
-    this.service.start_canister({ canister_id: canisterId });
+  startCanister = (canisterId: Principal): Promise<void> => {
+    const { start_canister } = this.service;
+
+    return start_canister({ canister_id: canisterId });
+  };
 
   /**
    * Stop a canister
@@ -264,8 +278,10 @@ export class ICManagementCanister {
    * @param {Principal} canisterId
    * @returns {Promise<void>}
    */
-  stopCanister = (canisterId: Principal): Promise<void> =>
-    this.service.stop_canister({ canister_id: canisterId });
+  stopCanister = (canisterId: Principal): Promise<void> => {
+    const { stop_canister } = this.service;
+    return stop_canister({ canister_id: canisterId });
+  };
 
   /**
    * Get canister details (memory size, status, etc.)
@@ -273,10 +289,13 @@ export class ICManagementCanister {
    * @param {Principal} canisterId
    * @returns {Promise<CanisterStatusResponse>}
    */
-  canisterStatus = (canisterId: Principal): Promise<CanisterStatusResponse> =>
-    this.service.canister_status({
+  canisterStatus = (canisterId: Principal): Promise<CanisterStatusResponse> => {
+    const { canister_status } = this.service;
+
+    return canister_status({
       canister_id: canisterId,
     });
+  };
 
   /**
    * Deletes a canister
@@ -284,8 +303,11 @@ export class ICManagementCanister {
    * @param {Principal} canisterId
    * @returns {Promise<void>}
    */
-  deleteCanister = (canisterId: Principal): Promise<void> =>
-    this.service.delete_canister({ canister_id: canisterId });
+  deleteCanister = (canisterId: Principal): Promise<void> => {
+    const { delete_canister } = this.service;
+
+    return delete_canister({ canister_id: canisterId });
+  };
 
   /**
    * Creates a canister. Only available on development instances.
@@ -301,13 +323,14 @@ export class ICManagementCanister {
     amount,
     canisterId,
   }: ProvisionalCreateCanisterWithCyclesParams = {}): Promise<Principal> => {
-    const { canister_id } =
-      await this.service.provisional_create_canister_with_cycles({
-        settings: toNullable(toCanisterSettings(settings)),
-        amount: toNullable(amount),
-        specified_id: toNullable(canisterId),
-        sender_canister_version: [],
-      });
+    const { provisional_create_canister_with_cycles } = this.service;
+
+    const { canister_id } = await provisional_create_canister_with_cycles({
+      settings: toNullable(toCanisterSettings(settings)),
+      amount: toNullable(amount),
+      specified_id: toNullable(canisterId),
+      sender_canister_version: [],
+    });
 
     return canister_id;
   };
@@ -320,8 +343,11 @@ export class ICManagementCanister {
    */
   fetchCanisterLogs = (
     canisterId: Principal,
-  ): Promise<FetchCanisterLogsResponse> =>
-    this.service.fetch_canister_logs({
+  ): Promise<FetchCanisterLogsResponse> => {
+    const { fetch_canister_logs } = this.service;
+
+    return fetch_canister_logs({
       canister_id: canisterId,
     });
+  };
 }

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -23,7 +23,7 @@ import {
   type InstallChunkedCodeParams,
   type InstallCodeParams,
   type ProvisionalCreateCanisterWithCyclesParams,
-  type SnapshotIdHex,
+  type SnapshotIdText,
   type StoredChunksParams,
   type UninstallCodeParams,
   type UpdateSettingsParams,
@@ -363,7 +363,7 @@ export class ICManagementCanister {
    *
    * @param {Object} params - Parameters for the snapshot operation.
    * @param {Principal} params.canisterId - The ID of the canister for which the snapshot will be taken.
-   * @param {SnapshotIdHex | snapshot_id} [params.snapshotId] - The ID of the snapshot to replace, if applicable.
+   * @param {SnapshotIdText | snapshot_id} [params.snapshotId] - The ID of the snapshot to replace, if applicable.
    * Can be provided as a `string` or a `Uint8Array`.
    * If not provided, a new snapshot will be created.
    *
@@ -377,7 +377,7 @@ export class ICManagementCanister {
     snapshotId,
   }: {
     canisterId: Principal;
-    snapshotId?: SnapshotIdHex | snapshot_id;
+    snapshotId?: SnapshotIdText | snapshot_id;
   }): Promise<take_canister_snapshot_result> => {
     const { take_canister_snapshot } = this.service;
 

--- a/packages/ic-management/src/index.ts
+++ b/packages/ic-management/src/index.ts
@@ -1,3 +1,8 @@
+export type {
+  canister_log_record,
+  fetch_canister_logs_result,
+  snapshot_id,
+} from "../candid/ic-management";
 export { ICManagementCanister } from "./ic-management.canister";
 export * from "./types/canister.options";
 export * from "./types/ic-management.params";

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -132,3 +132,5 @@ export interface ProvisionalTopUpCanisterParams {
   canisterId: Principal;
   amount: bigint;
 }
+
+export type SnapshotIdHex = string;

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -133,4 +133,4 @@ export interface ProvisionalTopUpCanisterParams {
   amount: bigint;
 }
 
-export type SnapshotIdHex = string;
+export type SnapshotIdText = string;

--- a/packages/ic-management/src/utils/ic-management.utils.ts
+++ b/packages/ic-management/src/utils/ic-management.utils.ts
@@ -1,5 +1,6 @@
 import { hexStringToUint8Array, uint8ArrayToHexString } from "@dfinity/utils";
 import type { snapshot_id } from "../../candid/ic-management";
+import type { SnapshotIdHex } from "../types/ic-management.params";
 
 /**
  * Encodes a snapshot ID into a hex string representation.
@@ -11,7 +12,7 @@ import type { snapshot_id } from "../../candid/ic-management";
  * @param {snapshot_id} snapshotId - The snapshot ID to encode, represented as a `Uint8Array` or an array of numbers.
  * @returns {string} The hex string representation of the snapshot ID.
  */
-export const encodeSnapshotId = (snapshotId: snapshot_id): string =>
+export const encodeSnapshotId = (snapshotId: snapshot_id): SnapshotIdHex =>
   uint8ArrayToHexString(snapshotId);
 
 /**
@@ -24,5 +25,5 @@ export const encodeSnapshotId = (snapshotId: snapshot_id): string =>
  * @param {string} snapshotId - The hex string representation of the snapshot ID.
  * @returns {snapshot_id} The decoded snapshot ID as a `Uint8Array`.
  */
-export const decodeSnapshotId = (snapshotId: string): snapshot_id =>
+export const decodeSnapshotId = (snapshotId: SnapshotIdHex): snapshot_id =>
   hexStringToUint8Array(snapshotId);

--- a/packages/ic-management/src/utils/ic-management.utils.ts
+++ b/packages/ic-management/src/utils/ic-management.utils.ts
@@ -1,6 +1,6 @@
 import { hexStringToUint8Array, uint8ArrayToHexString } from "@dfinity/utils";
 import type { snapshot_id } from "../../candid/ic-management";
-import type { SnapshotIdHex } from "../types/ic-management.params";
+import type { SnapshotIdText } from "../types/ic-management.params";
 
 /**
  * Encodes a snapshot ID into a hex string representation.
@@ -12,7 +12,7 @@ import type { SnapshotIdHex } from "../types/ic-management.params";
  * @param {snapshot_id} snapshotId - The snapshot ID to encode, represented as a `Uint8Array` or an array of numbers.
  * @returns {string} The hex string representation of the snapshot ID.
  */
-export const encodeSnapshotId = (snapshotId: snapshot_id): SnapshotIdHex =>
+export const encodeSnapshotId = (snapshotId: snapshot_id): SnapshotIdText =>
   uint8ArrayToHexString(snapshotId);
 
 /**
@@ -25,5 +25,5 @@ export const encodeSnapshotId = (snapshotId: snapshot_id): SnapshotIdHex =>
  * @param {string} snapshotId - The hex string representation of the snapshot ID.
  * @returns {snapshot_id} The decoded snapshot ID as a `Uint8Array`.
  */
-export const decodeSnapshotId = (snapshotId: SnapshotIdHex): snapshot_id =>
+export const decodeSnapshotId = (snapshotId: SnapshotIdText): snapshot_id =>
   hexStringToUint8Array(snapshotId);


### PR DESCRIPTION
# Motivation

Add support for [take_canister_snapshot](https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-take_canister_snapshot) to ic-mgmt.

# Changes

- Implement `takeCanisterSnapshot`
- Create a type `SnapshotId` for the string representation
- Expose related did types in index for the consumer
