### PR TITLE
feat: add support for get_subnet_types_to_subnets in CMC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Support `RefreshVotingPower` in `@dfinity/nns`.
 - Remove optional field `last_deposit_with_subaccount_scraped_block_number` from ckETH minter information.
 - Expose a few additional types related to snapshots in `ic-management`.
+- Add support for `get_subnet_types_to_subnets` to `@dfinity/cmc`.
 
 # 2024.11.27-1230Z
 

--- a/packages/cmc/README.md
+++ b/packages/cmc/README.md
@@ -127,7 +127,7 @@ Parameters:
 
 This function calls the `get_subnet_types_to_subnets` method of the CMC canister, which returns a list of subnets where canisters can be created.
 These subnets are excluded from the random subnet selection process used by the CMC when no explicit subnet ID is provided
-during canister creation.
+during canister creation and therefore, not provided in the results of the similar function `get_default_subnets`.
 
 | Method                    | Type                                                                      |
 | ------------------------- | ------------------------------------------------------------------------- |

--- a/packages/cmc/src/cmc.canister.spec.ts
+++ b/packages/cmc/src/cmc.canister.spec.ts
@@ -3,7 +3,7 @@ import { Principal } from "@dfinity/principal";
 import type { QueryParams } from "@dfinity/utils";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
-import {
+import type {
   _SERVICE as CMCService,
   IcpXdrConversionRateResponse,
   NotifyCreateCanisterResult,

--- a/packages/cmc/src/cmc.canister.ts
+++ b/packages/cmc/src/cmc.canister.ts
@@ -1,6 +1,6 @@
 import type { Principal } from "@dfinity/principal";
 import { Canister, createServices, type QueryParams } from "@dfinity/utils";
-import {
+import type {
   _SERVICE as CMCCanisterService,
   Cycles,
   NotifyCreateCanisterArg,

--- a/packages/cmc/src/cmc.canister.ts
+++ b/packages/cmc/src/cmc.canister.ts
@@ -109,7 +109,7 @@ export class CMCCanister extends Canister<CMCCanisterService> {
   /**
    * This function calls the `get_subnet_types_to_subnets` method of the CMC canister, which returns a list of subnets where canisters can be created.
    * These subnets are excluded from the random subnet selection process used by the CMC when no explicit subnet ID is provided
-   * during canister creation.
+   * during canister creation and therefore, not provided in the results of the similar function `get_default_subnets`.
    *
    * @param {Object} [params] - The optional query parameters for the call.
    * @param {boolean} [params.certified=false] - Specifies whether the response should be certified.

--- a/packages/cmc/src/cmc.canister.ts
+++ b/packages/cmc/src/cmc.canister.ts
@@ -1,10 +1,11 @@
 import type { Principal } from "@dfinity/principal";
 import { Canister, createServices, type QueryParams } from "@dfinity/utils";
-import type {
+import {
   _SERVICE as CMCCanisterService,
   Cycles,
   NotifyCreateCanisterArg,
   NotifyTopUpArg,
+  SubnetTypesToSubnetsResponse,
 } from "../candid/cmc";
 import { idlFactory as certifiedIdlFactory } from "../candid/cmc.certified.idl";
 import { idlFactory } from "../candid/cmc.idl";
@@ -103,5 +104,24 @@ export class CMCCanister extends Canister<CMCCanisterService> {
   > => {
     const { get_default_subnets } = this.caller({ certified });
     return get_default_subnets();
+  };
+
+  /**
+   * This function calls the `get_subnet_types_to_subnets` method of the CMC canister, which returns a list of subnets where canisters can be created.
+   * These subnets are excluded from the random subnet selection process used by the CMC when no explicit subnet ID is provided
+   * during canister creation.
+   *
+   * @param {Object} [params] - The optional query parameters for the call.
+   * @param {boolean} [params.certified=false] - Specifies whether the response should be certified.
+   * If not provided, the response defaults to non-certified.
+   *
+   * @returns {Promise<SubnetTypesToSubnetsResponse>} - A promise that resolves to an object representing
+   * the mapping of subnet types to subnets.
+   */
+  public getSubnetTypesToSubnets = async ({
+    certified,
+  }: QueryParams = {}): Promise<SubnetTypesToSubnetsResponse> => {
+    const { get_subnet_types_to_subnets } = this.caller({ certified });
+    return get_subnet_types_to_subnets();
   };
 }

--- a/packages/cmc/src/index.ts
+++ b/packages/cmc/src/index.ts
@@ -2,6 +2,7 @@ export type {
   Cycles,
   NotifyCreateCanisterArg,
   NotifyTopUpArg,
+  SubnetTypesToSubnetsResponse,
 } from "../candid/cmc";
 export { CMCCanister } from "./cmc.canister";
 export * from "./cmc.errors";


### PR DESCRIPTION
# Motivation

If a developer want to discover the list of subnet in which they can create canister, they should actually query another endpoint of the CMC in addition of the already exposed `get_default_subnets`.

The `get_subnet_types_to_subnets` provides additional subnets that can be used to create canisters but, are not used by the CMC itself to create canister on a random subnet when not targeted subnet ID is provided.

A bit complicated but, once you know you need both, it's a bit more clear. 

# Changes

- Expose `get_subnet_types_to_subnets`.
- Expose did type for the response.
