### PR TITLE
feat: extend transform for provisional_create_canister_with_cycles

### DIFF
--- a/packages/ic-management/src/utils/transform.utils.ts
+++ b/packages/ic-management/src/utils/transform.utils.ts
@@ -22,6 +22,7 @@ export const transform: CallTransform | QueryTransform = (
   args: (Record<string, unknown> & {
     canister_id?: unknown;
     target_canister?: unknown;
+    specified_id?: unknown;
   })[],
   _callConfig: CallConfig,
 ): { effectiveCanisterId: Principal } => {
@@ -33,6 +34,11 @@ export const transform: CallTransform | QueryTransform = (
       nonNullish(first.target_canister)
     ) {
       return { effectiveCanisterId: Principal.from(first.target_canister) };
+    } else if (
+      methodName === "provisional_create_canister_with_cycles" &&
+      nonNullish(first.specified_id)
+    ) {
+      return { effectiveCanisterId: Principal.from(first.specified_id) };
     } else if (nonNullish(first.canister_id)) {
       return { effectiveCanisterId: Principal.from(first.canister_id) };
     }


### PR DESCRIPTION
# Motivation

In order to install canister in development with pocket-ic, the `transform` function should be extended to intercept `provisional_create_canister_with_cycles` and potential `specified_id`.

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
