### PR TITLE
feat: expose did error types in ledger-icrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# YYYY.MM.DD-HHMMZ
+
+## Features
+
+- Expose types `IcrcApproveError` and `IcrcTransferFromError` in `@dfinity/ledger-icrc`.
+
 # 2024.12.23-1215Z
 
 ## Overview

--- a/packages/ledger-icrc/src/index.ts
+++ b/packages/ledger-icrc/src/index.ts
@@ -1,8 +1,10 @@
 export type {
+  ApproveError as IcrcApproveError,
   BlockIndex as IcrcBlockIndex,
   Subaccount as IcrcSubaccount,
   Tokens as IcrcTokens,
   TransferArg as IcrcTransferArg,
+  TransferFromError as IcrcTransferFromError,
   TransferError as IcrcTransferVariatError,
   Value as IcrcValue,
 } from "../candid/icrc_ledger";


### PR DESCRIPTION
# Motivation

We are re-exporting the ICRC transfer result error type. We can do the same for approve and transfer from as we might need those two in the OISY wallet signer.