### PR TITLE
feat(governance): implement pagination for list_neurons endpoint

### DIFF
--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -173,7 +173,7 @@ Parameters:
 
 ### :factory: GovernanceCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L92)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L91)
 
 #### Methods
 
@@ -217,7 +217,7 @@ Parameters:
 | -------- | ------------------------------------------------------------- |
 | `create` | `(options?: GovernanceCanisterOptions) => GovernanceCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L107)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L106)
 
 ##### :gear: listNeurons
 

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -173,7 +173,7 @@ Parameters:
 
 ### :factory: GovernanceCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L91)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L92)
 
 #### Methods
 
@@ -217,7 +217,7 @@ Parameters:
 | -------- | ------------------------------------------------------------- |
 | `create` | `(options?: GovernanceCanisterOptions) => GovernanceCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L106)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L107)
 
 ##### :gear: listNeurons
 
@@ -230,11 +230,14 @@ it is fetched using a query call.
 
 The backend treats `includeEmptyNeurons` as false if absent.
 
+The response might be paginated. In this case, all pages will be fetched in parallel and
+combined into a single response.
+
 | Method        | Type                                                                                                                                                                                                                                                                                                                  |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `listNeurons` | `({ certified, neuronIds, includeEmptyNeurons, includePublicNeurons, neuronSubaccounts, }: { certified: boolean; neuronIds?: bigint[] or undefined; includeEmptyNeurons?: boolean or undefined; includePublicNeurons?: boolean or undefined; neuronSubaccounts?: NeuronSubaccount[] or undefined; }) => Promise<...>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L147)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L150)
 
 ##### :gear: listKnownNeurons
 
@@ -248,7 +251,7 @@ it is fetched using a query call.
 | ------------------ | ------------------------------------------------- |
 | `listKnownNeurons` | `(certified?: boolean) => Promise<KnownNeuron[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L193)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L279)
 
 ##### :gear: getLastestRewardEvent
 
@@ -261,7 +264,7 @@ it's fetched using a query call.
 | ----------------------- | ----------------------------------------------- |
 | `getLastestRewardEvent` | `(certified?: boolean) => Promise<RewardEvent>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L215)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L301)
 
 ##### :gear: listProposals
 
@@ -280,7 +283,7 @@ Parameters:
 - `request`: the options to list the proposals (limit number of results, topics to search for, etc.)
 - `certified`: query or update calls
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L231)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L317)
 
 ##### :gear: stakeNeuron
 
@@ -288,7 +291,7 @@ Parameters:
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `stakeNeuron` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, fee, }: { stake: bigint; principal: Principal; fromSubAccount?: number[] or undefined; ledgerCanister: LedgerCanister; createdAt?: bigint or undefined; fee?: bigint or undefined; }) => Promise<...>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L250)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L336)
 
 ##### :gear: increaseDissolveDelay
 
@@ -298,7 +301,7 @@ Increases dissolve delay of a neuron
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `increaseDissolveDelay` | `({ neuronId, additionalDissolveDelaySeconds, }: { neuronId: bigint; additionalDissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L311)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L397)
 
 ##### :gear: setDissolveDelay
 
@@ -309,7 +312,7 @@ The new date is now + dissolveDelaySeconds.
 | ------------------ | ------------------------------------------------------------------------------------------------------------- |
 | `setDissolveDelay` | `({ neuronId, dissolveDelaySeconds, }: { neuronId: bigint; dissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L337)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L423)
 
 ##### :gear: startDissolving
 
@@ -319,7 +322,7 @@ Start dissolving process of a neuron
 | ----------------- | ------------------------------------- |
 | `startDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L360)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L446)
 
 ##### :gear: stopDissolving
 
@@ -329,7 +332,7 @@ Stop dissolving process of a neuron
 | ---------------- | ------------------------------------- |
 | `stopDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L374)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L460)
 
 ##### :gear: joinCommunityFund
 
@@ -339,7 +342,7 @@ Neuron joins the community fund
 | ------------------- | ------------------------------------- |
 | `joinCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L388)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L474)
 
 ##### :gear: autoStakeMaturity
 
@@ -354,7 +357,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to request a change of the auto stake feature
 - `autoStake`: `true` to enable the auto-stake maturity for this neuron, `false` to turn it off
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L406)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L492)
 
 ##### :gear: leaveCommunityFund
 
@@ -364,7 +367,7 @@ Neuron leaves the community fund
 | -------------------- | ------------------------------------- |
 | `leaveCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L421)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L507)
 
 ##### :gear: setVisibility
 
@@ -374,7 +377,7 @@ Set visibility of a neuron
 | --------------- | ------------------------------------------------------------------- |
 | `setVisibility` | `(neuronId: bigint, visibility: NeuronVisibility) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L435)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L521)
 
 ##### :gear: setNodeProviderAccount
 
@@ -385,7 +388,7 @@ Where the reward is paid to.
 | ------------------------ | ---------------------------------------------- |
 | `setNodeProviderAccount` | `(accountIdentifier: string) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L455)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L541)
 
 ##### :gear: mergeNeurons
 
@@ -395,7 +398,7 @@ Merge two neurons
 | -------------- | --------------------------------------------------------------------------------- |
 | `mergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L475)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L561)
 
 ##### :gear: simulateMergeNeurons
 
