### PR TITLE
ci: add zod-schemas to next release CI

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -57,3 +57,7 @@ jobs:
         run: npm publish --provenance --tag next --workspace=packages/ic-management
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - name: Publish Zod schemas
+        run: npm publish --provenance --tag next --workspace=packages/zod-schemas
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
# Motivation

The package `zod-schemas` was missing from the CI that releases the `next` version.