### PR TITLE
New voting power related fields in NeuronInfo

### DIFF
--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -142,7 +142,11 @@ export const toNeuronInfo = ({
       ? neuronInfo.joined_community_fund_timestamp_seconds[0]
       : undefined,
     retrievedAtTimestampSeconds: neuronInfo.retrieved_at_timestamp_seconds,
+    /** @deprecated */
     votingPower: neuronInfo.voting_power,
+    votingPowerRefreshedTimestampSeconds : fromNullable(neuronInfo.voting_power_refreshed_timestamp_seconds),
+    decidingVotingPower : fromNullable(neuronInfo.deciding_voting_power),
+    potentialVotingPower : fromNullable(neuronInfo.potential_voting_power),
     ageSeconds: neuronInfo.age_seconds,
     visibility: fromNullable(neuronInfo.visibility) as
       | NeuronVisibility

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -144,9 +144,11 @@ export const toNeuronInfo = ({
     retrievedAtTimestampSeconds: neuronInfo.retrieved_at_timestamp_seconds,
     /** @deprecated */
     votingPower: neuronInfo.voting_power,
-    votingPowerRefreshedTimestampSeconds : fromNullable(neuronInfo.voting_power_refreshed_timestamp_seconds),
-    decidingVotingPower : fromNullable(neuronInfo.deciding_voting_power),
-    potentialVotingPower : fromNullable(neuronInfo.potential_voting_power),
+    votingPowerRefreshedTimestampSeconds: fromNullable(
+      neuronInfo.voting_power_refreshed_timestamp_seconds,
+    ),
+    decidingVotingPower: fromNullable(neuronInfo.deciding_voting_power),
+    potentialVotingPower: fromNullable(neuronInfo.potential_voting_power),
     ageSeconds: neuronInfo.age_seconds,
     visibility: fromNullable(neuronInfo.visibility) as
       | NeuronVisibility

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -393,6 +393,9 @@ export interface NeuronInfo {
   joinedCommunityFundTimestampSeconds: Option<bigint>;
   retrievedAtTimestampSeconds: bigint;
   votingPower: bigint;
+  votingPowerRefreshedTimestampSeconds: Option<bigint>;
+  decidingVotingPower: Option<bigint>;
+  potentialVotingPower: Option<bigint>;
   ageSeconds: bigint;
   fullNeuron: Option<Neuron>;
   visibility: Option<NeuronVisibility>;


### PR DESCRIPTION
# Motivation

After introducing new neuron properties (`deciding_voting_power` and `potential_voting_power`), the original `voting_power` field has become [obsolete](https://github.com/dfinity/ic/blob/586c57afa7af796185c76c8ff26bc37e813957c2/rs/nns/governance/canister/governance.did#L744-L751). With this PR, we add three new fields to the NeuronInfo: `decidingVotingPower`, `potentialVotingPower`, and a small drive-by addition `votingPowerRefreshedTimestampSeconds`; and mark the original votingPower field as deprecated.

# Changes

- Added 3 new fields.
- Mark `votingPower` as deprecated.

# Tests

- Pass.
- Tested manually by utilizing new fields in the NNS Dapp.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.