### PR TITLE
fix(security): expose certified flag for ICP to XDR conversion rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # YYYY.MM.DD-HHMMZ
 
-# Features
+## Breaking Changes
+
+- Default `getIcpToCyclesConversionRate` to an update call while providing a `certified` parameter for queries.
+
+## Features
 
 - Support `NervousSystemParameters.automatically_advance_target_version` in `@dfinity/sns`.
-
-# Fix
-
-- Expose certified flag in `getIcpToCyclesConversionRate` to make update call.
 
 # 2025.01.20-1800Z
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Support `NervousSystemParameters.automatically_advance_target_version` in `@dfinity/sns`.
 
+# Fix
+
+- Expose certified flag in `getIcpToCyclesConversionRate` to make update call.
+
 # 2025.01.20-1800Z
 
 ## Overview

--- a/packages/cmc/README.md
+++ b/packages/cmc/README.md
@@ -98,7 +98,7 @@ It returns the new canister principal.
 | ---------------------- | ---------------------------------------------------------- |
 | `notifyCreateCanister` | `(request: NotifyCreateCanisterArg) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L56)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L57)
 
 ##### :gear: notifyTopUp
 
@@ -109,7 +109,7 @@ It returns the new Cycles of the canister.
 | ------------- | ---------------------------------------------- |
 | `notifyTopUp` | `(request: NotifyTopUpArg) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L84)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L85)
 
 ##### :gear: getDefaultSubnets
 
@@ -126,7 +126,7 @@ Parameters:
 - `params.certified`: - Determines whether the response should be certified
   (default: non-certified if not specified).
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L109)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L110)
 
 ##### :gear: getSubnetTypesToSubnets
 
@@ -144,6 +144,6 @@ Parameters:
 - `params.certified`: - Specifies whether the response should be certified.
   If not provided, the response defaults to non-certified.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L128)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L129)
 
 <!-- TSDOC_END -->

--- a/packages/cmc/README.md
+++ b/packages/cmc/README.md
@@ -76,13 +76,18 @@ const rate = await getIcpToCyclesConversionRate();
 
 ##### :gear: getIcpToCyclesConversionRate
 
-Returns conversion rate of ICP to Cycles
+Returns conversion rate of ICP to Cycles. It can be called as query or update.
 
-| Method                         | Type                    |
-| ------------------------------ | ----------------------- |
-| `getIcpToCyclesConversionRate` | `() => Promise<bigint>` |
+| Method                         | Type                                                |
+| ------------------------------ | --------------------------------------------------- |
+| `getIcpToCyclesConversionRate` | `({ certified, }?: QueryParams) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L32)
+Parameters:
+
+- `params`: - The parameters for the call.
+- `params.certified`: - Determines whether the response should be certified (default: non-certified)
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L35)
 
 ##### :gear: notifyCreateCanister
 
@@ -93,7 +98,7 @@ It returns the new canister principal.
 | ---------------------- | ---------------------------------------------------------- |
 | `notifyCreateCanister` | `(request: NotifyCreateCanisterArg) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L49)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L56)
 
 ##### :gear: notifyTopUp
 
