### PR TITLE
docs: review Icrc2ApproveRequest jsdocs types

### DIFF
--- a/packages/ledger-icp/src/types/ledger_converters.ts
+++ b/packages/ledger-icp/src/types/ledger_converters.ts
@@ -43,12 +43,12 @@ export type Icrc1TransferRequest = {
  *
  * @param {Account} spender The account of the spender.
  * @param {Tokens} amount The amount of tokens to approve.
- * @param {Subaccount?} from_subaccount The subaccount to transfer tokens from.
- * @param {Uint8Array|number?} icrc1Memo Approve memo.
- * @param {Timestamp?} created_at_time nanoseconds since unix epoc to trigger deduplication and avoid other issues
- * @param {Tokens?} fee The fee of the transfer when it's not the default fee.
- * @param {Tokens?} expected_allowance The optional allowance expected. If the expected_allowance field is set, the ledger MUST ensure that the current allowance for the spender from the caller's account is equal to the given value and return the AllowanceChanged error otherwise.
- * @param {Timestamp?} expires_at When the approval expires. If the field is set, it's greater than the current ledger time.
+ * @param {SubAccount?} from_subaccount The subaccount to transfer tokens from.
+ * @param {Uint8Array?} icrc1Memo Approve memo.
+ * @param {Icrc1Timestamp?} createdAt nanoseconds since unix epoc to trigger deduplication and avoid other issues
+ * @param {Icrc1Tokens?} fee The fee of the transfer when it's not the default fee.
+ * @param {Icrc1Tokens?} expected_allowance The optional allowance expected. If the expected_allowance field is set, the ledger MUST ensure that the current allowance for the spender from the caller's account is equal to the given value and return the AllowanceChanged error otherwise.
+ * @param {Icrc1Timestamp?} expires_at When the approval expires. If the field is set, it's greater than the current ledger time.
  */
 export type Icrc2ApproveRequest = Omit<Icrc1TransferRequest, "to"> & {
   expected_allowance?: Icrc1Tokens;


### PR DESCRIPTION
# Motivation

I noticed that the types and params of the jsdocs of `Icrc2ApproveRequest` were not exactly matching the implementation.

# Changes

- Review types and params js documentation.