@@ -405,7 +408,7 @@ Simulate merging two neurons
 | ---------------------- | --------------------------------------------------------------------------------------- |
 | `simulateMergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<NeuronInfo>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L492)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L578)
 
 ##### :gear: splitNeuron
 
@@ -415,7 +418,7 @@ Splits a neuron creating a new one
 | ------------- | ----------------------------------------------------------------------------------- |
 | `splitNeuron` | `({ neuronId, amount, }: { neuronId: bigint; amount: bigint; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L537)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L623)
 
 ##### :gear: getProposal
 
@@ -428,7 +431,7 @@ it is fetched using a query call.
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `getProposal` | `({ proposalId, certified, }: { proposalId: bigint; certified?: boolean or undefined; }) => Promise<ProposalInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L577)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L663)
 
 ##### :gear: makeProposal
 
@@ -438,7 +441,7 @@ Create new proposal
 | -------------- | ---------------------------------------------------------------- |
 | `makeProposal` | `(request: MakeProposalRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L595)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L681)
 
 ##### :gear: registerVote
 
@@ -448,7 +451,7 @@ Registers vote for a proposal from the neuron passed.
 | -------------- | ----------------------------------------------------------------------------------------------------------- |
 | `registerVote` | `({ neuronId, vote, proposalId, }: { neuronId: bigint; vote: Vote; proposalId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L616)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L702)
 
 ##### :gear: setFollowees
 
@@ -458,7 +461,7 @@ Edit neuron followees per topic
 | -------------- | ------------------------------------------------- |
 | `setFollowees` | `(followRequest: FollowRequest) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L638)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L724)
 
 ##### :gear: disburse
 
@@ -468,7 +471,7 @@ Disburse neuron on Account
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `disburse` | `({ neuronId, toAccountId, amount, }: { neuronId: bigint; toAccountId?: string or undefined; amount?: bigint or undefined; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L653)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L739)
 
 ##### :gear: refreshVotingPower
 
@@ -480,7 +483,7 @@ parameter of the neuron to the current time).
 | -------------------- | --------------------------------------------------------- |
 | `refreshVotingPower` | `({ neuronId, }: { neuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L689)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L775)
 
 ##### :gear: mergeMaturity
 
@@ -490,7 +493,7 @@ Merge Maturity of a neuron
 | --------------- | ------------------------------------------------------------------------------------------------------- |
 | `mergeMaturity` | `({ neuronId, percentageToMerge, }: { neuronId: bigint; percentageToMerge: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L711)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L797)
 
 ##### :gear: stakeMaturity
 
@@ -505,7 +508,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to stake the maturity
 - `percentageToStake`: Optional. Percentage of the current maturity to stake. If not provided, all of the neuron's current maturity will be staked.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L740)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L826)
 
 ##### :gear: spawnNeuron
 
@@ -515,7 +518,7 @@ Merge Maturity of a neuron
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `spawnNeuron` | `({ neuronId, percentageToSpawn, newController, nonce, }: { neuronId: bigint; percentageToSpawn?: number or undefined; newController?: Principal or undefined; nonce?: bigint or undefined; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L762)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L848)
 
 ##### :gear: addHotkey
 
@@ -525,7 +528,7 @@ Add hotkey to neuron
 | ----------- | ------------------------------------------------------------------------------------------ |
 | `addHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L809)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L895)
 
 ##### :gear: removeHotkey
 
@@ -535,7 +538,7 @@ Remove hotkey to neuron
 | -------------- | ------------------------------------------------------------------------------------------ |
 | `removeHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L829)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L915)
 
 ##### :gear: claimOrRefreshNeuronFromAccount
 
@@ -545,7 +548,7 @@ Gets the NeuronID of a newly created neuron.
 | --------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `claimOrRefreshNeuronFromAccount` | `({ memo, controller, }: { memo: bigint; controller?: Principal or undefined; }) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L847)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L933)
 
 ##### :gear: claimOrRefreshNeuron
 
@@ -556,7 +559,7 @@ Uses query call only.
 | ---------------------- | ------------------------------------------------------------------------ |
 | `claimOrRefreshNeuron` | `(request: ClaimOrRefreshNeuronRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L878)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L964)
 
 ##### :gear: getNeuron
 
@@ -566,7 +569,7 @@ Return the data of the neuron provided as id.
 | ----------- | ----------------------------------------------------------------------------------------------------------- |
 | `getNeuron` | `({ certified, neuronId, }: { certified: boolean; neuronId: bigint; }) => Promise<NeuronInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L903)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L989)
 
 ##### :gear: getNetworkEconomicsParameters
 
@@ -576,7 +579,7 @@ Return the [Network Economics](https://github.com/dfinity/ic/blob/d90e934eb440c7
 | ------------------------------- | ------------------------------------------------------------------------ |
 | `getNetworkEconomicsParameters` | `({ certified, }: { certified: boolean; }) => Promise<NetworkEconomics>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L924)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L1010)
 
 ### :factory: SnsWasmCanister
 

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -251,7 +251,7 @@ it is fetched using a query call.
 | ------------------ | ------------------------------------------------- |
 | `listKnownNeurons` | `(certified?: boolean) => Promise<KnownNeuron[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L280)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L278)
 
 ##### :gear: getLastestRewardEvent
 
@@ -264,7 +264,7 @@ it's fetched using a query call.
 | ----------------------- | ----------------------------------------------- |
 | `getLastestRewardEvent` | `(certified?: boolean) => Promise<RewardEvent>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L302)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L300)
 
 ##### :gear: listProposals
 
