### PR TITLE
docs: format jsdocs for nullish.utils

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -81,33 +81,45 @@ Parameters:
 
 #### :gear: isNullish
 
-Is null or undefined
+Checks if a given argument is null or undefined.
 
 | Function    | Type                                                                     |
 | ----------- | ------------------------------------------------------------------------ |
 | `isNullish` | `<T>(argument: T or null or undefined) => argument is null or undefined` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/nullish.utils.ts#L2)
+Parameters:
+
+- `argument`: - The argument to check.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/nullish.utils.ts#L8)
 
 #### :gear: nonNullish
 
-Not null and not undefined
+Checks if a given argument is neither null nor undefined.
 
 | Function     | Type                                                                  |
 | ------------ | --------------------------------------------------------------------- |
 | `nonNullish` | `<T>(argument: T or null or undefined) => argument is NonNullable<T>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/nullish.utils.ts#L7)
+Parameters:
+
+- `argument`: - The argument to check.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/nullish.utils.ts#L19)
 
 #### :gear: notEmptyString
 
-Not null and not undefined and not empty
+Checks if a given value is not null, not undefined, and not an empty string.
 
 | Function         | Type                                              |
 | ---------------- | ------------------------------------------------- |
 | `notEmptyString` | `(value: string or null or undefined) => boolean` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/nullish.utils.ts#L12)
+Parameters:
+
+- `value`: - The value to check.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/nullish.utils.ts#L29)
 
 #### :gear: defaultAgent
 

--- a/packages/utils/src/utils/nullish.utils.ts
+++ b/packages/utils/src/utils/nullish.utils.ts
@@ -1,13 +1,30 @@
-/** Is null or undefined */
+/**
+ * Checks if a given argument is null or undefined.
+ *
+ * @template T - The type of the argument.
+ * @param {T | undefined | null} argument - The argument to check.
+ * @returns {argument is undefined | null} `true` if the argument is null or undefined; otherwise, `false`.
+ */
 export const isNullish = <T>(
   argument: T | undefined | null,
 ): argument is undefined | null => argument === null || argument === undefined;
 
-/** Not null and not undefined */
+/**
+ * Checks if a given argument is neither null nor undefined.
+ *
+ * @template T - The type of the argument.
+ * @param {T | undefined | null} argument - The argument to check.
+ * @returns {argument is NonNullable<T>} `true` if the argument is not null or undefined; otherwise, `false`.
+ */
 export const nonNullish = <T>(
   argument: T | undefined | null,
 ): argument is NonNullable<T> => !isNullish(argument);
 
-/** Not null and not undefined and not empty */
+/**
+ * Checks if a given value is not null, not undefined, and not an empty string.
+ *
+ * @param {string | undefined | null} value - The value to check.
+ * @returns {boolean} `true` if the value is not null, not undefined, and not an empty string; otherwise, `false`.
+ */
 export const notEmptyString = (value: string | undefined | null): boolean =>
   nonNullish(value) && value !== "";


### PR DESCRIPTION
# Motivation

I noticed the jsdocs in `nullish.utils` was not yet well formatted.

# Changes

- Format jsdocs with `@template`, `@param` etc.