### PR TITLE
Update IC candid to release-2025-01-09_03-19-base

### DIFF
--- a/packages/ckbtc/candid/bitcoin.did
+++ b/packages/ckbtc/candid/bitcoin.did
@@ -1,7 +1,7 @@
-// Generated from dfinity/bitcoin-canister commit 85d5c2a497a9b91d565437315d9e489e50821d01 for file 'canister/candid.did'
+// Generated from dfinity/bitcoin-canister commit 47c5d1f14eff39282245ea6aec6e9f821571b024 for file 'canister/candid.did'
 type network = variant {
   mainnet;
-  testnet;
+  testnet;  // Bitcoin testnet4.
   regtest;
 };
 

--- a/packages/ckbtc/candid/minter.certified.idl.js
+++ b/packages/ckbtc/candid/minter.certified.idl.js
@@ -99,7 +99,7 @@ export const idlFactory = ({ IDL }) => {
     'p2wpkh_v0' : IDL.Vec(IDL.Nat8),
     'p2pkh' : IDL.Vec(IDL.Nat8),
   });
-  const Event = IDL.Variant({
+  const EventType = IDL.Variant({
     'received_utxos' : IDL.Record({
       'to_account' : Account,
       'mint_txid' : IDL.Opt(IDL.Nat64),
@@ -170,6 +170,10 @@ export const idlFactory = ({ IDL }) => {
       'burn_block_index' : IDL.Nat64,
       'mint_block_index' : IDL.Nat64,
     }),
+  });
+  const Event = IDL.Record({
+    'timestamp' : IDL.Opt(IDL.Nat64),
+    'payload' : EventType,
   });
   const MinterInfo = IDL.Record({
     'retrieve_btc_min_amount' : IDL.Nat64,

--- a/packages/ckbtc/candid/minter.d.ts
+++ b/packages/ckbtc/candid/minter.d.ts
@@ -39,7 +39,11 @@ export interface DefiniteCanisterSettings {
   memory_allocation: bigint;
   compute_allocation: bigint;
 }
-export type Event =
+export interface Event {
+  timestamp: [] | [bigint];
+  payload: EventType;
+}
+export type EventType =
   | {
       received_utxos: {
         to_account: Account;

--- a/packages/ckbtc/candid/minter.did
+++ b/packages/ckbtc/candid/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit d9fe207 (2024-12-06 tags: release-2024-12-06_03-16-base) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
 // Represents an account on the ckBTC ledger.
 type Account = record { owner : principal; subaccount : opt blob };
 
@@ -351,7 +351,12 @@ type SuspendedReason = variant {
     Quarantined;
 };
 
-type Event = variant {
+type Event = record {
+    timestamp : opt nat64;
+    payload : EventType;
+};
+
+type EventType = variant {
     init : InitArgs;
     upgrade : UpgradeArgs;
     received_utxos : record { to_account : Account; mint_txid : opt nat64; utxos : vec Utxo };

--- a/packages/ckbtc/candid/minter.idl.js
+++ b/packages/ckbtc/candid/minter.idl.js
@@ -99,7 +99,7 @@ export const idlFactory = ({ IDL }) => {
     'p2wpkh_v0' : IDL.Vec(IDL.Nat8),
     'p2pkh' : IDL.Vec(IDL.Nat8),
   });
-  const Event = IDL.Variant({
+  const EventType = IDL.Variant({
     'received_utxos' : IDL.Record({
       'to_account' : Account,
       'mint_txid' : IDL.Opt(IDL.Nat64),
@@ -170,6 +170,10 @@ export const idlFactory = ({ IDL }) => {
       'burn_block_index' : IDL.Nat64,
       'mint_block_index' : IDL.Nat64,
     }),
+  });
+  const Event = IDL.Record({
+    'timestamp' : IDL.Opt(IDL.Nat64),
+    'payload' : EventType,
   });
   const MinterInfo = IDL.Record({
     'retrieve_btc_min_amount' : IDL.Nat64,

--- a/packages/cketh/candid/minter.did
+++ b/packages/cketh/candid/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit d9fe207 (2024-12-06 tags: release-2024-12-06_03-16-base) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
 type EthereumNetwork = variant {
     // The public Ethereum mainnet.
     Mainnet;

--- a/packages/cketh/candid/orchestrator.did
+++ b/packages/cketh/candid/orchestrator.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit d9fe207 (2024-12-06 tags: release-2024-12-06_03-16-base) 'rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did' by import-candid
 type OrchestratorArg = variant {
     UpgradeArg : UpgradeArg;
     InitArg : InitArg;

--- a/packages/cmc/candid/cmc.did
+++ b/packages/cmc/candid/cmc.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit d9fe207 (2024-12-06 tags: release-2024-12-06_03-16-base) 'rs/nns/cmc/cmc.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/nns/cmc/cmc.did' by import-candid
 type Cycles = nat;
 type BlockIndex = nat64;
 type log_visibility = variant {

--- a/packages/ic-management/candid/ic-management.certified.idl.js
+++ b/packages/ic-management/candid/ic-management.certified.idl.js
@@ -308,7 +308,11 @@ export const idlFactory = ({ IDL }) => {
   const sign_with_ecdsa_result = IDL.Record({
     'signature' : IDL.Vec(IDL.Nat8),
   });
+  const schnorr_aux = IDL.Variant({
+    'bip341' : IDL.Record({ 'merkle_root_hash' : IDL.Vec(IDL.Nat8) }),
+  });
   const sign_with_schnorr_args = IDL.Record({
+    'aux' : IDL.Opt(schnorr_aux),
     'key_id' : IDL.Record({
       'algorithm' : schnorr_algorithm,
       'name' : IDL.Text,

--- a/packages/ic-management/candid/ic-management.d.ts
+++ b/packages/ic-management/candid/ic-management.d.ts
@@ -266,6 +266,9 @@ export interface provisional_top_up_canister_args {
 export type raw_rand_result = Uint8Array | number[];
 export type satoshi = bigint;
 export type schnorr_algorithm = { ed25519: null } | { bip340secp256k1: null };
+export type schnorr_aux = {
+  bip341: { merkle_root_hash: Uint8Array | number[] };
+};
 export interface schnorr_public_key_args {
   key_id: { algorithm: schnorr_algorithm; name: string };
   canister_id: [] | [canister_id];
@@ -284,6 +287,7 @@ export interface sign_with_ecdsa_result {
   signature: Uint8Array | number[];
 }
 export interface sign_with_schnorr_args {
+  aux: [] | [schnorr_aux];
   key_id: { algorithm: schnorr_algorithm; name: string };
   derivation_path: Array<Uint8Array | number[]>;
   message: Uint8Array | number[];

--- a/packages/ic-management/candid/ic-management.did
+++ b/packages/ic-management/candid/ic-management.did
@@ -1,4 +1,4 @@
-// Generated from dfinity/portal commit 7b300dc97a1636f8134410e9a40f3556acf9b496 for file 'docs/references/_attachments/ic.did'
+// Generated from dfinity/portal commit aed4ac730cc662713c0353609af96bbb2cd3a8ca for file 'docs/references/_attachments/ic.did'
 type canister_id = principal;
 type wasm_module = blob;
 type snapshot_id = blob;
@@ -324,10 +324,17 @@ type schnorr_public_key_result = record {
     chain_code : blob;
 };
 
+type schnorr_aux = variant {
+    bip341: record {
+      merkle_root_hash: blob;
+   }
+};
+
 type sign_with_schnorr_args = record {
     message : blob;
     derivation_path : vec blob;
     key_id : record { algorithm : schnorr_algorithm; name : text };
+    aux: opt schnorr_aux;
 };
 
 type sign_with_schnorr_result = record {

--- a/packages/ic-management/candid/ic-management.idl.js
+++ b/packages/ic-management/candid/ic-management.idl.js
@@ -308,7 +308,11 @@ export const idlFactory = ({ IDL }) => {
   const sign_with_ecdsa_result = IDL.Record({
     'signature' : IDL.Vec(IDL.Nat8),
   });
+  const schnorr_aux = IDL.Variant({
+    'bip341' : IDL.Record({ 'merkle_root_hash' : IDL.Vec(IDL.Nat8) }),
+  });
   const sign_with_schnorr_args = IDL.Record({
+    'aux' : IDL.Opt(schnorr_aux),
     'key_id' : IDL.Record({
       'algorithm' : schnorr_algorithm,
       'name' : IDL.Text,

--- a/packages/ledger-icp/candid/index.did
+++ b/packages/ledger-icp/candid/index.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit d9fe207 (2024-12-06 tags: release-2024-12-06_03-16-base) 'rs/ledger_suite/icp/index/index.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/ledger_suite/icp/index/index.did' by import-candid
 type Account = record { owner : principal; subaccount : opt vec nat8 };
 type GetAccountIdentifierTransactionsArgs = record {
   max_results : nat64;

--- a/packages/ledger-icp/candid/ledger.certified.idl.js
+++ b/packages/ledger-icp/candid/ledger.certified.idl.js
@@ -348,6 +348,7 @@ export const idlFactory = ({ IDL }) => {
         [TransferFromResult],
         [],
       ),
+    'is_ledger_ready' : IDL.Func([], [IDL.Bool], []),
     'name' : IDL.Func([], [IDL.Record({ 'name' : IDL.Text })], []),
     'query_blocks' : IDL.Func([GetBlocksArgs], [QueryBlocksResponse], []),
     'query_encoded_blocks' : IDL.Func(

--- a/packages/ledger-icp/candid/ledger.d.ts
+++ b/packages/ledger-icp/candid/ledger.d.ts
@@ -340,6 +340,7 @@ export interface _SERVICE {
   icrc2_allowance: ActorMethod<[AllowanceArgs], Allowance>;
   icrc2_approve: ActorMethod<[ApproveArgs], ApproveResult>;
   icrc2_transfer_from: ActorMethod<[TransferFromArgs], TransferFromResult>;
+  is_ledger_ready: ActorMethod<[], boolean>;
   name: ActorMethod<[], { name: string }>;
   query_blocks: ActorMethod<[GetBlocksArgs], QueryBlocksResponse>;
   query_encoded_blocks: ActorMethod<

--- a/packages/ledger-icp/candid/ledger.did
+++ b/packages/ledger-icp/candid/ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit d9fe207 (2024-12-06 tags: release-2024-12-06_03-16-base) 'rs/ledger_suite/icp/ledger.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/ledger_suite/icp/ledger.did' by import-candid
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.
@@ -536,4 +536,6 @@ service: (LedgerCanisterPayload) -> {
 
     icrc21_canister_call_consent_message: (icrc21_consent_message_request) -> (icrc21_consent_message_response);
     icrc10_supported_standards : () -> (vec record { name : text; url : text }) query;
+
+    is_ledger_ready: () -> (bool) query;
 }

--- a/packages/ledger-icp/candid/ledger.idl.js
+++ b/packages/ledger-icp/candid/ledger.idl.js
@@ -364,6 +364,7 @@ export const idlFactory = ({ IDL }) => {
         [TransferFromResult],
         [],
       ),
+    'is_ledger_ready' : IDL.Func([], [IDL.Bool], ['query']),
     'name' : IDL.Func([], [IDL.Record({ 'name' : IDL.Text })], ['query']),
     'query_blocks' : IDL.Func(
         [GetBlocksArgs],

--- a/packages/ledger-icrc/candid/icrc_index-ng.did
+++ b/packages/ledger-icrc/candid/icrc_index-ng.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit d9fe207 (2024-12-06 tags: release-2024-12-06_03-16-base) 'rs/ledger_suite/icrc1/index-ng/index-ng.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/ledger_suite/icrc1/index-ng/index-ng.did' by import-candid
 type Tokens = nat;
 
 type InitArg = record {

--- a/packages/ledger-icrc/candid/icrc_ledger.certified.idl.js
+++ b/packages/ledger-icrc/candid/icrc_ledger.certified.idl.js
@@ -34,7 +34,6 @@ export const idlFactory = ({ IDL }) => {
     'token_symbol' : IDL.Opt(IDL.Text),
     'transfer_fee' : IDL.Opt(IDL.Nat),
     'metadata' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, MetadataValue))),
-    'accounts_overflow_trim_quantity' : IDL.Opt(IDL.Nat64),
     'change_fee_collector' : IDL.Opt(ChangeFeeCollector),
     'max_memo_length' : IDL.Opt(IDL.Nat16),
     'token_name' : IDL.Opt(IDL.Text),
@@ -47,8 +46,6 @@ export const idlFactory = ({ IDL }) => {
     'metadata' : IDL.Vec(IDL.Tuple(IDL.Text, MetadataValue)),
     'minting_account' : Account,
     'initial_balances' : IDL.Vec(IDL.Tuple(Account, IDL.Nat)),
-    'maximum_number_of_accounts' : IDL.Opt(IDL.Nat64),
-    'accounts_overflow_trim_quantity' : IDL.Opt(IDL.Nat64),
     'fee_collector_account' : IDL.Opt(Account),
     'archive_options' : IDL.Record({
       'num_blocks_to_archive' : IDL.Nat64,
@@ -440,7 +437,6 @@ export const init = ({ IDL }) => {
     'token_symbol' : IDL.Opt(IDL.Text),
     'transfer_fee' : IDL.Opt(IDL.Nat),
     'metadata' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, MetadataValue))),
-    'accounts_overflow_trim_quantity' : IDL.Opt(IDL.Nat64),
     'change_fee_collector' : IDL.Opt(ChangeFeeCollector),
     'max_memo_length' : IDL.Opt(IDL.Nat16),
     'token_name' : IDL.Opt(IDL.Text),
@@ -453,8 +449,6 @@ export const init = ({ IDL }) => {
     'metadata' : IDL.Vec(IDL.Tuple(IDL.Text, MetadataValue)),
     'minting_account' : Account,
     'initial_balances' : IDL.Vec(IDL.Tuple(Account, IDL.Nat)),
-    'maximum_number_of_accounts' : IDL.Opt(IDL.Nat64),
-    'accounts_overflow_trim_quantity' : IDL.Opt(IDL.Nat64),
     'fee_collector_account' : IDL.Opt(Account),
     'archive_options' : IDL.Record({
       'num_blocks_to_archive' : IDL.Nat64,

--- a/packages/ledger-icrc/candid/icrc_ledger.d.ts
+++ b/packages/ledger-icrc/candid/icrc_ledger.d.ts
@@ -157,8 +157,6 @@ export interface InitArgs {
   metadata: Array<[string, MetadataValue]>;
   minting_account: Account;
   initial_balances: Array<[Account, bigint]>;
-  maximum_number_of_accounts: [] | [bigint];
-  accounts_overflow_trim_quantity: [] | [bigint];
   fee_collector_account: [] | [Account];
   archive_options: {
     num_blocks_to_archive: bigint;
@@ -269,7 +267,6 @@ export interface UpgradeArgs {
   token_symbol: [] | [string];
   transfer_fee: [] | [bigint];
   metadata: [] | [Array<[string, MetadataValue]>];
-  accounts_overflow_trim_quantity: [] | [bigint];
   change_fee_collector: [] | [ChangeFeeCollector];
   max_memo_length: [] | [number];
   token_name: [] | [string];

--- a/packages/ledger-icrc/candid/icrc_ledger.did
+++ b/packages/ledger-icrc/candid/icrc_ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit d9fe207 (2024-12-06 tags: release-2024-12-06_03-16-base) 'rs/ledger_suite/icrc1/ledger/ledger.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/ledger_suite/icrc1/ledger/ledger.did' by import-candid
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.
@@ -108,8 +108,6 @@ type InitArgs = record {
     metadata : vec record { text; MetadataValue };
     initial_balances : vec record { Account; nat };
     feature_flags : opt FeatureFlags;
-    maximum_number_of_accounts : opt nat64;
-    accounts_overflow_trim_quantity : opt nat64;
     archive_options : record {
         num_blocks_to_archive : nat64;
         max_transactions_per_response : opt nat64;
@@ -145,7 +143,6 @@ type UpgradeArgs = record {
     change_fee_collector : opt ChangeFeeCollector;
     max_memo_length : opt nat16;
     feature_flags : opt FeatureFlags;
-    accounts_overflow_trim_quantity: opt nat64;
     change_archive_options : opt ChangeArchiveOptions;
 };
 

--- a/packages/ledger-icrc/candid/icrc_ledger.idl.js
+++ b/packages/ledger-icrc/candid/icrc_ledger.idl.js
@@ -34,7 +34,6 @@ export const idlFactory = ({ IDL }) => {
     'token_symbol' : IDL.Opt(IDL.Text),
     'transfer_fee' : IDL.Opt(IDL.Nat),
     'metadata' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, MetadataValue))),
-    'accounts_overflow_trim_quantity' : IDL.Opt(IDL.Nat64),
     'change_fee_collector' : IDL.Opt(ChangeFeeCollector),
     'max_memo_length' : IDL.Opt(IDL.Nat16),
     'token_name' : IDL.Opt(IDL.Text),
@@ -47,8 +46,6 @@ export const idlFactory = ({ IDL }) => {
     'metadata' : IDL.Vec(IDL.Tuple(IDL.Text, MetadataValue)),
     'minting_account' : Account,
     'initial_balances' : IDL.Vec(IDL.Tuple(Account, IDL.Nat)),
-    'maximum_number_of_accounts' : IDL.Opt(IDL.Nat64),
-    'accounts_overflow_trim_quantity' : IDL.Opt(IDL.Nat64),
     'fee_collector_account' : IDL.Opt(Account),
     'archive_options' : IDL.Record({
       'num_blocks_to_archive' : IDL.Nat64,
@@ -452,7 +449,6 @@ export const init = ({ IDL }) => {
     'token_symbol' : IDL.Opt(IDL.Text),
     'transfer_fee' : IDL.Opt(IDL.Nat),
     'metadata' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, MetadataValue))),
-    'accounts_overflow_trim_quantity' : IDL.Opt(IDL.Nat64),
     'change_fee_collector' : IDL.Opt(ChangeFeeCollector),
     'max_memo_length' : IDL.Opt(IDL.Nat16),
     'token_name' : IDL.Opt(IDL.Text),
@@ -465,8 +461,6 @@ export const init = ({ IDL }) => {
     'metadata' : IDL.Vec(IDL.Tuple(IDL.Text, MetadataValue)),
     'minting_account' : Account,
     'initial_balances' : IDL.Vec(IDL.Tuple(Account, IDL.Nat)),
-    'maximum_number_of_accounts' : IDL.Opt(IDL.Nat64),
-    'accounts_overflow_trim_quantity' : IDL.Opt(IDL.Nat64),
     'fee_collector_account' : IDL.Opt(Account),
     'archive_options' : IDL.Record({
       'num_blocks_to_archive' : IDL.Nat64,

--- a/packages/sns/candid/sns_governance.certified.idl.js
+++ b/packages/sns/candid/sns_governance.certified.idl.js
@@ -224,6 +224,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const ManageDappCanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'canister_ids' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
     'log_visibility' : IDL.Opt(IDL.Int32),
@@ -526,6 +527,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const DefiniteCanisterSettingsArgs = IDL.Record({
     'freezing_threshold' : IDL.Nat,
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat),
     'controllers' : IDL.Vec(IDL.Principal),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat),
     'memory_allocation' : IDL.Nat,
@@ -927,6 +929,7 @@ export const init = ({ IDL }) => {
   });
   const ManageDappCanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'canister_ids' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
     'log_visibility' : IDL.Opt(IDL.Int32),

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -142,6 +142,7 @@ export interface DefaultFollowees {
 }
 export interface DefiniteCanisterSettingsArgs {
   freezing_threshold: bigint;
+  wasm_memory_threshold: [] | [bigint];
   controllers: Array<Principal>;
   wasm_memory_limit: [] | [bigint];
   memory_allocation: bigint;
@@ -327,6 +328,7 @@ export interface ListProposalsResponse {
 }
 export interface ManageDappCanisterSettings {
   freezing_threshold: [] | [bigint];
+  wasm_memory_threshold: [] | [bigint];
   canister_ids: Array<Principal>;
   reserved_cycles_limit: [] | [bigint];
   log_visibility: [] | [number];

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit d9fe207 (2024-12-06 tags: release-2024-12-06_03-16-base) 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -158,6 +158,7 @@ type DefiniteCanisterSettingsArgs = record {
   wasm_memory_limit : opt nat;
   memory_allocation : nat;
   compute_allocation : nat;
+  wasm_memory_threshold : opt nat;
 };
 
 type DeregisterDappCanisters = record {
@@ -376,6 +377,7 @@ type ManageDappCanisterSettings = record {
   wasm_memory_limit : opt nat64;
   memory_allocation : opt nat64;
   compute_allocation : opt nat64;
+  wasm_memory_threshold : opt nat64;
 };
 
 type SnsVersion = record {

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -224,6 +224,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const ManageDappCanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'canister_ids' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
     'log_visibility' : IDL.Opt(IDL.Int32),
@@ -526,6 +527,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const DefiniteCanisterSettingsArgs = IDL.Record({
     'freezing_threshold' : IDL.Nat,
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat),
     'controllers' : IDL.Vec(IDL.Principal),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat),
     'memory_allocation' : IDL.Nat,
@@ -935,6 +937,7 @@ export const init = ({ IDL }) => {
   });
   const ManageDappCanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'canister_ids' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
     'log_visibility' : IDL.Opt(IDL.Int32),

--- a/packages/sns/candid/sns_governance_test.certified.idl.js
+++ b/packages/sns/candid/sns_governance_test.certified.idl.js
@@ -224,6 +224,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const ManageDappCanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'canister_ids' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
     'log_visibility' : IDL.Opt(IDL.Int32),
@@ -537,6 +538,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const DefiniteCanisterSettingsArgs = IDL.Record({
     'freezing_threshold' : IDL.Nat,
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat),
     'controllers' : IDL.Vec(IDL.Principal),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat),
     'memory_allocation' : IDL.Nat,
@@ -955,6 +957,7 @@ export const init = ({ IDL }) => {
   });
   const ManageDappCanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'canister_ids' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
     'log_visibility' : IDL.Opt(IDL.Int32),

--- a/packages/sns/candid/sns_governance_test.d.ts
+++ b/packages/sns/candid/sns_governance_test.d.ts
@@ -153,6 +153,7 @@ export interface DefaultFollowees {
 }
 export interface DefiniteCanisterSettingsArgs {
   freezing_threshold: bigint;
+  wasm_memory_threshold: [] | [bigint];
   controllers: Array<Principal>;
   wasm_memory_limit: [] | [bigint];
   memory_allocation: bigint;
@@ -338,6 +339,7 @@ export interface ListProposalsResponse {
 }
 export interface ManageDappCanisterSettings {
   freezing_threshold: [] | [bigint];
+  wasm_memory_threshold: [] | [bigint];
   canister_ids: Array<Principal>;
   reserved_cycles_limit: [] | [bigint];
   log_visibility: [] | [number];

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit d9fe207 (2024-12-06 tags: release-2024-12-06_03-16-base) 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -167,6 +167,7 @@ type DefiniteCanisterSettingsArgs = record {
   wasm_memory_limit : opt nat;
   memory_allocation : nat;
   compute_allocation : nat;
+  wasm_memory_threshold : opt nat;
 };
 
 type DeregisterDappCanisters = record {
@@ -385,6 +386,7 @@ type ManageDappCanisterSettings = record {
   wasm_memory_limit : opt nat64;
   memory_allocation : opt nat64;
   compute_allocation : opt nat64;
+  wasm_memory_threshold : opt nat64;
 };
 
 type SnsVersion = record {

--- a/packages/sns/candid/sns_governance_test.idl.js
+++ b/packages/sns/candid/sns_governance_test.idl.js
@@ -224,6 +224,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const ManageDappCanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'canister_ids' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
     'log_visibility' : IDL.Opt(IDL.Int32),
@@ -537,6 +538,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const DefiniteCanisterSettingsArgs = IDL.Record({
     'freezing_threshold' : IDL.Nat,
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat),
     'controllers' : IDL.Vec(IDL.Principal),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat),
     'memory_allocation' : IDL.Nat,
@@ -963,6 +965,7 @@ export const init = ({ IDL }) => {
   });
   const ManageDappCanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'canister_ids' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
     'log_visibility' : IDL.Opt(IDL.Int32),

--- a/packages/sns/candid/sns_root.certified.idl.js
+++ b/packages/sns/candid/sns_root.certified.idl.js
@@ -27,6 +27,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const DefiniteCanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat),
     'controllers' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat),
     'log_visibility' : IDL.Opt(LogVisibility),
@@ -48,12 +49,18 @@ export const idlFactory = ({ IDL }) => {
     'upgrade' : IDL.Null,
     'install' : IDL.Null,
   });
+  const ChunkedCanisterWasm = IDL.Record({
+    'wasm_module_hash' : IDL.Vec(IDL.Nat8),
+    'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
+    'store_canister_id' : IDL.Principal,
+  });
   const ChangeCanisterRequest = IDL.Record({
     'arg' : IDL.Vec(IDL.Nat8),
     'wasm_module' : IDL.Vec(IDL.Nat8),
     'stop_before_installing' : IDL.Bool,
     'mode' : CanisterInstallMode,
     'canister_id' : IDL.Principal,
+    'chunked_canister_wasm' : IDL.Opt(ChunkedCanisterWasm),
     'memory_allocation' : IDL.Opt(IDL.Nat),
     'compute_allocation' : IDL.Opt(IDL.Nat),
   });
@@ -62,6 +69,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const DefiniteCanisterSettingsArgs = IDL.Record({
     'freezing_threshold' : IDL.Nat,
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat),
     'controllers' : IDL.Vec(IDL.Principal),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat),
     'memory_allocation' : IDL.Nat,
@@ -100,6 +108,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const ManageDappCanisterSettingsRequest = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'canister_ids' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
     'log_visibility' : IDL.Opt(IDL.Int32),

--- a/packages/sns/candid/sns_root.d.ts
+++ b/packages/sns/candid/sns_root.d.ts
@@ -44,11 +44,18 @@ export interface ChangeCanisterRequest {
   stop_before_installing: boolean;
   mode: CanisterInstallMode;
   canister_id: Principal;
+  chunked_canister_wasm: [] | [ChunkedCanisterWasm];
   memory_allocation: [] | [bigint];
   compute_allocation: [] | [bigint];
 }
+export interface ChunkedCanisterWasm {
+  wasm_module_hash: Uint8Array | number[];
+  chunk_hashes_list: Array<Uint8Array | number[]>;
+  store_canister_id: Principal;
+}
 export interface DefiniteCanisterSettings {
   freezing_threshold: [] | [bigint];
+  wasm_memory_threshold: [] | [bigint];
   controllers: Array<Principal>;
   reserved_cycles_limit: [] | [bigint];
   log_visibility: [] | [LogVisibility];
@@ -58,6 +65,7 @@ export interface DefiniteCanisterSettings {
 }
 export interface DefiniteCanisterSettingsArgs {
   freezing_threshold: bigint;
+  wasm_memory_threshold: [] | [bigint];
   controllers: Array<Principal>;
   wasm_memory_limit: [] | [bigint];
   memory_allocation: bigint;
@@ -94,6 +102,7 @@ export interface ListSnsCanistersResponse {
 export type LogVisibility = { controllers: null } | { public: null };
 export interface ManageDappCanisterSettingsRequest {
   freezing_threshold: [] | [bigint];
+  wasm_memory_threshold: [] | [bigint];
   canister_ids: Array<Principal>;
   reserved_cycles_limit: [] | [bigint];
   log_visibility: [] | [number];

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit d9fe207 (2024-12-06 tags: release-2024-12-06_03-16-base) 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/sns/root/canister/root.did' by import-candid
 type CanisterCallError = record {
   code : opt int32;
   description : text;
@@ -44,9 +44,16 @@ type CanisterSummary = record {
   canister_id : opt principal;
 };
 
+type ChunkedCanisterWasm = record {
+  wasm_module_hash : blob;
+  store_canister_id : principal;
+  chunk_hashes_list : vec blob;
+};
+
 type ChangeCanisterRequest = record {
   arg : blob;
   wasm_module : blob;
+  chunked_canister_wasm : opt ChunkedCanisterWasm;
   stop_before_installing : bool;
   mode : CanisterInstallMode;
   canister_id : principal;
@@ -62,6 +69,7 @@ type DefiniteCanisterSettings = record {
   wasm_memory_limit : opt nat;
   memory_allocation : opt nat;
   compute_allocation : opt nat;
+  wasm_memory_threshold : opt nat;
 };
 
 type DefiniteCanisterSettingsArgs = record {
@@ -70,6 +78,7 @@ type DefiniteCanisterSettingsArgs = record {
   wasm_memory_limit : opt nat;
   memory_allocation : nat;
   compute_allocation : nat;
+  wasm_memory_threshold : opt nat;
 };
 
 type FailedUpdate = record {
@@ -114,6 +123,7 @@ type ManageDappCanisterSettingsRequest = record {
   wasm_memory_limit : opt nat64;
   memory_allocation : opt nat64;
   compute_allocation : opt nat64;
+  wasm_memory_threshold : opt nat64;
 };
 
 type ManageDappCanisterSettingsResponse = record {

--- a/packages/sns/candid/sns_root.idl.js
+++ b/packages/sns/candid/sns_root.idl.js
@@ -27,6 +27,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const DefiniteCanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat),
     'controllers' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat),
     'log_visibility' : IDL.Opt(LogVisibility),
@@ -48,12 +49,18 @@ export const idlFactory = ({ IDL }) => {
     'upgrade' : IDL.Null,
     'install' : IDL.Null,
   });
+  const ChunkedCanisterWasm = IDL.Record({
+    'wasm_module_hash' : IDL.Vec(IDL.Nat8),
+    'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
+    'store_canister_id' : IDL.Principal,
+  });
   const ChangeCanisterRequest = IDL.Record({
     'arg' : IDL.Vec(IDL.Nat8),
     'wasm_module' : IDL.Vec(IDL.Nat8),
     'stop_before_installing' : IDL.Bool,
     'mode' : CanisterInstallMode,
     'canister_id' : IDL.Principal,
+    'chunked_canister_wasm' : IDL.Opt(ChunkedCanisterWasm),
     'memory_allocation' : IDL.Opt(IDL.Nat),
     'compute_allocation' : IDL.Opt(IDL.Nat),
   });
@@ -62,6 +69,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const DefiniteCanisterSettingsArgs = IDL.Record({
     'freezing_threshold' : IDL.Nat,
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat),
     'controllers' : IDL.Vec(IDL.Principal),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat),
     'memory_allocation' : IDL.Nat,
@@ -100,6 +108,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const ManageDappCanisterSettingsRequest = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat64),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat64),
     'canister_ids' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat64),
     'log_visibility' : IDL.Opt(IDL.Int32),

--- a/packages/sns/candid/sns_swap.certified.idl.js
+++ b/packages/sns/candid/sns_swap.certified.idl.js
@@ -164,6 +164,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const DefiniteCanisterSettingsArgs = IDL.Record({
     'freezing_threshold' : IDL.Nat,
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat),
     'controllers' : IDL.Vec(IDL.Principal),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat),
     'memory_allocation' : IDL.Nat,

--- a/packages/sns/candid/sns_swap.d.ts
+++ b/packages/sns/candid/sns_swap.d.ts
@@ -44,6 +44,7 @@ export interface Countries {
 }
 export interface DefiniteCanisterSettingsArgs {
   freezing_threshold: bigint;
+  wasm_memory_threshold: [] | [bigint];
   controllers: Array<Principal>;
   wasm_memory_limit: [] | [bigint];
   memory_allocation: bigint;

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit d9fe207 (2024-12-06 tags: release-2024-12-06_03-16-base) 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;
@@ -54,6 +54,7 @@ type DefiniteCanisterSettingsArgs = record {
   wasm_memory_limit : opt nat;
   memory_allocation : nat;
   compute_allocation : nat;
+  wasm_memory_threshold : opt nat;
 };
 
 type DerivedState = record {

--- a/packages/sns/candid/sns_swap.idl.js
+++ b/packages/sns/candid/sns_swap.idl.js
@@ -164,6 +164,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const DefiniteCanisterSettingsArgs = IDL.Record({
     'freezing_threshold' : IDL.Nat,
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat),
     'controllers' : IDL.Vec(IDL.Principal),
     'wasm_memory_limit' : IDL.Opt(IDL.Nat),
     'memory_allocation' : IDL.Nat,


### PR DESCRIPTION
# Motivation

Because [last week's automatic candid update](https://github.com/dfinity/ic-js/pull/807) failed, we updated the nns package separately with a fix in https://github.com/dfinity/ic-js/pull/821

This PR updated the other packages without manual fixes.
The used release (`release-2025-01-09_03-19-base`) is already not the newest release anymore.
We don't just straight to the newest release (`release-2025-01-16_16-18-base`) because it does require additional manual fixed.

# Changes

1. Checked out `release-2025-01-09_03-19-base` in IC repo.
2. Ran `scripts/import-candid ../../ic`.
3. Ran `scripts/compile-idl-js`.

# Tests

Existing tests pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary