### PR TITLE
chore: update sns Candid Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# YYYY.MM.DD-HHMMZ
+
+# Features
+
+- Support `topic` and `list_topics` in @dfinity/sns`.
+
 # 2025.02.19-1030Z
 
 ## Overview

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     {
       "name": "@dfinity/sns",
       "path": "./packages/sns/dist/index.js",
-      "limit": "18 kB",
+      "limit": "19 kB",
       "gzip": true,
       "ignore": [
         "@dfinity/agent",

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -100,13 +100,14 @@ Lookup for the canister ids of a Sns and initialize the wrapper to access its fe
 
 ### :factory: SnsGovernanceCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L63)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L65)
 
 #### Methods
 
 - [create](#gear-create)
 - [listNeurons](#gear-listneurons)
 - [listProposals](#gear-listproposals)
+- [listTopics](#gear-listtopics)
 - [getProposal](#gear-getproposal)
 - [listNervousSystemFunctions](#gear-listnervoussystemfunctions)
 - [metadata](#gear-metadata)
@@ -142,7 +143,7 @@ Parameters:
 
 - `options`: Miscellaneous options to initialize the canister. Its ID being the only mandatory parammeter.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L69)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L71)
 
 ##### :gear: listNeurons
 
@@ -152,7 +153,7 @@ List the neurons of the Sns
 | ------------- | ----------------------------------------------------- |
 | `listNeurons` | `(params: SnsListNeuronsParams) => Promise<Neuron[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L83)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L85)
 
 ##### :gear: listProposals
 
@@ -162,7 +163,17 @@ List the proposals of the Sns
 | --------------- | -------------------------------------------------------------------- |
 | `listProposals` | `(params: SnsListProposalsParams) => Promise<ListProposalsResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L97)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L99)
+
+##### :gear: listTopics
+
+List the topics of the Sns
+
+| Method       | Type                                                           |
+| ------------ | -------------------------------------------------------------- |
+| `listTopics` | `(params: SnsListTopicsParams) => Promise<ListTopicsResponse>` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L114)
 
 ##### :gear: getProposal
 
@@ -172,7 +183,7 @@ Get the proposal of the Sns
 | ------------- | --------------------------------------------------------- |
 | `getProposal` | `(params: SnsGetProposalParams) => Promise<ProposalData>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L111)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L125)
 
 ##### :gear: listNervousSystemFunctions
 
@@ -183,7 +194,7 @@ Neurons can follow other neurons in specific Nervous System Functions.
 | ---------------------------- | ---------------------------------------------------------------------- |
 | `listNervousSystemFunctions` | `(params: QueryParams) => Promise<ListNervousSystemFunctionsResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L130)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L144)
 
 ##### :gear: metadata
 
@@ -193,7 +204,7 @@ Get the Sns metadata (title, description, etc.)
 | ---------- | ------------------------------------------------------- |
 | `metadata` | `(params: QueryParams) => Promise<GetMetadataResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L138)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L152)
 
 ##### :gear: nervousSystemParameters
 
@@ -203,7 +214,7 @@ Get the Sns nervous system parameters (default followees, max dissolve delay, ma
 | ------------------------- | ----------------------------------------------------------- |
 | `nervousSystemParameters` | `(params: QueryParams) => Promise<NervousSystemParameters>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L144)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L158)
 
 ##### :gear: getNeuron
 
@@ -213,7 +224,7 @@ Get the neuron of the Sns
 | ----------- | ------------------------------------------------- |
 | `getNeuron` | `(params: SnsGetNeuronParams) => Promise<Neuron>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L152)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L166)
 
 ##### :gear: queryNeuron
 
@@ -223,7 +234,7 @@ Same as `getNeuron` but returns undefined instead of raising error when not foun
 | ------------- | -------------------------------------------------------------- |
 | `queryNeuron` | `(params: SnsGetNeuronParams) => Promise<Neuron or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L170)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L184)
 
 ##### :gear: manageNeuron
 
@@ -233,7 +244,7 @@ Manage neuron. For advanced users.
 | -------------- | ---------------------------------------------------------- |
 | `manageNeuron` | `(request: ManageNeuron) => Promise<ManageNeuronResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L190)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L204)
 
 ##### :gear: addNeuronPermissions
 
@@ -243,7 +254,7 @@ Add permissions to a neuron for a specific principal
 | ---------------------- | ------------------------------------------------------- |
 | `addNeuronPermissions` | `(params: SnsNeuronPermissionsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L203)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L217)
 
 ##### :gear: removeNeuronPermissions
 
@@ -253,7 +264,7 @@ Remove permissions to a neuron for a specific principal
 | ------------------------- | ------------------------------------------------------- |
 | `removeNeuronPermissions` | `(params: SnsNeuronPermissionsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L213)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L227)
 
 ##### :gear: splitNeuron
 
