### PR TITLE
feat: utils to mapSnapshotId

### DIFF
--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -33,7 +33,7 @@ import type {
   CanisterStatusResponse,
   FetchCanisterLogsResponse,
 } from "./types/ic-management.responses";
-import { decodeSnapshotId } from "./utils/ic-management.utils";
+import { mapSnapshotId } from "./utils/ic-management.utils";
 
 export class ICManagementCanister {
   private constructor(private readonly service: IcManagementService) {
@@ -384,11 +384,7 @@ export class ICManagementCanister {
     return take_canister_snapshot({
       canister_id: canisterId,
       replace_snapshot: toNullable(
-        nonNullish(snapshotId)
-          ? typeof snapshotId === "string"
-            ? decodeSnapshotId(snapshotId)
-            : snapshotId
-          : undefined,
+        nonNullish(snapshotId) ? mapSnapshotId(snapshotId) : undefined,
       ),
     });
   };

--- a/packages/ic-management/src/utils/ic-management.utils.spec.ts
+++ b/packages/ic-management/src/utils/ic-management.utils.spec.ts
@@ -1,5 +1,9 @@
 import { mockCanisterId } from "../ic-management.mock";
-import { decodeSnapshotId, encodeSnapshotId } from "./ic-management.utils";
+import {
+  decodeSnapshotId,
+  encodeSnapshotId,
+  mapSnapshotId,
+} from "./ic-management.utils";
 
 describe("ic-management.utils", () => {
   const mockLocalSubnetId = [0, 0, 0, 0, 0, 0, 0, 1];
@@ -28,5 +32,18 @@ describe("ic-management.utils", () => {
     const decoded = decodeSnapshotId(encoded);
 
     expect(decoded).toEqual(mockSnapshotId);
+  });
+
+  describe("mapSnapshotId", () => {
+    it("should map a Uint8Array snapshot ID without changes", () => {
+      const result = mapSnapshotId(mockSnapshotId);
+
+      expect(result).toEqual(mockSnapshotId);
+    });
+
+    it("should map a string snapshot ID by decoding it", () => {
+      const result = mapSnapshotId(snapshotIdHex);
+      expect(result).toEqual(mockSnapshotId);
+    });
   });
 });

--- a/packages/ic-management/src/utils/ic-management.utils.ts
+++ b/packages/ic-management/src/utils/ic-management.utils.ts
@@ -27,3 +27,17 @@ export const encodeSnapshotId = (snapshotId: snapshot_id): SnapshotIdText =>
  */
 export const decodeSnapshotId = (snapshotId: SnapshotIdText): snapshot_id =>
   hexStringToUint8Array(snapshotId);
+
+/**
+ * Maps a snapshot ID to the appropriate format for the IC interface.
+ *
+ * @param {SnapshotIdText | snapshot_id} snapshotId - The snapshot ID to map.
+ * It can either be a `string` (SnapshotIdText) or a `Uint8Array | number[]` (snapshot_id).
+ * If a `string` is provided, it is decoded into a `Uint8Array` using `decodeSnapshotId`.
+ *
+ * @returns {Uint8Array | number[]} The mapped snapshot ID.
+ */
+export const mapSnapshotId = (
+  snapshotId: SnapshotIdText | snapshot_id,
+): snapshot_id =>
+  typeof snapshotId === "string" ? decodeSnapshotId(snapshotId) : snapshotId;


### PR DESCRIPTION
# Motivation

As suggested by @AntonioVentilii in https://github.com/dfinity/ic-js/pull/759#discussion_r1850750053 we can create a function to map the snapshot id because we will reuse similar pattern in #763.

# Changes

- Extract mapper in utils
- Use mapper in existing implementation
