### PR TITLE
Update sns candid files

### DIFF
--- a/packages/sns/candid/sns_governance.certified.idl.js
+++ b/packages/sns/candid/sns_governance.certified.idl.js
@@ -244,6 +244,9 @@ export const idlFactory = ({ IDL }) => {
     'memory_allocation' : IDL.Opt(IDL.Nat64),
     'compute_allocation' : IDL.Opt(IDL.Nat64),
   });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -301,6 +304,7 @@ export const idlFactory = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
+    'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
@@ -988,6 +992,9 @@ export const init = ({ IDL }) => {
     'memory_allocation' : IDL.Opt(IDL.Nat64),
     'compute_allocation' : IDL.Opt(IDL.Nat64),
   });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -1045,6 +1052,7 @@ export const init = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
+    'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -13,6 +13,7 @@ export type Action =
   | { AddGenericNervousSystemFunction: NervousSystemFunction }
   | { ManageDappCanisterSettings: ManageDappCanisterSettings }
   | { RemoveGenericNervousSystemFunction: bigint }
+  | { SetTopicsForCustomProposals: SetTopicsForCustomProposals }
   | { UpgradeSnsToNextVersion: {} }
   | { RegisterDappCanisters: RegisterDappCanisters }
   | { TransferSnsTreasuryFunds: TransferSnsTreasuryFunds }
@@ -569,6 +570,9 @@ export interface SetDissolveTimestamp {
 }
 export interface SetMode {
   mode: number;
+}
+export interface SetTopicsForCustomProposals {
+  custom_function_id_to_topic: Array<[bigint, Topic]>;
 }
 export interface SnsVersion {
   archive_wasm_hash: [] | [Uint8Array | number[]];

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 2f02a66 (2025-02-13 tags: release-2025-02-20_10-16-disable-best-effort-messaging) 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 9769228872 (2025-02-13 tags: release-2025-03-06_03-10-disable-best-effort-messaging) 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -7,6 +7,7 @@ type Account = record {
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
   AddGenericNervousSystemFunction : NervousSystemFunction;
+  SetTopicsForCustomProposals : SetTopicsForCustomProposals;
   ManageDappCanisterSettings : ManageDappCanisterSettings;
   RemoveGenericNervousSystemFunction : nat64;
   UpgradeSnsToNextVersion : record {};
@@ -393,6 +394,10 @@ type SnsVersion = record {
 
 type AdvanceSnsTargetVersion = record {
   new_target : opt SnsVersion;
+};
+
+type SetTopicsForCustomProposals = record {
+  custom_function_id_to_topic : vec record { nat64; Topic };
 };
 
 type ManageLedgerParameters = record {

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -244,6 +244,9 @@ export const idlFactory = ({ IDL }) => {
     'memory_allocation' : IDL.Opt(IDL.Nat64),
     'compute_allocation' : IDL.Opt(IDL.Nat64),
   });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -301,6 +304,7 @@ export const idlFactory = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
+    'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
@@ -1000,6 +1004,9 @@ export const init = ({ IDL }) => {
     'memory_allocation' : IDL.Opt(IDL.Nat64),
     'compute_allocation' : IDL.Opt(IDL.Nat64),
   });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -1057,6 +1064,7 @@ export const init = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
+    'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,

--- a/packages/sns/candid/sns_governance_test.certified.idl.js
+++ b/packages/sns/candid/sns_governance_test.certified.idl.js
@@ -244,6 +244,9 @@ export const idlFactory = ({ IDL }) => {
     'memory_allocation' : IDL.Opt(IDL.Nat64),
     'compute_allocation' : IDL.Opt(IDL.Nat64),
   });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -301,6 +304,7 @@ export const idlFactory = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
+    'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
@@ -1016,6 +1020,9 @@ export const init = ({ IDL }) => {
     'memory_allocation' : IDL.Opt(IDL.Nat64),
     'compute_allocation' : IDL.Opt(IDL.Nat64),
   });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -1073,6 +1080,7 @@ export const init = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
+    'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,

--- a/packages/sns/candid/sns_governance_test.d.ts
+++ b/packages/sns/candid/sns_governance_test.d.ts
@@ -13,6 +13,7 @@ export type Action =
   | { AddGenericNervousSystemFunction: NervousSystemFunction }
   | { ManageDappCanisterSettings: ManageDappCanisterSettings }
   | { RemoveGenericNervousSystemFunction: bigint }
+  | { SetTopicsForCustomProposals: SetTopicsForCustomProposals }
   | { UpgradeSnsToNextVersion: {} }
   | { RegisterDappCanisters: RegisterDappCanisters }
   | { TransferSnsTreasuryFunds: TransferSnsTreasuryFunds }
