### PR TITLE
docs: fix next version changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next version
+
+## Features
+
+- Add utility `toBigIntNanoSeconds` to convert `Date` object to timestamp in nanoseconds `bigint`.
+
 # 2025.02.21-1530Z
 
 ## Overview
@@ -19,7 +25,6 @@
 ## Features
 
 - Support `topic` and `list_topics` in `@dfinity/sns`.
-- Add utility `toBigIntNanoSeconds` to convert `Date` object to timestamp in nanoseconds `bigint`.
 
 # 2025.02.19-1030Z
 


### PR DESCRIPTION
# Motivation

I incorrectly added my entry to the CHANGELOG today in already released release instead of opening a new section for the "next version".