@@ -283,7 +283,7 @@ Parameters:
 - `request`: the options to list the proposals (limit number of results, topics to search for, etc.)
 - `certified`: query or update calls
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L318)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L316)
 
 ##### :gear: stakeNeuron
 
@@ -291,7 +291,7 @@ Parameters:
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `stakeNeuron` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, fee, }: { stake: bigint; principal: Principal; fromSubAccount?: number[] or undefined; ledgerCanister: LedgerCanister; createdAt?: bigint or undefined; fee?: bigint or undefined; }) => Promise<...>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L337)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L335)
 
 ##### :gear: increaseDissolveDelay
 
@@ -301,7 +301,7 @@ Increases dissolve delay of a neuron
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `increaseDissolveDelay` | `({ neuronId, additionalDissolveDelaySeconds, }: { neuronId: bigint; additionalDissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L398)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L396)
 
 ##### :gear: setDissolveDelay
 
@@ -312,7 +312,7 @@ The new date is now + dissolveDelaySeconds.
 | ------------------ | ------------------------------------------------------------------------------------------------------------- |
 | `setDissolveDelay` | `({ neuronId, dissolveDelaySeconds, }: { neuronId: bigint; dissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L424)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L422)
 
 ##### :gear: startDissolving
 
@@ -322,7 +322,7 @@ Start dissolving process of a neuron
 | ----------------- | ------------------------------------- |
 | `startDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L447)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L445)
 
 ##### :gear: stopDissolving
 
@@ -332,7 +332,7 @@ Stop dissolving process of a neuron
 | ---------------- | ------------------------------------- |
 | `stopDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L461)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L459)
 
 ##### :gear: joinCommunityFund
 
@@ -342,7 +342,7 @@ Neuron joins the community fund
 | ------------------- | ------------------------------------- |
 | `joinCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L475)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L473)
 
 ##### :gear: autoStakeMaturity
 
@@ -357,7 +357,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to request a change of the auto stake feature
 - `autoStake`: `true` to enable the auto-stake maturity for this neuron, `false` to turn it off
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L493)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L491)
 
 ##### :gear: leaveCommunityFund
 
@@ -367,7 +367,7 @@ Neuron leaves the community fund
 | -------------------- | ------------------------------------- |
 | `leaveCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L508)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L506)
 
 ##### :gear: setVisibility
 
@@ -377,7 +377,7 @@ Set visibility of a neuron
 | --------------- | ------------------------------------------------------------------- |
 | `setVisibility` | `(neuronId: bigint, visibility: NeuronVisibility) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L522)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L520)
 
 ##### :gear: setNodeProviderAccount
 
@@ -388,7 +388,7 @@ Where the reward is paid to.
 | ------------------------ | ---------------------------------------------- |
 | `setNodeProviderAccount` | `(accountIdentifier: string) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L542)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L540)
 
 ##### :gear: mergeNeurons
 
@@ -398,7 +398,7 @@ Merge two neurons
 | -------------- | --------------------------------------------------------------------------------- |
 | `mergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L562)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L560)
 
 ##### :gear: simulateMergeNeurons
 
@@ -408,7 +408,7 @@ Simulate merging two neurons
 | ---------------------- | --------------------------------------------------------------------------------------- |
 | `simulateMergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<NeuronInfo>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L579)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L577)
 
 ##### :gear: splitNeuron
 
@@ -418,7 +418,7 @@ Splits a neuron creating a new one
 | ------------- | ----------------------------------------------------------------------------------- |
 | `splitNeuron` | `({ neuronId, amount, }: { neuronId: bigint; amount: bigint; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L624)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L622)
 
 ##### :gear: getProposal
 
@@ -431,7 +431,7 @@ it is fetched using a query call.
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `getProposal` | `({ proposalId, certified, }: { proposalId: bigint; certified?: boolean or undefined; }) => Promise<ProposalInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L664)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L662)
 
 ##### :gear: makeProposal
 
@@ -441,7 +441,7 @@ Create new proposal
 | -------------- | ---------------------------------------------------------------- |
 | `makeProposal` | `(request: MakeProposalRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L682)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L680)
 
 ##### :gear: registerVote
 
@@ -451,7 +451,7 @@ Registers vote for a proposal from the neuron passed.
 | -------------- | ----------------------------------------------------------------------------------------------------------- |
 | `registerVote` | `({ neuronId, vote, proposalId, }: { neuronId: bigint; vote: Vote; proposalId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L703)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L701)
 
 ##### :gear: setFollowees
 
