### PR TITLE
docs(governance): update list_neurons default behavior comment

### DIFF
--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -228,7 +228,7 @@ If an array of neuron IDs is provided, precisely those neurons will be fetched.
 If `certified` is true, the request is fetched as an update call, otherwise
 it is fetched using a query call.
 
-The backend treats `includeEmptyNeurons` as true if absent.
+The backend treats `includeEmptyNeurons` as false if absent.
 
 | Method        | Type                                                                                                                                                                                                                                                   |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -141,7 +141,7 @@ export class GovernanceCanister {
    * If `certified` is true, the request is fetched as an update call, otherwise
    * it is fetched using a query call.
    *
-   * The backend treats `includeEmptyNeurons` as true if absent.
+   * The backend treats `includeEmptyNeurons` as false if absent.
    */
   public listNeurons = async ({
     certified = true,


### PR DESCRIPTION
# Motivation

As mentioned [here](https://dfinity.slack.com/archives/C0175CHJ0P6/p1738018577231269) and [here](https://forum.dfinity.org/t/listneurons-api-change-empty-neurons/40311),  the default behavior of `include_empty_neurons_readable_by_caller` in `list_neurons` has been changed from `true` to `false`.

# Changes

- Update comment

# Tests

- Test should pass as before

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary