### PR TITLE
Update sns Candid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# YYYY.MM.DD-HHMMZ
+
+# Features
+
+- Support `NervousSystemParameters.automatically_advance_target_version` in `@dfinity/sns`.
+
 # 2025.01.20-1800Z
 
 ## Overview

--- a/packages/sns/candid/sns_governance.certified.idl.js
+++ b/packages/sns/candid/sns_governance.certified.idl.js
@@ -67,6 +67,7 @@ export const idlFactory = ({ IDL }) => {
   const TargetVersionSet = IDL.Record({
     'old_target_version' : IDL.Opt(Version),
     'new_target_version' : IDL.Opt(Version),
+    'is_advanced_automatically' : IDL.Opt(IDL.Bool),
   });
   const UpgradeStepsReset = IDL.Record({
     'human_readable' : IDL.Opt(IDL.Text),
@@ -137,6 +138,7 @@ export const idlFactory = ({ IDL }) => {
     'max_dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_dissolve_delay_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'max_followees_per_function' : IDL.Opt(IDL.Nat64),
+    'automatically_advance_target_version' : IDL.Opt(IDL.Bool),
     'neuron_claimer_permissions' : IDL.Opt(NeuronPermissionList),
     'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
     'max_neuron_age_for_age_bonus' : IDL.Opt(IDL.Nat64),
@@ -778,6 +780,7 @@ export const init = ({ IDL }) => {
   const TargetVersionSet = IDL.Record({
     'old_target_version' : IDL.Opt(Version),
     'new_target_version' : IDL.Opt(Version),
+    'is_advanced_automatically' : IDL.Opt(IDL.Bool),
   });
   const UpgradeStepsReset = IDL.Record({
     'human_readable' : IDL.Opt(IDL.Text),
@@ -848,6 +851,7 @@ export const init = ({ IDL }) => {
     'max_dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_dissolve_delay_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'max_followees_per_function' : IDL.Opt(IDL.Nat64),
+    'automatically_advance_target_version' : IDL.Opt(IDL.Bool),
     'neuron_claimer_permissions' : IDL.Opt(NeuronPermissionList),
     'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
     'max_neuron_age_for_age_bonus' : IDL.Opt(IDL.Nat64),

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -398,6 +398,7 @@ export interface NervousSystemParameters {
   max_dissolve_delay_seconds: [] | [bigint];
   max_dissolve_delay_bonus_percentage: [] | [bigint];
   max_followees_per_function: [] | [bigint];
+  automatically_advance_target_version: [] | [boolean];
   neuron_claimer_permissions: [] | [NeuronPermissionList];
   neuron_minimum_stake_e8s: [] | [bigint];
   max_neuron_age_for_age_bonus: [] | [bigint];
@@ -599,6 +600,7 @@ export interface TargetVersionReset {
 export interface TargetVersionSet {
   old_target_version: [] | [Version];
   new_target_version: [] | [Version];
+  is_advanced_automatically: [] | [boolean];
 }
 export interface Timers {
   last_spawned_timestamp_seconds: [] | [bigint];

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 233c1ee2ef (2025-01-16 tags: release-2025-01-16_16-18-base) 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 4ba5834 (2025-01-22 tags: release-2025-01-23_03-04-hashes-in-blocks) 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -482,6 +482,7 @@ type NervousSystemParameters = record {
   voting_rewards_parameters : opt VotingRewardsParameters;
   maturity_modulation_disabled : opt bool;
   max_number_of_principals_per_neuron : opt nat64;
+  automatically_advance_target_version : opt bool;
 };
 
 type Neuron = record {
@@ -785,6 +786,7 @@ type UpgradeStepsReset = record {
 type TargetVersionSet = record {
   new_target_version : opt Version;
   old_target_version : opt Version;
+  is_advanced_automatically : opt bool;
 };
 
 type TargetVersionReset = record {

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -67,6 +67,7 @@ export const idlFactory = ({ IDL }) => {
   const TargetVersionSet = IDL.Record({
     'old_target_version' : IDL.Opt(Version),
     'new_target_version' : IDL.Opt(Version),
+    'is_advanced_automatically' : IDL.Opt(IDL.Bool),
   });
   const UpgradeStepsReset = IDL.Record({
     'human_readable' : IDL.Opt(IDL.Text),
@@ -137,6 +138,7 @@ export const idlFactory = ({ IDL }) => {
     'max_dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_dissolve_delay_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'max_followees_per_function' : IDL.Opt(IDL.Nat64),
+    'automatically_advance_target_version' : IDL.Opt(IDL.Bool),
     'neuron_claimer_permissions' : IDL.Opt(NeuronPermissionList),
     'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
     'max_neuron_age_for_age_bonus' : IDL.Opt(IDL.Nat64),
@@ -786,6 +788,7 @@ export const init = ({ IDL }) => {
   const TargetVersionSet = IDL.Record({
     'old_target_version' : IDL.Opt(Version),
     'new_target_version' : IDL.Opt(Version),
+    'is_advanced_automatically' : IDL.Opt(IDL.Bool),
   });
   const UpgradeStepsReset = IDL.Record({
     'human_readable' : IDL.Opt(IDL.Text),
@@ -856,6 +859,7 @@ export const init = ({ IDL }) => {
     'max_dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_dissolve_delay_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'max_followees_per_function' : IDL.Opt(IDL.Nat64),
+    'automatically_advance_target_version' : IDL.Opt(IDL.Bool),
     'neuron_claimer_permissions' : IDL.Opt(NeuronPermissionList),
     'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
     'max_neuron_age_for_age_bonus' : IDL.Opt(IDL.Nat64),

--- a/packages/sns/candid/sns_governance_test.certified.idl.js
+++ b/packages/sns/candid/sns_governance_test.certified.idl.js
@@ -67,6 +67,7 @@ export const idlFactory = ({ IDL }) => {
   const TargetVersionSet = IDL.Record({
     'old_target_version' : IDL.Opt(Version),
     'new_target_version' : IDL.Opt(Version),
+    'is_advanced_automatically' : IDL.Opt(IDL.Bool),
   });
   const UpgradeStepsReset = IDL.Record({
     'human_readable' : IDL.Opt(IDL.Text),
@@ -137,6 +138,7 @@ export const idlFactory = ({ IDL }) => {
     'max_dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_dissolve_delay_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'max_followees_per_function' : IDL.Opt(IDL.Nat64),
+    'automatically_advance_target_version' : IDL.Opt(IDL.Bool),
     'neuron_claimer_permissions' : IDL.Opt(NeuronPermissionList),
     'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
     'max_neuron_age_for_age_bonus' : IDL.Opt(IDL.Nat64),
@@ -806,6 +808,7 @@ export const init = ({ IDL }) => {
   const TargetVersionSet = IDL.Record({
     'old_target_version' : IDL.Opt(Version),
     'new_target_version' : IDL.Opt(Version),
+    'is_advanced_automatically' : IDL.Opt(IDL.Bool),
   });
   const UpgradeStepsReset = IDL.Record({
     'human_readable' : IDL.Opt(IDL.Text),
@@ -876,6 +879,7 @@ export const init = ({ IDL }) => {
     'max_dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_dissolve_delay_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'max_followees_per_function' : IDL.Opt(IDL.Nat64),
+    'automatically_advance_target_version' : IDL.Opt(IDL.Bool),
     'neuron_claimer_permissions' : IDL.Opt(NeuronPermissionList),
     'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
     'max_neuron_age_for_age_bonus' : IDL.Opt(IDL.Nat64),

--- a/packages/sns/candid/sns_governance_test.d.ts
+++ b/packages/sns/candid/sns_governance_test.d.ts
@@ -413,6 +413,7 @@ export interface NervousSystemParameters {
   max_dissolve_delay_seconds: [] | [bigint];
   max_dissolve_delay_bonus_percentage: [] | [bigint];
   max_followees_per_function: [] | [bigint];
+  automatically_advance_target_version: [] | [boolean];
   neuron_claimer_permissions: [] | [NeuronPermissionList];
   neuron_minimum_stake_e8s: [] | [bigint];
   max_neuron_age_for_age_bonus: [] | [bigint];
@@ -614,6 +615,7 @@ export interface TargetVersionReset {
 export interface TargetVersionSet {
   old_target_version: [] | [Version];
   new_target_version: [] | [Version];
+  is_advanced_automatically: [] | [boolean];
 }
 export interface Timers {
   last_spawned_timestamp_seconds: [] | [bigint];

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 233c1ee2ef (2025-01-16 tags: release-2025-01-16_16-18-base) 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 4ba5834 (2025-01-22 tags: release-2025-01-23_03-04-hashes-in-blocks) 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -496,6 +496,7 @@ type NervousSystemParameters = record {
   voting_rewards_parameters : opt VotingRewardsParameters;
   maturity_modulation_disabled : opt bool;
   max_number_of_principals_per_neuron : opt nat64;
+  automatically_advance_target_version : opt bool;
 };
 
 type Neuron = record {
@@ -799,6 +800,7 @@ type UpgradeStepsReset = record {
 type TargetVersionSet = record {
   new_target_version : opt Version;
   old_target_version : opt Version;
+  is_advanced_automatically : opt bool;
 };
 
 type TargetVersionReset = record {

--- a/packages/sns/candid/sns_governance_test.idl.js
+++ b/packages/sns/candid/sns_governance_test.idl.js
@@ -67,6 +67,7 @@ export const idlFactory = ({ IDL }) => {
   const TargetVersionSet = IDL.Record({
     'old_target_version' : IDL.Opt(Version),
     'new_target_version' : IDL.Opt(Version),
+    'is_advanced_automatically' : IDL.Opt(IDL.Bool),
   });
   const UpgradeStepsReset = IDL.Record({
     'human_readable' : IDL.Opt(IDL.Text),
@@ -137,6 +138,7 @@ export const idlFactory = ({ IDL }) => {
     'max_dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_dissolve_delay_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'max_followees_per_function' : IDL.Opt(IDL.Nat64),
+    'automatically_advance_target_version' : IDL.Opt(IDL.Bool),
     'neuron_claimer_permissions' : IDL.Opt(NeuronPermissionList),
     'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
     'max_neuron_age_for_age_bonus' : IDL.Opt(IDL.Nat64),
@@ -814,6 +816,7 @@ export const init = ({ IDL }) => {
   const TargetVersionSet = IDL.Record({
     'old_target_version' : IDL.Opt(Version),
     'new_target_version' : IDL.Opt(Version),
+    'is_advanced_automatically' : IDL.Opt(IDL.Bool),
   });
   const UpgradeStepsReset = IDL.Record({
     'human_readable' : IDL.Opt(IDL.Text),
@@ -884,6 +887,7 @@ export const init = ({ IDL }) => {
     'max_dissolve_delay_seconds' : IDL.Opt(IDL.Nat64),
     'max_dissolve_delay_bonus_percentage' : IDL.Opt(IDL.Nat64),
     'max_followees_per_function' : IDL.Opt(IDL.Nat64),
+    'automatically_advance_target_version' : IDL.Opt(IDL.Bool),
     'neuron_claimer_permissions' : IDL.Opt(NeuronPermissionList),
     'neuron_minimum_stake_e8s' : IDL.Opt(IDL.Nat64),
     'max_neuron_age_for_age_bonus' : IDL.Opt(IDL.Nat64),

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 233c1ee2ef (2025-01-16 tags: release-2025-01-16_16-18-base) 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit 4ba5834 (2025-01-22 tags: release-2025-01-23_03-04-hashes-in-blocks) 'rs/sns/root/canister/root.did' by import-candid
 type CanisterCallError = record {
   code : opt int32;
   description : text;

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 233c1ee2ef (2025-01-16 tags: release-2025-01-16_16-18-base) 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 4ba5834 (2025-01-22 tags: release-2025-01-23_03-04-hashes-in-blocks) 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;

--- a/packages/sns/src/converters/governance.converters.spec.ts
+++ b/packages/sns/src/converters/governance.converters.spec.ts
@@ -73,6 +73,7 @@ describe("governance converters", () => {
             max_number_of_principals_per_neuron,
           ],
           maturity_modulation_disabled: [false],
+          automatically_advance_target_version: [true],
         },
       };
       const expectedAction: Action = {
@@ -101,6 +102,7 @@ describe("governance converters", () => {
             round_duration_seconds,
           },
           max_number_of_principals_per_neuron,
+          automatically_advance_target_version: true,
         },
       };
       expect(fromCandidAction(action)).toEqual(expectedAction);

--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -523,4 +523,7 @@ const convertNervousSystemParams = (
   max_number_of_principals_per_neuron: fromNullable(
     params.max_number_of_principals_per_neuron,
   ),
+  automatically_advance_target_version: fromNullable(
+    params.automatically_advance_target_version,
+  ),
 });

--- a/packages/sns/src/types/actions.ts
+++ b/packages/sns/src/types/actions.ts
@@ -48,6 +48,7 @@ export interface NervousSystemParameters {
   neuron_grantable_permissions: Option<NeuronPermissionList>;
   voting_rewards_parameters: Option<VotingRewardsParameters>;
   max_number_of_principals_per_neuron: Option<bigint>;
+  automatically_advance_target_version: Option<boolean>;
 }
 
 export interface VotingRewardsParameters {


### PR DESCRIPTION
# Motivation

The automatic [Candid update PR](https://github.com/dfinity/ic-js/pull/826) [failed](https://github.com/dfinity/ic-js/actions/runs/12981563131/job/36200149623?pr=826) because of a new field `automatically_advance_target_version` in `NervousSystemParameters`.

# Changes

1. Checked out the branch from https://github.com/dfinity/ic-js/pull/826
2. Reverted the changes not in the `sns` package.
3. Fixed the test by supporting `NervousSystemParameters.automatically_advance_target_version`.

# Tests

Fixed

# Todos

- [x] Add entry to changelog (if necessary).
