### PR TITLE
chore: prepare ic-mgmt release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The current status of the libraries at the time of the release is as follows:
 | `@dfinity/ckbtc`         | v3.1.3  | Unchanged️          |
 | `@dfinity/cketh`         | v3.4.0  | Unchanged️          |
 | `@dfinity/cmc`           | v4.0.1  | Unchanged️          |
-| `@dfinity/ic-management` | v5.3.0  | Breaking Changes ⚠️ |
+| `@dfinity/ic-management` | v6.0.0  | Breaking Changes ⚠️ |
 | `@dfinity/ledger-icp`    | v2.6.3  | Unchanged️          |
 | `@dfinity/ledger-icrc`   | v2.6.3  | Unchanged️          |
 | `@dfinity/nns`           | v8.0.0  | Unchanged️          |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
-# 2024.xx.yy-hhmmZ
+# 2024.11.22-1600Z
+
+## Overview
+
+The current status of the libraries at the time of the release is as follows:
+
+| Library                  | Version | Status              |
+| ------------------------ | ------- |---------------------|
+| `@dfinity/ckbtc`         | v3.1.3  | Unchanged️          |
+| `@dfinity/cketh`         | v3.4.0  | Unchanged️          |
+| `@dfinity/cmc`           | v4.0.1  | Unchanged️          |
+| `@dfinity/ic-management` | v5.3.0  | Breaking Changes ⚠️ |
+| `@dfinity/ledger-icp`    | v2.6.3  | Unchanged️          |
+| `@dfinity/ledger-icrc`   | v2.6.3  | Unchanged️          |
+| `@dfinity/nns`           | v8.0.0  | Unchanged️          |
+| `@dfinity/nns-proto`     | v2.0.1  | Unchanged️          |
+| `@dfinity/sns`           | v3.2.4  | Unchanged️          |
+| `@dfinity/utils`         | v2.7.0  | Unchanged️          |
 
 # Breaking changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7581,7 +7581,7 @@
     },
     "packages/ic-management": {
       "name": "@dfinity/ic-management",
-      "version": "5.3.0",
+      "version": "6.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "2024.11.21-1600Z",
+  "version": "2024.11.22-1600Z",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/ic-js",
-      "version": "2024.11.21-1600Z",
+      "version": "2024.11.22-1600Z",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/utils",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "2024.11.21-1600Z",
+  "version": "2024.11.22-1600Z",
   "description": "A collection of library for interfacing with the Internet Computer.",
   "license": "Apache-2.0",
   "workspaces": [

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-management",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "description": "A library for interfacing with the IC management canister.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",


### PR DESCRIPTION
# Motivation

I should have thought to integrate the `InstallMode` breaking change in yesterday release but, it's nice to have it officially out as well.

# Changes

- Bump ic-mgmt and version tag
- Add overview to CHANGELOG