@@ -461,7 +461,7 @@ Edit neuron followees per topic
 | -------------- | ------------------------------------------------- |
 | `setFollowees` | `(followRequest: FollowRequest) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L725)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L723)
 
 ##### :gear: disburse
 
@@ -471,7 +471,7 @@ Disburse neuron on Account
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `disburse` | `({ neuronId, toAccountId, amount, }: { neuronId: bigint; toAccountId?: string or undefined; amount?: bigint or undefined; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L740)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L738)
 
 ##### :gear: refreshVotingPower
 
@@ -483,7 +483,7 @@ parameter of the neuron to the current time).
 | -------------------- | --------------------------------------------------------- |
 | `refreshVotingPower` | `({ neuronId, }: { neuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L776)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L774)
 
 ##### :gear: mergeMaturity
 
@@ -493,7 +493,7 @@ Merge Maturity of a neuron
 | --------------- | ------------------------------------------------------------------------------------------------------- |
 | `mergeMaturity` | `({ neuronId, percentageToMerge, }: { neuronId: bigint; percentageToMerge: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L798)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L796)
 
 ##### :gear: stakeMaturity
 
@@ -508,7 +508,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to stake the maturity
 - `percentageToStake`: Optional. Percentage of the current maturity to stake. If not provided, all of the neuron's current maturity will be staked.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L827)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L825)
 
 ##### :gear: spawnNeuron
 
@@ -518,7 +518,7 @@ Merge Maturity of a neuron
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `spawnNeuron` | `({ neuronId, percentageToSpawn, newController, nonce, }: { neuronId: bigint; percentageToSpawn?: number or undefined; newController?: Principal or undefined; nonce?: bigint or undefined; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L849)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L847)
 
 ##### :gear: addHotkey
 
@@ -528,7 +528,7 @@ Add hotkey to neuron
 | ----------- | ------------------------------------------------------------------------------------------ |
 | `addHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L896)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L894)
 
 ##### :gear: removeHotkey
 
@@ -538,7 +538,7 @@ Remove hotkey to neuron
 | -------------- | ------------------------------------------------------------------------------------------ |
 | `removeHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L916)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L914)
 
 ##### :gear: claimOrRefreshNeuronFromAccount
 
@@ -548,7 +548,7 @@ Gets the NeuronID of a newly created neuron.
 | --------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `claimOrRefreshNeuronFromAccount` | `({ memo, controller, }: { memo: bigint; controller?: Principal or undefined; }) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L934)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L932)
 
 ##### :gear: claimOrRefreshNeuron
 
@@ -559,7 +559,7 @@ Uses query call only.
 | ---------------------- | ------------------------------------------------------------------------ |
 | `claimOrRefreshNeuron` | `(request: ClaimOrRefreshNeuronRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L965)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L963)
 
 ##### :gear: getNeuron
 
@@ -569,7 +569,7 @@ Return the data of the neuron provided as id.
 | ----------- | ----------------------------------------------------------------------------------------------------------- |
 | `getNeuron` | `({ certified, neuronId, }: { certified: boolean; neuronId: bigint; }) => Promise<NeuronInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L990)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L988)
 
 ##### :gear: getNetworkEconomicsParameters
 
@@ -579,7 +579,7 @@ Return the [Network Economics](https://github.com/dfinity/ic/blob/d90e934eb440c7
 | ------------------------------- | ------------------------------------------------------------------------ |
 | `getNetworkEconomicsParameters` | `({ certified, }: { certified: boolean; }) => Promise<NetworkEconomics>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L1011)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L1009)
 
 ### :factory: SnsWasmCanister
 

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -230,8 +230,8 @@ it is fetched using a query call.
 
 The backend treats `includeEmptyNeurons` as false if absent.
 
-The response might be paginated. In this case, all pages will be fetched in parallel and
-combined into a single response.
+The response from the canister might be paginated. In this case, all pages will be fetched in parallel and
+combined into a single return value.
 
 | Method        | Type                                                                                                                                                                                                                                                                                                                  |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -251,7 +251,7 @@ it is fetched using a query call.
 | ------------------ | ------------------------------------------------- |
 | `listKnownNeurons` | `(certified?: boolean) => Promise<KnownNeuron[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L279)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L280)
 
 ##### :gear: getLastestRewardEvent
 
@@ -264,7 +264,7 @@ it's fetched using a query call.
 | ----------------------- | ----------------------------------------------- |
 | `getLastestRewardEvent` | `(certified?: boolean) => Promise<RewardEvent>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L301)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L302)
 
 ##### :gear: listProposals
 
@@ -283,7 +283,7 @@ Parameters:
 - `request`: the options to list the proposals (limit number of results, topics to search for, etc.)
 - `certified`: query or update calls
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L317)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L318)
 
 ##### :gear: stakeNeuron
 
@@ -291,7 +291,7 @@ Parameters:
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `stakeNeuron` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, fee, }: { stake: bigint; principal: Principal; fromSubAccount?: number[] or undefined; ledgerCanister: LedgerCanister; createdAt?: bigint or undefined; fee?: bigint or undefined; }) => Promise<...>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L336)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L337)
 
 ##### :gear: increaseDissolveDelay
 
@@ -301,7 +301,7 @@ Increases dissolve delay of a neuron
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `increaseDissolveDelay` | `({ neuronId, additionalDissolveDelaySeconds, }: { neuronId: bigint; additionalDissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L397)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L398)
 
 ##### :gear: setDissolveDelay
 
