### PR TITLE
Update candid for sns package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Features
 
 - Support `CanisterSettings.wasm_memory_threshold` in `@dfinity/nns`.
+- Support `UpgradeSnsControlledCanister.chunked_canister_wasm` in `@dfinity/sns`.
 
 # 2025.01.20-1030Z
 

--- a/packages/sns/candid/sns_governance.certified.idl.js
+++ b/packages/sns/candid/sns_governance.certified.idl.js
@@ -242,10 +242,16 @@ export const idlFactory = ({ IDL }) => {
     'memo' : IDL.Opt(IDL.Nat64),
     'amount_e8s' : IDL.Nat64,
   });
+  const ChunkedCanisterWasm = IDL.Record({
+    'wasm_module_hash' : IDL.Vec(IDL.Nat8),
+    'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
+    'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
   const UpgradeSnsControlledCanister = IDL.Record({
     'new_canister_wasm' : IDL.Vec(IDL.Nat8),
     'mode' : IDL.Opt(IDL.Int32),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'chunked_canister_wasm' : IDL.Opt(ChunkedCanisterWasm),
     'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
   const DeregisterDappCanisters = IDL.Record({
@@ -947,10 +953,16 @@ export const init = ({ IDL }) => {
     'memo' : IDL.Opt(IDL.Nat64),
     'amount_e8s' : IDL.Nat64,
   });
+  const ChunkedCanisterWasm = IDL.Record({
+    'wasm_module_hash' : IDL.Vec(IDL.Nat8),
+    'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
+    'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
   const UpgradeSnsControlledCanister = IDL.Record({
     'new_canister_wasm' : IDL.Vec(IDL.Nat8),
     'mode' : IDL.Opt(IDL.Int32),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'chunked_canister_wasm' : IDL.Opt(ChunkedCanisterWasm),
     'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
   const DeregisterDappCanisters = IDL.Record({

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -72,6 +72,11 @@ export type CanisterStatusType =
 export interface ChangeAutoStakeMaturity {
   requested_setting_for_auto_stake_maturity: boolean;
 }
+export interface ChunkedCanisterWasm {
+  wasm_module_hash: Uint8Array | number[];
+  chunk_hashes_list: Array<Uint8Array | number[]>;
+  store_canister_id: [] | [Principal];
+}
 export interface ClaimOrRefresh {
   by: [] | [By];
 }
@@ -647,6 +652,7 @@ export interface UpgradeSnsControlledCanister {
   new_canister_wasm: Uint8Array | number[];
   mode: [] | [number];
   canister_id: [] | [Principal];
+  chunked_canister_wasm: [] | [ChunkedCanisterWasm];
   canister_upgrade_arg: [] | [Uint8Array | number[]];
 }
 export interface UpgradeStarted {

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 233c1ee2ef (2025-01-16 tags: release-2025-01-16_16-18-base) 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -712,8 +712,15 @@ type PendingVersion = record {
   target_version : opt Version;
 };
 
+type ChunkedCanisterWasm = record {
+  wasm_module_hash : blob;
+  store_canister_id : opt principal;
+  chunk_hashes_list : vec blob;
+};
+
 type UpgradeSnsControlledCanister = record {
   new_canister_wasm : blob;
+  chunked_canister_wasm : opt ChunkedCanisterWasm;
   mode : opt int32;
   canister_id : opt principal;
   canister_upgrade_arg : opt blob;

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -242,10 +242,16 @@ export const idlFactory = ({ IDL }) => {
     'memo' : IDL.Opt(IDL.Nat64),
     'amount_e8s' : IDL.Nat64,
   });
+  const ChunkedCanisterWasm = IDL.Record({
+    'wasm_module_hash' : IDL.Vec(IDL.Nat8),
+    'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
+    'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
   const UpgradeSnsControlledCanister = IDL.Record({
     'new_canister_wasm' : IDL.Vec(IDL.Nat8),
     'mode' : IDL.Opt(IDL.Int32),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'chunked_canister_wasm' : IDL.Opt(ChunkedCanisterWasm),
     'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
   const DeregisterDappCanisters = IDL.Record({
@@ -955,10 +961,16 @@ export const init = ({ IDL }) => {
     'memo' : IDL.Opt(IDL.Nat64),
     'amount_e8s' : IDL.Nat64,
   });
+  const ChunkedCanisterWasm = IDL.Record({
+    'wasm_module_hash' : IDL.Vec(IDL.Nat8),
+    'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
+    'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
   const UpgradeSnsControlledCanister = IDL.Record({
     'new_canister_wasm' : IDL.Vec(IDL.Nat8),
     'mode' : IDL.Opt(IDL.Int32),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'chunked_canister_wasm' : IDL.Opt(ChunkedCanisterWasm),
     'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
   const DeregisterDappCanisters = IDL.Record({

--- a/packages/sns/candid/sns_governance_test.certified.idl.js
+++ b/packages/sns/candid/sns_governance_test.certified.idl.js
@@ -242,10 +242,16 @@ export const idlFactory = ({ IDL }) => {
     'memo' : IDL.Opt(IDL.Nat64),
     'amount_e8s' : IDL.Nat64,
   });
+  const ChunkedCanisterWasm = IDL.Record({
+    'wasm_module_hash' : IDL.Vec(IDL.Nat8),
+    'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
+    'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
   const UpgradeSnsControlledCanister = IDL.Record({
     'new_canister_wasm' : IDL.Vec(IDL.Nat8),
     'mode' : IDL.Opt(IDL.Int32),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'chunked_canister_wasm' : IDL.Opt(ChunkedCanisterWasm),
     'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
   const DeregisterDappCanisters = IDL.Record({
@@ -975,10 +981,16 @@ export const init = ({ IDL }) => {
     'memo' : IDL.Opt(IDL.Nat64),
     'amount_e8s' : IDL.Nat64,
   });
+  const ChunkedCanisterWasm = IDL.Record({
+    'wasm_module_hash' : IDL.Vec(IDL.Nat8),
+    'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
+    'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
   const UpgradeSnsControlledCanister = IDL.Record({
     'new_canister_wasm' : IDL.Vec(IDL.Nat8),
     'mode' : IDL.Opt(IDL.Int32),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'chunked_canister_wasm' : IDL.Opt(ChunkedCanisterWasm),
     'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
   const DeregisterDappCanisters = IDL.Record({

--- a/packages/sns/candid/sns_governance_test.d.ts
+++ b/packages/sns/candid/sns_governance_test.d.ts
@@ -83,6 +83,11 @@ export type CanisterStatusType =
 export interface ChangeAutoStakeMaturity {
   requested_setting_for_auto_stake_maturity: boolean;
 }
+export interface ChunkedCanisterWasm {
+  wasm_module_hash: Uint8Array | number[];
+  chunk_hashes_list: Array<Uint8Array | number[]>;
+  store_canister_id: [] | [Principal];
+}
 export interface ClaimOrRefresh {
   by: [] | [By];
 }
@@ -662,6 +667,7 @@ export interface UpgradeSnsControlledCanister {
   new_canister_wasm: Uint8Array | number[];
   mode: [] | [number];
   canister_id: [] | [Principal];
+  chunked_canister_wasm: [] | [ChunkedCanisterWasm];
   canister_upgrade_arg: [] | [Uint8Array | number[]];
 }
 export interface UpgradeStarted {

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 233c1ee2ef (2025-01-16 tags: release-2025-01-16_16-18-base) 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -726,8 +726,15 @@ type PendingVersion = record {
   target_version : opt Version;
 };
 
+type ChunkedCanisterWasm = record {
+  wasm_module_hash : blob;
+  store_canister_id : opt principal;
+  chunk_hashes_list : vec blob;
+};
+
 type UpgradeSnsControlledCanister = record {
   new_canister_wasm : blob;
+  chunked_canister_wasm : opt ChunkedCanisterWasm;
   mode : opt int32;
   canister_id : opt principal;
   canister_upgrade_arg : opt blob;

--- a/packages/sns/candid/sns_governance_test.idl.js
+++ b/packages/sns/candid/sns_governance_test.idl.js
@@ -242,10 +242,16 @@ export const idlFactory = ({ IDL }) => {
     'memo' : IDL.Opt(IDL.Nat64),
     'amount_e8s' : IDL.Nat64,
   });
+  const ChunkedCanisterWasm = IDL.Record({
+    'wasm_module_hash' : IDL.Vec(IDL.Nat8),
+    'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
+    'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
   const UpgradeSnsControlledCanister = IDL.Record({
     'new_canister_wasm' : IDL.Vec(IDL.Nat8),
     'mode' : IDL.Opt(IDL.Int32),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'chunked_canister_wasm' : IDL.Opt(ChunkedCanisterWasm),
     'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
   const DeregisterDappCanisters = IDL.Record({
@@ -983,10 +989,16 @@ export const init = ({ IDL }) => {
     'memo' : IDL.Opt(IDL.Nat64),
     'amount_e8s' : IDL.Nat64,
   });
+  const ChunkedCanisterWasm = IDL.Record({
+    'wasm_module_hash' : IDL.Vec(IDL.Nat8),
+    'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
+    'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
   const UpgradeSnsControlledCanister = IDL.Record({
     'new_canister_wasm' : IDL.Vec(IDL.Nat8),
     'mode' : IDL.Opt(IDL.Int32),
     'canister_id' : IDL.Opt(IDL.Principal),
+    'chunked_canister_wasm' : IDL.Opt(ChunkedCanisterWasm),
     'canister_upgrade_arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
   const DeregisterDappCanisters = IDL.Record({

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit 233c1ee2ef (2025-01-16 tags: release-2025-01-16_16-18-base) 'rs/sns/root/canister/root.did' by import-candid
 type CanisterCallError = record {
   code : opt int32;
   description : text;

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 233c1ee2ef (2025-01-16 tags: release-2025-01-16_16-18-base) 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;

--- a/packages/sns/src/converters/governance.converters.spec.ts
+++ b/packages/sns/src/converters/governance.converters.spec.ts
@@ -201,10 +201,23 @@ describe("governance converters", () => {
     it("converts UpgradeSnsControlledCanister action", () => {
       const new_canister_wasm = new Uint8Array();
       const canister_id = mockPrincipal;
+      const wasm_module_hash = new Uint8Array([1, 2, 3]);
+      const store_canister_id = Principal.fromHex("123f");
+      const chunk_hashes_list = [
+        new Uint8Array([4, 5, 6]),
+        new Uint8Array([7, 8, 9]),
+      ];
       const mode = 1;
       const action: ActionCandid = {
         UpgradeSnsControlledCanister: {
           new_canister_wasm,
+          chunked_canister_wasm: [
+            {
+              wasm_module_hash,
+              store_canister_id: [store_canister_id],
+              chunk_hashes_list,
+            },
+          ],
           canister_id: [canister_id],
           canister_upgrade_arg: [],
           mode: [mode],
@@ -213,6 +226,11 @@ describe("governance converters", () => {
       const expectedAction: Action = {
         UpgradeSnsControlledCanister: {
           new_canister_wasm: new Uint8Array(),
+          chunked_canister_wasm: {
+            wasm_module_hash,
+            store_canister_id,
+            chunk_hashes_list,
+          },
           canister_id,
           canister_upgrade_arg: undefined,
           mode,

--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -3,6 +3,7 @@ import { fromNullable, toNullable } from "@dfinity/utils";
 import type {
   Account,
   Action as ActionCandid,
+  ChunkedCanisterWasm as ChunkedCanisterWasmCandid,
   Command,
   FunctionType as FunctionTypeCandid,
   GenericNervousSystemFunction as GenericNervousSystemFunctionCandid,
@@ -20,6 +21,7 @@ import type {
 import { DEFAULT_PROPOSALS_LIMIT } from "../constants/governance.constants";
 import type {
   Action,
+  ChunkedCanisterWasm,
   FunctionType,
   GenericNervousSystemFunction,
   ManageSnsMetadata,
@@ -388,10 +390,26 @@ const convertManageSnsMetadata = (
   description: fromNullable(params.description),
 });
 
+const convertChunkedCanisterWasm = (
+  params: ChunkedCanisterWasmCandid | undefined,
+): ChunkedCanisterWasm | undefined => {
+  if (params === undefined) {
+    return undefined;
+  }
+  return {
+    wasm_module_hash: params.wasm_module_hash,
+    store_canister_id: fromNullable(params.store_canister_id),
+    chunk_hashes_list: params.chunk_hashes_list,
+  };
+};
+
 const convertUpgradeSnsControlledCanister = (
   params: UpgradeSnsControlledCanisterCandid,
 ): UpgradeSnsControlledCanister => ({
   new_canister_wasm: params.new_canister_wasm,
+  chunked_canister_wasm: convertChunkedCanisterWasm(
+    fromNullable(params.chunked_canister_wasm),
+  ),
   canister_id: fromNullable(params.canister_id),
   canister_upgrade_arg: fromNullable(params.canister_upgrade_arg),
   mode: fromNullable(params.mode),

--- a/packages/sns/src/types/actions.ts
+++ b/packages/sns/src/types/actions.ts
@@ -83,8 +83,15 @@ export interface TransferSnsTreasuryFunds {
   amount_e8s: bigint;
 }
 
+export interface ChunkedCanisterWasm {
+  wasm_module_hash: Uint8Array | number[];
+  store_canister_id: Option<Principal>;
+  chunk_hashes_list: Array<Uint8Array | number[]>;
+}
+
 export interface UpgradeSnsControlledCanister {
   new_canister_wasm: Uint8Array | number[];
+  chunked_canister_wasm: Option<ChunkedCanisterWasm>;
   canister_id: Option<Principal>;
   canister_upgrade_arg: Option<Uint8Array | number[]>;
   mode: Option<number>;


### PR DESCRIPTION
# Motivation

Candid for the `sns` package can't be updated automatically because of a new field `chunked_canister_wasm` in `UpgradeSnsControlledCanister`.

# Changes

1. Checked out `release-2025-01-16_16-18-base` in IC repo.
2. Ran `scripts/import-candid ../../ic`.
3. Ran `scripts/compile-idl-js`.
4. Reverted files outside `packages/sns`.
5. Updated types and tests to take into account the new field.

# Tests

Unit tests updated.

# Todos

- [x] Add entry to changelog (if necessary).
