### PR TITLE
Add BOT_APPROVED_FILES

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -1,0 +1,3 @@
+packages/*/candid/*.did
+packages/*/candid/*.idl.js
+packages/*/candid/*.d.ts

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -87,7 +87,7 @@ jobs:
           branch: bot-ic-update
           branch-suffix: timestamp # Creates a new branch & PR with every run.  If this gets spammy, please delete this line and instead block the PR from making a PR if there is already an open one.
           delete-branch: true
-          title: 'Update Candid Files'
+          title: 'bot: Update Candid Files'
           body: |
             # Motivation
             The canisters APIs have been updated.


### PR DESCRIPTION
# Motivation

Starting soon, files changed by bots must be listed in `.github/repo_policies/BOT_APPROVED_FILES`.

# Changes

1. Added Candid related files which are updated weekly by a bot to `.github/repo_policies/BOT_APPROVED_FILES`.
2. Made bot PRs easier to spot in the future by prepending "bot: " to their titles, like we do in nns-dapp.