### PR TITLE
feat: add utility isValidDate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Support `topic` and `list_topics` in `@dfinity/sns`.
 - Add utility `toBigIntNanoSeconds` to convert `Date` object to timestamp in nanoseconds `bigint`.
+- Add utility `isValidDate` to assert a given given value is a valid `Date` object.
 
 # 2025.02.19-1030Z
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -60,6 +60,7 @@ npm i @dfinity/agent @dfinity/candid @dfinity/principal
 - [secondsToDuration](#gear-secondstoduration)
 - [nowInBigIntNanoSeconds](#gear-nowinbigintnanoseconds)
 - [toBigIntNanoSeconds](#gear-tobigintnanoseconds)
+- [isValidDate](#gear-isvaliddate)
 - [debounce](#gear-debounce)
 - [toNullable](#gear-tonullable)
 - [fromNullable](#gear-fromnullable)
@@ -385,6 +386,23 @@ Parameters:
 - `date`: - The `Date` object to convert.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/date.utils.ts#L126)
+
+#### :gear: isValidDate
+
+Checks if the given value is a valid Date object.
+
+A valid Date must be an instance of `Date` and must not be `NaN`
+(e.g., `new Date('invalid')` is an invalid Date).
+
+| Function      | Type                                |
+| ------------- | ----------------------------------- |
+| `isValidDate` | `(value: unknown) => value is Date` |
+
+Parameters:
+
+- `value`: - The potential date to check.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/date.utils.ts#L138)
 
 #### :gear: debounce
 

--- a/packages/utils/src/utils/date.utils.spec.ts
+++ b/packages/utils/src/utils/date.utils.spec.ts
@@ -1,7 +1,7 @@
 import { Principal } from "@dfinity/principal";
 import { describe } from "@jest/globals";
+import type { I18nSecondsToDuration } from "./date.utils";
 import {
-  I18nSecondsToDuration,
   isValidDate,
   nowInBigIntNanoSeconds,
   secondsToDuration,

--- a/packages/utils/src/utils/date.utils.spec.ts
+++ b/packages/utils/src/utils/date.utils.spec.ts
@@ -1,6 +1,8 @@
+import { Principal } from "@dfinity/principal";
 import { describe } from "@jest/globals";
-import type { I18nSecondsToDuration } from "./date.utils";
 import {
+  I18nSecondsToDuration,
+  isValidDate,
   nowInBigIntNanoSeconds,
   secondsToDuration,
   toBigIntNanoSeconds,
@@ -277,6 +279,35 @@ describe("date.utils", () => {
       const date = new Date();
       const result = toBigIntNanoSeconds(date);
       expect(typeof result).toBe("bigint");
+    });
+  });
+
+  describe("isValidDate", () => {
+    it("returns true for a valid Date object", () => {
+      expect(isValidDate(new Date())).toBe(true);
+      expect(isValidDate(new Date(2024, 1, 26))).toBe(true);
+      expect(isValidDate(new Date(Date.now()))).toBe(true);
+    });
+
+    it("returns false for an invalid Date object", () => {
+      expect(isValidDate(new Date("invalid"))).toBe(false);
+      expect(isValidDate(new Date(NaN))).toBe(false);
+    });
+
+    it("returns false for non-Date values", () => {
+      expect(isValidDate("2024-02-26")).toBe(false);
+      expect(isValidDate(Date.now())).toBe(false);
+      expect(isValidDate(123)).toBe(false);
+      expect(isValidDate(null)).toBe(false);
+      expect(isValidDate(undefined)).toBe(false);
+      expect(isValidDate({})).toBe(false);
+      expect(isValidDate([])).toBe(false);
+      expect(isValidDate(Symbol())).toBe(false);
+      expect(isValidDate(Principal.anonymous())).toBe(false);
+    });
+
+    it("returns false for objects with a Date-like structure", () => {
+      expect(isValidDate({ getTime: () => Date.now() })).toBe(false);
     });
   });
 });

--- a/packages/utils/src/utils/date.utils.ts
+++ b/packages/utils/src/utils/date.utils.ts
@@ -125,3 +125,15 @@ export const nowInBigIntNanoSeconds = (): bigint =>
  */
 export const toBigIntNanoSeconds = (date: Date): bigint =>
   BigInt(date.getTime()) * NANOSECONDS_PER_MILLISECOND;
+
+/**
+ * Checks if the given value is a valid Date object.
+ *
+ * A valid Date must be an instance of `Date` and must not be `NaN`
+ * (e.g., `new Date('invalid')` is an invalid Date).
+ *
+ * @param {unknown} value - The potential date to check.
+ * @returns {value is Date} `true` if the value is a valid Date object, otherwise `false`.
+ */
+export const isValidDate = (value: unknown): value is Date =>
+  value instanceof Date && !isNaN(value.getTime());


### PR DESCRIPTION
# Motivation

To extend the JSON reviver and replacer to supports dates, we will need to detect if potential object is effectively a date object or something else. This PR provides a utility to do so.

# Changes

- Add utility `isValidDate`
