### PR TITLE
fix error with starting page number

### DIFF
--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -459,7 +459,7 @@ describe("GovernanceCanister", () => {
         include_empty_neurons_readable_by_caller: [true],
         include_public_neurons_in_full_neurons: [true],
         neuron_subaccounts: [],
-        page_number: [1n],
+        page_number: [0n],
         page_size: [500n],
       });
       expect(neurons.length).toBe(1);
@@ -502,7 +502,7 @@ describe("GovernanceCanister", () => {
         include_empty_neurons_readable_by_caller: [true],
         include_public_neurons_in_full_neurons: [true],
         neuron_subaccounts: [],
-        page_number: [1n],
+        page_number: [0n],
         page_size: [500n],
       });
 
@@ -543,7 +543,7 @@ describe("GovernanceCanister", () => {
         include_empty_neurons_readable_by_caller: [false],
         include_public_neurons_in_full_neurons: [],
         neuron_subaccounts: [],
-        page_number: [1n],
+        page_number: [0n],
         page_size: [500n],
       });
       expect(service.list_neurons).toBeCalledTimes(1);
@@ -570,7 +570,7 @@ describe("GovernanceCanister", () => {
         include_empty_neurons_readable_by_caller: [],
         include_public_neurons_in_full_neurons: [false],
         neuron_subaccounts: [],
-        page_number: [1n],
+        page_number: [0n],
         page_size: [500n],
       });
       expect(service.list_neurons).toBeCalledTimes(1);
@@ -601,7 +601,7 @@ describe("GovernanceCanister", () => {
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: [true],
         include_public_neurons_in_full_neurons: [true],
-        page_number: [1n],
+        page_number: [0n],
         page_size: [500n],
         neuron_subaccounts: [
           [
@@ -665,7 +665,7 @@ describe("GovernanceCanister", () => {
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: [],
         include_public_neurons_in_full_neurons: [],
-        page_number: [1n],
+        page_number: [0n],
         page_size: [500n],
         neuron_subaccounts: [],
       });

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -178,7 +178,7 @@ export class GovernanceCanister {
       includeEmptyNeurons,
       includePublicNeurons,
       neuronSubaccounts,
-      pageNumber: 1n,
+      pageNumber: 0n,
     });
     const { neurons: firstPageNeurons, totalPages } = firstPageResult;
 


### PR DESCRIPTION
# Motivation

A bug was introduced in #833 in commit https://github.com/dfinity/ic-js/pull/833/commits/45eb69de418cc22a7b7f8a9da2eb80db47a8c414#diff-f4f0835b56118edf98f5b690eb524de8bd8738c8d742c69c3c2cd516d55e9857R174 as the initial page is `0` and not `1` as shown [here](https://github.com/dfinity/ic/blob/a34724ef3feef15510ab055b4f5e4aa961ce9e86/rs/nns/governance/src/governance.rs#L2085).

# Changes

- Changed the initially requested page from `1n` to `0n`.

# Tests

- Update expectations for the requested page.

# Todos

- [ ] Add entry to changelog (if necessary).
