### PR TITLE
feat: add util to check if a string is a valid account identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Next version
+
+## Features
+
+- Add utility `isIcpAccountIdentifier` to check if a string is a valid ICP account identifier.
+
+
 # 2025.03.10-1330Z
 
 ## Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Add utility `isIcpAccountIdentifier` to check if a string is a valid ICP account identifier.
 
-
 # 2025.03.10-1330Z
 
 ## Overview

--- a/packages/ledger-icp/src/utils/accounts.utils.spec.ts
+++ b/packages/ledger-icp/src/utils/accounts.utils.spec.ts
@@ -21,7 +21,11 @@ describe("accounts-utils", () => {
     });
 
     it("should return true if valid account id", () => {
-      expect(isIcpAccountIdentifier("cd70bfa0f092c38a0ff8643d4617219761eb61d199b15418c0b1114d59e30f8e")).toBe(true);
+      expect(
+        isIcpAccountIdentifier(
+          "cd70bfa0f092c38a0ff8643d4617219761eb61d199b15418c0b1114d59e30f8e",
+        ),
+      ).toBe(true);
     });
 
     it("should return false if not valid account id", () => {

--- a/packages/ledger-icp/src/utils/accounts.utils.spec.ts
+++ b/packages/ledger-icp/src/utils/accounts.utils.spec.ts
@@ -1,5 +1,5 @@
 import { InvalidAccountIDError } from "../errors/ledger.errors";
-import { checkAccountId } from "./accounts.utils";
+import { checkAccountId, isIcpAccountIdentifier } from "./accounts.utils";
 
 describe("accounts-utils", () => {
   describe("checkAccountId", () => {
@@ -12,6 +12,20 @@ describe("accounts-utils", () => {
     it("should throw if not valid account id", () => {
       const call1 = () => checkAccountId("not-valid");
       expect(call1).toThrow(InvalidAccountIDError);
+    });
+  });
+
+  describe("isIcpAccountIdentifier", () => {
+    it("should return false if input is undefined", () => {
+      expect(isIcpAccountIdentifier(undefined)).toBe(false);
+    });
+
+    it("should return true if valid account id", () => {
+      expect(isIcpAccountIdentifier("cd70bfa0f092c38a0ff8643d4617219761eb61d199b15418c0b1114d59e30f8e")).toBe(true);
+    });
+
+    it("should return false if not valid account id", () => {
+      expect(isIcpAccountIdentifier("not-valid")).toBe(false);
     });
   });
 });

--- a/packages/ledger-icp/src/utils/accounts.utils.ts
+++ b/packages/ledger-icp/src/utils/accounts.utils.ts
@@ -1,4 +1,4 @@
-import { bigEndianCrc32 } from "@dfinity/utils";
+import { bigEndianCrc32, isNullish } from "@dfinity/utils";
 import { InvalidAccountIDError } from "../errors/ledger.errors";
 
 /**
@@ -24,4 +24,29 @@ export const checkAccountId = (accountId: string): void => {
       )}\nFound checksum: ${foundChecksum.toString("hex")}`,
     );
   }
+};
+
+/**
+ * Checks if a given string (or undefined) is a valid ICP account identifier.
+ *
+ * It uses the `checkAccountId` function to validate the checksum, but it does not throw an error.
+ *
+ * @param {string | undefined} address The putative ICP account identifier.
+ */
+
+export const isIcpAccountIdentifier = (
+  address: string | undefined,
+): boolean => {
+  if (isNullish(address)) {
+    return false;
+  }
+
+  try {
+    checkAccountId(address);
+    return true;
+  } catch (_: unknown) {
+    // We do not parse the error
+  }
+
+  return false;
 };


### PR DESCRIPTION
# Motivation

It may be useful to have a specific function that checks if a string is a valid ICP account identifier, without throwing an error. We [use it in OISY](https://github.com/dfinity/oisy-wallet/blob/3264177e8f3bac3a13ac112b10f24cc565a5d1eb/src/frontend/src/lib/utils/account.utils.ts#L5) already.

# Changes

- Add function that uses `checkAccountId` but does not throw an error.

# Tests

Added specific tests.

# Todos

- [x] Add entry to changelog (if necessary).
