### PR TITLE
Update Candid files for nns and convert RefreshVotingPower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# YYYY.MM.DD-HHMMZ
+
+## Features
+
+- Support `RefreshVotingPower` in `@dfinity/nns`.
+
 # 2024.11.27-1230Z
 
 ## Overview

--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 5d20289 (2024-11-21 tags: release-2024-11-21_03-11-24.04-base-kernel) 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit f9085dbe8d (2024-11-28 tags: release-2024-11-28_03-15-revert-hashes-in-blocks) 'rs/nns/gtc/canister/gtc.did' by import-candid
 type AccountState = record {
   authenticated_principal_id : opt principal;
   successfully_transferred_neurons : vec TransferredNeuron;

--- a/packages/nns/candid/governance.certified.idl.js
+++ b/packages/nns/candid/governance.certified.idl.js
@@ -22,6 +22,7 @@ export const idlFactory = ({ IDL }) => {
     'topic' : IDL.Int32,
     'followees' : IDL.Vec(NeuronId),
   });
+  const RefreshVotingPower = IDL.Record({});
   const ClaimOrRefreshNeuronFromAccount = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
     'memo' : IDL.Nat64,
@@ -86,6 +87,7 @@ export const idlFactory = ({ IDL }) => {
     'Spawn' : Spawn,
     'Split' : Split,
     'Follow' : Follow,
+    'RefreshVotingPower' : RefreshVotingPower,
     'ClaimOrRefresh' : ClaimOrRefresh,
     'Configure' : Configure,
     'RegisterVote' : RegisterVote,
@@ -808,6 +810,7 @@ export const idlFactory = ({ IDL }) => {
     })
   );
   const SpawnResponse = IDL.Record({ 'created_neuron_id' : IDL.Opt(NeuronId) });
+  const RefreshVotingPowerResponse = IDL.Record({});
   const ClaimOrRefreshResponse = IDL.Record({
     'refreshed_neuron_id' : IDL.Opt(NeuronId),
   });
@@ -835,6 +838,7 @@ export const idlFactory = ({ IDL }) => {
     'Spawn' : SpawnResponse,
     'Split' : SpawnResponse,
     'Follow' : IDL.Record({}),
+    'RefreshVotingPower' : RefreshVotingPowerResponse,
     'ClaimOrRefresh' : ClaimOrRefreshResponse,
     'Configure' : IDL.Record({}),
     'RegisterVote' : IDL.Record({}),
@@ -991,6 +995,7 @@ export const init = ({ IDL }) => {
     'topic' : IDL.Int32,
     'followees' : IDL.Vec(NeuronId),
   });
+  const RefreshVotingPower = IDL.Record({});
   const ClaimOrRefreshNeuronFromAccount = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
     'memo' : IDL.Nat64,
