### PR TITLE
Stop updating old ICRC1 index canister candid

### DIFF
--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -105,7 +105,6 @@ import_did "rs/ledger_suite/icp/index/index.did" "index.did" "ledger-icp"
 
 mkdir -p packages/ledger-icrc/candid
 import_did "rs/ledger_suite/icrc1/ledger/ledger.did" "icrc_ledger.did" "ledger-icrc"
-import_did "rs/ledger_suite/icrc1/index/index.did" "icrc_index.did" "ledger-icrc"
 import_did "rs/ledger_suite/icrc1/index-ng/index-ng.did" "icrc_index-ng.did" "ledger-icrc"
 
 mkdir -p packages/ckbtc/candid


### PR DESCRIPTION
# Motivation

The old ICRC1 index canister was deleted in https://github.com/dfinity/ic/pull/3286
This caused the automatic candid update job to fail when it tried to download the candid for this canister:
https://github.com/dfinity/ic-js/actions/runs/12626049412/job/35178612469

I think it will be good to keep the canister in `ic-js` for backwards compatibility, at least for a while.
But since the canister code is deleted, the candid definitely won't be changing anymore so we can stop automatically updating it.

# Changes

Stop updating the candid for the old ICRC1 index canister in `scripts/import-candid`.

# Tests

Ran the script before and after and saw that it started working again.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary