### PR TITLE
docs: typo in changelog in the name of the new lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status        |
-|--------------------------| ------- | ------------- |
+| ------------------------ | ------- | ------------- |
 | `@dfinity/ckbtc`         | v3.1.5  | Unchanged️    |
 | `@dfinity/cketh`         | v3.4.2  | Unchanged️    |
 | `@dfinity/cmc`           | v4.1.0  | Unchanged️    |
@@ -16,7 +16,7 @@ The current status of the libraries at the time of the release is as follows:
 | `@dfinity/nns-proto`     | v2.0.1  | Unchanged️    |
 | `@dfinity/sns`           | v3.2.7  | Maintained ⚙️ |
 | `@dfinity/utils`         | v2.8.0  | Unchanged️    |
-| `@dfinity/zod-schemas`         | v0.0.1  | New 🚀        |
+| `@dfinity/zod-schemas`   | v0.0.1  | New 🚀        |
 
 ## Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status        |
-| ------------------------ | ------- | ------------- |
+|--------------------------| ------- | ------------- |
 | `@dfinity/ckbtc`         | v3.1.5  | Unchanged️    |
 | `@dfinity/cketh`         | v3.4.2  | Unchanged️    |
 | `@dfinity/cmc`           | v4.1.0  | Unchanged️    |
@@ -16,7 +16,7 @@ The current status of the libraries at the time of the release is as follows:
 | `@dfinity/nns-proto`     | v2.0.1  | Unchanged️    |
 | `@dfinity/sns`           | v3.2.7  | Maintained ⚙️ |
 | `@dfinity/utils`         | v2.8.0  | Unchanged️    |
-| `@dfinity/utils`         | v0.0.1  | New 🚀        |
+| `@dfinity/zod-schemas`         | v0.0.1  | New 🚀        |
 
 ## Features
 


### PR DESCRIPTION
# Motivation

Typo. I corrected it manually in the [release](https://github.com/dfinity/ic-js/releases/tag/2025.01.20-1030Z) but, we can also update the CHANGELOG.