@@ -312,7 +312,7 @@ The new date is now + dissolveDelaySeconds.
 | ------------------ | ------------------------------------------------------------------------------------------------------------- |
 | `setDissolveDelay` | `({ neuronId, dissolveDelaySeconds, }: { neuronId: bigint; dissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L423)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L424)
 
 ##### :gear: startDissolving
 
@@ -322,7 +322,7 @@ Start dissolving process of a neuron
 | ----------------- | ------------------------------------- |
 | `startDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L446)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L447)
 
 ##### :gear: stopDissolving
 
@@ -332,7 +332,7 @@ Stop dissolving process of a neuron
 | ---------------- | ------------------------------------- |
 | `stopDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L460)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L461)
 
 ##### :gear: joinCommunityFund
 
@@ -342,7 +342,7 @@ Neuron joins the community fund
 | ------------------- | ------------------------------------- |
 | `joinCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L474)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L475)
 
 ##### :gear: autoStakeMaturity
 
@@ -357,7 +357,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to request a change of the auto stake feature
 - `autoStake`: `true` to enable the auto-stake maturity for this neuron, `false` to turn it off
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L492)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L493)
 
 ##### :gear: leaveCommunityFund
 
@@ -367,7 +367,7 @@ Neuron leaves the community fund
 | -------------------- | ------------------------------------- |
 | `leaveCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L507)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L508)
 
 ##### :gear: setVisibility
 
@@ -377,7 +377,7 @@ Set visibility of a neuron
 | --------------- | ------------------------------------------------------------------- |
 | `setVisibility` | `(neuronId: bigint, visibility: NeuronVisibility) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L521)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L522)
 
 ##### :gear: setNodeProviderAccount
 
@@ -388,7 +388,7 @@ Where the reward is paid to.
 | ------------------------ | ---------------------------------------------- |
 | `setNodeProviderAccount` | `(accountIdentifier: string) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L541)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L542)
 
 ##### :gear: mergeNeurons
 
@@ -398,7 +398,7 @@ Merge two neurons
 | -------------- | --------------------------------------------------------------------------------- |
 | `mergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L561)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L562)
 
 ##### :gear: simulateMergeNeurons
 
@@ -408,7 +408,7 @@ Simulate merging two neurons
 | ---------------------- | --------------------------------------------------------------------------------------- |
 | `simulateMergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<NeuronInfo>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L578)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L579)
 
 ##### :gear: splitNeuron
 
@@ -418,7 +418,7 @@ Splits a neuron creating a new one
 | ------------- | ----------------------------------------------------------------------------------- |
 | `splitNeuron` | `({ neuronId, amount, }: { neuronId: bigint; amount: bigint; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L623)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L624)
 
 ##### :gear: getProposal
 
@@ -431,7 +431,7 @@ it is fetched using a query call.
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `getProposal` | `({ proposalId, certified, }: { proposalId: bigint; certified?: boolean or undefined; }) => Promise<ProposalInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L663)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L664)
 
 ##### :gear: makeProposal
 
@@ -441,7 +441,7 @@ Create new proposal
 | -------------- | ---------------------------------------------------------------- |
 | `makeProposal` | `(request: MakeProposalRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L681)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L682)
 
 ##### :gear: registerVote
 
@@ -451,7 +451,7 @@ Registers vote for a proposal from the neuron passed.
 | -------------- | ----------------------------------------------------------------------------------------------------------- |
 | `registerVote` | `({ neuronId, vote, proposalId, }: { neuronId: bigint; vote: Vote; proposalId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L702)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L703)
 
 ##### :gear: setFollowees
 
@@ -461,7 +461,7 @@ Edit neuron followees per topic
 | -------------- | ------------------------------------------------- |
 | `setFollowees` | `(followRequest: FollowRequest) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L724)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L725)
 
 ##### :gear: disburse
 
@@ -471,7 +471,7 @@ Disburse neuron on Account
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `disburse` | `({ neuronId, toAccountId, amount, }: { neuronId: bigint; toAccountId?: string or undefined; amount?: bigint or undefined; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L739)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L740)
 
 ##### :gear: refreshVotingPower
 
@@ -483,7 +483,7 @@ parameter of the neuron to the current time).
 | -------------------- | --------------------------------------------------------- |
 | `refreshVotingPower` | `({ neuronId, }: { neuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L775)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L776)
 
 ##### :gear: mergeMaturity
 