@@ -263,7 +274,7 @@ Split neuron
 | ------------- | ------------------------------------------------------------------ |
 | `splitNeuron` | `(params: SnsSplitNeuronParams) => Promise<NeuronId or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L223)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L237)
 
 ##### :gear: disburse
 
@@ -273,7 +284,7 @@ Disburse neuron on Account
 | ---------- | ---------------------------------------------------- |
 | `disburse` | `(params: SnsDisburseNeuronParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L254)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L268)
 
 ##### :gear: startDissolving
 
@@ -283,7 +294,7 @@ Start dissolving process of a neuron
 | ----------------- | --------------------------------------- |
 | `startDissolving` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L262)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L276)
 
 ##### :gear: stopDissolving
 
@@ -293,7 +304,7 @@ Stop dissolving process of a neuron
 | ---------------- | --------------------------------------- |
 | `stopDissolving` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L270)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L284)
 
 ##### :gear: stakeMaturity
 
@@ -308,7 +319,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to stake the maturity
 - `percentageToStake`: Optional. Percentage of the current maturity to stake. If not provided, all of the neuron's current maturity will be staked.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L282)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L296)
 
 ##### :gear: disburseMaturity
 
@@ -324,7 +335,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to disburse the maturity
 - `percentageToDisburse`: What percentage of the available maturity to disburse.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L303)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L317)
 
 ##### :gear: autoStakeMaturity
 
@@ -339,7 +350,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to request a change of the auto stake feature
 - `autoStake`: `true` to enable the auto-stake maturity for this neuron, `false` to turn it off
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L319)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L333)
 
 ##### :gear: setDissolveTimestamp
 
@@ -349,7 +360,7 @@ Increase dissolve delay of a neuron
 | ---------------------- | ---------------------------------------------------------- |
 | `setDissolveTimestamp` | `(params: SnsSetDissolveTimestampParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L329)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L343)
 
 ##### :gear: increaseDissolveDelay
 
@@ -359,7 +370,7 @@ Increase dissolve delay of a neuron
 | ----------------------- | ----------------------------------------------------------- |
 | `increaseDissolveDelay` | `(params: SnsIncreaseDissolveDelayParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L339)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L353)
 
 ##### :gear: setTopicFollowees
 
@@ -369,7 +380,7 @@ Sets followees of a neuron for a specific Nervous System Function (topic)
 | ------------------- | ------------------------------------------------- |
 | `setTopicFollowees` | `(params: SnsSetTopicFollowees) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L349)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L363)
 
 ##### :gear: registerVote
 
@@ -379,7 +390,7 @@ Registers vote for a proposal from the neuron passed.
 | -------------- | -------------------------------------------------- |
 | `registerVote` | `(params: SnsRegisterVoteParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L357)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L371)
 
 ##### :gear: refreshNeuron
 
@@ -389,7 +400,7 @@ Refresh neuron
 | --------------- | --------------------------------------- |
 | `refreshNeuron` | `(neuronId: NeuronId) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L365)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L379)
 
 ##### :gear: claimNeuron
 
@@ -399,7 +410,7 @@ Claim neuron
 | ------------- | -------------------------------------------------------------------------------- |
 | `claimNeuron` | `({ memo, controller, subaccount, }: SnsClaimNeuronParams) => Promise<NeuronId>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L375)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L389)
 
 ### :factory: SnsRootCanister
 

