### PR TITLE
chore: update nns Candid Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - Support `NervousSystemParameters.automatically_advance_target_version` in `@dfinity/sns`.
 - Add converters to encode or decode base64 string into Uint8Array.
+- Support `neuron_subaccounts` in `list_neurons` from `@dfinity/nns`.
 
 # 2025.01.20-1800Z
 

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -173,7 +173,7 @@ Parameters:
 
 ### :factory: GovernanceCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L91)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L92)
 
 #### Methods
 
@@ -217,7 +217,7 @@ Parameters:
 | -------- | ------------------------------------------------------------- |
 | `create` | `(options?: GovernanceCanisterOptions) => GovernanceCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L106)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L107)
 
 ##### :gear: listNeurons
 
@@ -230,11 +230,11 @@ it is fetched using a query call.
 
 The backend treats `includeEmptyNeurons` as false if absent.
 
-| Method        | Type                                                                                                                                                                                                                                                   |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `listNeurons` | `({ certified, neuronIds, includeEmptyNeurons, includePublicNeurons, }: { certified: boolean; neuronIds?: bigint[] or undefined; includeEmptyNeurons?: boolean or undefined; includePublicNeurons?: boolean or undefined; }) => Promise<NeuronInfo[]>` |
+| Method        | Type                                                                                                                                                                                                                                                                                                                  |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listNeurons` | `({ certified, neuronIds, includeEmptyNeurons, includePublicNeurons, neuronSubaccounts, }: { certified: boolean; neuronIds?: bigint[] or undefined; includeEmptyNeurons?: boolean or undefined; includePublicNeurons?: boolean or undefined; neuronSubaccounts?: NeuronSubaccount[] or undefined; }) => Promise<...>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L146)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L147)
 
 ##### :gear: listKnownNeurons
 
@@ -248,7 +248,7 @@ it is fetched using a query call.
 | ------------------ | ------------------------------------------------- |
 | `listKnownNeurons` | `(certified?: boolean) => Promise<KnownNeuron[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L189)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L193)
 
 ##### :gear: getLastestRewardEvent
 
@@ -261,7 +261,7 @@ it's fetched using a query call.
 | ----------------------- | ----------------------------------------------- |
 | `getLastestRewardEvent` | `(certified?: boolean) => Promise<RewardEvent>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L211)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L215)
 
 ##### :gear: listProposals
 
@@ -280,7 +280,7 @@ Parameters:
 - `request`: the options to list the proposals (limit number of results, topics to search for, etc.)
 - `certified`: query or update calls
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L227)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L231)
 
 ##### :gear: stakeNeuron
 
@@ -288,7 +288,7 @@ Parameters:
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `stakeNeuron` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, fee, }: { stake: bigint; principal: Principal; fromSubAccount?: number[] or undefined; ledgerCanister: LedgerCanister; createdAt?: bigint or undefined; fee?: bigint or undefined; }) => Promise<...>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L246)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L250)
 
 ##### :gear: increaseDissolveDelay
 
@@ -298,7 +298,7 @@ Increases dissolve delay of a neuron
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `increaseDissolveDelay` | `({ neuronId, additionalDissolveDelaySeconds, }: { neuronId: bigint; additionalDissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L307)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L311)
 
 ##### :gear: setDissolveDelay
 
@@ -309,7 +309,7 @@ The new date is now + dissolveDelaySeconds.
 | ------------------ | ------------------------------------------------------------------------------------------------------------- |
 | `setDissolveDelay` | `({ neuronId, dissolveDelaySeconds, }: { neuronId: bigint; dissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L333)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L337)
 
 ##### :gear: startDissolving
 
@@ -319,7 +319,7 @@ Start dissolving process of a neuron
 | ----------------- | ------------------------------------- |
 | `startDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L356)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L360)
 
 ##### :gear: stopDissolving
 
@@ -329,7 +329,7 @@ Stop dissolving process of a neuron
 | ---------------- | ------------------------------------- |
 | `stopDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L370)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L374)
 
 ##### :gear: joinCommunityFund
 
@@ -339,7 +339,7 @@ Neuron joins the community fund
 | ------------------- | ------------------------------------- |
 | `joinCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L384)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L388)
 
 ##### :gear: autoStakeMaturity
 