@@ -493,7 +493,7 @@ Merge Maturity of a neuron
 | --------------- | ------------------------------------------------------------------------------------------------------- |
 | `mergeMaturity` | `({ neuronId, percentageToMerge, }: { neuronId: bigint; percentageToMerge: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L797)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L798)
 
 ##### :gear: stakeMaturity
 
@@ -508,7 +508,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to stake the maturity
 - `percentageToStake`: Optional. Percentage of the current maturity to stake. If not provided, all of the neuron's current maturity will be staked.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L826)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L827)
 
 ##### :gear: spawnNeuron
 
@@ -518,7 +518,7 @@ Merge Maturity of a neuron
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `spawnNeuron` | `({ neuronId, percentageToSpawn, newController, nonce, }: { neuronId: bigint; percentageToSpawn?: number or undefined; newController?: Principal or undefined; nonce?: bigint or undefined; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L848)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L849)
 
 ##### :gear: addHotkey
 
@@ -528,7 +528,7 @@ Add hotkey to neuron
 | ----------- | ------------------------------------------------------------------------------------------ |
 | `addHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L895)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L896)
 
 ##### :gear: removeHotkey
 
@@ -538,7 +538,7 @@ Remove hotkey to neuron
 | -------------- | ------------------------------------------------------------------------------------------ |
 | `removeHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L915)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L916)
 
 ##### :gear: claimOrRefreshNeuronFromAccount
 
@@ -548,7 +548,7 @@ Gets the NeuronID of a newly created neuron.
 | --------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `claimOrRefreshNeuronFromAccount` | `({ memo, controller, }: { memo: bigint; controller?: Principal or undefined; }) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L933)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L934)
 
 ##### :gear: claimOrRefreshNeuron
 
@@ -559,7 +559,7 @@ Uses query call only.
 | ---------------------- | ------------------------------------------------------------------------ |
 | `claimOrRefreshNeuron` | `(request: ClaimOrRefreshNeuronRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L964)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L965)
 
 ##### :gear: getNeuron
 