--- a/packages/sns/candid/sns_governance.certified.idl.js
+++ b/packages/sns/candid/sns_governance.certified.idl.js
@@ -19,7 +19,17 @@ export const idlFactory = ({ IDL }) => {
     'response_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'requested_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const Topic = IDL.Variant({
+    'DappCanisterManagement' : IDL.Null,
+    'DaoCommunitySettings' : IDL.Null,
+    'ApplicationBusinessLogic' : IDL.Null,
+    'CriticalDappOperations' : IDL.Null,
+    'TreasuryAssetManagement' : IDL.Null,
+    'Governance' : IDL.Null,
+    'SnsFrameworkManagement' : IDL.Null,
+  });
   const GenericNervousSystemFunction = IDL.Record({
+    'topic' : IDL.Opt(Topic),
     'validator_canister_id' : IDL.Opt(IDL.Principal),
     'target_canister_id' : IDL.Opt(IDL.Principal),
     'validator_method_name' : IDL.Opt(IDL.Text),
@@ -604,6 +614,19 @@ export const idlFactory = ({ IDL }) => {
     'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
   });
+  const ListTopicsRequest = IDL.Record({});
+  const TopicInfo = IDL.Record({
+    'native_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
+    'topic' : IDL.Opt(Topic),
+    'is_critical' : IDL.Opt(IDL.Bool),
+    'name' : IDL.Opt(IDL.Text),
+    'description' : IDL.Opt(IDL.Text),
+    'custom_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
+  });
+  const ListTopicsResponse = IDL.Record({
+    'uncategorized_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
+    'topics' : IDL.Opt(IDL.Vec(TopicInfo)),
+  });
   const StakeMaturity = IDL.Record({
     'percentage_to_stake' : IDL.Opt(IDL.Nat32),
   });
@@ -714,6 +737,7 @@ export const idlFactory = ({ IDL }) => {
       ),
     'list_neurons' : IDL.Func([ListNeurons], [ListNeuronsResponse], []),
     'list_proposals' : IDL.Func([ListProposals], [ListProposalsResponse], []),
+    'list_topics' : IDL.Func([ListTopicsRequest], [ListTopicsResponse], []),
     'manage_neuron' : IDL.Func([ManageNeuron], [ManageNeuronResponse], []),
     'reset_timers' : IDL.Func([IDL.Record({})], [IDL.Record({})], []),
     'set_mode' : IDL.Func([SetMode], [IDL.Record({})], []),
@@ -739,7 +763,17 @@ export const init = ({ IDL }) => {
     'response_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'requested_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const Topic = IDL.Variant({
+    'DappCanisterManagement' : IDL.Null,
+    'DaoCommunitySettings' : IDL.Null,
+    'ApplicationBusinessLogic' : IDL.Null,
+    'CriticalDappOperations' : IDL.Null,
+    'TreasuryAssetManagement' : IDL.Null,
+    'Governance' : IDL.Null,
+    'SnsFrameworkManagement' : IDL.Null,
+  });
   const GenericNervousSystemFunction = IDL.Record({
+    'topic' : IDL.Opt(Topic),
     'validator_canister_id' : IDL.Opt(IDL.Principal),
     'target_canister_id' : IDL.Opt(IDL.Principal),
     'validator_method_name' : IDL.Opt(IDL.Text),

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -201,6 +201,7 @@ export type FunctionType =
   | { NativeNervousSystemFunction: {} }
   | { GenericNervousSystemFunction: GenericNervousSystemFunction };
 export interface GenericNervousSystemFunction {
+  topic: [] | [Topic];
   validator_canister_id: [] | [Principal];
   target_canister_id: [] | [Principal];
   validator_method_name: [] | [string];
@@ -331,6 +332,11 @@ export interface ListProposals {
 export interface ListProposalsResponse {
   include_ballots_by_caller: [] | [boolean];
   proposals: Array<ProposalData>;
+}
+export type ListTopicsRequest = {};
+export interface ListTopicsResponse {
+  uncategorized_functions: [] | [Array<NervousSystemFunction>];
+  topics: [] | [Array<TopicInfo>];
 }
 export interface ManageDappCanisterSettings {
   freezing_threshold: [] | [bigint];
@@ -617,6 +623,22 @@ export interface Timers {
 export interface Tokens {
   e8s: [] | [bigint];
 }
+export type Topic =
+  | { DappCanisterManagement: null }
+  | { DaoCommunitySettings: null }
+  | { ApplicationBusinessLogic: null }
+  | { CriticalDappOperations: null }
+  | { TreasuryAssetManagement: null }
+  | { Governance: null }
+  | { SnsFrameworkManagement: null };
+export interface TopicInfo {
+  native_functions: [] | [Array<NervousSystemFunction>];
+  topic: [] | [Topic];
+  is_critical: [] | [boolean];
+  name: [] | [string];
+  description: [] | [string];
+  custom_functions: [] | [Array<NervousSystemFunction>];
+}
 export interface TransferSnsTreasuryFunds {
   from_treasury: number;
   to_principal: [] | [Principal];
@@ -743,6 +765,7 @@ export interface _SERVICE {
   >;
   list_neurons: ActorMethod<[ListNeurons], ListNeuronsResponse>;
   list_proposals: ActorMethod<[ListProposals], ListProposalsResponse>;
+  list_topics: ActorMethod<[ListTopicsRequest], ListTopicsResponse>;
   manage_neuron: ActorMethod<[ManageNeuron], ManageNeuronResponse>;
   reset_timers: ActorMethod<[{}], {}>;
   set_mode: ActorMethod<[SetMode], {}>;

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 14c8f44 (2025-02-07 tags: release-2025-02-06_12-26-revert-hashes-in-blocks) 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 2f02a660f6 (2025-02-13 tags: release-2025-02-20_10-16-disable-best-effort-messaging) 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -227,6 +227,7 @@ type GenericNervousSystemFunction = record {
   target_canister_id : opt principal;
   validator_method_name : opt text;
   target_method_name : opt text;
+  topic: opt Topic;
 };
 
 type GetMaturityModulationResponse = record {
@@ -840,6 +841,31 @@ type GetUpgradeJournalResponse = record {
   upgrade_journal_entry_count: opt nat64;
 };
 
+type Topic = variant {
+  DaoCommunitySettings;
+  SnsFrameworkManagement;
+  DappCanisterManagement;
+  ApplicationBusinessLogic;
+  Governance;
+  TreasuryAssetManagement;
+  CriticalDappOperations;
+};
+
+type TopicInfo = record {
+  topic : opt Topic;
+  name : opt text;
+  description : opt text;
+  native_functions : opt vec NervousSystemFunction;
+  custom_functions : opt vec NervousSystemFunction;
+  is_critical : opt bool;
+};
+
+type ListTopicsRequest = record {};
+type ListTopicsResponse = record {
+  topics: opt vec TopicInfo;
+  uncategorized_functions: opt vec NervousSystemFunction
+};
+
 service : (Governance) -> {
   claim_swap_neurons : (ClaimSwapNeuronsRequest) -> (ClaimSwapNeuronsResponse);
   fail_stuck_upgrade_in_progress : (record {}) -> (record {});
@@ -858,6 +884,7 @@ service : (Governance) -> {
   list_nervous_system_functions : () -> (ListNervousSystemFunctionsResponse) query;
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
   list_proposals : (ListProposals) -> (ListProposalsResponse) query;
+  list_topics : (ListTopicsRequest) -> (ListTopicsResponse) query;
   manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
   set_mode : (SetMode) -> (record {});
   reset_timers : (record {}) -> (record {});

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -19,7 +19,17 @@ export const idlFactory = ({ IDL }) => {
     'response_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'requested_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const Topic = IDL.Variant({
+    'DappCanisterManagement' : IDL.Null,
+    'DaoCommunitySettings' : IDL.Null,
+    'ApplicationBusinessLogic' : IDL.Null,
+    'CriticalDappOperations' : IDL.Null,
+    'TreasuryAssetManagement' : IDL.Null,
+    'Governance' : IDL.Null,
+    'SnsFrameworkManagement' : IDL.Null,
+  });
   const GenericNervousSystemFunction = IDL.Record({
+    'topic' : IDL.Opt(Topic),
     'validator_canister_id' : IDL.Opt(IDL.Principal),
     'target_canister_id' : IDL.Opt(IDL.Principal),
     'validator_method_name' : IDL.Opt(IDL.Text),
@@ -604,6 +614,19 @@ export const idlFactory = ({ IDL }) => {
     'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
   });
+  const ListTopicsRequest = IDL.Record({});
+  const TopicInfo = IDL.Record({
+    'native_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
+    'topic' : IDL.Opt(Topic),
+    'is_critical' : IDL.Opt(IDL.Bool),
+    'name' : IDL.Opt(IDL.Text),
+    'description' : IDL.Opt(IDL.Text),
+    'custom_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
+  });
+  const ListTopicsResponse = IDL.Record({
+    'uncategorized_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
+    'topics' : IDL.Opt(IDL.Vec(TopicInfo)),
+  });
   const StakeMaturity = IDL.Record({
     'percentage_to_stake' : IDL.Opt(IDL.Nat32),
   });
@@ -722,6 +745,11 @@ export const idlFactory = ({ IDL }) => {
         [ListProposalsResponse],
         ['query'],
       ),
+    'list_topics' : IDL.Func(
+        [ListTopicsRequest],
+        [ListTopicsResponse],
+        ['query'],
+      ),
     'manage_neuron' : IDL.Func([ManageNeuron], [ManageNeuronResponse], []),
     'reset_timers' : IDL.Func([IDL.Record({})], [IDL.Record({})], []),
     'set_mode' : IDL.Func([SetMode], [IDL.Record({})], []),
@@ -747,7 +775,17 @@ export const init = ({ IDL }) => {
     'response_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'requested_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const Topic = IDL.Variant({
+    'DappCanisterManagement' : IDL.Null,
+    'DaoCommunitySettings' : IDL.Null,
+    'ApplicationBusinessLogic' : IDL.Null,
+    'CriticalDappOperations' : IDL.Null,
+    'TreasuryAssetManagement' : IDL.Null,
+    'Governance' : IDL.Null,
+    'SnsFrameworkManagement' : IDL.Null,
+  });
   const GenericNervousSystemFunction = IDL.Record({
+    'topic' : IDL.Opt(Topic),
     'validator_canister_id' : IDL.Opt(IDL.Principal),
     'target_canister_id' : IDL.Opt(IDL.Principal),
     'validator_method_name' : IDL.Opt(IDL.Text),

--- a/packages/sns/candid/sns_governance_test.certified.idl.js
+++ b/packages/sns/candid/sns_governance_test.certified.idl.js
@@ -19,7 +19,17 @@ export const idlFactory = ({ IDL }) => {
     'response_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'requested_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const Topic = IDL.Variant({
+    'DappCanisterManagement' : IDL.Null,
+    'DaoCommunitySettings' : IDL.Null,
+    'ApplicationBusinessLogic' : IDL.Null,
+    'CriticalDappOperations' : IDL.Null,
+    'TreasuryAssetManagement' : IDL.Null,
+    'Governance' : IDL.Null,
+    'SnsFrameworkManagement' : IDL.Null,
+  });
   const GenericNervousSystemFunction = IDL.Record({
+    'topic' : IDL.Opt(Topic),
     'validator_canister_id' : IDL.Opt(IDL.Principal),
     'target_canister_id' : IDL.Opt(IDL.Principal),
     'validator_method_name' : IDL.Opt(IDL.Text),
@@ -615,6 +625,19 @@ export const idlFactory = ({ IDL }) => {
     'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
   });
+  const ListTopicsRequest = IDL.Record({});
+  const TopicInfo = IDL.Record({
+    'native_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
+    'topic' : IDL.Opt(Topic),
+    'is_critical' : IDL.Opt(IDL.Bool),
+    'name' : IDL.Opt(IDL.Text),
+    'description' : IDL.Opt(IDL.Text),
+    'custom_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
+  });
+  const ListTopicsResponse = IDL.Record({
+    'uncategorized_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
+    'topics' : IDL.Opt(IDL.Vec(TopicInfo)),
+  });
   const StakeMaturity = IDL.Record({
     'percentage_to_stake' : IDL.Opt(IDL.Nat32),
   });
@@ -735,6 +758,7 @@ export const idlFactory = ({ IDL }) => {
       ),
     'list_neurons' : IDL.Func([ListNeurons], [ListNeuronsResponse], []),
     'list_proposals' : IDL.Func([ListProposals], [ListProposalsResponse], []),
+    'list_topics' : IDL.Func([ListTopicsRequest], [ListTopicsResponse], []),
     'manage_neuron' : IDL.Func([ManageNeuron], [ManageNeuronResponse], []),
     'mint_tokens' : IDL.Func([MintTokensRequest], [IDL.Record({})], []),
     'refresh_cached_upgrade_steps' : IDL.Func(
@@ -767,7 +791,17 @@ export const init = ({ IDL }) => {
     'response_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'requested_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const Topic = IDL.Variant({
+    'DappCanisterManagement' : IDL.Null,
+    'DaoCommunitySettings' : IDL.Null,
+    'ApplicationBusinessLogic' : IDL.Null,
+    'CriticalDappOperations' : IDL.Null,
+    'TreasuryAssetManagement' : IDL.Null,
+    'Governance' : IDL.Null,
+    'SnsFrameworkManagement' : IDL.Null,
+  });
   const GenericNervousSystemFunction = IDL.Record({
+    'topic' : IDL.Opt(Topic),
     'validator_canister_id' : IDL.Opt(IDL.Principal),
     'target_canister_id' : IDL.Opt(IDL.Principal),
     'validator_method_name' : IDL.Opt(IDL.Text),

--- a/packages/sns/candid/sns_governance_test.d.ts
+++ b/packages/sns/candid/sns_governance_test.d.ts
@@ -212,6 +212,7 @@ export type FunctionType =
   | { NativeNervousSystemFunction: {} }
   | { GenericNervousSystemFunction: GenericNervousSystemFunction };
 export interface GenericNervousSystemFunction {
+  topic: [] | [Topic];
   validator_canister_id: [] | [Principal];
   target_canister_id: [] | [Principal];
   validator_method_name: [] | [string];
@@ -342,6 +343,11 @@ export interface ListProposals {
 export interface ListProposalsResponse {
   include_ballots_by_caller: [] | [boolean];
   proposals: Array<ProposalData>;
+}
+export type ListTopicsRequest = {};
+export interface ListTopicsResponse {
+  uncategorized_functions: [] | [Array<NervousSystemFunction>];
+  topics: [] | [Array<TopicInfo>];
 }
 export interface ManageDappCanisterSettings {
   freezing_threshold: [] | [bigint];
@@ -632,6 +638,22 @@ export interface Timers {
 export interface Tokens {
   e8s: [] | [bigint];
 }
+export type Topic =
+  | { DappCanisterManagement: null }
+  | { DaoCommunitySettings: null }
+  | { ApplicationBusinessLogic: null }
+  | { CriticalDappOperations: null }
+  | { TreasuryAssetManagement: null }
+  | { Governance: null }
+  | { SnsFrameworkManagement: null };
+export interface TopicInfo {
+  native_functions: [] | [Array<NervousSystemFunction>];
+  topic: [] | [Topic];
+  is_critical: [] | [boolean];
+  name: [] | [string];
+  description: [] | [string];
+  custom_functions: [] | [Array<NervousSystemFunction>];
+}
 export interface TransferSnsTreasuryFunds {
   from_treasury: number;
   to_principal: [] | [Principal];
@@ -763,6 +785,7 @@ export interface _SERVICE {
   >;
   list_neurons: ActorMethod<[ListNeurons], ListNeuronsResponse>;
   list_proposals: ActorMethod<[ListProposals], ListProposalsResponse>;
+  list_topics: ActorMethod<[ListTopicsRequest], ListTopicsResponse>;
   manage_neuron: ActorMethod<[ManageNeuron], ManageNeuronResponse>;
   mint_tokens: ActorMethod<[MintTokensRequest], {}>;
   refresh_cached_upgrade_steps: ActorMethod<[{}], {}>;

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 14c8f44 (2025-02-07 tags: release-2025-02-06_12-26-revert-hashes-in-blocks) 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 2f02a660f6 (2025-02-13 tags: release-2025-02-20_10-16-disable-best-effort-messaging) 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -236,6 +236,7 @@ type GenericNervousSystemFunction = record {
   target_canister_id : opt principal;
   validator_method_name : opt text;
   target_method_name : opt text;
+  topic: opt Topic;
 };
 
 type GetMaturityModulationResponse = record {
@@ -857,6 +858,32 @@ type GetUpgradeJournalResponse = record {
 type AdvanceTargetVersionRequest = record { target_version : opt Version; };
 type AdvanceTargetVersionResponse = record {};
 
+
+type Topic = variant {
+  DaoCommunitySettings;
+  SnsFrameworkManagement;
+  DappCanisterManagement;
+  ApplicationBusinessLogic;
+  Governance;
+  TreasuryAssetManagement;
+  CriticalDappOperations;
+};
+
+type TopicInfo = record {
+  topic : opt Topic;
+  name : opt text;
+  description : opt text;
+  native_functions : opt vec NervousSystemFunction;
+  custom_functions : opt vec NervousSystemFunction;
+  is_critical : opt bool;
+};
+
+type ListTopicsRequest = record {};
+type ListTopicsResponse = record {
+  topics: opt vec TopicInfo;
+  uncategorized_functions: opt vec NervousSystemFunction
+};
+
 service : (Governance) -> {
   add_maturity : (AddMaturityRequest) -> (AddMaturityResponse);
   claim_swap_neurons : (ClaimSwapNeuronsRequest) -> (ClaimSwapNeuronsResponse);
@@ -876,6 +903,7 @@ service : (Governance) -> {
   list_nervous_system_functions : () -> (ListNervousSystemFunctionsResponse) query;
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
   list_proposals : (ListProposals) -> (ListProposalsResponse) query;
+  list_topics : (ListTopicsRequest) -> (ListTopicsResponse) query;
   manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
   mint_tokens : (MintTokensRequest) -> (record {});
   set_mode : (SetMode) -> (record {});

--- a/packages/sns/candid/sns_governance_test.idl.js
+++ b/packages/sns/candid/sns_governance_test.idl.js
@@ -19,7 +19,17 @@ export const idlFactory = ({ IDL }) => {
     'response_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'requested_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const Topic = IDL.Variant({
+    'DappCanisterManagement' : IDL.Null,
+    'DaoCommunitySettings' : IDL.Null,
+    'ApplicationBusinessLogic' : IDL.Null,
+    'CriticalDappOperations' : IDL.Null,
+    'TreasuryAssetManagement' : IDL.Null,
+    'Governance' : IDL.Null,
+    'SnsFrameworkManagement' : IDL.Null,
+  });
   const GenericNervousSystemFunction = IDL.Record({
+    'topic' : IDL.Opt(Topic),
     'validator_canister_id' : IDL.Opt(IDL.Principal),
     'target_canister_id' : IDL.Opt(IDL.Principal),
     'validator_method_name' : IDL.Opt(IDL.Text),
@@ -615,6 +625,19 @@ export const idlFactory = ({ IDL }) => {
     'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
   });
+  const ListTopicsRequest = IDL.Record({});
+  const TopicInfo = IDL.Record({
+    'native_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
+    'topic' : IDL.Opt(Topic),
+    'is_critical' : IDL.Opt(IDL.Bool),
+    'name' : IDL.Opt(IDL.Text),
+    'description' : IDL.Opt(IDL.Text),
+    'custom_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
+  });
+  const ListTopicsResponse = IDL.Record({
+    'uncategorized_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
+    'topics' : IDL.Opt(IDL.Vec(TopicInfo)),
+  });
   const StakeMaturity = IDL.Record({
     'percentage_to_stake' : IDL.Opt(IDL.Nat32),
   });
@@ -743,6 +766,11 @@ export const idlFactory = ({ IDL }) => {
         [ListProposalsResponse],
         ['query'],
       ),
+    'list_topics' : IDL.Func(
+        [ListTopicsRequest],
+        [ListTopicsResponse],
+        ['query'],
+      ),
     'manage_neuron' : IDL.Func([ManageNeuron], [ManageNeuronResponse], []),
     'mint_tokens' : IDL.Func([MintTokensRequest], [IDL.Record({})], []),
     'refresh_cached_upgrade_steps' : IDL.Func(
@@ -775,7 +803,17 @@ export const init = ({ IDL }) => {
     'response_timestamp_seconds' : IDL.Opt(IDL.Nat64),
     'requested_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
+  const Topic = IDL.Variant({
+    'DappCanisterManagement' : IDL.Null,
+    'DaoCommunitySettings' : IDL.Null,
+    'ApplicationBusinessLogic' : IDL.Null,
+    'CriticalDappOperations' : IDL.Null,
+    'TreasuryAssetManagement' : IDL.Null,
+    'Governance' : IDL.Null,
+    'SnsFrameworkManagement' : IDL.Null,
+  });
   const GenericNervousSystemFunction = IDL.Record({
+    'topic' : IDL.Opt(Topic),
     'validator_canister_id' : IDL.Opt(IDL.Principal),
     'target_canister_id' : IDL.Opt(IDL.Principal),
     'validator_method_name' : IDL.Opt(IDL.Text),

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 14c8f44 (2025-02-07 tags: release-2025-02-06_12-26-revert-hashes-in-blocks) 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit 2f02a660f6 (2025-02-13 tags: release-2025-02-20_10-16-disable-best-effort-messaging) 'rs/sns/root/canister/root.did' by import-candid
 type CanisterCallError = record {
   code : opt int32;
   description : text;

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 14c8f44 (2025-02-07 tags: release-2025-02-06_12-26-revert-hashes-in-blocks) 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 2f02a660f6 (2025-02-13 tags: release-2025-02-20_10-16-disable-best-effort-messaging) 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;

--- a/packages/sns/src/converters/governance.converters.spec.ts
+++ b/packages/sns/src/converters/governance.converters.spec.ts
@@ -116,6 +116,7 @@ describe("governance converters", () => {
       const target_canister_id = Principal.fromHex("AB");
       const validator_method_name = "validator_method_name";
       const target_method_name = "target_method_name";
+
       const action: ActionCandid = {
         AddGenericNervousSystemFunction: {
           id,
@@ -128,6 +129,7 @@ describe("governance converters", () => {
                 target_canister_id: [target_canister_id],
                 validator_method_name: [validator_method_name],
                 target_method_name: [target_method_name],
+                topic: [],
               },
             },
           ],

--- a/packages/sns/src/converters/governance.converters.spec.ts
+++ b/packages/sns/src/converters/governance.converters.spec.ts
@@ -2,7 +2,9 @@ import { Principal } from "@dfinity/principal";
 import type {
   Action as ActionCandid,
   DefaultFollowees,
+  Topic,
 } from "../../candid/sns_governance";
+import { topicMock } from "../mocks/governance.mock";
 import type { Action } from "../types/actions";
 import { fromCandidAction } from "./governance.converters";
 
@@ -116,6 +118,7 @@ describe("governance converters", () => {
       const target_canister_id = Principal.fromHex("AB");
       const validator_method_name = "validator_method_name";
       const target_method_name = "target_method_name";
+      const topic: Topic = topicMock;
 
       const action: ActionCandid = {
         AddGenericNervousSystemFunction: {
@@ -129,7 +132,7 @@ describe("governance converters", () => {
                 target_canister_id: [target_canister_id],
                 validator_method_name: [validator_method_name],
                 target_method_name: [target_method_name],
-                topic: [],
+                topic: [topic],
               },
             },
           ],
@@ -146,6 +149,7 @@ describe("governance converters", () => {
               target_canister_id,
               validator_method_name,
               target_method_name,
+              topic,
             },
           },
         },

--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -432,6 +432,7 @@ const convertGenericNervousSystemFunction = (
   target_canister_id: fromNullable(params.target_canister_id),
   validator_method_name: fromNullable(params.validator_method_name),
   target_method_name: fromNullable(params.target_method_name),
+  topic: fromNullable(params.topic),
 });
 
 const convertFunctionType = (

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -36,6 +36,7 @@ import {
   proposalIdMock,
   proposalMock,
   proposalsMock,
+  topicsMock,
 } from "./mocks/governance.mock";
 import { rootCanisterIdMock } from "./mocks/sns.mock";
 import type {
@@ -228,6 +229,25 @@ describe("Governance canister", () => {
 
       const call = () => canister.listProposals({});
       expect(call).rejects.toThrowError("error");
+    });
+  });
+
+  describe("listTopics", () => {
+    it("should return the list of topics", async () => {
+      const service = mock<ActorSubclass<SnsGovernanceService>>();
+      const mockListProposals = service.list_topics.mockResolvedValue({
+        topics: [topicsMock],
+        uncategorized_functions: [],
+      });
+
+      const canister = SnsGovernanceCanister.create({
+        canisterId: rootCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+
+      const { topics: expectedTopics } = await canister.listTopics({});
+      expect(mockListProposals).toBeCalled();
+      expect(expectedTopics).toEqual([topicsMock]);
     });
   });
 

--- a/packages/sns/src/governance.canister.ts
+++ b/packages/sns/src/governance.canister.ts
@@ -11,6 +11,7 @@ import type {
   GetMetadataResponse,
   ListNervousSystemFunctionsResponse,
   ListProposalsResponse,
+  ListTopicsResponse,
   ManageNeuron,
   ManageNeuronResponse,
   NervousSystemParameters,
@@ -50,6 +51,7 @@ import type {
   SnsIncreaseDissolveDelayParams,
   SnsListNeuronsParams,
   SnsListProposalsParams,
+  SnsListTopicsParams,
   SnsNeuronAutoStakeMaturityParams,
   SnsNeuronDisburseMaturityParams,
   SnsNeuronPermissionsParams,
@@ -102,6 +104,18 @@ export class SnsGovernanceCanister extends Canister<SnsGovernanceService> {
     const response = await this.caller({ certified }).list_proposals(
       toListProposalRequest(params),
     );
+    return response;
+  };
+
+  /**
+   *
+   * List the topics of the Sns
+   */
+  listTopics = async (
+    params: SnsListTopicsParams,
+  ): Promise<ListTopicsResponse> => {
+    const { certified } = params;
+    const response = await this.caller({ certified }).list_topics({});
     return response;
   };
 

--- a/packages/sns/src/mocks/governance.mock.ts
+++ b/packages/sns/src/mocks/governance.mock.ts
@@ -4,6 +4,8 @@ import type {
   Neuron,
   NeuronId,
   ProposalData,
+  Topic,
+  TopicInfo,
 } from "../../candid/sns_governance";
 
 export const neuronIdMock: NeuronId = { id: arrayOfNumberToUint8Array([1]) };
@@ -28,3 +30,18 @@ export const proposalMock = {
 } as ProposalData;
 
 export const proposalsMock: ProposalData[] = [proposalMock];
+
+export const topicMock: Topic = {
+  ApplicationBusinessLogic: null,
+};
+
+export const topicInfoMock: TopicInfo = {
+  custom_functions: [],
+  description: ["Description"],
+  is_critical: [false],
+  name: ["Name"],
+  native_functions: [],
+  topic: [topicMock],
+};
+
+export const topicsMock: TopicInfo[] = [topicInfoMock];

--- a/packages/sns/src/types/actions.ts
+++ b/packages/sns/src/types/actions.ts
@@ -7,6 +7,7 @@ import type {
   NeuronPermissionList,
   RegisterDappCanisters,
   Subaccount,
+  Topic,
 } from "../../candid/sns_governance";
 import type { Option } from "./common";
 
@@ -74,6 +75,7 @@ export interface GenericNervousSystemFunction {
   target_canister_id: Option<Principal>;
   validator_method_name: Option<string>;
   target_method_name: Option<string>;
+  topic: Option<Topic>;
 }
 
 export interface TransferSnsTreasuryFunds {

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -52,6 +52,8 @@ export interface SnsListProposalsParams extends QueryParams {
   includeStatus?: SnsProposalDecisionStatus[];
 }
 
+export interface SnsListTopicsParams extends QueryParams {}
+
 /**
  * The parameters to get an sns proposal
  */


### PR DESCRIPTION
# Motivation

#846 is blocked due to a new field, `topic`, expected by `convertGenericNervousSystemFunction`. 

This PR adds this new field and also exposes a new function, `list_topics`, to retrieve a list of all topics.

# Changes

- Checkout ic at `2f02a660f6`
- Ran `./scripts/import-candid ../ic` from ic-js root folder 
- Ran `./scripts/compile-idl-js` from ic-js root folder 
- Revert changes not related to the `sns` package
- Exposed `list_topics` 
- Updated expectations for tests based on the new API
- Increased the size of the `sns` package.

# Tests

- Added new test for the new function `list_topics`

# Todos

- [ ] Add entry to changelog (if necessary).
