### PR TITLE
feat: Base64 string to and from Uint8Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Features
 
 - Support `NervousSystemParameters.automatically_advance_target_version` in `@dfinity/sns`.
+- Add converters to encode or decode base64 string into Uint8Array.
 
 # 2025.01.20-1800Z
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -54,6 +54,8 @@ npm i @dfinity/agent @dfinity/candid @dfinity/principal
 - [candidNumberArrayToBigInt](#gear-candidnumberarraytobigint)
 - [encodeBase32](#gear-encodebase32)
 - [decodeBase32](#gear-decodebase32)
+- [uint8ArrayToBase64](#gear-uint8arraytobase64)
+- [base64ToUint8Array](#gear-base64touint8array)
 - [bigEndianCrc32](#gear-bigendiancrc32)
 - [secondsToDuration](#gear-secondstoduration)
 - [nowInBigIntNanoSeconds](#gear-nowinbigintnanoseconds)
@@ -306,6 +308,34 @@ Parameters:
 - `input`: The base32 encoded string to decode.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/base32.utils.ts#L67)
+
+#### :gear: uint8ArrayToBase64
+
+Converts a Uint8Array (binary data) to a base64 encoded string.
+
+| Function             | Type                                 |
+| -------------------- | ------------------------------------ |
+| `uint8ArrayToBase64` | `(uint8Array: Uint8Array) => string` |
+
+Parameters:
+
+- `uint8Array`: - The Uint8Array containing binary data to be encoded.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/base64.utils.ts#L7)
+
+#### :gear: base64ToUint8Array
+
+Converts a base64 encoded string to a Uint8Array (binary data).
+
+| Function             | Type                                   |
+| -------------------- | -------------------------------------- |
+| `base64ToUint8Array` | `(base64String: string) => Uint8Array` |
+
+Parameters:
+
+- `base64String`: - The base64 encoded string to be decoded.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/base64.utils.ts#L16)
 
 #### :gear: bigEndianCrc32
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -10,6 +10,7 @@ export * from "./utils/agent.utils";
 export * from "./utils/arrays.utils";
 export * from "./utils/asserts.utils";
 export * from "./utils/base32.utils";
+export * from "./utils/base64.utils";
 export * from "./utils/crc.utils";
 export * from "./utils/date.utils";
 export * from "./utils/debounce.utils";

--- a/packages/utils/src/utils/base64.utils.spec.ts
+++ b/packages/utils/src/utils/base64.utils.spec.ts
@@ -1,0 +1,58 @@
+import { base64ToUint8Array, uint8ArrayToBase64 } from "./base64.utils";
+
+describe("Base64 Encoding and Decoding", () => {
+  describe("Success", () => {
+    it("should correctly encode Uint8Array to base64 string", () => {
+      const uint8Array = new Uint8Array([104, 101, 108, 108, 111]);
+      const base64String = uint8ArrayToBase64(uint8Array);
+      expect(base64String).toBe(btoa("hello"));
+    });
+
+    it("should correctly decode base64 string to Uint8Array", () => {
+      const base64String = btoa("hello");
+      const uint8Array = base64ToUint8Array(base64String);
+      expect(uint8Array).toEqual(new Uint8Array([104, 101, 108, 108, 111]));
+    });
+
+    it("should handle empty Uint8Array encoding", () => {
+      const uint8Array = new Uint8Array([]);
+      const base64String = uint8ArrayToBase64(uint8Array);
+      expect(base64String).toBe("");
+    });
+
+    it("should handle empty base64 string decoding", () => {
+      const base64String = "";
+      const uint8Array = base64ToUint8Array(base64String);
+      expect(uint8Array).toEqual(new Uint8Array([]));
+    });
+
+    it("should encode and decode non-ASCII binary data correctly", () => {
+      const uint8Array = new Uint8Array([255, 254, 253, 252, 251]);
+      const base64String = uint8ArrayToBase64(uint8Array);
+      const decodedArray = base64ToUint8Array(base64String);
+      expect(decodedArray).toEqual(uint8Array);
+    });
+  });
+
+  describe("Errors", () => {
+    it("should throw an error when decoding an invalid base64 string", () => {
+      const invalidBase64String = "invalid!base64";
+      expect(() => {
+        base64ToUint8Array(invalidBase64String);
+      }).toThrowError();
+    });
+
+    it("should not encode non-Uint8Array values properly", () => {
+      const invalidInput = "hello";
+      // @ts-expect-error: we are testing this on purpose
+      const result = uint8ArrayToBase64(invalidInput);
+      expect(result).not.toBe(uint8ArrayToBase64(new Uint8Array([1, 2, 3, 4])));
+    });
+
+    it("should decode correctly even if base64 string is missing padding", () => {
+      const base64StringWithoutPadding = "YWJjZA"; // missing '==' padding
+      const result = base64ToUint8Array(base64StringWithoutPadding);
+      expect(result).toEqual(new Uint8Array([97, 98, 99, 100])); // 'abcd'
+    });
+  });
+});

--- a/packages/utils/src/utils/base64.utils.ts
+++ b/packages/utils/src/utils/base64.utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Converts a Uint8Array (binary data) to a base64 encoded string.
+ *
+ * @param {Uint8Array} uint8Array - The Uint8Array containing binary data to be encoded.
+ * @returns {string} - The base64 encoded string representation of the binary data.
+ */
+export const uint8ArrayToBase64 = (uint8Array: Uint8Array): string =>
+  btoa(String.fromCharCode(...new Uint8Array(uint8Array)));
+
+/**
+ * Converts a base64 encoded string to a Uint8Array (binary data).
+ *
+ * @param {string} base64String - The base64 encoded string to be decoded.
+ * @returns {Uint8Array} - The Uint8Array representation of the decoded binary data.
+ */
+export const base64ToUint8Array = (base64String: string): Uint8Array =>
+  Uint8Array.from(atob(base64String), (c) => c.charCodeAt(0));


### PR DESCRIPTION
# Motivation

In today's Juno live session, I was looking to decode an `IcrcAccount` provided by the OISY Wallet Signer to a string using the `owner` and `subaccount`. The `subaccount`, in this case, is provided as a `base64` string, so I needed to convert it to a `Uint8Array`. I could have done this if I had access to a utility within the `@dfinity/oisy-wallet-signer` library. However, this utility is not exposed. 

I considered exposing it in the signer library but later realized that it makes more sense to move it to the `@dfinity/utils` package, as it could be useful for other use cases.

# Changes

- Copy `base64.utils` from https://github.com/dfinity/oisy-wallet-signer/blob/main/src/utils/base64.utils.ts to ic-js