@@ -569,7 +569,7 @@ Return the data of the neuron provided as id.
 | ----------- | ----------------------------------------------------------------------------------------------------------- |
 | `getNeuron` | `({ certified, neuronId, }: { certified: boolean; neuronId: bigint; }) => Promise<NeuronInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L989)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L990)
 
 ##### :gear: getNetworkEconomicsParameters
 
@@ -579,7 +579,7 @@ Return the [Network Economics](https://github.com/dfinity/ic/blob/d90e934eb440c7
 | ------------------------------- | ------------------------------------------------------------------------ |
 | `getNetworkEconomicsParameters` | `({ certified, }: { certified: boolean; }) => Promise<NetworkEconomics>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L1010)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L1011)
 
 ### :factory: SnsWasmCanister
 

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -1033,8 +1033,6 @@ export const fromListNeurons = ({
   include_neurons_readable_by_caller: neuronIds ? false : true,
   include_empty_neurons_readable_by_caller: toNullable(includeEmptyNeurons),
   include_public_neurons_in_full_neurons: toNullable(includePublicNeurons),
-  page_number: [],
-  page_size: [],
   neuron_subaccounts: toNullable(neuronSubaccounts),
   page_number: toNullable(pageNumber),
   page_size: toNullable(pageSize),

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -1019,11 +1019,15 @@ export const fromListNeurons = ({
   includeEmptyNeurons,
   includePublicNeurons,
   neuronSubaccounts,
+  pageNumber,
+  pageSize,
 }: {
   neuronIds?: NeuronId[];
   includeEmptyNeurons?: boolean;
   includePublicNeurons?: boolean;
   neuronSubaccounts?: NeuronSubaccount[];
+  pageNumber?: bigint;
+  pageSize?: bigint;
 }): RawListNeurons => ({
   neuron_ids: BigUint64Array.from(neuronIds ?? []),
   include_neurons_readable_by_caller: neuronIds ? false : true,
@@ -1032,6 +1036,8 @@ export const fromListNeurons = ({
   page_number: [],
   page_size: [],
   neuron_subaccounts: toNullable(neuronSubaccounts),
+  page_number: toNullable(pageNumber),
+  page_size: toNullable(pageSize),
 });
 
 export const fromManageNeuron = ({

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -459,7 +459,7 @@ describe("GovernanceCanister", () => {
         include_empty_neurons_readable_by_caller: [true],
         include_public_neurons_in_full_neurons: [true],
         neuron_subaccounts: [],
-        page_number: [],
+        page_number: [1n],
         page_size: [500n],
       });
       expect(neurons.length).toBe(1);
@@ -502,7 +502,7 @@ describe("GovernanceCanister", () => {
         include_empty_neurons_readable_by_caller: [true],
         include_public_neurons_in_full_neurons: [true],
         neuron_subaccounts: [],
-        page_number: [],
+        page_number: [1n],
         page_size: [500n],
       });
 
@@ -543,7 +543,7 @@ describe("GovernanceCanister", () => {
         include_empty_neurons_readable_by_caller: [false],
         include_public_neurons_in_full_neurons: [],
         neuron_subaccounts: [],
-        page_number: [],
+        page_number: [1n],
         page_size: [500n],
       });
       expect(service.list_neurons).toBeCalledTimes(1);
@@ -570,7 +570,7 @@ describe("GovernanceCanister", () => {
         include_empty_neurons_readable_by_caller: [],
         include_public_neurons_in_full_neurons: [false],
         neuron_subaccounts: [],
-        page_number: [],
+        page_number: [1n],
         page_size: [500n],
       });
       expect(service.list_neurons).toBeCalledTimes(1);
@@ -601,7 +601,7 @@ describe("GovernanceCanister", () => {
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: [true],
         include_public_neurons_in_full_neurons: [true],
-        page_number: [],
+        page_number: [1n],
         page_size: [500n],
         neuron_subaccounts: [
           [
@@ -665,7 +665,7 @@ describe("GovernanceCanister", () => {
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: [],
         include_public_neurons_in_full_neurons: [],
-        page_number: [],
+        page_number: [1n],
         page_size: [500n],
         neuron_subaccounts: [],
       });

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -428,32 +428,40 @@ describe("GovernanceCanister", () => {
   });
 
   describe("GovernanceCanister.listNeurons", () => {
-    it("list user neurons - backwards compability no pagination", async () => {
+    it("list user neurons no pagination", async () => {
       const service = mock<ActorSubclass<GovernanceService>>();
       const certifiedService = mock<ActorSubclass<GovernanceService>>();
       const oldService = mock<ActorSubclass<GovernanceService>>();
-      certifiedService.list_neurons.mockResolvedValue(mockListNeuronsResponse);
+
+      certifiedService.list_neurons.mockResolvedValue({
+        ...mockListNeuronsResponse,
+        total_pages_available: [],
+      });
 
       const governance = GovernanceCanister.create({
         certifiedServiceOverride: certifiedService,
         serviceOverride: service,
         oldListNeuronsServiceOverride: oldService,
       });
+
+      expect(certifiedService.list_neurons).toBeCalledTimes(0);
+
       const neurons = await governance.listNeurons({
         certified: true,
         includeEmptyNeurons: true,
         includePublicNeurons: true,
       });
+
+      expect(certifiedService.list_neurons).toBeCalledTimes(1);
       expect(certifiedService.list_neurons).toBeCalledWith({
         neuron_ids: new BigUint64Array(),
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: [true],
         include_public_neurons_in_full_neurons: [true],
-        page_number: [],
-        page_size: [],
         neuron_subaccounts: [],
+        page_number: [],
+        page_size: [500n],
       });
-      expect(certifiedService.list_neurons).toBeCalledTimes(1);
       expect(neurons.length).toBe(1);
       expect(service.list_neurons).not.toBeCalled();
       expect(oldService.list_neurons).not.toBeCalled();
@@ -479,18 +487,21 @@ describe("GovernanceCanister", () => {
         oldListNeuronsServiceOverride: oldService,
       });
 
+      expect(certifiedService.list_neurons).toBeCalledTimes(0);
+
       const neurons = await governance.listNeurons({
         certified: true,
         includeEmptyNeurons: true,
         includePublicNeurons: true,
       });
 
-      // Get first page and page number
+      // Get first page
       expect(certifiedService.list_neurons).toHaveBeenNthCalledWith(1, {
         neuron_ids: new BigUint64Array(),
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: [true],
         include_public_neurons_in_full_neurons: [true],
+        neuron_subaccounts: [],
         page_number: [],
         page_size: [500n],
       });
@@ -501,49 +512,13 @@ describe("GovernanceCanister", () => {
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: [true],
         include_public_neurons_in_full_neurons: [true],
+        neuron_subaccounts: [],
         page_number: [1n],
         page_size: [500n],
       });
 
       expect(certifiedService.list_neurons).toBeCalledTimes(2);
       expect(neurons.length).toBe(2); // One neuron per page
-      expect(service.list_neurons).not.toBeCalled();
-      expect(oldService.list_neurons).not.toBeCalled();
-    });
-
-    it("list user neurons without pagination", async () => {
-      const service = mock<ActorSubclass<GovernanceService>>();
-      const certifiedService = mock<ActorSubclass<GovernanceService>>();
-      const oldService = mock<ActorSubclass<GovernanceService>>();
-
-      certifiedService.list_neurons.mockResolvedValue({
-        ...mockListNeuronsResponse,
-        total_pages_available: [],
-      });
-
-      const governance = GovernanceCanister.create({
-        certifiedServiceOverride: certifiedService,
-        serviceOverride: service,
-        oldListNeuronsServiceOverride: oldService,
-      });
-
-      const neurons = await governance.listNeurons({
-        certified: true,
-        includeEmptyNeurons: true,
-        includePublicNeurons: true,
-      });
-
-      expect(certifiedService.list_neurons).toBeCalledWith({
-        neuron_ids: new BigUint64Array(),
-        include_neurons_readable_by_caller: true,
-        include_empty_neurons_readable_by_caller: [true],
-        include_public_neurons_in_full_neurons: [true],
-        page_number: [],
-        page_size: [500n],
-      });
-
-      expect(certifiedService.list_neurons).toBeCalledTimes(1);
-      expect(neurons.length).toBe(1);
       expect(service.list_neurons).not.toBeCalled();
       expect(oldService.list_neurons).not.toBeCalled();
     });
@@ -567,9 +542,9 @@ describe("GovernanceCanister", () => {
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: [false],
         include_public_neurons_in_full_neurons: [],
-        page_number: [],
-        page_size: [],
         neuron_subaccounts: [],
+        page_number: [],
+        page_size: [500n],
       });
       expect(service.list_neurons).toBeCalledTimes(1);
       expect(neurons.length).toBe(1);
@@ -594,9 +569,9 @@ describe("GovernanceCanister", () => {
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: [],
         include_public_neurons_in_full_neurons: [false],
-        page_number: [],
-        page_size: [],
         neuron_subaccounts: [],
+        page_number: [],
+        page_size: [500n],
       });
       expect(service.list_neurons).toBeCalledTimes(1);
       expect(neurons.length).toBe(1);
@@ -627,7 +602,7 @@ describe("GovernanceCanister", () => {
         include_empty_neurons_readable_by_caller: [true],
         include_public_neurons_in_full_neurons: [true],
         page_number: [],
-        page_size: [],
+        page_size: [500n],
         neuron_subaccounts: [
           [
             { subaccount: new Uint8Array([1, 2, 3]) },
@@ -691,7 +666,7 @@ describe("GovernanceCanister", () => {
         include_empty_neurons_readable_by_caller: [],
         include_public_neurons_in_full_neurons: [],
         page_number: [],
-        page_size: [],
+        page_size: [500n],
         neuron_subaccounts: [],
       });
       expect(service.list_neurons).toBeCalledTimes(1);

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -435,7 +435,7 @@ describe("GovernanceCanister", () => {
 
       certifiedService.list_neurons.mockResolvedValue({
         ...mockListNeuronsResponse,
-        total_pages_available: [],
+        total_pages_available: [1n],
       });
 
       const governance = GovernanceCanister.create({

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -171,8 +171,6 @@ export class GovernanceCanister {
       });
     }
 
-    let pageNumber = 1n;
-
     // Fetch the first page to get the total number of pages
     const firstPageResult = await this.fetchNeuronsPage({
       certified,
@@ -180,7 +178,7 @@ export class GovernanceCanister {
       includeEmptyNeurons,
       includePublicNeurons,
       neuronSubaccounts,
-      pageNumber,
+      pageNumber: 1n,
     });
     const { neurons: firstPageNeurons, totalPages } = firstPageResult;
 
@@ -188,7 +186,7 @@ export class GovernanceCanister {
     if (totalPages < 2n) return firstPageNeurons;
 
     const pagePromises = [];
-    for (pageNumber; pageNumber < totalPages; pageNumber++) {
+    for (let pageNumber = 1n; pageNumber < totalPages; pageNumber++) {
       pagePromises.push(
         this.fetchNeuronsPage({
           certified,

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -6,7 +6,6 @@ import type { Principal } from "@dfinity/principal";
 import {
   assertPercentageNumber,
   createServices,
-  fromDefinedNullable,
   fromNullable,
   isNullish,
   nonNullish,
@@ -259,7 +258,8 @@ export class GovernanceCanister {
       response: rawResponse,
       canisterId: this.canisterId,
     });
-    const totalPages = fromDefinedNullable(rawResponse.total_pages_available);
+
+    const totalPages = fromNullable(rawResponse.total_pages_available) ?? 1n;
 
     return { neurons, totalPages };
   };

--- a/packages/nns/src/mocks/governance.mock.ts
+++ b/packages/nns/src/mocks/governance.mock.ts
@@ -54,5 +54,5 @@ export const mockNeuron: Neuron = {
 export const mockListNeuronsResponse: ListNeuronsResponse = {
   neuron_infos: [[mockNeuronId, mockNeuronInfo]],
   full_neurons: [mockNeuron],
-  total_pages_available: [],
+  total_pages_available: [1n],
 };


### PR DESCRIPTION
# Motivation

As presented [here](https://forum.dfinity.org/t/request-for-feedback-on-governance-list-neurons-pagination-api/40362) and changed [here](https://github.com/dfinity/ic/pull/3358), the NNS governance canister will implement pagination for the `list_neurons` endpoint.

Pagination will only activate if the response contains more than 500 neurons. Currently, most of our cases involve requesting non-empty neurons, and we do not have users with such a high number of neurons, so for those users nothing has changed. However, the nns-dapp has a use case, Reporting, where we also request empty neurons. In this case, we have a few hundred users with more than 500 neurons.

Some [insights](https://dfinity.slack.com/archives/C01R76CSJ4R/p1738328033654549?thread_ts=1738243719.968339&cid=C01R76CSJ4R) from the Boundary Node.

Expect usage patterns:  
-  Non-empty neurons:  
   - All users with fewer than 500 neurons → 1 page  
-  Non-empty and empty neurons, such as Reporting feature:  
   - Most users with fewer than 500 neurons → 1 page  
   - Some users with approximately 5,000 neurons → 10 pages  
   - Few users with approximately 40,000 neurons → 80 pages  

# Changes

- Implements pagination by checking the number of available pages from the initial call to `list-neurons`.

# Tests

- Added unit tests to check pagination.
- Manually tested locally in the nns-dapp with over 1000 neurons.

https://github.com/user-attachments/assets/c3a484aa-60a6-4b58-af92-23db109fb8d0

# Todos

- [ ] Add entry to changelog (if necessary).
