### PR TITLE
feat: expose ic-mgmt types

### DIFF
--- a/packages/ic-management/src/index.ts
+++ b/packages/ic-management/src/index.ts
@@ -1,6 +1,9 @@
 export type {
   canister_log_record,
+  canister_status_result,
+  definite_canister_settings,
   fetch_canister_logs_result,
+  log_visibility,
   snapshot_id,
 } from "../candid/ic-management";
 export { ICManagementCanister } from "./ic-management.canister";

--- a/packages/ic-management/src/index.ts
+++ b/packages/ic-management/src/index.ts
@@ -1,6 +1,7 @@
 export type {
   canister_log_record,
   canister_status_result,
+  chunk_hash,
   definite_canister_settings,
   fetch_canister_logs_result,
   log_visibility,


### PR DESCRIPTION
# Motivation

Few DID types should probably be exposed as they are part of the response but defined by Candid.

# Changes

- Expose few types in `index.ts` of ic-mgmt
