### PR TITLE
chore: bump copyright year to 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 DFINITY Stiftung.
+   Copyright 2025 DFINITY Stiftung.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/ckbtc/LICENSE
+++ b/packages/ckbtc/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 DFINITY Stiftung.
+   Copyright 2025 DFINITY Stiftung.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/cketh/LICENSE
+++ b/packages/cketh/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 DFINITY Stiftung.
+   Copyright 2025 DFINITY Stiftung.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/cmc/LICENSE
+++ b/packages/cmc/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 DFINITY Stiftung.
+   Copyright 2025 DFINITY Stiftung.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/ic-management/LICENSE
+++ b/packages/ic-management/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 DFINITY Stiftung.
+   Copyright 2025 DFINITY Stiftung.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/ledger-icp/LICENSE
+++ b/packages/ledger-icp/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 DFINITY Stiftung.
+   Copyright 2025 DFINITY Stiftung.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/ledger-icrc/LICENSE
+++ b/packages/ledger-icrc/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 DFINITY Stiftung.
+   Copyright 2025 DFINITY Stiftung.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/nns-proto/LICENSE
+++ b/packages/nns-proto/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 DFINITY Stiftung.
+   Copyright 2025 DFINITY Stiftung.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/nns/LICENSE
+++ b/packages/nns/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 DFINITY Stiftung.
+   Copyright 2025 DFINITY Stiftung.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/sns/LICENSE
+++ b/packages/sns/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 DFINITY Stiftung.
+   Copyright 2025 DFINITY Stiftung.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/utils/LICENSE
+++ b/packages/utils/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 DFINITY Stiftung.
+   Copyright 2025 DFINITY Stiftung.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/zod-schemas/LICENSE
+++ b/packages/zod-schemas/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 DFINITY Stiftung.
+   Copyright 2025 DFINITY Stiftung.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Motivation

In OISY we were requested to bump the copyright year to 2025 therefore makes sense to do so in ic-js as well.

# Changes

- Bump 2021 to 2025
