### PR TITLE
build: bump tsdoc-markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "text-encoding": "^0.7.0",
         "ts-jest": "^29.2.5",
         "ts-protoc-gen": "^0.15.0",
-        "tsdoc-markdown": "^0.6.3",
+        "tsdoc-markdown": "^1.1.0",
         "typescript": "^5.4.4"
       }
     },
@@ -7192,9 +7192,9 @@
       }
     },
     "node_modules/tsdoc-markdown": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-0.6.3.tgz",
-      "integrity": "sha512-F/1kpmjj9g31GMQl7rWCFaxuvrpfC8DYw06P8fvpUdKANl7Uo+27hl8zRzELEwwOJ0K0sMA/qR/kfFMc5OJ1oA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.1.0.tgz",
+      "integrity": "sha512-uzToA1DlETBIW9lkPfeaWD7TXusL0/mEvRW2NWRYsy+57HwbFiolmeRYrqoIgPA0GOBY9D9jX3fB2dnwybmabg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -12693,9 +12693,9 @@
       }
     },
     "tsdoc-markdown": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-0.6.3.tgz",
-      "integrity": "sha512-F/1kpmjj9g31GMQl7rWCFaxuvrpfC8DYw06P8fvpUdKANl7Uo+27hl8zRzELEwwOJ0K0sMA/qR/kfFMc5OJ1oA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.1.0.tgz",
+      "integrity": "sha512-uzToA1DlETBIW9lkPfeaWD7TXusL0/mEvRW2NWRYsy+57HwbFiolmeRYrqoIgPA0GOBY9D9jX3fB2dnwybmabg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "text-encoding": "^0.7.0",
     "ts-jest": "^29.2.5",
     "ts-protoc-gen": "^0.15.0",
-    "tsdoc-markdown": "^0.6.3",
+    "tsdoc-markdown": "^1.1.0",
     "typescript": "^5.4.4"
   },
   "size-limit": [

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -179,7 +179,7 @@ Parameters:
 | ------------------ | --------------------------------------------------------------------------------- |
 | `assertNonNullish` | `<T>(value: T, message?: string or undefined) => asserts value is NonNullable<T>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/asserts.utils.ts#L7)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/asserts.utils.ts#L4)
 
 #### :gear: asNonNullish
 


### PR DESCRIPTION
# Motivation

I implemented few fixes and improvements in `tsdoc-markdown`, notably this evening, which I thinnk have no impacts on `ic-js` but, to follow-up with the version, this PR bumps the library to latest.

# Note

There was no breaking changes. I started adopting semver therefore the jump to v1.x.y.
