### PR TITLE
feat: delete canister snapshot

### DIFF
--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -76,6 +76,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 - [takeCanisterSnapshot](#gear-takecanistersnapshot)
 - [listCanisterSnapshots](#gear-listcanistersnapshots)
 - [loadCanisterSnapshot](#gear-loadcanistersnapshot)
+- [deleteCanisterSnapshot](#gear-deletecanistersnapshot)
 
 ##### :gear: create
 
@@ -297,6 +298,22 @@ Parameters:
 - `params.senderCanisterVersion`: - The optional sender canister version. If provided, its value must be equal to ic0.canister_version.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L431)
+
+##### :gear: deleteCanisterSnapshot
+
+Deletes a specific snapshot of a canister.
+
+| Method                   | Type                                                                                                            |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `deleteCanisterSnapshot` | `({ canisterId, snapshotId, }: { canisterId: Principal; snapshotId: string or snapshot_id; }) => Promise<void>` |
+
+Parameters:
+
+- `params`: - Parameters for the deletion operation.
+- `params.canisterId`: - The ID of the canister for which the snapshot will be deleted.
+- `params.snapshotId`: - The ID of the snapshot to delete.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L462)
 
 <!-- TSDOC_END -->
 

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -279,7 +279,7 @@ Parameters:
 - `params.canisterId`: - The ID of the canister for which the snapshot will be deleted.
 - `params.snapshotId`: - The ID of the snapshot to delete.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L409)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L405)
 
 <!-- TSDOC_END -->
 

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -75,6 +75,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 - [fetchCanisterLogs](#gear-fetchcanisterlogs)
 - [takeCanisterSnapshot](#gear-takecanistersnapshot)
 - [listCanisterSnapshots](#gear-listcanistersnapshots)
+- [deleteCanisterSnapshot](#gear-deletecanistersnapshot)
 
 ##### :gear: create
 
@@ -279,6 +280,22 @@ Parameters:
 - `params.canisterId`: - The ID of the canister for which snapshots will be listed.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L405)
+
+##### :gear: deleteCanisterSnapshot
+
+Deletes a specific snapshot of a canister.
+
+| Method                   | Type                                                                                                            |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `deleteCanisterSnapshot` | `({ canisterId, snapshotId, }: { canisterId: Principal; snapshotId: string or snapshot_id; }) => Promise<void>` |
+
+Parameters:
+
+- `params`: - Parameters for the deletion operation.
+- `params.canisterId`: - The ID of the canister for which the snapshot will be deleted.
+- `params.snapshotId`: - The ID of the snapshot to delete.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L430)
 
 <!-- TSDOC_END -->
 

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -74,6 +74,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 - [provisionalCreateCanisterWithCycles](#gear-provisionalcreatecanisterwithcycles)
 - [fetchCanisterLogs](#gear-fetchcanisterlogs)
 - [takeCanisterSnapshot](#gear-takecanistersnapshot)
+- [deleteCanisterSnapshot](#gear-deletecanistersnapshot)
 
 ##### :gear: create
 
@@ -263,6 +264,22 @@ Parameters:
   If not provided, a new snapshot will be created.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L375)
+
+##### :gear: deleteCanisterSnapshot
+
+Deletes a specific snapshot of a canister.
+
+| Method                   | Type                                                                                                            |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `deleteCanisterSnapshot` | `({ canisterId, snapshotId, }: { canisterId: Principal; snapshotId: string or snapshot_id; }) => Promise<void>` |
+
+Parameters:
+
+- `params`: - Parameters for the deletion operation.
+- `params.canisterId`: - The ID of the canister for which the snapshot will be deleted.
+- `params.snapshotId`: - The ID of the snapshot to delete.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L409)
 
 <!-- TSDOC_END -->
 

--- a/packages/ic-management/src/ic-management.canister.spec.ts
+++ b/packages/ic-management/src/ic-management.canister.spec.ts
@@ -805,4 +805,60 @@ describe("ICManagementCanister", () => {
       await expect(call).rejects.toThrow(error);
     });
   });
+
+  describe("deleteCanisterSnapshot", () => {
+    it("should call delete_canister_snapshot with Uint8Array snapshotId", async () => {
+      const service = mock<IcManagementService>();
+      service.delete_canister_snapshot.mockResolvedValue(undefined);
+
+      const icManagement = await createICManagement(service);
+
+      const params = {
+        canisterId: mockCanisterId,
+        snapshotId: Uint8Array.from([1, 2, 3, 4]),
+      };
+
+      await icManagement.deleteCanisterSnapshot(params);
+
+      expect(service.delete_canister_snapshot).toHaveBeenCalledWith({
+        canister_id: params.canisterId,
+        snapshot_id: params.snapshotId,
+      });
+    });
+
+    it("should call delete_canister_snapshot with string snapshotId", async () => {
+      const service = mock<IcManagementService>();
+      service.delete_canister_snapshot.mockResolvedValue(undefined);
+
+      const icManagement = await createICManagement(service);
+
+      const params = {
+        canisterId: mockCanisterId,
+        snapshotId: "000000000000000201010000000000000001",
+      };
+
+      await icManagement.deleteCanisterSnapshot(params);
+
+      expect(service.delete_canister_snapshot).toHaveBeenCalledWith({
+        canister_id: params.canisterId,
+        snapshot_id: decodeSnapshotId(params.snapshotId),
+      });
+    });
+
+    it("should throw an error if delete_canister_snapshot fails", async () => {
+      const error = new Error("Test error");
+      const service = mock<IcManagementService>();
+      service.delete_canister_snapshot.mockRejectedValue(error);
+
+      const icManagement = await createICManagement(service);
+
+      const call = () =>
+        icManagement.deleteCanisterSnapshot({
+          canisterId: mockCanisterId,
+          snapshotId: Uint8Array.from([1, 2, 3, 4]),
+        });
+
+      await expect(call).rejects.toThrow(error);
+    });
+  });
 });

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -413,10 +413,7 @@ export class ICManagementCanister {
 
     await delete_canister_snapshot({
       canister_id: canisterId,
-      snapshot_id:
-        typeof snapshotId === "string"
-          ? decodeSnapshotId(snapshotId)
-          : snapshotId,
+      snapshot_id: mapSnapshotId(snapshotId),
     });
   };
 }

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -392,4 +392,35 @@ export class ICManagementCanister {
       ),
     });
   };
+
+  /**
+   * Deletes a specific snapshot of a canister.
+   *
+   * @link https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-delete_canister_snapshot
+   *
+   * @param {Object} params - Parameters for the deletion operation.
+   * @param {Principal} params.canisterId - The ID of the canister for which the snapshot will be deleted.
+   * @param {snapshot_id} params.snapshotId - The ID of the snapshot to delete.
+   *
+   * @returns {Promise<void>} A promise that resolves when the snapshot is successfully deleted.
+   *
+   * @throws {Error} If the deletion operation fails.
+   */
+  deleteCanisterSnapshot = async ({
+    canisterId,
+    snapshotId,
+  }: {
+    canisterId: Principal;
+    snapshotId: SnapshotIdText | snapshot_id;
+  }): Promise<void> => {
+    const { delete_canister_snapshot } = this.service;
+
+    await delete_canister_snapshot({
+      canister_id: canisterId,
+      snapshot_id:
+        typeof snapshotId === "string"
+          ? decodeSnapshotId(snapshotId)
+          : snapshotId,
+    });
+  };
 }


### PR DESCRIPTION
# Motivation

Support for the last feature of snapshot: [delete_canister_snapshot](https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-delete_canister_snapshot)

# Changes

- Add `deleteCanisterSnapshot` to ic-mgmt