### PR TITLE
fix: typo in renamed exposed type IcrcTransferVariatError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# YYYY.MM.DD-HHMMZ
+
+## Fix
+
+- Typo in renamed exposed type `IcrcTransferVariatError`.
+
 # 2024.12.23-1215Z
 
 ## Overview

--- a/packages/ledger-icrc/src/index.ts
+++ b/packages/ledger-icrc/src/index.ts
@@ -3,7 +3,7 @@ export type {
   Subaccount as IcrcSubaccount,
   Tokens as IcrcTokens,
   TransferArg as IcrcTransferArg,
-  TransferError as IcrcTransferVariatError,
+  TransferError as IcrcTransferVariantError,
   Value as IcrcValue,
 } from "../candid/icrc_ledger";
 export * from "./converters/ledger.converters";


### PR DESCRIPTION
# Motivation

Spotted a typo in a re-exported did type of the ledger-icrc.

# Notes

Fundamentaly this is a breaking change but, given it's "just" a TypeScript type and no functional code, I did not listed the change as a "Breaking Change" but as "Fix".
