### PR TITLE
chore: prepare new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,18 @@
 The current status of the libraries at the time of the release is as follows:
 
 | Library                  | Version | Status        |
-| ------------------------ |---------| ------------- |
-| `@dfinity/ckbtc`         | v3.1.6  | Maintained ⚙️     |
-| `@dfinity/cketh`         | v3.4.3  | Maintained ⚙️     |
-| `@dfinity/cmc`           | v4.1.1  | Maintained ⚙️     |
-| `@dfinity/ic-management` | v6.0.3  | Maintained ⚙️     |
+| ------------------------ | ------- | ------------- |
+| `@dfinity/ckbtc`         | v3.1.6  | Maintained ⚙️ |
+| `@dfinity/cketh`         | v3.4.3  | Maintained ⚙️ |
+| `@dfinity/cmc`           | v4.1.1  | Maintained ⚙️ |
+| `@dfinity/ic-management` | v6.0.3  | Maintained ⚙️ |
 | `@dfinity/ledger-icp`    | v2.6.7  | Maintained ⚙️ |
 | `@dfinity/ledger-icrc`   | v2.7.2  | Maintained ⚙️ |
-| `@dfinity/nns`           | v8.2.1  | Maintained ⚙️  |
+| `@dfinity/nns`           | v8.2.1  | Maintained ⚙️ |
 | `@dfinity/nns-proto`     | v2.0.1  | Unchanged️    |
 | `@dfinity/sns`           | v3.2.8  | Maintained ⚙️ |
 | `@dfinity/utils`         | v2.9.0  | Enhanced 🔧️  |
-| `@dfinity/zod-schemas`   | v0.0.1  | Unchanged️      |
+| `@dfinity/zod-schemas`   | v0.0.1  | Unchanged️    |
 
 # Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,28 @@
-# YYYY.MM.DD-HHMMZ
+# 2025.01.20-1730Z
+
+## Overview
+
+The current status of the libraries at the time of the release is as follows:
+
+| Library                  | Version | Status        |
+| ------------------------ |---------| ------------- |
+| `@dfinity/ckbtc`         | v3.1.6  | Maintained ⚙️     |
+| `@dfinity/cketh`         | v3.4.3  | Maintained ⚙️     |
+| `@dfinity/cmc`           | v4.1.1  | Maintained ⚙️     |
+| `@dfinity/ic-management` | v6.0.3  | Maintained ⚙️     |
+| `@dfinity/ledger-icp`    | v2.6.7  | Maintained ⚙️ |
+| `@dfinity/ledger-icrc`   | v2.7.2  | Maintained ⚙️ |
+| `@dfinity/nns`           | v8.2.1  | Maintained ⚙️  |
+| `@dfinity/nns-proto`     | v2.0.1  | Unchanged️    |
+| `@dfinity/sns`           | v3.2.8  | Maintained ⚙️ |
+| `@dfinity/utils`         | v2.9.0  | Enhanced 🔧️  |
+| `@dfinity/zod-schemas`   | v0.0.1  | Unchanged️      |
 
 # Features
 
 - Support `CanisterSettings.wasm_memory_threshold` in `@dfinity/nns`.
 - Support `UpgradeSnsControlledCanister.chunked_canister_wasm` in `@dfinity/sns`.
+- Add utility `fromNullishNullable` extracts the value from a nullish Candid-style variant representation.
 
 # 2025.01.20-1030Z
 
@@ -29,7 +48,6 @@ The current status of the libraries at the time of the release is as follows:
 
 - Expose types `IcrcApproveError` and `IcrcTransferFromError` in `@dfinity/ledger-icrc`.
 - Expose few additional did types in `@dfinity/ledger-icp`.