@@ -354,7 +354,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to request a change of the auto stake feature
 - `autoStake`: `true` to enable the auto-stake maturity for this neuron, `false` to turn it off
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L402)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L406)
 
 ##### :gear: leaveCommunityFund
 
@@ -364,7 +364,7 @@ Neuron leaves the community fund
 | -------------------- | ------------------------------------- |
 | `leaveCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L417)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L421)
 
 ##### :gear: setVisibility
 
@@ -374,7 +374,7 @@ Set visibility of a neuron
 | --------------- | ------------------------------------------------------------------- |
 | `setVisibility` | `(neuronId: bigint, visibility: NeuronVisibility) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L431)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L435)
 
 ##### :gear: setNodeProviderAccount
 
@@ -385,7 +385,7 @@ Where the reward is paid to.
 | ------------------------ | ---------------------------------------------- |
 | `setNodeProviderAccount` | `(accountIdentifier: string) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L451)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L455)
 
 ##### :gear: mergeNeurons
 
@@ -395,7 +395,7 @@ Merge two neurons
 | -------------- | --------------------------------------------------------------------------------- |
 | `mergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L471)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L475)
 
 ##### :gear: simulateMergeNeurons
 
@@ -405,7 +405,7 @@ Simulate merging two neurons
 | ---------------------- | --------------------------------------------------------------------------------------- |
 | `simulateMergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<NeuronInfo>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L488)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L492)
 
 ##### :gear: splitNeuron
 
@@ -415,7 +415,7 @@ Splits a neuron creating a new one
 | ------------- | ----------------------------------------------------------------------------------- |
 | `splitNeuron` | `({ neuronId, amount, }: { neuronId: bigint; amount: bigint; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L533)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L537)
 
 ##### :gear: getProposal
 
@@ -428,7 +428,7 @@ it is fetched using a query call.
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `getProposal` | `({ proposalId, certified, }: { proposalId: bigint; certified?: boolean or undefined; }) => Promise<ProposalInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L573)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L577)
 
 ##### :gear: makeProposal
 
@@ -438,7 +438,7 @@ Create new proposal
 | -------------- | ---------------------------------------------------------------- |
 | `makeProposal` | `(request: MakeProposalRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L591)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L595)
 
 ##### :gear: registerVote
 
@@ -448,7 +448,7 @@ Registers vote for a proposal from the neuron passed.
 | -------------- | ----------------------------------------------------------------------------------------------------------- |
 | `registerVote` | `({ neuronId, vote, proposalId, }: { neuronId: bigint; vote: Vote; proposalId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L612)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L616)
 
 ##### :gear: setFollowees
 
@@ -458,7 +458,7 @@ Edit neuron followees per topic
 | -------------- | ------------------------------------------------- |
 | `setFollowees` | `(followRequest: FollowRequest) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L634)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L638)
 
 ##### :gear: disburse
 
@@ -468,7 +468,7 @@ Disburse neuron on Account
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `disburse` | `({ neuronId, toAccountId, amount, }: { neuronId: bigint; toAccountId?: string or undefined; amount?: bigint or undefined; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L649)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L653)
 
 ##### :gear: refreshVotingPower
 
@@ -480,7 +480,7 @@ parameter of the neuron to the current time).
 | -------------------- | --------------------------------------------------------- |
 | `refreshVotingPower` | `({ neuronId, }: { neuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L685)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L689)
 
 ##### :gear: mergeMaturity
 
@@ -490,7 +490,7 @@ Merge Maturity of a neuron
 | --------------- | ------------------------------------------------------------------------------------------------------- |
 | `mergeMaturity` | `({ neuronId, percentageToMerge, }: { neuronId: bigint; percentageToMerge: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L707)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L711)
 
 ##### :gear: stakeMaturity
 
@@ -505,7 +505,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to stake the maturity
 - `percentageToStake`: Optional. Percentage of the current maturity to stake. If not provided, all of the neuron's current maturity will be staked.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L736)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L740)
 
 ##### :gear: spawnNeuron
 
@@ -515,7 +515,7 @@ Merge Maturity of a neuron
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `spawnNeuron` | `({ neuronId, percentageToSpawn, newController, nonce, }: { neuronId: bigint; percentageToSpawn?: number or undefined; newController?: Principal or undefined; nonce?: bigint or undefined; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L758)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L762)
 
 ##### :gear: addHotkey
 