@@ -104,7 +109,7 @@ It returns the new Cycles of the canister.
 | ------------- | ---------------------------------------------- |
 | `notifyTopUp` | `(request: NotifyTopUpArg) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L77)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L84)
 
 ##### :gear: getDefaultSubnets
 
@@ -121,7 +126,7 @@ Parameters:
 - `params.certified`: - Determines whether the response should be certified
   (default: non-certified if not specified).
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L102)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L109)
 
 ##### :gear: getSubnetTypesToSubnets
 
@@ -139,6 +144,6 @@ Parameters:
 - `params.certified`: - Specifies whether the response should be certified.
   If not provided, the response defaults to non-certified.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L121)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L128)
 
 <!-- TSDOC_END -->

--- a/packages/cmc/src/cmc.canister.spec.ts
+++ b/packages/cmc/src/cmc.canister.spec.ts
@@ -35,7 +35,7 @@ describe("CyclesMintingCanister", () => {
   };
 
   describe("CMCCanister.getIcpToCyclesConversionRate", () => {
-    it("should returns the conversion rate from ICP to cycles", async () => {
+    it("should returns the conversion rate from ICP to cycles for a query", async () => {
       const exchangeRate = BigInt(10_000);
       const response: IcpXdrConversionRateResponse = {
         certificate: arrayOfNumberToUint8Array([]),
@@ -49,10 +49,46 @@ describe("CyclesMintingCanister", () => {
       service.get_icp_xdr_conversion_rate.mockResolvedValue(response);
 
       const cmc = await createCMC(service);
+      const callerSpy = jest.spyOn(
+        cmc as unknown as {
+          caller: (params: QueryParams) => Promise<CMCService>;
+        },
+        "caller",
+      );
 
-      const res = await cmc.getIcpToCyclesConversionRate();
+      const res = await cmc.getIcpToCyclesConversionRate({ certified: false });
 
       expect(res).toEqual(exchangeRate);
+      expect(service.get_icp_xdr_conversion_rate).toHaveBeenCalledTimes(1);
+      expect(callerSpy).toHaveBeenCalledWith({ certified: false });
+    });
+
+    it("should returns the conversion rate from ICP to cycles for an update", async () => {
+      const exchangeRate = BigInt(10_000);
+      const response: IcpXdrConversionRateResponse = {
+        certificate: arrayOfNumberToUint8Array([]),
+        data: {
+          xdr_permyriad_per_icp: exchangeRate,
+          timestamp_seconds: BigInt(10),
+        },
+        hash_tree: arrayOfNumberToUint8Array([]),
+      };
+      const service = mock<CMCService>();
+      service.get_icp_xdr_conversion_rate.mockResolvedValue(response);
+
+      const cmc = await createCMC(service);
+      const callerSpy = jest.spyOn(
+        cmc as unknown as {
+          caller: (params: QueryParams) => Promise<CMCService>;
+        },
+        "caller",
+      );
+
+      const res = await cmc.getIcpToCyclesConversionRate({ certified: true });
+
+      expect(res).toEqual(exchangeRate);
+      expect(service.get_icp_xdr_conversion_rate).toHaveBeenCalledTimes(1);
+      expect(callerSpy).toHaveBeenCalledWith({ certified: true });
     });
   });
 

--- a/packages/cmc/src/cmc.canister.ts
+++ b/packages/cmc/src/cmc.canister.ts
@@ -25,12 +25,19 @@ export class CMCCanister extends Canister<CMCCanisterService> {
   }
 
   /**
-   * Returns conversion rate of ICP to Cycles
+   * Returns conversion rate of ICP to Cycles. It can be called as query or update.
+   *
+   * @param {Object} [params] - The parameters for the call.
+   * @param {boolean} [params.certified] - Determines whether the response should be certified (default: non-certified)
    *
    * @returns Promise<BigInt>
    */
-  public getIcpToCyclesConversionRate = async (): Promise<bigint> => {
-    const { data } = await this.service.get_icp_xdr_conversion_rate();
+  public getIcpToCyclesConversionRate = async ({
+    certified,
+  }: QueryParams = {}): Promise<bigint> => {
+    const { data } = await this.caller({
+      certified,
+    }).get_icp_xdr_conversion_rate();
 
     return data.xdr_permyriad_per_icp;
   };

--- a/packages/cmc/src/cmc.canister.ts
+++ b/packages/cmc/src/cmc.canister.ts
@@ -40,6 +40,7 @@ export class CMCCanister extends Canister<CMCCanisterService> {
     }).get_icp_xdr_conversion_rate();
 
     // TODO: validate the certificate in the response - https://dfinity.atlassian.net/browse/GIX-150
+    // Example: https://github.com/dfinity/response-verification/tree/main/examples/certification/certified-counter
     return data.xdr_permyriad_per_icp;
   };
 

--- a/packages/cmc/src/cmc.canister.ts
+++ b/packages/cmc/src/cmc.canister.ts
@@ -32,7 +32,6 @@ export class CMCCanister extends Canister<CMCCanisterService> {
   public getIcpToCyclesConversionRate = async (): Promise<bigint> => {
     const { data } = await this.service.get_icp_xdr_conversion_rate();
 
-    // TODO: validate the certificate in the response - https://dfinity.atlassian.net/browse/FOLLOW-223
     return data.xdr_permyriad_per_icp;
   };
 

--- a/packages/cmc/src/cmc.canister.ts
+++ b/packages/cmc/src/cmc.canister.ts
@@ -39,6 +39,7 @@ export class CMCCanister extends Canister<CMCCanisterService> {
       certified,
     }).get_icp_xdr_conversion_rate();
 
+    // TODO: validate the certificate in the response - https://dfinity.atlassian.net/browse/GIX-150
     return data.xdr_permyriad_per_icp;
   };
 


### PR DESCRIPTION
# Motivation

It has been flagged as a security concern not to use a certified query when reading the ICP to XDR conversion rate. 

One option is to implement certificate validation, but its complexity seems beyond the scope of the security ticket. Therefore, I am exposing a new parameter to make the call an update call instead of a query call.

[SECFIND-421](https://dfinity.atlassian.net/browse/SECFIND-421)

# Changes

- New `certified` parameter for `getIcpToCyclesConversionRate` to use the `certifiedService`

# Tests

- Updated existing test to check that `service` is call when `certified: false`
-  Add  new test to check that `certifiedService` is call when `certified: true`

# Todos

- [x] Add entry to changelog (if necessary).


[SECFIND-421]: https://dfinity.atlassian.net/browse/SECFIND-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