### PR TITLE
Update candid for nns package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# YYYY.MM.DD-HHMMZ
+
+# Features
+
+- Support `CanisterSettings.wasm_memory_threshold` in `@dfinity/nns`.
+
 # 2025.01.20-1030Z
 
 ## Overview

--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 0f35ac817b (2024-12-06) 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/nns/gtc/canister/gtc.did' by import-candid
 type AccountState = record {
   authenticated_principal_id : opt principal;
   successfully_transferred_neurons : vec TransferredNeuron;

--- a/packages/nns/candid/governance.certified.idl.js
+++ b/packages/nns/candid/governance.certified.idl.js
@@ -110,6 +110,7 @@ export const idlFactory = ({ IDL }) => {
   const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
   const CanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'controllers' : IDL.Opt(Controllers),
     'log_visibility' : IDL.Opt(IDL.Int32),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
@@ -365,12 +366,16 @@ export const idlFactory = ({ IDL }) => {
     'voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_e8s' : IDL.Opt(IDL.Nat64),
     'count' : IDL.Opt(IDL.Nat64),
+    'deciding_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
+    'total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'total_deciding_voting_power' : IDL.Opt(IDL.Nat64),
     'staked_maturity_e8s_equivalent_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Nat64)
     ),
     'staked_e8s_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_voting_power' : IDL.Opt(IDL.Nat64),
+    'potential_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'count_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
   });
   const GovernanceCachedMetrics = IDL.Record({
@@ -395,6 +400,9 @@ export const idlFactory = ({ IDL }) => {
     'total_staked_e8s_seed' : IDL.Nat64,
     'total_staked_maturity_e8s_equivalent_ect' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
+    'fully_lost_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
+    ),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'total_locked_e8s' : IDL.Nat64,
     'neurons_fund_total_active_neurons' : IDL.Nat64,
@@ -404,6 +412,9 @@ export const idlFactory = ({ IDL }) => {
     'total_staked_maturity_e8s_equivalent' : IDL.Nat64,
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
     ),
     'total_staked_e8s_ect' : IDL.Nat64,
     'not_dissolving_neurons_staked_maturity_e8s_equivalent_sum' : IDL.Nat64,
@@ -1093,6 +1104,7 @@ export const init = ({ IDL }) => {
   const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
   const CanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'controllers' : IDL.Opt(Controllers),
     'log_visibility' : IDL.Opt(IDL.Int32),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
@@ -1348,12 +1360,16 @@ export const init = ({ IDL }) => {
     'voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_e8s' : IDL.Opt(IDL.Nat64),
     'count' : IDL.Opt(IDL.Nat64),
+    'deciding_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
+    'total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'total_deciding_voting_power' : IDL.Opt(IDL.Nat64),
     'staked_maturity_e8s_equivalent_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Nat64)
     ),
     'staked_e8s_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_voting_power' : IDL.Opt(IDL.Nat64),
+    'potential_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'count_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
   });
   const GovernanceCachedMetrics = IDL.Record({
@@ -1378,6 +1394,9 @@ export const init = ({ IDL }) => {
     'total_staked_e8s_seed' : IDL.Nat64,
     'total_staked_maturity_e8s_equivalent_ect' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
+    'fully_lost_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
+    ),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'total_locked_e8s' : IDL.Nat64,
     'neurons_fund_total_active_neurons' : IDL.Nat64,
@@ -1387,6 +1406,9 @@ export const init = ({ IDL }) => {
     'total_staked_maturity_e8s_equivalent' : IDL.Nat64,
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
     ),
     'total_staked_e8s_ect' : IDL.Nat64,
     'not_dissolving_neurons_staked_maturity_e8s_equivalent_sum' : IDL.Nat64,

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -51,6 +51,7 @@ export interface Canister {
 }
 export interface CanisterSettings {
   freezing_threshold: [] | [bigint];
+  wasm_memory_threshold: [] | [bigint];
   controllers: [] | [Controllers];
   log_visibility: [] | [number];
   wasm_memory_limit: [] | [bigint];
@@ -258,12 +259,14 @@ export interface GovernanceCachedMetrics {
   total_staked_e8s_seed: bigint;
   total_staked_maturity_e8s_equivalent_ect: bigint;
   total_staked_e8s: bigint;
+  fully_lost_voting_power_neuron_subset_metrics: [] | [NeuronSubsetMetrics];
   not_dissolving_neurons_count: bigint;
   total_locked_e8s: bigint;
   neurons_fund_total_active_neurons: bigint;
   total_voting_power_non_self_authenticating_controller: [] | [bigint];
   total_staked_maturity_e8s_equivalent: bigint;
   not_dissolving_neurons_e8s_buckets_ect: Array<[bigint, number]>;
+  declining_voting_power_neuron_subset_metrics: [] | [NeuronSubsetMetrics];
   total_staked_e8s_ect: bigint;
   not_dissolving_neurons_staked_maturity_e8s_equivalent_sum: bigint;
   dissolved_neurons_e8s: bigint;
@@ -554,10 +557,14 @@ export interface NeuronSubsetMetrics {
   voting_power_buckets: Array<[bigint, bigint]>;
   total_staked_e8s: [] | [bigint];
   count: [] | [bigint];
+  deciding_voting_power_buckets: Array<[bigint, bigint]>;
   total_staked_maturity_e8s_equivalent: [] | [bigint];
+  total_potential_voting_power: [] | [bigint];
+  total_deciding_voting_power: [] | [bigint];
   staked_maturity_e8s_equivalent_buckets: Array<[bigint, bigint]>;
   staked_e8s_buckets: Array<[bigint, bigint]>;
   total_voting_power: [] | [bigint];
+  potential_voting_power_buckets: Array<[bigint, bigint]>;
   count_buckets: Array<[bigint, bigint]>;
 }
 export interface NeuronsFundAuditInfo {

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 0f35ac817b (2024-12-06) 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -65,6 +65,7 @@ type CanisterSettings = record {
   wasm_memory_limit : opt nat64;
   memory_allocation : opt nat64;
   compute_allocation : opt nat64;
+  wasm_memory_threshold : opt nat64;
 };
 
 type CanisterStatusResultV2 = record {
@@ -124,8 +125,6 @@ type RefreshVotingPowerResponse = record {
 };
 
 // KEEP THIS IN SYNC WITH ManageNeuronCommandRequest!
-//
-// Deprecated. Use ManageNeuronCommandRequest instead. It is equivalent.
 type Command = variant {
   Spawn : Spawn;
   Split : Split;
@@ -349,15 +348,18 @@ type GovernanceCachedMetrics = record {
   };
   dissolving_neurons_count_buckets : vec record { nat64; nat64 };
   dissolving_neurons_e8s_buckets_ect : vec record { nat64; float64 };
-  non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
   dissolving_neurons_count : nat64;
   dissolving_neurons_e8s_buckets : vec record { nat64; float64 };
   total_staked_maturity_e8s_equivalent_seed : nat64;
   community_fund_total_staked_e8s : nat64;
   not_dissolving_neurons_e8s_buckets_seed : vec record { nat64; float64 };
-  public_neuron_subset_metrics : opt NeuronSubsetMetrics;
   timestamp_seconds : nat64;
   seed_neuron_count : nat64;
+
+  non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  public_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  declining_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  fully_lost_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
 };
 
 type GovernanceError = record {
@@ -496,10 +498,6 @@ type ManageNeuron = record {
 };
 
 // KEEP THIS IN SYNC WITH COMMAND!
-//
-// Command is deprecated, but people need time to migrate to this. Therefore, we
-// have not deleted Command yet. In the meantime, ManageNeuronCommandRequest
-// must be kept in sync with Command.
 type ManageNeuronCommandRequest = variant {
   Spawn : Spawn;
   Split : Split;
@@ -768,16 +766,25 @@ type NeuronStakeTransfer = record {
 };
 
 type NeuronSubsetMetrics = record {
-  total_maturity_e8s_equivalent : opt nat64;
-  maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
-  voting_power_buckets : vec record { nat64; nat64 };
-  total_staked_e8s : opt nat64;
   count : opt nat64;
+
+  total_staked_e8s : opt nat64;
+  total_maturity_e8s_equivalent : opt nat64;
   total_staked_maturity_e8s_equivalent : opt nat64;
-  staked_maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
-  staked_e8s_buckets : vec record { nat64; nat64 };
+
   total_voting_power : opt nat64;
+  total_deciding_voting_power : opt nat64;
+  total_potential_voting_power : opt nat64;
+
   count_buckets : vec record { nat64; nat64 };
+
+  staked_e8s_buckets : vec record { nat64; nat64 };
+  maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
+  staked_maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
+
+  voting_power_buckets : vec record { nat64; nat64 };
+  deciding_voting_power_buckets : vec record { nat64; nat64 };
+  potential_voting_power_buckets : vec record { nat64; nat64 };
 };
 
 type NeuronsFundAuditInfo = record {

--- a/packages/nns/candid/governance.idl.js
+++ b/packages/nns/candid/governance.idl.js
@@ -110,6 +110,7 @@ export const idlFactory = ({ IDL }) => {
   const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
   const CanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'controllers' : IDL.Opt(Controllers),
     'log_visibility' : IDL.Opt(IDL.Int32),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
@@ -365,12 +366,16 @@ export const idlFactory = ({ IDL }) => {
     'voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_e8s' : IDL.Opt(IDL.Nat64),
     'count' : IDL.Opt(IDL.Nat64),
+    'deciding_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
+    'total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'total_deciding_voting_power' : IDL.Opt(IDL.Nat64),
     'staked_maturity_e8s_equivalent_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Nat64)
     ),
     'staked_e8s_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_voting_power' : IDL.Opt(IDL.Nat64),
+    'potential_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'count_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
   });
   const GovernanceCachedMetrics = IDL.Record({
@@ -395,6 +400,9 @@ export const idlFactory = ({ IDL }) => {
     'total_staked_e8s_seed' : IDL.Nat64,
     'total_staked_maturity_e8s_equivalent_ect' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
+    'fully_lost_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
+    ),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'total_locked_e8s' : IDL.Nat64,
     'neurons_fund_total_active_neurons' : IDL.Nat64,
@@ -404,6 +412,9 @@ export const idlFactory = ({ IDL }) => {
     'total_staked_maturity_e8s_equivalent' : IDL.Nat64,
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
     ),
     'total_staked_e8s_ect' : IDL.Nat64,
     'not_dissolving_neurons_staked_maturity_e8s_equivalent_sum' : IDL.Nat64,
@@ -1109,6 +1120,7 @@ export const init = ({ IDL }) => {
   const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
   const CanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'controllers' : IDL.Opt(Controllers),
     'log_visibility' : IDL.Opt(IDL.Int32),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
@@ -1364,12 +1376,16 @@ export const init = ({ IDL }) => {
     'voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_e8s' : IDL.Opt(IDL.Nat64),
     'count' : IDL.Opt(IDL.Nat64),
+    'deciding_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
+    'total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'total_deciding_voting_power' : IDL.Opt(IDL.Nat64),
     'staked_maturity_e8s_equivalent_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Nat64)
     ),
     'staked_e8s_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_voting_power' : IDL.Opt(IDL.Nat64),
+    'potential_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'count_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
   });
   const GovernanceCachedMetrics = IDL.Record({
@@ -1394,6 +1410,9 @@ export const init = ({ IDL }) => {
     'total_staked_e8s_seed' : IDL.Nat64,
     'total_staked_maturity_e8s_equivalent_ect' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
+    'fully_lost_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
+    ),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'total_locked_e8s' : IDL.Nat64,
     'neurons_fund_total_active_neurons' : IDL.Nat64,
@@ -1403,6 +1422,9 @@ export const init = ({ IDL }) => {
     'total_staked_maturity_e8s_equivalent' : IDL.Nat64,
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
     ),
     'total_staked_e8s_ect' : IDL.Nat64,
     'not_dissolving_neurons_staked_maturity_e8s_equivalent_sum' : IDL.Nat64,

--- a/packages/nns/candid/governance_test.certified.idl.js
+++ b/packages/nns/candid/governance_test.certified.idl.js
@@ -110,6 +110,7 @@ export const idlFactory = ({ IDL }) => {
   const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
   const CanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'controllers' : IDL.Opt(Controllers),
     'log_visibility' : IDL.Opt(IDL.Int32),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
@@ -365,12 +366,16 @@ export const idlFactory = ({ IDL }) => {
     'voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_e8s' : IDL.Opt(IDL.Nat64),
     'count' : IDL.Opt(IDL.Nat64),
+    'deciding_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
+    'total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'total_deciding_voting_power' : IDL.Opt(IDL.Nat64),
     'staked_maturity_e8s_equivalent_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Nat64)
     ),
     'staked_e8s_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_voting_power' : IDL.Opt(IDL.Nat64),
+    'potential_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'count_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
   });
   const GovernanceCachedMetrics = IDL.Record({
@@ -395,6 +400,9 @@ export const idlFactory = ({ IDL }) => {
     'total_staked_e8s_seed' : IDL.Nat64,
     'total_staked_maturity_e8s_equivalent_ect' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
+    'fully_lost_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
+    ),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'total_locked_e8s' : IDL.Nat64,
     'neurons_fund_total_active_neurons' : IDL.Nat64,
@@ -404,6 +412,9 @@ export const idlFactory = ({ IDL }) => {
     'total_staked_maturity_e8s_equivalent' : IDL.Nat64,
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
     ),
     'total_staked_e8s_ect' : IDL.Nat64,
     'not_dissolving_neurons_staked_maturity_e8s_equivalent_sum' : IDL.Nat64,
@@ -1094,6 +1105,7 @@ export const init = ({ IDL }) => {
   const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
   const CanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'controllers' : IDL.Opt(Controllers),
     'log_visibility' : IDL.Opt(IDL.Int32),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
@@ -1349,12 +1361,16 @@ export const init = ({ IDL }) => {
     'voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_e8s' : IDL.Opt(IDL.Nat64),
     'count' : IDL.Opt(IDL.Nat64),
+    'deciding_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
+    'total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'total_deciding_voting_power' : IDL.Opt(IDL.Nat64),
     'staked_maturity_e8s_equivalent_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Nat64)
     ),
     'staked_e8s_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_voting_power' : IDL.Opt(IDL.Nat64),
+    'potential_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'count_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
   });
   const GovernanceCachedMetrics = IDL.Record({
@@ -1379,6 +1395,9 @@ export const init = ({ IDL }) => {
     'total_staked_e8s_seed' : IDL.Nat64,
     'total_staked_maturity_e8s_equivalent_ect' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
+    'fully_lost_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
+    ),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'total_locked_e8s' : IDL.Nat64,
     'neurons_fund_total_active_neurons' : IDL.Nat64,
@@ -1388,6 +1407,9 @@ export const init = ({ IDL }) => {
     'total_staked_maturity_e8s_equivalent' : IDL.Nat64,
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
     ),
     'total_staked_e8s_ect' : IDL.Nat64,
     'not_dissolving_neurons_staked_maturity_e8s_equivalent_sum' : IDL.Nat64,

--- a/packages/nns/candid/governance_test.d.ts
+++ b/packages/nns/candid/governance_test.d.ts
@@ -51,6 +51,7 @@ export interface Canister {
 }
 export interface CanisterSettings {
   freezing_threshold: [] | [bigint];
+  wasm_memory_threshold: [] | [bigint];
   controllers: [] | [Controllers];
   log_visibility: [] | [number];
   wasm_memory_limit: [] | [bigint];
@@ -258,12 +259,14 @@ export interface GovernanceCachedMetrics {
   total_staked_e8s_seed: bigint;
   total_staked_maturity_e8s_equivalent_ect: bigint;
   total_staked_e8s: bigint;
+  fully_lost_voting_power_neuron_subset_metrics: [] | [NeuronSubsetMetrics];
   not_dissolving_neurons_count: bigint;
   total_locked_e8s: bigint;
   neurons_fund_total_active_neurons: bigint;
   total_voting_power_non_self_authenticating_controller: [] | [bigint];
   total_staked_maturity_e8s_equivalent: bigint;
   not_dissolving_neurons_e8s_buckets_ect: Array<[bigint, number]>;
+  declining_voting_power_neuron_subset_metrics: [] | [NeuronSubsetMetrics];
   total_staked_e8s_ect: bigint;
   not_dissolving_neurons_staked_maturity_e8s_equivalent_sum: bigint;
   dissolved_neurons_e8s: bigint;
@@ -554,10 +557,14 @@ export interface NeuronSubsetMetrics {
   voting_power_buckets: Array<[bigint, bigint]>;
   total_staked_e8s: [] | [bigint];
   count: [] | [bigint];
+  deciding_voting_power_buckets: Array<[bigint, bigint]>;
   total_staked_maturity_e8s_equivalent: [] | [bigint];
+  total_potential_voting_power: [] | [bigint];
+  total_deciding_voting_power: [] | [bigint];
   staked_maturity_e8s_equivalent_buckets: Array<[bigint, bigint]>;
   staked_e8s_buckets: Array<[bigint, bigint]>;
   total_voting_power: [] | [bigint];
+  potential_voting_power_buckets: Array<[bigint, bigint]>;
   count_buckets: Array<[bigint, bigint]>;
 }
 export interface NeuronsFundAuditInfo {

--- a/packages/nns/candid/governance_test.did
+++ b/packages/nns/candid/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 0f35ac817b (2024-12-06) 'rs/nns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/nns/governance/canister/governance_test.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -65,6 +65,7 @@ type CanisterSettings = record {
   wasm_memory_limit : opt nat64;
   memory_allocation : opt nat64;
   compute_allocation : opt nat64;
+  wasm_memory_threshold : opt nat64;
 };
 
 type CanisterStatusResultV2 = record {
@@ -346,15 +347,18 @@ type GovernanceCachedMetrics = record {
   };
   dissolving_neurons_count_buckets : vec record { nat64; nat64 };
   dissolving_neurons_e8s_buckets_ect : vec record { nat64; float64 };
-  non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
   dissolving_neurons_count : nat64;
   dissolving_neurons_e8s_buckets : vec record { nat64; float64 };
   total_staked_maturity_e8s_equivalent_seed : nat64;
   community_fund_total_staked_e8s : nat64;
   not_dissolving_neurons_e8s_buckets_seed : vec record { nat64; float64 };
-  public_neuron_subset_metrics : opt NeuronSubsetMetrics;
   timestamp_seconds : nat64;
   seed_neuron_count : nat64;
+
+  non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  public_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  declining_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
+  fully_lost_voting_power_neuron_subset_metrics : opt NeuronSubsetMetrics;
 };
 
 type GovernanceError = record {
@@ -694,16 +698,25 @@ type NeuronStakeTransfer = record {
 };
 
 type NeuronSubsetMetrics = record {
-  total_maturity_e8s_equivalent : opt nat64;
-  maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
-  voting_power_buckets : vec record { nat64; nat64 };
-  total_staked_e8s : opt nat64;
   count : opt nat64;
+
+  total_staked_e8s : opt nat64;
+  total_maturity_e8s_equivalent : opt nat64;
   total_staked_maturity_e8s_equivalent : opt nat64;
-  staked_maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
-  staked_e8s_buckets : vec record { nat64; nat64 };
+
   total_voting_power : opt nat64;
+  total_deciding_voting_power : opt nat64;
+  total_potential_voting_power : opt nat64;
+
   count_buckets : vec record { nat64; nat64 };
+
+  staked_e8s_buckets : vec record { nat64; nat64 };
+  maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
+  staked_maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
+
+  voting_power_buckets : vec record { nat64; nat64 };
+  deciding_voting_power_buckets : vec record { nat64; nat64 };
+  potential_voting_power_buckets : vec record { nat64; nat64 };
 };
 
 type NeuronsFundAuditInfo = record {

--- a/packages/nns/candid/governance_test.idl.js
+++ b/packages/nns/candid/governance_test.idl.js
@@ -110,6 +110,7 @@ export const idlFactory = ({ IDL }) => {
   const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
   const CanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'controllers' : IDL.Opt(Controllers),
     'log_visibility' : IDL.Opt(IDL.Int32),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
@@ -365,12 +366,16 @@ export const idlFactory = ({ IDL }) => {
     'voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_e8s' : IDL.Opt(IDL.Nat64),
     'count' : IDL.Opt(IDL.Nat64),
+    'deciding_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
+    'total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'total_deciding_voting_power' : IDL.Opt(IDL.Nat64),
     'staked_maturity_e8s_equivalent_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Nat64)
     ),
     'staked_e8s_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_voting_power' : IDL.Opt(IDL.Nat64),
+    'potential_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'count_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
   });
   const GovernanceCachedMetrics = IDL.Record({
@@ -395,6 +400,9 @@ export const idlFactory = ({ IDL }) => {
     'total_staked_e8s_seed' : IDL.Nat64,
     'total_staked_maturity_e8s_equivalent_ect' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
+    'fully_lost_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
+    ),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'total_locked_e8s' : IDL.Nat64,
     'neurons_fund_total_active_neurons' : IDL.Nat64,
@@ -404,6 +412,9 @@ export const idlFactory = ({ IDL }) => {
     'total_staked_maturity_e8s_equivalent' : IDL.Nat64,
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
     ),
     'total_staked_e8s_ect' : IDL.Nat64,
     'not_dissolving_neurons_staked_maturity_e8s_equivalent_sum' : IDL.Nat64,
@@ -1110,6 +1121,7 @@ export const init = ({ IDL }) => {
   const Controllers = IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) });
   const CanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'controllers' : IDL.Opt(Controllers),
     'log_visibility' : IDL.Opt(IDL.Int32),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat64),
@@ -1365,12 +1377,16 @@ export const init = ({ IDL }) => {
     'voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_e8s' : IDL.Opt(IDL.Nat64),
     'count' : IDL.Opt(IDL.Nat64),
+    'deciding_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_staked_maturity_e8s_equivalent' : IDL.Opt(IDL.Nat64),
+    'total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'total_deciding_voting_power' : IDL.Opt(IDL.Nat64),
     'staked_maturity_e8s_equivalent_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Nat64)
     ),
     'staked_e8s_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'total_voting_power' : IDL.Opt(IDL.Nat64),
+    'potential_voting_power_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'count_buckets' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
   });
   const GovernanceCachedMetrics = IDL.Record({
@@ -1395,6 +1411,9 @@ export const init = ({ IDL }) => {
     'total_staked_e8s_seed' : IDL.Nat64,
     'total_staked_maturity_e8s_equivalent_ect' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
+    'fully_lost_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
+    ),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'total_locked_e8s' : IDL.Nat64,
     'neurons_fund_total_active_neurons' : IDL.Nat64,
@@ -1404,6 +1423,9 @@ export const init = ({ IDL }) => {
     'total_staked_maturity_e8s_equivalent' : IDL.Nat64,
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
+    ),
+    'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
+      NeuronSubsetMetrics
     ),
     'total_staked_e8s_ect' : IDL.Nat64,
     'not_dissolving_neurons_staked_maturity_e8s_equivalent_sum' : IDL.Nat64,

--- a/packages/nns/candid/sns_wasm.did
+++ b/packages/nns/candid/sns_wasm.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 0f35ac817b (2024-12-06) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/packages/nns/src/canisters/governance/request.converters.spec.ts
+++ b/packages/nns/src/canisters/governance/request.converters.spec.ts
@@ -615,6 +615,7 @@ describe("request.converters", () => {
 
     it("UpdateCanisterSettings", () => {
       const summary = "Proposal summary";
+      const wasmMemoryThreshold = 222222n;
 
       const mockRequest = {
         url,
@@ -629,6 +630,7 @@ describe("request.converters", () => {
               memoryAllocation: 234567n,
               computeAllocation: 1n,
               wasmMemoryLimit: 123456n,
+              wasmMemoryThreshold,
               logVisibility: LogVisibility.Controllers,
             },
           },
@@ -659,6 +661,7 @@ describe("request.converters", () => {
                         memory_allocation: [234567n],
                         compute_allocation: [1n],
                         wasm_memory_limit: [123456n],
+                        wasm_memory_threshold: [wasmMemoryThreshold],
                         log_visibility: [1],
                       },
                     ],

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -463,6 +463,9 @@ const fromCanisterSettings = (
           wasm_memory_limit: toNullable(canisterSettings.wasmMemoryLimit),
           compute_allocation: toNullable(canisterSettings.computeAllocation),
           memory_allocation: toNullable(canisterSettings.memoryAllocation),
+          wasm_memory_threshold: toNullable(
+            canisterSettings.wasmMemoryThreshold,
+          ),
         },
       ];
 };

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -1379,5 +1379,8 @@ const toCanisterSettings = (
         wasmMemoryLimit: fromNullable(canisterSettings.wasm_memory_limit),
         computeAllocation: fromNullable(canisterSettings.compute_allocation),
         memoryAllocation: fromNullable(canisterSettings.memory_allocation),
+        wasmMemoryThreshold: fromNullable(
+          canisterSettings.wasm_memory_threshold,
+        ),
       };
 };

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -912,6 +912,8 @@ describe("GovernanceCanister", () => {
     });
 
     it("should fetch and convert UpdateCanisterSettings on ProposalInfo", async () => {
+      const wasmMemoryThreshold = 222222n;
+
       const service = mock<ActorSubclass<GovernanceService>>();
       const governance = GovernanceCanister.create({
         certifiedServiceOverride: service,
@@ -930,6 +932,7 @@ describe("GovernanceCanister", () => {
             compute_allocation: [1n],
             memory_allocation: [123456n],
             wasm_memory_limit: [234567n],
+            wasm_memory_threshold: [wasmMemoryThreshold],
             freezing_threshold: [100n],
             log_visibility: [1],
           },
@@ -943,6 +946,7 @@ describe("GovernanceCanister", () => {
           computeAllocation: 1n,
           memoryAllocation: 123456n,
           wasmMemoryLimit: 234567n,
+          wasmMemoryThreshold,
           freezingThreshold: 100n,
           logVisibility: LogVisibility.Controllers,
         },

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -256,6 +256,7 @@ export interface CanisterSettings {
   wasmMemoryLimit: Option<bigint>;
   memoryAllocation: Option<bigint>;
   computeAllocation: Option<bigint>;
+  wasmMemoryThreshold: Option<bigint>;
 }
 export interface UpdateCanisterSettings {
   canisterId: Option<PrincipalString>;


### PR DESCRIPTION
# Motivation

The automatic candid update PR from last week broke some tests because of a new field `wasm_memory_threshold` in `CanisterSettings`.

# Changes

1. Checked out `release-2025-01-09_03-19-base` in IC repo.
2. Ran `scripts/import-candid ../../ic`.
3. Ran `scripts/compile-idl-js`.
4. Reverted files outside `packages/nns`.
5. Updated types and tests to take into account the new field.

# Tests

Unit tests updated.

# Todos

- [x] Add entry to changelog (if necessary).