@@ -525,7 +525,7 @@ Add hotkey to neuron
 | ----------- | ------------------------------------------------------------------------------------------ |
 | `addHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L805)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L809)
 
 ##### :gear: removeHotkey
 
@@ -535,7 +535,7 @@ Remove hotkey to neuron
 | -------------- | ------------------------------------------------------------------------------------------ |
 | `removeHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L825)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L829)
 
 ##### :gear: claimOrRefreshNeuronFromAccount
 
@@ -545,7 +545,7 @@ Gets the NeuronID of a newly created neuron.
 | --------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `claimOrRefreshNeuronFromAccount` | `({ memo, controller, }: { memo: bigint; controller?: Principal or undefined; }) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L843)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L847)
 
 ##### :gear: claimOrRefreshNeuron
 
@@ -556,7 +556,7 @@ Uses query call only.
 | ---------------------- | ------------------------------------------------------------------------ |
 | `claimOrRefreshNeuron` | `(request: ClaimOrRefreshNeuronRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L874)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L878)
 
 ##### :gear: getNeuron
 
@@ -566,7 +566,7 @@ Return the data of the neuron provided as id.
 | ----------- | ----------------------------------------------------------------------------------------------------------- |
 | `getNeuron` | `({ certified, neuronId, }: { certified: boolean; neuronId: bigint; }) => Promise<NeuronInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L899)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L903)
 
 ##### :gear: getNetworkEconomicsParameters
 
@@ -576,7 +576,7 @@ Return the [Network Economics](https://github.com/dfinity/ic/blob/d90e934eb440c7
 | ------------------------------- | ------------------------------------------------------------------------ |
 | `getNetworkEconomicsParameters` | `({ certified, }: { certified: boolean; }) => Promise<NetworkEconomics>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L920)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L924)
 
 ### :factory: SnsWasmCanister
 

