### PR TITLE
chore: update nns Candid Files 

### DIFF
--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit fb16293158 (2025-01-22 tags: release-2025-01-30_03-03-hashes-in-blocks) 'rs/nns/gtc/canister/gtc.did' by import-candid
 type AccountState = record {
   authenticated_principal_id : opt principal;
   successfully_transferred_neurons : vec TransferredNeuron;

--- a/packages/nns/candid/governance.certified.idl.js
+++ b/packages/nns/candid/governance.certified.idl.js
@@ -746,14 +746,17 @@ export const idlFactory = ({ IDL }) => {
     'known_neurons' : IDL.Vec(KnownNeuron),
   });
   const ListNeurons = IDL.Record({
+    'page_size' : IDL.Opt(IDL.Nat64),
     'include_public_neurons_in_full_neurons' : IDL.Opt(IDL.Bool),
     'neuron_ids' : IDL.Vec(IDL.Nat64),
+    'page_number' : IDL.Opt(IDL.Nat64),
     'include_empty_neurons_readable_by_caller' : IDL.Opt(IDL.Bool),
     'include_neurons_readable_by_caller' : IDL.Bool,
   });
   const ListNeuronsResponse = IDL.Record({
     'neuron_infos' : IDL.Vec(IDL.Tuple(IDL.Nat64, NeuronInfo)),
     'full_neurons' : IDL.Vec(Neuron),
+    'total_pages_available' : IDL.Opt(IDL.Nat64),
   });
   const DateRangeFilter = IDL.Record({
     'start_timestamp_seconds' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -352,14 +352,17 @@ export interface ListKnownNeuronsResponse {
   known_neurons: Array<KnownNeuron>;
 }
 export interface ListNeurons {
+  page_size: [] | [bigint];
   include_public_neurons_in_full_neurons: [] | [boolean];
   neuron_ids: BigUint64Array | bigint[];
+  page_number: [] | [bigint];
   include_empty_neurons_readable_by_caller: [] | [boolean];
   include_neurons_readable_by_caller: boolean;
 }
 export interface ListNeuronsResponse {
   neuron_infos: Array<[bigint, NeuronInfo]>;
   full_neurons: Array<Neuron>;
+  total_pages_available: [] | [bigint];
 }
 export interface ListNodeProviderRewardsRequest {
   date_filter: [] | [DateRangeFilter];

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit fb16293158 (2025-01-22 tags: release-2025-01-30_03-03-hashes-in-blocks) 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -435,16 +435,38 @@ type ListKnownNeuronsResponse = record {
   known_neurons : vec KnownNeuron;
 };
 
+// Parameters of the list_neurons method.
 type ListNeurons = record {
-  include_public_neurons_in_full_neurons : opt bool;
+  // These fields select neurons to be in the result set.
   neuron_ids : vec nat64;
-  include_empty_neurons_readable_by_caller : opt bool;
   include_neurons_readable_by_caller : bool;
+
+  // Only has an effect when include_neurons_readable_by_caller.
+  include_empty_neurons_readable_by_caller : opt bool;
+
+  // When a public neuron is a member of the result set, include it in the
+  // full_neurons field (of ListNeuronsResponse). This does not affect which
+  // neurons are part of the result set.
+  include_public_neurons_in_full_neurons : opt bool;
+
+  page_number: opt nat64;
+  page_size: opt nat64;
 };
 
+// Output of the list_neurons method.
 type ListNeuronsResponse = record {
+  // Per the NeuronInfo type, this is a redacted view of the neurons in the
+  // result set consisting of information that require no special privileges to
+  // view.
   neuron_infos : vec record { nat64; NeuronInfo };
+
+  // If the caller has the necessary special privileges (or the neuron is
+  // public, and the request sets include_public_neurons_in_full_neurons to
+  // true), then all the information about the neurons in the result set is made
+  // available here.
   full_neurons : vec Neuron;
+
+  total_pages_available: opt nat64;
 };
 
 type ListNodeProviderRewardsRequest = record {
@@ -491,6 +513,8 @@ type MakingSnsProposal = record {
   proposer_id : opt NeuronId;
 };
 
+// Not to be confused with ManageNeuronRequest. (Yes, this is very structurally
+// similar to that, but not actually exactly equivalent.)
 type ManageNeuron = record {
   id : opt NeuronId;
   command : opt Command;
@@ -516,13 +540,22 @@ type ManageNeuronCommandRequest = variant {
   // KEEP THIS IN SYNC WITH COMMAND!
 };
 
+// Parameters of the manage_neuron method.
 type ManageNeuronRequest = record {
-  id : opt NeuronId;
-  command : opt ManageNeuronCommandRequest;
+  // Which neuron to operate on.
   neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
+
+  // What operation to perform on the neuron.
+  command : opt ManageNeuronCommandRequest;
+
+  // Deprecated. Use neuron_id_or_subaccount instead.
+  id : opt NeuronId;
 };
 
+// Output of the manage_neuron method.
 type ManageNeuronResponse = record {
+  // Corresponds to the command field in ManageNeuronRequest, which determines
+  // what operation was performed.
   command : opt Command_1;
 };
 
@@ -728,14 +761,26 @@ type NeuronInFlightCommand = record {
   timestamp : nat64;
 };
 
-// In general, this is a subset of Neuron.
+// A limit view of Neuron that allows some aspects of all neurons to be read by
+// anyone (i.e. without having to be the neuron's controller nor one of its
+// hotkeys).
+//
+// As such, the meaning of each field in this type is generally the same as the
+// one of the same (or at least similar) name in Neuron.
 type NeuronInfo = record {
   dissolve_delay_seconds : nat64;
   recent_ballots : vec BallotInfo;
   neuron_type : opt int32;
   created_timestamp_seconds : nat64;
   state : int32;
+
+  // The amount of ICP (and staked maturity) locked in this neuron.
+  //
+  // This is the foundation of the neuron's voting power.
+  //
+  // cached_neuron_stake_e8s - neuron_fees_e8s + staked_maturity_e8s_equivalent
   stake_e8s : nat64;
+
   joined_community_fund_timestamp_seconds : opt nat64;
   retrieved_at_timestamp_seconds : nat64;
   visibility : opt int32;
@@ -750,6 +795,7 @@ type NeuronInfo = record {
   // Now that this is set to deciding_voting_power, this actually does get
   // zeroed out.
   voting_power : nat64;
+
   voting_power_refreshed_timestamp_seconds : opt nat64;
   deciding_voting_power : opt nat64;
   potential_voting_power : opt nat64;

--- a/packages/nns/candid/governance.idl.js
+++ b/packages/nns/candid/governance.idl.js
@@ -746,14 +746,17 @@ export const idlFactory = ({ IDL }) => {
     'known_neurons' : IDL.Vec(KnownNeuron),
   });
   const ListNeurons = IDL.Record({
+    'page_size' : IDL.Opt(IDL.Nat64),
     'include_public_neurons_in_full_neurons' : IDL.Opt(IDL.Bool),
     'neuron_ids' : IDL.Vec(IDL.Nat64),
+    'page_number' : IDL.Opt(IDL.Nat64),
     'include_empty_neurons_readable_by_caller' : IDL.Opt(IDL.Bool),
     'include_neurons_readable_by_caller' : IDL.Bool,
   });
   const ListNeuronsResponse = IDL.Record({
     'neuron_infos' : IDL.Vec(IDL.Tuple(IDL.Nat64, NeuronInfo)),
     'full_neurons' : IDL.Vec(Neuron),
+    'total_pages_available' : IDL.Opt(IDL.Nat64),
   });
   const DateRangeFilter = IDL.Record({
     'start_timestamp_seconds' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/candid/governance_test.certified.idl.js
+++ b/packages/nns/candid/governance_test.certified.idl.js
@@ -746,14 +746,17 @@ export const idlFactory = ({ IDL }) => {
     'known_neurons' : IDL.Vec(KnownNeuron),
   });
   const ListNeurons = IDL.Record({
+    'page_size' : IDL.Opt(IDL.Nat64),
     'include_public_neurons_in_full_neurons' : IDL.Opt(IDL.Bool),
     'neuron_ids' : IDL.Vec(IDL.Nat64),
+    'page_number' : IDL.Opt(IDL.Nat64),
     'include_empty_neurons_readable_by_caller' : IDL.Opt(IDL.Bool),
     'include_neurons_readable_by_caller' : IDL.Bool,
   });
   const ListNeuronsResponse = IDL.Record({
     'neuron_infos' : IDL.Vec(IDL.Tuple(IDL.Nat64, NeuronInfo)),
     'full_neurons' : IDL.Vec(Neuron),
+    'total_pages_available' : IDL.Opt(IDL.Nat64),
   });
   const DateRangeFilter = IDL.Record({
     'start_timestamp_seconds' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/candid/governance_test.d.ts
+++ b/packages/nns/candid/governance_test.d.ts
@@ -352,14 +352,17 @@ export interface ListKnownNeuronsResponse {
   known_neurons: Array<KnownNeuron>;
 }
 export interface ListNeurons {
+  page_size: [] | [bigint];
   include_public_neurons_in_full_neurons: [] | [boolean];
   neuron_ids: BigUint64Array | bigint[];
+  page_number: [] | [bigint];
   include_empty_neurons_readable_by_caller: [] | [boolean];
   include_neurons_readable_by_caller: boolean;
 }
 export interface ListNeuronsResponse {
   neuron_infos: Array<[bigint, NeuronInfo]>;
   full_neurons: Array<Neuron>;
+  total_pages_available: [] | [bigint];
 }
 export interface ListNodeProviderRewardsRequest {
   date_filter: [] | [DateRangeFilter];

--- a/packages/nns/candid/governance_test.did
+++ b/packages/nns/candid/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/nns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit fb16293158 (2025-01-22 tags: release-2025-01-30_03-03-hashes-in-blocks) 'rs/nns/governance/canister/governance_test.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -439,11 +439,14 @@ type ListNeurons = record {
   neuron_ids : vec nat64;
   include_empty_neurons_readable_by_caller : opt bool;
   include_neurons_readable_by_caller : bool;
+  page_number: opt nat64;
+  page_size: opt nat64;
 };
 
 type ListNeuronsResponse = record {
   neuron_infos : vec record { nat64; NeuronInfo };
   full_neurons : vec Neuron;
+  total_pages_available: opt nat64;
 };
 
 type ListNodeProviderRewardsRequest = record {

--- a/packages/nns/candid/governance_test.idl.js
+++ b/packages/nns/candid/governance_test.idl.js
@@ -746,14 +746,17 @@ export const idlFactory = ({ IDL }) => {
     'known_neurons' : IDL.Vec(KnownNeuron),
   });
   const ListNeurons = IDL.Record({
+    'page_size' : IDL.Opt(IDL.Nat64),
     'include_public_neurons_in_full_neurons' : IDL.Opt(IDL.Bool),
     'neuron_ids' : IDL.Vec(IDL.Nat64),
+    'page_number' : IDL.Opt(IDL.Nat64),
     'include_empty_neurons_readable_by_caller' : IDL.Opt(IDL.Bool),
     'include_neurons_readable_by_caller' : IDL.Bool,
   });
   const ListNeuronsResponse = IDL.Record({
     'neuron_infos' : IDL.Vec(IDL.Tuple(IDL.Nat64, NeuronInfo)),
     'full_neurons' : IDL.Vec(Neuron),
+    'total_pages_available' : IDL.Opt(IDL.Nat64),
   });
   const DateRangeFilter = IDL.Record({
     'start_timestamp_seconds' : IDL.Opt(IDL.Nat64),

--- a/packages/nns/candid/sns_wasm.did
+++ b/packages/nns/candid/sns_wasm.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit aa705aaa62 (2025-01-08 tags: release-2025-01-09_03-19-base) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit fb16293158 (2025-01-22 tags: release-2025-01-30_03-03-hashes-in-blocks) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -1026,6 +1026,8 @@ export const fromListNeurons = ({
   include_neurons_readable_by_caller: neuronIds ? false : true,
   include_empty_neurons_readable_by_caller: toNullable(includeEmptyNeurons),
   include_public_neurons_in_full_neurons: toNullable(includePublicNeurons),
+  page_number: [],
+  page_size: [],
 });
 
 export const fromManageNeuron = ({

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -449,6 +449,8 @@ describe("GovernanceCanister", () => {
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: [true],
         include_public_neurons_in_full_neurons: [true],
+        page_number: [],
+        page_size: [],
       });
       expect(certifiedService.list_neurons).toBeCalledTimes(1);
       expect(neurons.length).toBe(1);
@@ -475,6 +477,8 @@ describe("GovernanceCanister", () => {
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: [false],
         include_public_neurons_in_full_neurons: [],
+        page_number: [],
+        page_size: [],
       });
       expect(service.list_neurons).toBeCalledTimes(1);
       expect(neurons.length).toBe(1);
@@ -499,6 +503,8 @@ describe("GovernanceCanister", () => {
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: [],
         include_public_neurons_in_full_neurons: [false],
+        page_number: [],
+        page_size: [],
       });
       expect(service.list_neurons).toBeCalledTimes(1);
       expect(neurons.length).toBe(1);
@@ -524,6 +530,10 @@ describe("GovernanceCanister", () => {
         include_empty_neurons_readable_by_caller: [],
         // The field is present in the argument but ignored by the old service.
         include_public_neurons_in_full_neurons: [],
+        // The field is present in the argument but ignored by the old service.
+        page_number: [],
+        // The field is present in the argument but ignored by the old service.
+        page_size: [],
       });
       expect(oldService.list_neurons).toBeCalledTimes(1);
       expect(neurons.length).toBe(1);
@@ -549,6 +559,8 @@ describe("GovernanceCanister", () => {
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: [],
         include_public_neurons_in_full_neurons: [],
+        page_number: [],
+        page_size: [],
       });
       expect(service.list_neurons).toBeCalledTimes(1);
       expect(neurons.length).toBe(1);

--- a/packages/nns/src/mocks/governance.mock.ts
+++ b/packages/nns/src/mocks/governance.mock.ts
@@ -54,4 +54,5 @@ export const mockNeuron: Neuron = {
 export const mockListNeuronsResponse: ListNeuronsResponse = {
   neuron_infos: [[mockNeuronId, mockNeuronInfo]],
   full_neurons: [mockNeuron],
+  total_pages_available: [],
 };


### PR DESCRIPTION
# Motivation

The [automatic Candid update](https://github.com/dfinity/ic-js/pull/834) failed because of new optional fields in `list_neurons`.

This PR addresses just the issues in the nns package.

A follow-up PR will implement pagination for `list_neurons`. At that time, the new fields will be utilized.

# Changes

- Checkout ic at `fb16293`
- Ran `./scripts/import-candid ../ic` from ic-js root folder 
- Ran `./scripts/compile-idl-js` from ic-js root folder 
- Revert changes not related to the `nns` package
- Fix `fromListNeurons` type with default 
- Updated expectations for tests based on the new API

# Tests

- Should pass as before

# Todos

- [x] Add entry to changelog (if necessary).