-- Add utility `fromNullishNullable` extracts the value from a nullish Candid-style variant representation.
 - Introduce a new zod-schemas library to provide a collection of reusable Zod schemas and validators for common data patterns in ICP applications.
 - Api get network economics parameters.
 - Update `old_list_neurons_service.certified.idl.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "2025.01.20-1030Z",
+  "version": "2025.01.20-1730Z",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/ic-js",
-      "version": "2025.01.20-1030Z",
+      "version": "2025.01.20-1730Z",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/utils",
@@ -7560,7 +7560,7 @@
     },
     "packages/ckbtc": {
       "name": "@dfinity/ckbtc",
-      "version": "3.1.5",
+      "version": "3.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -7571,67 +7571,67 @@
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.8.0"
+        "@dfinity/utils": "^2.9.0"
       }
     },
     "packages/cketh": {
       "name": "@dfinity/cketh",
-      "version": "3.4.2",
+      "version": "3.4.3",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.8.0"
+        "@dfinity/utils": "^2.9.0"
       }
     },
     "packages/cmc": {
       "name": "@dfinity/cmc",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.8.0"
+        "@dfinity/utils": "^2.9.0"
       }
     },
     "packages/ic-management": {
       "name": "@dfinity/ic-management",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.8.0"
+        "@dfinity/utils": "^2.9.0"
       }
     },
     "packages/ledger-icp": {
       "name": "@dfinity/ledger-icp",
-      "version": "2.6.6",
+      "version": "2.6.7",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.8.0"
+        "@dfinity/utils": "^2.9.0"
       }
     },
     "packages/ledger-icrc": {
       "name": "@dfinity/ledger-icrc",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.8.0"
+        "@dfinity/utils": "^2.9.0"
       }
     },
     "packages/nns": {
       "name": "@dfinity/nns",
-      "version": "8.2.0",
+      "version": "8.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -7643,9 +7643,9 @@
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
-        "@dfinity/ledger-icp": "^2.6.6",
+        "@dfinity/ledger-icp": "^2.6.7",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.8.0"
+        "@dfinity/utils": "^2.9.0"
       }
     },
     "packages/nns-proto": {
@@ -7661,7 +7661,7 @@
     },
     "packages/sns": {
       "name": "@dfinity/sns",
-      "version": "3.2.7",
+      "version": "3.2.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
@@ -7669,14 +7669,14 @@
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
-        "@dfinity/ledger-icrc": "^2.7.1",
+        "@dfinity/ledger-icrc": "^2.7.2",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.8.0"
+        "@dfinity/utils": "^2.9.0"
       }
     },
     "packages/utils": {
       "name": "@dfinity/utils",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "2025.01.20-1030Z",
+  "version": "2025.01.20-1730Z",
   "description": "A collection of library for interfacing with the Internet Computer.",
   "license": "Apache-2.0",
   "workspaces": [

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ckbtc",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "A library for interfacing with ckBTC.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -41,7 +41,7 @@
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.8.0"
+    "@dfinity/utils": "^2.9.0"
   },
   "dependencies": {
     "@noble/hashes": "^1.3.2",

--- a/packages/cketh/package.json
+++ b/packages/cketh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/cketh",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "A library for interfacing with ckETH.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -41,6 +41,6 @@
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.8.0"
+    "@dfinity/utils": "^2.9.0"
   }
 }

--- a/packages/cmc/package.json
+++ b/packages/cmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/cmc",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "A library for interfacing with the cycle minting canister.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -39,6 +39,6 @@
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.8.0"
+    "@dfinity/utils": "^2.9.0"
   }
 }

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-management",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "A library for interfacing with the IC management canister.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -37,6 +37,6 @@
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.8.0"
+    "@dfinity/utils": "^2.9.0"
   }
 }

--- a/packages/ledger-icp/package.json
+++ b/packages/ledger-icp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ledger-icp",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "description": "A library for interfacing with the ICP ledger on the Internet Computer.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -41,6 +41,6 @@
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.8.0"
+    "@dfinity/utils": "^2.9.0"
   }
 }

--- a/packages/ledger-icrc/package.json
+++ b/packages/ledger-icrc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ledger-icrc",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "A library for interfacing with ICRC ledgers on the Internet Computer.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -40,6 +40,6 @@
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.8.0"
+    "@dfinity/utils": "^2.9.0"
   }
 }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "description": "A library for interfacing with the Internet Computer's Network Nervous System.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -53,8 +53,8 @@
   "peerDependencies": {
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
-    "@dfinity/ledger-icp": "^2.6.6",
+    "@dfinity/ledger-icp": "^2.6.7",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.8.0"
+    "@dfinity/utils": "^2.9.0"
   }
 }

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/sns",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "description": "A library for interfacing with a Service Nervous System (SNS) project.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -38,9 +38,9 @@
   "peerDependencies": {
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
-    "@dfinity/ledger-icrc": "^2.7.1",
+    "@dfinity/ledger-icrc": "^2.7.2",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.8.0"
+    "@dfinity/utils": "^2.9.0"
   },
   "dependencies": {
     "@noble/hashes": "^1.3.2"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/utils",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "A collection of utilities and constants for NNS/SNS projects.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",


### PR DESCRIPTION
# Motivation

In today's release [2025.01.20-1030Z](https://github.com/dfinity/ic-js/releases/tag/2025.01.20-1030Z) I did not bumped utils. As a result the new utility `fromNullishNullable` is not released. So I think it's cleaner to make a new release which bumps utils and all libs that use it.

# Changes

- Bump version and update CHANGELOG