--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit fb16293 (2025-01-22 tags: release-2025-01-30_03-03-hashes-in-blocks) 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit 14c8f44cd6 (2025-02-07 tags: release-2025-02-06_12-26-revert-hashes-in-blocks) 'rs/nns/gtc/canister/gtc.did' by import-candid
 type AccountState = record {
   authenticated_principal_id : opt principal;
   successfully_transferred_neurons : vec TransferredNeuron;

--- a/packages/nns/candid/governance.certified.idl.js
+++ b/packages/nns/candid/governance.certified.idl.js
@@ -745,12 +745,14 @@ export const idlFactory = ({ IDL }) => {
   const ListKnownNeuronsResponse = IDL.Record({
     'known_neurons' : IDL.Vec(KnownNeuron),
   });
+  const NeuronSubaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
   const ListNeurons = IDL.Record({
     'page_size' : IDL.Opt(IDL.Nat64),
     'include_public_neurons_in_full_neurons' : IDL.Opt(IDL.Bool),
     'neuron_ids' : IDL.Vec(IDL.Nat64),
     'page_number' : IDL.Opt(IDL.Nat64),
     'include_empty_neurons_readable_by_caller' : IDL.Opt(IDL.Bool),
+    'neuron_subaccounts' : IDL.Opt(IDL.Vec(NeuronSubaccount)),
     'include_neurons_readable_by_caller' : IDL.Bool,
   });
   const ListNeuronsResponse = IDL.Record({

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -357,6 +357,7 @@ export interface ListNeurons {
   neuron_ids: BigUint64Array | bigint[];
   page_number: [] | [bigint];
   include_empty_neurons_readable_by_caller: [] | [boolean];
+  neuron_subaccounts: [] | [Array<NeuronSubaccount>];
   include_neurons_readable_by_caller: boolean;
 }
 export interface ListNeuronsResponse {
@@ -553,6 +554,9 @@ export interface NeuronStakeTransfer {
   from_subaccount: Uint8Array | number[];
   transfer_timestamp: bigint;
   block_height: bigint;
+}
+export interface NeuronSubaccount {
+  subaccount: Uint8Array | number[];
 }
 export interface NeuronSubsetMetrics {
   total_maturity_e8s_equivalent: [] | [bigint];

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit fb16293 (2025-01-22 tags: release-2025-01-30_03-03-hashes-in-blocks) 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 14c8f44cd6 (2025-02-07 tags: release-2025-02-06_12-26-revert-hashes-in-blocks) 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -451,6 +451,11 @@ type ListNeurons = record {
 
   page_number: opt nat64;
   page_size: opt nat64;
+  neuron_subaccounts: opt vec NeuronSubaccount;
+};
+
+type NeuronSubaccount = record {
+  subaccount : blob;
 };
 
 // Output of the list_neurons method.

--- a/packages/nns/candid/governance.idl.js
+++ b/packages/nns/candid/governance.idl.js
@@ -745,12 +745,14 @@ export const idlFactory = ({ IDL }) => {
   const ListKnownNeuronsResponse = IDL.Record({
     'known_neurons' : IDL.Vec(KnownNeuron),
   });
+  const NeuronSubaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
   const ListNeurons = IDL.Record({
     'page_size' : IDL.Opt(IDL.Nat64),
     'include_public_neurons_in_full_neurons' : IDL.Opt(IDL.Bool),
     'neuron_ids' : IDL.Vec(IDL.Nat64),
     'page_number' : IDL.Opt(IDL.Nat64),
     'include_empty_neurons_readable_by_caller' : IDL.Opt(IDL.Bool),
+    'neuron_subaccounts' : IDL.Opt(IDL.Vec(NeuronSubaccount)),
     'include_neurons_readable_by_caller' : IDL.Bool,
   });
   const ListNeuronsResponse = IDL.Record({

--- a/packages/nns/candid/governance_test.certified.idl.js
+++ b/packages/nns/candid/governance_test.certified.idl.js
@@ -745,12 +745,14 @@ export const idlFactory = ({ IDL }) => {
   const ListKnownNeuronsResponse = IDL.Record({
     'known_neurons' : IDL.Vec(KnownNeuron),
   });
+  const NeuronSubaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
   const ListNeurons = IDL.Record({
     'page_size' : IDL.Opt(IDL.Nat64),
     'include_public_neurons_in_full_neurons' : IDL.Opt(IDL.Bool),
     'neuron_ids' : IDL.Vec(IDL.Nat64),
     'page_number' : IDL.Opt(IDL.Nat64),
     'include_empty_neurons_readable_by_caller' : IDL.Opt(IDL.Bool),
+    'neuron_subaccounts' : IDL.Opt(IDL.Vec(NeuronSubaccount)),
     'include_neurons_readable_by_caller' : IDL.Bool,
   });
   const ListNeuronsResponse = IDL.Record({

--- a/packages/nns/candid/governance_test.d.ts
+++ b/packages/nns/candid/governance_test.d.ts
@@ -357,6 +357,7 @@ export interface ListNeurons {
   neuron_ids: BigUint64Array | bigint[];
   page_number: [] | [bigint];
   include_empty_neurons_readable_by_caller: [] | [boolean];
+  neuron_subaccounts: [] | [Array<NeuronSubaccount>];
   include_neurons_readable_by_caller: boolean;
 }
 export interface ListNeuronsResponse {
@@ -553,6 +554,9 @@ export interface NeuronStakeTransfer {
   from_subaccount: Uint8Array | number[];
   transfer_timestamp: bigint;
   block_height: bigint;
+}
+export interface NeuronSubaccount {
+  subaccount: Uint8Array | number[];
 }
 export interface NeuronSubsetMetrics {
   total_maturity_e8s_equivalent: [] | [bigint];

--- a/packages/nns/candid/governance_test.did
+++ b/packages/nns/candid/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit fb16293 (2025-01-22 tags: release-2025-01-30_03-03-hashes-in-blocks) 'rs/nns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 14c8f44cd6 (2025-02-07 tags: release-2025-02-06_12-26-revert-hashes-in-blocks) 'rs/nns/governance/canister/governance_test.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -441,6 +441,11 @@ type ListNeurons = record {
   include_neurons_readable_by_caller : bool;
   page_number: opt nat64;
   page_size: opt nat64;
+  neuron_subaccounts: opt vec NeuronSubaccount;
+};
+
+type NeuronSubaccount = record {
+  subaccount : blob;
 };
 
 type ListNeuronsResponse = record {

--- a/packages/nns/candid/governance_test.idl.js
+++ b/packages/nns/candid/governance_test.idl.js
@@ -745,12 +745,14 @@ export const idlFactory = ({ IDL }) => {
   const ListKnownNeuronsResponse = IDL.Record({
     'known_neurons' : IDL.Vec(KnownNeuron),
   });
+  const NeuronSubaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
   const ListNeurons = IDL.Record({
     'page_size' : IDL.Opt(IDL.Nat64),
     'include_public_neurons_in_full_neurons' : IDL.Opt(IDL.Bool),
     'neuron_ids' : IDL.Vec(IDL.Nat64),
     'page_number' : IDL.Opt(IDL.Nat64),
     'include_empty_neurons_readable_by_caller' : IDL.Opt(IDL.Bool),
+    'neuron_subaccounts' : IDL.Opt(IDL.Vec(NeuronSubaccount)),
     'include_neurons_readable_by_caller' : IDL.Bool,
   });
   const ListNeuronsResponse = IDL.Record({

--- a/packages/nns/candid/sns_wasm.did
+++ b/packages/nns/candid/sns_wasm.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit fb16293 (2025-01-22 tags: release-2025-01-30_03-03-hashes-in-blocks) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit 14c8f44cd6 (2025-02-07 tags: release-2025-02-06_12-26-revert-hashes-in-blocks) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -1031,7 +1031,7 @@ export const fromListNeurons = ({
   include_public_neurons_in_full_neurons: toNullable(includePublicNeurons),
   page_number: [],
   page_size: [],
-  neuron_subaccounts: neuronSubaccounts ? [neuronSubaccounts] : [],
+  neuron_subaccounts: toNullable(neuronSubaccounts),
 });
 
 export const fromManageNeuron = ({

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -13,6 +13,7 @@ import {
 import type {
   Amount,
   ListProposalInfo,
+  NeuronSubaccount,
   AccountIdentifier as RawAccountIdentifier,
   ProposalActionRequest as RawAction,
   By as RawBy,
@@ -1017,10 +1018,12 @@ export const fromListNeurons = ({
   neuronIds,
   includeEmptyNeurons,
   includePublicNeurons,
+  neuronSubaccounts,
 }: {
   neuronIds?: NeuronId[];
   includeEmptyNeurons?: boolean;
   includePublicNeurons?: boolean;
+  neuronSubaccounts?: NeuronSubaccount[];
 }): RawListNeurons => ({
   neuron_ids: BigUint64Array.from(neuronIds ?? []),
   include_neurons_readable_by_caller: neuronIds ? false : true,
@@ -1028,6 +1031,7 @@ export const fromListNeurons = ({
   include_public_neurons_in_full_neurons: toNullable(includePublicNeurons),
   page_number: [],
   page_size: [],
+  neuron_subaccounts: neuronSubaccounts ? [neuronSubaccounts] : [],
 });
 
 export const fromManageNeuron = ({

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -451,6 +451,7 @@ describe("GovernanceCanister", () => {
         include_public_neurons_in_full_neurons: [true],
         page_number: [],
         page_size: [],
+        neuron_subaccounts: [],
       });
       expect(certifiedService.list_neurons).toBeCalledTimes(1);
       expect(neurons.length).toBe(1);
@@ -479,6 +480,7 @@ describe("GovernanceCanister", () => {
         include_public_neurons_in_full_neurons: [],
         page_number: [],
         page_size: [],
+        neuron_subaccounts: [],
       });
       expect(service.list_neurons).toBeCalledTimes(1);
       expect(neurons.length).toBe(1);
@@ -505,6 +507,7 @@ describe("GovernanceCanister", () => {
         include_public_neurons_in_full_neurons: [false],
         page_number: [],
         page_size: [],
+        neuron_subaccounts: [],
       });
       expect(service.list_neurons).toBeCalledTimes(1);
       expect(neurons.length).toBe(1);
@@ -534,6 +537,8 @@ describe("GovernanceCanister", () => {
         page_number: [],
         // The field is present in the argument but ignored by the old service.
         page_size: [],
+        // The field is present in the argument but ignored by the old service.
+        neuron_subaccounts: [],
       });
       expect(oldService.list_neurons).toBeCalledTimes(1);
       expect(neurons.length).toBe(1);
@@ -561,6 +566,7 @@ describe("GovernanceCanister", () => {
         include_public_neurons_in_full_neurons: [],
         page_number: [],
         page_size: [],
+        neuron_subaccounts: [],
       });
       expect(service.list_neurons).toBeCalledTimes(1);
       expect(neurons.length).toBe(1);

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -513,6 +513,43 @@ describe("GovernanceCanister", () => {
       expect(neurons.length).toBe(1);
     });
 
+    it("list user neurons by neurons sub-account", async () => {
+      const service = mock<ActorSubclass<GovernanceService>>();
+      const oldService = mock<ActorSubclass<GovernanceService>>();
+      service.list_neurons.mockResolvedValue(mockListNeuronsResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+        oldListNeuronsServiceOverride: oldService,
+      });
+      const neurons = await governance.listNeurons({
+        certified: true,
+        includeEmptyNeurons: true,
+        includePublicNeurons: true,
+        neuronSubaccounts: [
+          { subaccount: new Uint8Array([1, 2, 3]) },
+          { subaccount: new Uint8Array([4, 5, 6]) },
+        ],
+      });
+      expect(service.list_neurons).toBeCalledWith({
+        neuron_ids: new BigUint64Array(),
+        include_neurons_readable_by_caller: true,
+        include_empty_neurons_readable_by_caller: [true],
+        include_public_neurons_in_full_neurons: [true],
+        page_number: [],
+        page_size: [],
+        neuron_subaccounts: [
+          [
+            { subaccount: new Uint8Array([1, 2, 3]) },
+            { subaccount: new Uint8Array([4, 5, 6]) },
+          ],
+        ],
+      });
+      expect(service.list_neurons).toBeCalledTimes(1);
+      expect(neurons.length).toBe(1);
+    });
+
     it("should use old service when not excluding empty neurons", async () => {
       const service = mock<ActorSubclass<GovernanceService>>();
       const oldService = mock<ActorSubclass<GovernanceService>>();

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -17,6 +17,7 @@ import type {
   _SERVICE as GovernanceService,
   ListProposalInfo,
   MergeResponse,
+  NeuronSubaccount,
   Neuron as RawNeuron,
   NeuronInfo as RawNeuronInfo,
   ProposalInfo as RawProposalInfo,
@@ -148,16 +149,19 @@ export class GovernanceCanister {
     neuronIds,
     includeEmptyNeurons,
     includePublicNeurons,
+    neuronSubaccounts,
   }: {
     certified: boolean;
     neuronIds?: NeuronId[];
     includeEmptyNeurons?: boolean;
     includePublicNeurons?: boolean;
+    neuronSubaccounts?: NeuronSubaccount[];
   }): Promise<NeuronInfo[]> => {
     const rawRequest = fromListNeurons({
       neuronIds,
       includeEmptyNeurons,
       includePublicNeurons,
+      neuronSubaccounts,
     });
     // The Ledger app version 2.4.9 does not support
     // include_empty_neurons_readable_by_caller nor include_public_neurons_in_full_neurons,


### PR DESCRIPTION
# Motivation

#837 is currently blocked because a new field in the `list_neurons` requests is breaking our tests. This PR unblocks it by updating the tests and exposing this new parameter.

This PR addresses just the issues in the nns package.

# Changes

- Checkout ic at `14c8f44`
- Ran `./scripts/import-candid ../ic` from ic-js root folder 
- Ran `./scripts/compile-idl-js` from ic-js root folder 
- Revert changes not related to the `nns` package
- Fix `fromListNeurons` type 
- Exposed `neuron_subaccounts` through `listNeurons`
- Updated expectations for tests based on the new API

# Tests

- Should pass as before

# Todos

- [x] Add entry to changelog (if necessary).