@@ -584,6 +585,9 @@ export interface SetDissolveTimestamp {
 }
 export interface SetMode {
   mode: number;
+}
+export interface SetTopicsForCustomProposals {
+  custom_function_id_to_topic: Array<[bigint, Topic]>;
 }
 export interface SnsVersion {
   archive_wasm_hash: [] | [Uint8Array | number[]];

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 2f02a66 (2025-02-13 tags: release-2025-02-20_10-16-disable-best-effort-messaging) 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 9769228872 (2025-02-13 tags: release-2025-03-06_03-10-disable-best-effort-messaging) 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -7,6 +7,7 @@ type Account = record {
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
   AddGenericNervousSystemFunction : NervousSystemFunction;
+  SetTopicsForCustomProposals : SetTopicsForCustomProposals;
   ManageDappCanisterSettings : ManageDappCanisterSettings;
   RemoveGenericNervousSystemFunction : nat64;
   UpgradeSnsToNextVersion : record {};
@@ -402,6 +403,10 @@ type SnsVersion = record {
 
 type AdvanceSnsTargetVersion = record {
   new_target : opt SnsVersion;
+};
+
+type SetTopicsForCustomProposals = record {
+  custom_function_id_to_topic : vec record { nat64; Topic };
 };
 
 type ManageLedgerParameters = record {

--- a/packages/sns/candid/sns_governance_test.idl.js
+++ b/packages/sns/candid/sns_governance_test.idl.js
@@ -244,6 +244,9 @@ export const idlFactory = ({ IDL }) => {
     'memory_allocation' : IDL.Opt(IDL.Nat64),
     'compute_allocation' : IDL.Opt(IDL.Nat64),
   });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -301,6 +304,7 @@ export const idlFactory = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
+    'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,
@@ -1028,6 +1032,9 @@ export const init = ({ IDL }) => {
     'memory_allocation' : IDL.Opt(IDL.Nat64),
     'compute_allocation' : IDL.Opt(IDL.Nat64),
   });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
+  });
   const RegisterDappCanisters = IDL.Record({
     'canister_ids' : IDL.Vec(IDL.Principal),
   });
@@ -1085,6 +1092,7 @@ export const init = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
+    'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'UpgradeSnsToNextVersion' : IDL.Record({}),
     'RegisterDappCanisters' : RegisterDappCanisters,
     'TransferSnsTreasuryFunds' : TransferSnsTreasuryFunds,

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 2f02a66 (2025-02-13 tags: release-2025-02-20_10-16-disable-best-effort-messaging) 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit 9769228872 (2025-02-13 tags: release-2025-03-06_03-10-disable-best-effort-messaging) 'rs/sns/root/canister/root.did' by import-candid
 type CanisterCallError = record {
   code : opt int32;
   description : text;

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 2f02a66 (2025-02-13 tags: release-2025-02-20_10-16-disable-best-effort-messaging) 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 9769228872 (2025-02-13 tags: release-2025-03-06_03-10-disable-best-effort-messaging) 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;

--- a/packages/sns/src/converters/governance.converters.spec.ts
+++ b/packages/sns/src/converters/governance.converters.spec.ts
@@ -157,6 +157,15 @@ describe("governance converters", () => {
       expect(fromCandidAction(action)).toEqual(expectedAction);
     });
 
+    it("converts SetTopicsForCustomProposals action", () => {
+      const action: ActionCandid = {
+        SetTopicsForCustomProposals: {
+          custom_function_id_to_topic: [[BigInt(3), topicMock]],
+        },
+      };
+      expect(fromCandidAction(action)).toEqual(action);
+    });
+
     it("converts RemoveGenericNervousSystemFunction action", () => {
       const action: ActionCandid = {
         RemoveGenericNervousSystemFunction: BigInt(3),

--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -322,6 +322,12 @@ export const fromCandidAction = (action: ActionCandid): Action => {
     };
   }
 
+  if ("SetTopicsForCustomProposals" in action) {
+    return {
+      SetTopicsForCustomProposals: action.SetTopicsForCustomProposals,
+    };
+  }
+
   if ("RemoveGenericNervousSystemFunction" in action) {
     return {
       RemoveGenericNervousSystemFunction:
@@ -378,6 +384,7 @@ export const fromCandidAction = (action: ActionCandid): Action => {
     return { Motion: action.Motion };
   }
 
+  // TODO: Find a better way to log this because JSON.stringify doesn't support BigInt.
   throw new Error(`Unknown action type ${JSON.stringify(action)}`);
 };
 

--- a/packages/sns/src/types/actions.ts
+++ b/packages/sns/src/types/actions.ts
@@ -16,6 +16,7 @@ export type Action =
       ManageNervousSystemParameters: NervousSystemParameters;
     }
   | { AddGenericNervousSystemFunction: NervousSystemFunction }
+  | { SetTopicsForCustomProposals: SetTopicsForCustomProposals }
   | { RemoveGenericNervousSystemFunction: bigint }
   | { UpgradeSnsToNextVersion: Record<string, never> }
   | { RegisterDappCanisters: RegisterDappCanisters }
@@ -64,6 +65,10 @@ export interface NervousSystemFunction {
   name: string;
   description: Option<string>;
   function_type: Option<FunctionType>;
+}
+
+export interface SetTopicsForCustomProposals {
+  custom_function_id_to_topic: Array<[bigint, Topic]>;
 }
 
 export type FunctionType =


### PR DESCRIPTION
# Motivation

The SNS Candid types need to be updated to support `SetTopicsForCustomProposals`. One SNS has already created a proposal of this type, causing the proposals page for this SNS to break in NNS-dapp. To fix this issue and minimize risks, we are updating only the SNS-related types.

# Changes

1. Checkout ic repo to commit 9769228 (from https://github.com/dfinity/ic-js/pull/855/files#diff-3c03137e7f91cc4a673bcd7bec8c3eb37899014f3ba207b135d1c4809d57b892R1)
2. Run `./scripts/import-candid ic`
3. Revert not “sns” folders

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
