### PR TITLE
chore: zod peer dependencies wildcard v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7690,7 +7690,7 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/principal": "^2.0.0",
-        "zod": "^3.24.1"
+        "zod": "^3"
       }
     }
   },


### PR DESCRIPTION
# Motivation

Accepting all zod v3 library in #812 was not replicated, it seems, in package-lock.json.
