### PR TITLE
build: bump tsdoc-markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "text-encoding": "^0.7.0",
         "ts-jest": "^29.2.5",
         "ts-protoc-gen": "^0.15.0",
-        "tsdoc-markdown": "^1.1.0",
+        "tsdoc-markdown": "^1.1.1",
         "typescript": "^5.4.4"
       }
     },
@@ -7192,9 +7192,9 @@
       }
     },
     "node_modules/tsdoc-markdown": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.1.0.tgz",
-      "integrity": "sha512-uzToA1DlETBIW9lkPfeaWD7TXusL0/mEvRW2NWRYsy+57HwbFiolmeRYrqoIgPA0GOBY9D9jX3fB2dnwybmabg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.1.1.tgz",
+      "integrity": "sha512-Ntww+xHtV/DjHVLWohV3ZX01z09v+12jLYS3CqJXCr2mHc1Jz6WSG8dnNj/zk/7xp8yNKJRoWtxvv4WWaNsMEA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -12693,9 +12693,9 @@
       }
     },
     "tsdoc-markdown": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.1.0.tgz",
-      "integrity": "sha512-uzToA1DlETBIW9lkPfeaWD7TXusL0/mEvRW2NWRYsy+57HwbFiolmeRYrqoIgPA0GOBY9D9jX3fB2dnwybmabg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.1.1.tgz",
+      "integrity": "sha512-Ntww+xHtV/DjHVLWohV3ZX01z09v+12jLYS3CqJXCr2mHc1Jz6WSG8dnNj/zk/7xp8yNKJRoWtxvv4WWaNsMEA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "text-encoding": "^0.7.0",
     "ts-jest": "^29.2.5",
     "ts-protoc-gen": "^0.15.0",
-    "tsdoc-markdown": "^1.1.0",
+    "tsdoc-markdown": "^1.1.1",
     "typescript": "^5.4.4"
   },
   "size-limit": [


### PR DESCRIPTION
# Motivation

We need a small patch shipped in `tsdoc-markdown` [v1.1.1](https://github.com/peterpeterparker/tsdoc-markdown/releases/tag/v1.1.1) to generate documentation in #813.