@@ -1055,6 +1060,7 @@ export const init = ({ IDL }) => {
     'Spawn' : Spawn,
     'Split' : Split,
     'Follow' : Follow,
+    'RefreshVotingPower' : RefreshVotingPower,
     'ClaimOrRefresh' : ClaimOrRefresh,
     'Configure' : Configure,
     'RegisterVote' : RegisterVote,

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -91,6 +91,7 @@ export type Command =
   | { Spawn: Spawn }
   | { Split: Split }
   | { Follow: Follow }
+  | { RefreshVotingPower: RefreshVotingPower }
   | { ClaimOrRefresh: ClaimOrRefresh }
   | { Configure: Configure }
   | { RegisterVote: RegisterVote }
@@ -105,6 +106,7 @@ export type Command_1 =
   | { Spawn: SpawnResponse }
   | { Split: SpawnResponse }
   | { Follow: {} }
+  | { RefreshVotingPower: RefreshVotingPowerResponse }
   | { ClaimOrRefresh: ClaimOrRefreshResponse }
   | { Configure: {} }
   | { RegisterVote: {} }
@@ -716,6 +718,8 @@ export interface ProposalInfo {
   proposer: [] | [NeuronId];
   executed_timestamp_seconds: bigint;
 }
+export type RefreshVotingPower = {};
+export type RefreshVotingPowerResponse = {};
 export interface RegisterVote {
   vote: number;
   proposal: [] | [ProposalId];

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 5d20289 (2024-11-21 tags: release-2024-11-21_03-11-24.04-base-kernel) 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit f9085dbe8d (2024-11-28 tags: release-2024-11-28_03-15-revert-hashes-in-blocks) 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -108,6 +108,21 @@ type ClaimOrRefreshResponse = record {
   refreshed_neuron_id : opt NeuronId;
 };
 
+// This is one way for a neuron to make sure that its deciding_voting_power is
+// not less than its potential_voting_power. See the description of those fields
+// in Neuron.
+type RefreshVotingPower = record {
+  // Intentionally left blank.
+};
+
+type RefreshVotingPowerResponse = record {
+  // Intentionally left blank.
+  //
+  // We could add information such as the value in the neuron's
+  // voting_power_refreshed_timestamp_second's field, but let's keep things
+  // minimal until we discover there is a "real need". YAGNI.
+};
+
 type Command = variant {
   Spawn : Spawn;
   Split : Split;
@@ -121,6 +136,7 @@ type Command = variant {
   StakeMaturity : StakeMaturity;
   MergeMaturity : MergeMaturity;
   Disburse : Disburse;
+  RefreshVotingPower : RefreshVotingPower;
 };
 
 type Command_1 = variant {
@@ -137,6 +153,7 @@ type Command_1 = variant {
   StakeMaturity : StakeMaturityResponse;
   MergeMaturity : MergeMaturityResponse;
   Disburse : DisburseResponse;
+  RefreshVotingPower : RefreshVotingPowerResponse;
 };
 
 type Command_2 = variant {

--- a/packages/nns/candid/governance.idl.js
+++ b/packages/nns/candid/governance.idl.js
@@ -22,6 +22,7 @@ export const idlFactory = ({ IDL }) => {
     'topic' : IDL.Int32,
     'followees' : IDL.Vec(NeuronId),
   });
+  const RefreshVotingPower = IDL.Record({});
   const ClaimOrRefreshNeuronFromAccount = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
     'memo' : IDL.Nat64,
@@ -86,6 +87,7 @@ export const idlFactory = ({ IDL }) => {
     'Spawn' : Spawn,
     'Split' : Split,
     'Follow' : Follow,
+    'RefreshVotingPower' : RefreshVotingPower,
     'ClaimOrRefresh' : ClaimOrRefresh,
     'Configure' : Configure,
     'RegisterVote' : RegisterVote,
@@ -808,6 +810,7 @@ export const idlFactory = ({ IDL }) => {
     })
   );
   const SpawnResponse = IDL.Record({ 'created_neuron_id' : IDL.Opt(NeuronId) });
+  const RefreshVotingPowerResponse = IDL.Record({});
   const ClaimOrRefreshResponse = IDL.Record({
     'refreshed_neuron_id' : IDL.Opt(NeuronId),
   });
@@ -835,6 +838,7 @@ export const idlFactory = ({ IDL }) => {
     'Spawn' : SpawnResponse,
     'Split' : SpawnResponse,
     'Follow' : IDL.Record({}),
+    'RefreshVotingPower' : RefreshVotingPowerResponse,
     'ClaimOrRefresh' : ClaimOrRefreshResponse,
     'Configure' : IDL.Record({}),
     'RegisterVote' : IDL.Record({}),
@@ -1007,6 +1011,7 @@ export const init = ({ IDL }) => {
     'topic' : IDL.Int32,
     'followees' : IDL.Vec(NeuronId),
   });
+  const RefreshVotingPower = IDL.Record({});
   const ClaimOrRefreshNeuronFromAccount = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
     'memo' : IDL.Nat64,
@@ -1071,6 +1076,7 @@ export const init = ({ IDL }) => {
     'Spawn' : Spawn,
     'Split' : Split,
     'Follow' : Follow,
+    'RefreshVotingPower' : RefreshVotingPower,
     'ClaimOrRefresh' : ClaimOrRefresh,
     'Configure' : Configure,
     'RegisterVote' : RegisterVote,

--- a/packages/nns/candid/governance_test.certified.idl.js
+++ b/packages/nns/candid/governance_test.certified.idl.js
@@ -22,6 +22,7 @@ export const idlFactory = ({ IDL }) => {
     'topic' : IDL.Int32,
     'followees' : IDL.Vec(NeuronId),
   });
+  const RefreshVotingPower = IDL.Record({});
   const ClaimOrRefreshNeuronFromAccount = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
     'memo' : IDL.Nat64,
@@ -86,6 +87,7 @@ export const idlFactory = ({ IDL }) => {
     'Spawn' : Spawn,
     'Split' : Split,
     'Follow' : Follow,
+    'RefreshVotingPower' : RefreshVotingPower,
     'ClaimOrRefresh' : ClaimOrRefresh,
     'Configure' : Configure,
     'RegisterVote' : RegisterVote,
@@ -808,6 +810,7 @@ export const idlFactory = ({ IDL }) => {
     })
   );
   const SpawnResponse = IDL.Record({ 'created_neuron_id' : IDL.Opt(NeuronId) });
+  const RefreshVotingPowerResponse = IDL.Record({});
   const ClaimOrRefreshResponse = IDL.Record({
     'refreshed_neuron_id' : IDL.Opt(NeuronId),
   });
@@ -835,6 +838,7 @@ export const idlFactory = ({ IDL }) => {
     'Spawn' : SpawnResponse,
     'Split' : SpawnResponse,
     'Follow' : IDL.Record({}),
+    'RefreshVotingPower' : RefreshVotingPowerResponse,
     'ClaimOrRefresh' : ClaimOrRefreshResponse,
     'Configure' : IDL.Record({}),
     'RegisterVote' : IDL.Record({}),
@@ -992,6 +996,7 @@ export const init = ({ IDL }) => {
     'topic' : IDL.Int32,
     'followees' : IDL.Vec(NeuronId),
   });
+  const RefreshVotingPower = IDL.Record({});
   const ClaimOrRefreshNeuronFromAccount = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
     'memo' : IDL.Nat64,
@@ -1056,6 +1061,7 @@ export const init = ({ IDL }) => {
     'Spawn' : Spawn,
     'Split' : Split,
     'Follow' : Follow,
+    'RefreshVotingPower' : RefreshVotingPower,
     'ClaimOrRefresh' : ClaimOrRefresh,
     'Configure' : Configure,
     'RegisterVote' : RegisterVote,

--- a/packages/nns/candid/governance_test.d.ts
+++ b/packages/nns/candid/governance_test.d.ts
@@ -91,6 +91,7 @@ export type Command =
   | { Spawn: Spawn }
   | { Split: Split }
   | { Follow: Follow }
+  | { RefreshVotingPower: RefreshVotingPower }
   | { ClaimOrRefresh: ClaimOrRefresh }
   | { Configure: Configure }
   | { RegisterVote: RegisterVote }
@@ -105,6 +106,7 @@ export type Command_1 =
   | { Spawn: SpawnResponse }
   | { Split: SpawnResponse }
   | { Follow: {} }
+  | { RefreshVotingPower: RefreshVotingPowerResponse }
   | { ClaimOrRefresh: ClaimOrRefreshResponse }
   | { Configure: {} }
   | { RegisterVote: {} }
@@ -716,6 +718,8 @@ export interface ProposalInfo {
   proposer: [] | [NeuronId];
   executed_timestamp_seconds: bigint;
 }
+export type RefreshVotingPower = {};
+export type RefreshVotingPowerResponse = {};
 export interface RegisterVote {
   vote: number;
   proposal: [] | [ProposalId];

--- a/packages/nns/candid/governance_test.did
+++ b/packages/nns/candid/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 5d20289 (2024-11-21 tags: release-2024-11-21_03-11-24.04-base-kernel) 'rs/nns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit f9085dbe8d (2024-11-28 tags: release-2024-11-28_03-15-revert-hashes-in-blocks) 'rs/nns/governance/canister/governance_test.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -108,6 +108,21 @@ type ClaimOrRefreshResponse = record {
   refreshed_neuron_id : opt NeuronId;
 };
 
+// This is one way for a neuron to make sure that its deciding_voting_power is
+// not less than its potential_voting_power. See the description of those fields
+// in Neuron.
+type RefreshVotingPower = record {
+  // Intentionally left blank.
+};
+
+type RefreshVotingPowerResponse = record {
+  // Intentionally left blank.
+  //
+  // We could add information such as the value in the neuron's
+  // voting_power_refreshed_timestamp_second's field, but let's keep things
+  // minimal until we discover there is a "real need". YAGNI.
+};
+
 type Command = variant {
   Spawn : Spawn;
   Split : Split;
@@ -121,6 +136,7 @@ type Command = variant {
   StakeMaturity : StakeMaturity;
   MergeMaturity : MergeMaturity;
   Disburse : Disburse;
+  RefreshVotingPower : RefreshVotingPower;
 };
 
 type Command_1 = variant {
@@ -137,6 +153,7 @@ type Command_1 = variant {
   StakeMaturity : StakeMaturityResponse;
   MergeMaturity : MergeMaturityResponse;
   Disburse : DisburseResponse;
+  RefreshVotingPower : RefreshVotingPowerResponse;
 };
 
 type Command_2 = variant {

--- a/packages/nns/candid/governance_test.idl.js
+++ b/packages/nns/candid/governance_test.idl.js
@@ -22,6 +22,7 @@ export const idlFactory = ({ IDL }) => {
     'topic' : IDL.Int32,
     'followees' : IDL.Vec(NeuronId),
   });
+  const RefreshVotingPower = IDL.Record({});
   const ClaimOrRefreshNeuronFromAccount = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
     'memo' : IDL.Nat64,
@@ -86,6 +87,7 @@ export const idlFactory = ({ IDL }) => {
     'Spawn' : Spawn,
     'Split' : Split,
     'Follow' : Follow,
+    'RefreshVotingPower' : RefreshVotingPower,
     'ClaimOrRefresh' : ClaimOrRefresh,
     'Configure' : Configure,
     'RegisterVote' : RegisterVote,
@@ -808,6 +810,7 @@ export const idlFactory = ({ IDL }) => {
     })
   );
   const SpawnResponse = IDL.Record({ 'created_neuron_id' : IDL.Opt(NeuronId) });
+  const RefreshVotingPowerResponse = IDL.Record({});
   const ClaimOrRefreshResponse = IDL.Record({
     'refreshed_neuron_id' : IDL.Opt(NeuronId),
   });
@@ -835,6 +838,7 @@ export const idlFactory = ({ IDL }) => {
     'Spawn' : SpawnResponse,
     'Split' : SpawnResponse,
     'Follow' : IDL.Record({}),
+    'RefreshVotingPower' : RefreshVotingPowerResponse,
     'ClaimOrRefresh' : ClaimOrRefreshResponse,
     'Configure' : IDL.Record({}),
     'RegisterVote' : IDL.Record({}),
@@ -1008,6 +1012,7 @@ export const init = ({ IDL }) => {
     'topic' : IDL.Int32,
     'followees' : IDL.Vec(NeuronId),
   });
+  const RefreshVotingPower = IDL.Record({});
   const ClaimOrRefreshNeuronFromAccount = IDL.Record({
     'controller' : IDL.Opt(IDL.Principal),
     'memo' : IDL.Nat64,
@@ -1072,6 +1077,7 @@ export const init = ({ IDL }) => {
     'Spawn' : Spawn,
     'Split' : Split,
     'Follow' : Follow,
+    'RefreshVotingPower' : RefreshVotingPower,
     'ClaimOrRefresh' : ClaimOrRefresh,
     'Configure' : Configure,
     'RegisterVote' : RegisterVote,

--- a/packages/nns/candid/sns_wasm.did
+++ b/packages/nns/candid/sns_wasm.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 5d20289 (2024-11-21 tags: release-2024-11-21_03-11-24.04-base-kernel) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit f9085dbe8d (2024-11-28 tags: release-2024-11-28_03-15-revert-hashes-in-blocks) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -735,6 +735,13 @@ const toCommand = (command: RawCommand): Command => {
       },
     };
   }
+  if ("RefreshVotingPower" in command) {
+    return {
+      RefreshVotingPower: {
+        // Intentionally left blank.
+      },
+    };
+  }
 
   throw new UnsupportedValueError(command);
 };

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -106,7 +106,8 @@ export type Command =
   | { MergeMaturity: MergeMaturity }
   | { StakeMaturity: StakeMaturity }
   | { MakeProposal: Proposal }
-  | { Disburse: Disburse };
+  | { Disburse: Disburse }
+  | { RefreshVotingPower: RefreshVotingPower };
 export type ManageNeuronCommandRequest =
   | { Spawn: Spawn }
   | { Split: Split }
@@ -122,6 +123,9 @@ export type ManageNeuronCommandRequest =
   | { Disburse: Disburse };
 export interface Configure {
   operation: Option<Operation>;
+}
+export interface RefreshVotingPower {
+  // Intentionally left blank.
 }
 export interface Disburse {
   toAccountId: Option<AccountIdentifierHex>;


### PR DESCRIPTION
# Motivation

The automatic update PR (https://github.com/dfinity/ic-js/pull/778) had failures in the `nns` and `cketh` packages.
This PR addresses the update of the `nns` package.

# Changes

1. Checked out `git checkout release-2024-11-28_03-15-revert-hashes-in-blocks` in my `ic` repo.
2. Ran `scripts/import-candid ../../ic`
3. Ran `scripts/compile-idl-js`
4. Added conversion for `RefreshVotingPower` command.
5. Removed changes outside the `nns` package by running `git checkout packages/{ckbtc,cketh,cmc,ledger-icp,ledger-icrc,sns}`

# Tests

The issue was caught by the compiler. There is no logic as the body of the `RefreshVotingPower` type is empty. And there are no existing tests for the changed function.

# Todos

- [x] Add entry to changelog (if necessary).