### PR TITLE
refactor: make methods of AgentManager usable after deconstruction

### DIFF
--- a/packages/utils/src/utils/agent.utils.spec.ts
+++ b/packages/utils/src/utils/agent.utils.spec.ts
@@ -27,7 +27,7 @@ describe("AgentManager", () => {
 
   describe("getAgent", () => {
     it("should create a new agent when there is none", async () => {
-      const {getAgent} = agentManager;
+      const { getAgent } = agentManager;
 
       const agent = await getAgent({ identity: mockIdentity });
 
@@ -38,7 +38,7 @@ describe("AgentManager", () => {
     });
 
     it("should return cached agent if already created", async () => {
-      const {getAgent} = agentManager;
+      const { getAgent } = agentManager;
 
       await getAgent({ identity: mockIdentity });
 
@@ -49,7 +49,7 @@ describe("AgentManager", () => {
     });
 
     it("should handle multiple agents for multiple identities", async () => {
-      const {getAgent} = agentManager;
+      const { getAgent } = agentManager;
 
       await getAgent({ identity: mockIdentity });
 
@@ -70,7 +70,7 @@ describe("AgentManager", () => {
 
   describe("clearAgents", () => {
     it("should clear cached agents", async () => {
-      const {getAgent, clearAgents} = agentManager;
+      const { getAgent, clearAgents } = agentManager;
 
       await getAgent({ identity: mockIdentity });
 

--- a/packages/utils/src/utils/agent.utils.spec.ts
+++ b/packages/utils/src/utils/agent.utils.spec.ts
@@ -60,6 +60,17 @@ describe("AgentManager", () => {
       expect(agent2).toBe(mockHttpAgent2);
       expect(agent2).not.toBe(mockHttpAgent);
     });
+
+    it("should be used after deconstruction", async () => {
+      const {getAgent} = agentManager;
+
+      const agent = await getAgent({ identity: mockIdentity });
+
+      expect(mockHttpAgentCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ identity: mockIdentity }),
+      );
+      expect(agent).toBe(mockHttpAgent);
+    })
   });
 
   describe("clearAgents", () => {

--- a/packages/utils/src/utils/agent.utils.spec.ts
+++ b/packages/utils/src/utils/agent.utils.spec.ts
@@ -62,7 +62,7 @@ describe("AgentManager", () => {
     });
 
     it("should be used after deconstruction", async () => {
-      const {getAgent} = agentManager;
+      const { getAgent } = agentManager;
 
       const agent = await getAgent({ identity: mockIdentity });
 
@@ -70,7 +70,7 @@ describe("AgentManager", () => {
         expect.objectContaining({ identity: mockIdentity }),
       );
       expect(agent).toBe(mockHttpAgent);
-    })
+    });
   });
 
   describe("clearAgents", () => {

--- a/packages/utils/src/utils/agent.utils.spec.ts
+++ b/packages/utils/src/utils/agent.utils.spec.ts
@@ -27,7 +27,9 @@ describe("AgentManager", () => {
 
   describe("getAgent", () => {
     it("should create a new agent when there is none", async () => {
-      const agent = await agentManager.getAgent({ identity: mockIdentity });
+      const {getAgent} = agentManager;
+
+      const agent = await getAgent({ identity: mockIdentity });
 
       expect(mockHttpAgentCreate).toHaveBeenCalledWith(
         expect.objectContaining({ identity: mockIdentity }),
@@ -36,21 +38,25 @@ describe("AgentManager", () => {
     });
 
     it("should return cached agent if already created", async () => {
-      await agentManager.getAgent({ identity: mockIdentity });
+      const {getAgent} = agentManager;
 
-      const agent = await agentManager.getAgent({ identity: mockIdentity });
+      await getAgent({ identity: mockIdentity });
+
+      const agent = await getAgent({ identity: mockIdentity });
 
       expect(mockHttpAgentCreate).toHaveBeenCalledTimes(1);
       expect(agent).toBe(mockHttpAgent);
     });
 
     it("should handle multiple agents for multiple identities", async () => {
-      await agentManager.getAgent({ identity: mockIdentity });
+      const {getAgent} = agentManager;
+
+      await getAgent({ identity: mockIdentity });
 
       mockHttpAgentCreate.mockResolvedValueOnce(mockHttpAgent2);
 
-      const agent2 = await agentManager.getAgent({ identity: mockIdentity2 });
-      const agent1 = await agentManager.getAgent({ identity: mockIdentity });
+      const agent2 = await getAgent({ identity: mockIdentity2 });
+      const agent1 = await getAgent({ identity: mockIdentity });
 
       expect(mockHttpAgentCreate).toHaveBeenCalledTimes(2);
 
@@ -60,32 +66,23 @@ describe("AgentManager", () => {
       expect(agent2).toBe(mockHttpAgent2);
       expect(agent2).not.toBe(mockHttpAgent);
     });
-
-    it("should be used after deconstruction", async () => {
-      const { getAgent } = agentManager;
-
-      const agent = await getAgent({ identity: mockIdentity });
-
-      expect(mockHttpAgentCreate).toHaveBeenCalledWith(
-        expect.objectContaining({ identity: mockIdentity }),
-      );
-      expect(agent).toBe(mockHttpAgent);
-    });
   });
 
   describe("clearAgents", () => {
     it("should clear cached agents", async () => {
-      await agentManager.getAgent({ identity: mockIdentity });
+      const {getAgent, clearAgents} = agentManager;
 
-      const agentBefore = await agentManager.getAgent({
+      await getAgent({ identity: mockIdentity });
+
+      const agentBefore = await getAgent({
         identity: mockIdentity,
       });
 
       expect(agentBefore).toBe(mockHttpAgent);
 
-      agentManager.clearAgents();
+      clearAgents();
 
-      const agentAfter = await agentManager.getAgent({
+      const agentAfter = await getAgent({
         identity: mockIdentity,
       });
 

--- a/packages/utils/src/utils/agent.utils.ts
+++ b/packages/utils/src/utils/agent.utils.ts
@@ -113,5 +113,5 @@ export class AgentManager {
    */
   public clearAgents = (): void => {
     this.agents = null;
-  }
+  };
 }

--- a/packages/utils/src/utils/agent.utils.ts
+++ b/packages/utils/src/utils/agent.utils.ts
@@ -79,11 +79,11 @@ export class AgentManager {
    * @param {Identity} identity - The identity to be used to create the agent.
    * @returns {Promise<HttpAgent>} The HttpAgent associated with the given identity.
    */
-  public async getAgent({
+  public getAgent = async ({
     identity,
   }: {
     identity: Identity;
-  }): Promise<HttpAgent> {
+  }): Promise<HttpAgent> => {
     const key = identity.getPrincipal().toText();
 
     if (isNullish(this.agents) || isNullish(this.agents[key])) {
@@ -103,7 +103,7 @@ export class AgentManager {
     }
 
     return this.agents[key];
-  }
+  };
 
   /**
    * Clear the cache of HTTP agents.

--- a/packages/utils/src/utils/agent.utils.ts
+++ b/packages/utils/src/utils/agent.utils.ts
@@ -111,7 +111,7 @@ export class AgentManager {
    * This method removes all cached agents, forcing new agent creation on the next request for any identity.
    * Useful when identities have changed or if you want to reset all active connections.
    */
-  public clearAgents(): void {
+  public clearAgents = (): void => {
     this.agents = null;
   }
 }


### PR DESCRIPTION
# Motivation

As per @peterpeterparker 's suggestion, we change the method `getAgent` and `clearAgents` of `AgentManager` class to arrow functions. In this way, they can be used after deconstruction.


# Tests

Adjusted the tests.


