### PR TITLE
chore: bump tsdoc-markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "text-encoding": "^0.7.0",
         "ts-jest": "^29.2.5",
         "ts-protoc-gen": "^0.15.0",
-        "tsdoc-markdown": "^1.1.1",
+        "tsdoc-markdown": "^1.2.0",
         "typescript": "^5.4.4"
       }
     },
@@ -7220,9 +7220,9 @@
       }
     },
     "node_modules/tsdoc-markdown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.1.1.tgz",
-      "integrity": "sha512-Ntww+xHtV/DjHVLWohV3ZX01z09v+12jLYS3CqJXCr2mHc1Jz6WSG8dnNj/zk/7xp8yNKJRoWtxvv4WWaNsMEA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.2.0.tgz",
+      "integrity": "sha512-EqOtzSzWMKyDXJFuiCBCkAulpspb9goZ+IsqrQeDwlGDmetU4PhEQIXPDQdIGaeMnty0lBa5xaht8nOdL16HEg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -12752,9 +12752,9 @@
       }
     },
     "tsdoc-markdown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.1.1.tgz",
-      "integrity": "sha512-Ntww+xHtV/DjHVLWohV3ZX01z09v+12jLYS3CqJXCr2mHc1Jz6WSG8dnNj/zk/7xp8yNKJRoWtxvv4WWaNsMEA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.2.0.tgz",
+      "integrity": "sha512-EqOtzSzWMKyDXJFuiCBCkAulpspb9goZ+IsqrQeDwlGDmetU4PhEQIXPDQdIGaeMnty0lBa5xaht8nOdL16HEg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "text-encoding": "^0.7.0",
     "ts-jest": "^29.2.5",
     "ts-protoc-gen": "^0.15.0",
-    "tsdoc-markdown": "^1.1.1",
+    "tsdoc-markdown": "^1.2.0",
     "typescript": "^5.4.4"
   },
   "size-limit": [

--- a/packages/ckbtc/README.md
+++ b/packages/ckbtc/README.md
@@ -78,9 +78,20 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L42)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
+
+##### :gear: create
+
+| Method   | Type                                                               |
+| -------- | ------------------------------------------------------------------ |
+| `create` | `(options: CkBTCCanisterOptions<_SERVICE>) => CkBTCMinterCanister` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L43)
+
+#### Methods
+
 - [getBtcAddress](#gear-getbtcaddress)
 - [updateBalance](#gear-updatebalance)
 - [getWithdrawalAccount](#gear-getwithdrawalaccount)
@@ -91,14 +102,6 @@ Parameters:
 - [estimateWithdrawalFee](#gear-estimatewithdrawalfee)
 - [getMinterInfo](#gear-getminterinfo)
 - [getKnownUtxos](#gear-getknownutxos)
-
-##### :gear: create
-
-| Method   | Type                                                               |
-| -------- | ------------------------------------------------------------------ |
-| `create` | `(options: CkBTCCanisterOptions<_SERVICE>) => CkBTCMinterCanister` |
-
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/minter.canister.ts#L43)
 
 ##### :gear: getBtcAddress
 
@@ -278,11 +281,9 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/bitcoin.canister.ts#L17)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
-- [getUtxosQuery](#gear-getutxosquery)
-- [getBalanceQuery](#gear-getbalancequery)
 
 ##### :gear: create
 
@@ -291,6 +292,11 @@ Parameters:
 | `create` | `(options: CkBTCCanisterOptions<_SERVICE>) => BitcoinCanister` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ckbtc/src/bitcoin.canister.ts#L18)
+
+#### Methods
+
+- [getUtxosQuery](#gear-getutxosquery)
+- [getBalanceQuery](#gear-getbalancequery)
 
 ##### :gear: getUtxosQuery
 

--- a/packages/cketh/README.md
+++ b/packages/cketh/README.md
@@ -55,15 +55,9 @@ const address = await getSmartContractAddress({});
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L29)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
-- [getSmartContractAddress](#gear-getsmartcontractaddress)
-- [withdrawEth](#gear-withdraweth)
-- [withdrawErc20](#gear-withdrawerc20)
-- [eip1559TransactionPrice](#gear-eip1559transactionprice)
-- [retrieveEthStatus](#gear-retrieveethstatus)
-- [getMinterInfo](#gear-getminterinfo)
 
 ##### :gear: create
 
@@ -72,6 +66,15 @@ const address = await getSmartContractAddress({});
 | `create` | `(options: CkETHMinterCanisterOptions<_SERVICE>) => CkETHMinterCanister` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/minter.canister.ts#L30)
+
+#### Methods
+
+- [getSmartContractAddress](#gear-getsmartcontractaddress)
+- [withdrawEth](#gear-withdraweth)
+- [withdrawErc20](#gear-withdrawerc20)
+- [eip1559TransactionPrice](#gear-eip1559transactionprice)
+- [retrieveEthStatus](#gear-retrieveethstatus)
+- [getMinterInfo](#gear-getminterinfo)
 
 ##### :gear: getSmartContractAddress
 
@@ -180,10 +183,9 @@ Class representing the CkETH Orchestrator Canister, which manages the Ledger and
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/orchestrator.canister.ts#L15)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
-- [getOrchestratorInfo](#gear-getorchestratorinfo)
 
 ##### :gear: create
 
@@ -198,6 +200,10 @@ Parameters:
 - `options`: - Options for creating the canister.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/orchestrator.canister.ts#L21)
+
+#### Methods
+
+- [getOrchestratorInfo](#gear-getorchestratorinfo)
 
 ##### :gear: getOrchestratorInfo
 

--- a/packages/cmc/README.md
+++ b/packages/cmc/README.md
@@ -57,14 +57,9 @@ const rate = await getIcpToCyclesConversionRate();
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L15)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
-- [getIcpToCyclesConversionRate](#gear-geticptocyclesconversionrate)
-- [notifyCreateCanister](#gear-notifycreatecanister)
-- [notifyTopUp](#gear-notifytopup)
-- [getDefaultSubnets](#gear-getdefaultsubnets)
-- [getSubnetTypesToSubnets](#gear-getsubnettypestosubnets)
 
 ##### :gear: create
 
@@ -73,6 +68,14 @@ const rate = await getIcpToCyclesConversionRate();
 | `create` | `(options: CMCCanisterOptions) => CMCCanister` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cmc/src/cmc.canister.ts#L16)
+
+#### Methods
+
+- [getIcpToCyclesConversionRate](#gear-geticptocyclesconversionrate)
+- [notifyCreateCanister](#gear-notifycreatecanister)
+- [notifyTopUp](#gear-notifytopup)
+- [getDefaultSubnets](#gear-getdefaultsubnets)
+- [getSubnetTypesToSubnets](#gear-getsubnettypestosubnets)
 
 ##### :gear: getIcpToCyclesConversionRate
 

--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -56,9 +56,20 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L38)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
+
+##### :gear: create
+
+| Method   | Type                                                             |
+| -------- | ---------------------------------------------------------------- |
+| `create` | `(options: ICManagementCanisterOptions) => ICManagementCanister` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L43)
+
+#### Methods
+
 - [createCanister](#gear-createcanister)
 - [updateSettings](#gear-updatesettings)
 - [installCode](#gear-installcode)
@@ -77,14 +88,6 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 - [listCanisterSnapshots](#gear-listcanistersnapshots)
 - [loadCanisterSnapshot](#gear-loadcanistersnapshot)
 - [deleteCanisterSnapshot](#gear-deletecanistersnapshot)
-
-##### :gear: create
-
-| Method   | Type                                                             |
-| -------- | ---------------------------------------------------------------- |
-| `create` | `(options: ICManagementCanisterOptions) => ICManagementCanister` |
-
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L43)
 
 ##### :gear: createCanister
 

--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -60,14 +60,10 @@ const data = await metadata();
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L10)
 
-#### Methods
+#### Static Methods
 
 - [fromHex](#gear-fromhex)
 - [fromPrincipal](#gear-fromprincipal)
-- [toHex](#gear-tohex)
-- [toUint8Array](#gear-touint8array)
-- [toNumbers](#gear-tonumbers)
-- [toAccountIdentifierHash](#gear-toaccountidentifierhash)
 
 ##### :gear: fromHex
 
@@ -84,6 +80,13 @@ const data = await metadata();
 | `fromPrincipal` | `({ principal, subAccount, }: { principal: Principal; subAccount?: SubAccount or undefined; }) => AccountIdentifier` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L17)
+
+#### Methods
+
+- [toHex](#gear-tohex)
+- [toUint8Array](#gear-touint8array)
+- [toNumbers](#gear-tonumbers)
+- [toAccountIdentifierHash](#gear-toaccountidentifierhash)
 
 ##### :gear: toHex
 
@@ -121,12 +124,11 @@ const data = await metadata();
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L62)
 
-#### Methods
+#### Static Methods
 
 - [fromBytes](#gear-frombytes)
 - [fromPrincipal](#gear-fromprincipal)
 - [fromID](#gear-fromid)
-- [toUint8Array](#gear-touint8array)
 
 ##### :gear: fromBytes
 
@@ -152,6 +154,10 @@ const data = await metadata();
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L86)
 
+#### Methods
+
+- [toUint8Array](#gear-touint8array)
+
 ##### :gear: toUint8Array
 
 | Method         | Type               |
@@ -164,16 +170,9 @@ const data = await metadata();
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L35)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
-- [accountBalance](#gear-accountbalance)
-- [metadata](#gear-metadata)
-- [transactionFee](#gear-transactionfee)
-- [transfer](#gear-transfer)
-- [icrc1Transfer](#gear-icrc1transfer)
-- [icrc2Approve](#gear-icrc2approve)
-- [icrc21ConsentMessage](#gear-icrc21consentmessage)
 
 ##### :gear: create
 
@@ -182,6 +181,16 @@ const data = await metadata();
 | `create` | `(options?: LedgerCanisterOptions) => LedgerCanister` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/ledger.canister.ts#L36)
+
+#### Methods
+
+- [accountBalance](#gear-accountbalance)
+- [metadata](#gear-metadata)
+- [transactionFee](#gear-transactionfee)
+- [transfer](#gear-transfer)
+- [icrc1Transfer](#gear-icrc1transfer)
+- [icrc2Approve](#gear-icrc2approve)
+- [icrc21ConsentMessage](#gear-icrc21consentmessage)
 
 ##### :gear: accountBalance
 
@@ -286,11 +295,9 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/index.canister.ts#L19)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
-- [accountBalance](#gear-accountbalance)
-- [getTransactions](#gear-gettransactions)
 
 ##### :gear: create
 
@@ -299,6 +306,11 @@ Parameters:
 | `create` | `({ canisterId: optionsCanisterId, ...options }: CanisterOptions<_SERVICE>) => IndexCanister` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/index.canister.ts#L20)
+
+#### Methods
+
+- [accountBalance](#gear-accountbalance)
+- [getTransactions](#gear-gettransactions)
 
 ##### :gear: accountBalance
 

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -167,9 +167,20 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L33)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
+
+##### :gear: create
+
+| Method   | Type                                                                   |
+| -------- | ---------------------------------------------------------------------- |
+| `create` | `(options: IcrcLedgerCanisterOptions<_SERVICE>) => IcrcLedgerCanister` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L34)
+
+#### Methods
+
 - [metadata](#gear-metadata)
 - [transactionFee](#gear-transactionfee)
 - [balance](#gear-balance)
@@ -179,14 +190,6 @@ Parameters:
 - [approve](#gear-approve)
 - [allowance](#gear-allowance)
 - [consentMessage](#gear-consentmessage)
-
-##### :gear: create
-
-| Method   | Type                                                                   |
-| -------- | ---------------------------------------------------------------------- |
-| `create` | `(options: IcrcLedgerCanisterOptions<_SERVICE>) => IcrcLedgerCanister` |
-
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L34)
 
 ##### :gear: metadata
 
@@ -312,11 +315,9 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L14)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
-- [getTransactions](#gear-gettransactions)
-- [ledgerId](#gear-ledgerid)
 
 ##### :gear: create
 
@@ -325,6 +326,11 @@ Parameters:
 | `create` | `(options: IcrcLedgerCanisterOptions<_SERVICE>) => IcrcIndexCanister` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index.canister.ts#L15)
+
+#### Methods
+
+- [getTransactions](#gear-gettransactions)
+- [ledgerId](#gear-ledgerid)
 
 ##### :gear: getTransactions
 
@@ -355,11 +361,9 @@ Returns the ledger canister ID related to the index canister.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L15)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
-- [getTransactions](#gear-gettransactions)
-- [ledgerId](#gear-ledgerid)
 
 ##### :gear: create
 
@@ -368,6 +372,11 @@ Returns the ledger canister ID related to the index canister.
 | `create` | `(options: IcrcLedgerCanisterOptions<_SERVICE>) => IcrcIndexNgCanister` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L16)
+
+#### Methods
+
+- [getTransactions](#gear-gettransactions)
+- [ledgerId](#gear-ledgerid)
 
 ##### :gear: getTransactions
 

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -176,7 +176,7 @@ Parameters:
 
 ### :factory: GovernanceCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L92)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L93)
 
 #### Static Methods
 
@@ -188,7 +188,7 @@ Parameters:
 | -------- | ------------------------------------------------------------- |
 | `create` | `(options?: GovernanceCanisterOptions) => GovernanceCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L107)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L108)
 
 #### Methods
 
@@ -224,6 +224,7 @@ Parameters:
 - [claimOrRefreshNeuron](#gear-claimorrefreshneuron)
 - [getNeuron](#gear-getneuron)
 - [getNetworkEconomicsParameters](#gear-getnetworkeconomicsparameters)
+- [disburseMaturity](#gear-disbursematurity)
 
 ##### :gear: listNeurons
 
@@ -243,7 +244,7 @@ combined into a single return value.
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `listNeurons` | `({ certified, neuronIds, includeEmptyNeurons, includePublicNeurons, neuronSubaccounts, }: { certified: boolean; neuronIds?: bigint[] or undefined; includeEmptyNeurons?: boolean or undefined; includePublicNeurons?: boolean or undefined; neuronSubaccounts?: NeuronSubaccount[] or undefined; }) => Promise<...>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L150)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L151)
 
 ##### :gear: listKnownNeurons
 
@@ -257,7 +258,7 @@ it is fetched using a query call.
 | ------------------ | ------------------------------------------------- |
 | `listKnownNeurons` | `(certified?: boolean) => Promise<KnownNeuron[]>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L278)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L279)
 
 ##### :gear: getLastestRewardEvent
 
@@ -270,7 +271,7 @@ it's fetched using a query call.
 | ----------------------- | ----------------------------------------------- |
 | `getLastestRewardEvent` | `(certified?: boolean) => Promise<RewardEvent>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L300)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L301)
 
 ##### :gear: listProposals
 
@@ -289,7 +290,7 @@ Parameters:
 - `request`: the options to list the proposals (limit number of results, topics to search for, etc.)
 - `certified`: query or update calls
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L316)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L317)
 
 ##### :gear: stakeNeuron
 
@@ -297,7 +298,7 @@ Parameters:
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `stakeNeuron` | `({ stake, principal, fromSubAccount, ledgerCanister, createdAt, fee, }: { stake: bigint; principal: Principal; fromSubAccount?: number[] or undefined; ledgerCanister: LedgerCanister; createdAt?: bigint or undefined; fee?: bigint or undefined; }) => Promise<...>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L335)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L336)
 
 ##### :gear: increaseDissolveDelay
 
@@ -307,7 +308,7 @@ Increases dissolve delay of a neuron
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `increaseDissolveDelay` | `({ neuronId, additionalDissolveDelaySeconds, }: { neuronId: bigint; additionalDissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L396)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L397)
 
 ##### :gear: setDissolveDelay
 
@@ -318,7 +319,7 @@ The new date is now + dissolveDelaySeconds.
 | ------------------ | ------------------------------------------------------------------------------------------------------------- |
 | `setDissolveDelay` | `({ neuronId, dissolveDelaySeconds, }: { neuronId: bigint; dissolveDelaySeconds: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L422)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L423)
 
 ##### :gear: startDissolving
 
@@ -328,7 +329,7 @@ Start dissolving process of a neuron
 | ----------------- | ------------------------------------- |
 | `startDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L445)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L446)
 
 ##### :gear: stopDissolving
 
@@ -338,7 +339,7 @@ Stop dissolving process of a neuron
 | ---------------- | ------------------------------------- |
 | `stopDissolving` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L459)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L460)
 
 ##### :gear: joinCommunityFund
 
@@ -348,7 +349,7 @@ Neuron joins the community fund
 | ------------------- | ------------------------------------- |
 | `joinCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L473)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L474)
 
 ##### :gear: autoStakeMaturity
 
@@ -363,7 +364,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to request a change of the auto stake feature
 - `autoStake`: `true` to enable the auto-stake maturity for this neuron, `false` to turn it off
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L491)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L492)
 
 ##### :gear: leaveCommunityFund
 
@@ -373,7 +374,7 @@ Neuron leaves the community fund
 | -------------------- | ------------------------------------- |
 | `leaveCommunityFund` | `(neuronId: bigint) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L506)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L507)
 
 ##### :gear: setVisibility
 
@@ -383,7 +384,7 @@ Set visibility of a neuron
 | --------------- | ------------------------------------------------------------------- |
 | `setVisibility` | `(neuronId: bigint, visibility: NeuronVisibility) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L520)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L521)
 
 ##### :gear: setNodeProviderAccount
 
@@ -394,7 +395,7 @@ Where the reward is paid to.
 | ------------------------ | ---------------------------------------------- |
 | `setNodeProviderAccount` | `(accountIdentifier: string) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L540)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L541)
 
 ##### :gear: mergeNeurons
 
@@ -404,7 +405,7 @@ Merge two neurons
 | -------------- | --------------------------------------------------------------------------------- |
 | `mergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L560)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L561)
 
 ##### :gear: simulateMergeNeurons
 
@@ -414,7 +415,7 @@ Simulate merging two neurons
 | ---------------------- | --------------------------------------------------------------------------------------- |
 | `simulateMergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<NeuronInfo>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L577)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L578)
 
 ##### :gear: splitNeuron
 
@@ -424,7 +425,7 @@ Splits a neuron creating a new one
 | ------------- | ----------------------------------------------------------------------------------- |
 | `splitNeuron` | `({ neuronId, amount, }: { neuronId: bigint; amount: bigint; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L622)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L623)
 
 ##### :gear: getProposal
 
@@ -437,7 +438,7 @@ it is fetched using a query call.
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `getProposal` | `({ proposalId, certified, }: { proposalId: bigint; certified?: boolean or undefined; }) => Promise<ProposalInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L662)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L663)
 
 ##### :gear: makeProposal
 
@@ -447,7 +448,7 @@ Create new proposal
 | -------------- | ---------------------------------------------------------------- |
 | `makeProposal` | `(request: MakeProposalRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L680)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L681)
 
 ##### :gear: registerVote
 
@@ -457,7 +458,7 @@ Registers vote for a proposal from the neuron passed.
 | -------------- | ----------------------------------------------------------------------------------------------------------- |
 | `registerVote` | `({ neuronId, vote, proposalId, }: { neuronId: bigint; vote: Vote; proposalId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L701)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L702)
 
 ##### :gear: setFollowees
 
@@ -467,7 +468,7 @@ Edit neuron followees per topic
 | -------------- | ------------------------------------------------- |
 | `setFollowees` | `(followRequest: FollowRequest) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L723)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L724)
 
 ##### :gear: disburse
 
@@ -477,7 +478,7 @@ Disburse neuron on Account
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `disburse` | `({ neuronId, toAccountId, amount, }: { neuronId: bigint; toAccountId?: string or undefined; amount?: bigint or undefined; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L738)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L739)
 
 ##### :gear: refreshVotingPower
 
@@ -489,7 +490,7 @@ parameter of the neuron to the current time).
 | -------------------- | --------------------------------------------------------- |
 | `refreshVotingPower` | `({ neuronId, }: { neuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L774)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L775)
 
 ##### :gear: mergeMaturity
 
@@ -499,7 +500,7 @@ Merge Maturity of a neuron
 | --------------- | ------------------------------------------------------------------------------------------------------- |
 | `mergeMaturity` | `({ neuronId, percentageToMerge, }: { neuronId: bigint; percentageToMerge: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L796)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L797)
 
 ##### :gear: stakeMaturity
 
@@ -514,7 +515,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to stake the maturity
 - `percentageToStake`: Optional. Percentage of the current maturity to stake. If not provided, all of the neuron's current maturity will be staked.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L825)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L826)
 
 ##### :gear: spawnNeuron
 
@@ -524,7 +525,7 @@ Merge Maturity of a neuron
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `spawnNeuron` | `({ neuronId, percentageToSpawn, newController, nonce, }: { neuronId: bigint; percentageToSpawn?: number or undefined; newController?: Principal or undefined; nonce?: bigint or undefined; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L847)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L848)
 
 ##### :gear: addHotkey
 
@@ -534,7 +535,7 @@ Add hotkey to neuron
 | ----------- | ------------------------------------------------------------------------------------------ |
 | `addHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L894)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L895)
 
 ##### :gear: removeHotkey
 
@@ -544,7 +545,7 @@ Remove hotkey to neuron
 | -------------- | ------------------------------------------------------------------------------------------ |
 | `removeHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L914)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L915)
 
 ##### :gear: claimOrRefreshNeuronFromAccount
 
@@ -554,7 +555,7 @@ Gets the NeuronID of a newly created neuron.
 | --------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `claimOrRefreshNeuronFromAccount` | `({ memo, controller, }: { memo: bigint; controller?: Principal or undefined; }) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L932)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L933)
 
 ##### :gear: claimOrRefreshNeuron
 
@@ -565,7 +566,7 @@ Uses query call only.
 | ---------------------- | ------------------------------------------------------------------------ |
 | `claimOrRefreshNeuron` | `(request: ClaimOrRefreshNeuronRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L963)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L964)
 
 ##### :gear: getNeuron
 
@@ -575,7 +576,7 @@ Return the data of the neuron provided as id.
 | ----------- | ----------------------------------------------------------------------------------------------------------- |
 | `getNeuron` | `({ certified, neuronId, }: { certified: boolean; neuronId: bigint; }) => Promise<NeuronInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L988)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L989)
 
 ##### :gear: getNetworkEconomicsParameters
 
@@ -585,7 +586,18 @@ Return the [Network Economics](https://github.com/dfinity/ic/blob/d90e934eb440c7
 | ------------------------------- | ------------------------------------------------------------------------ |
 | `getNetworkEconomicsParameters` | `({ certified, }: { certified: boolean; }) => Promise<NetworkEconomics>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L1009)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L1010)
+
+##### :gear: disburseMaturity
+
+Disburses a neuron's maturity (always certified).
+Reference: https://github.com/dfinity/ic/blob/ca2be53acf413bb92478ee7694ac0fb92af07030/rs/sns/governance/src/governance.rs#L1614
+
+| Method             | Type                                                                                                          |
+| ------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `disburseMaturity` | `({ neuronId, percentageToDisburse, }: { neuronId: bigint; percentageToDisburse: number; }) => Promise<void>` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L1033)
 
 ### :factory: SnsWasmCanister
 

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -150,10 +150,9 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/genesis_token.canister.ts#L9)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
-- [claimNeurons](#gear-claimneurons)
 
 ##### :gear: create
 
@@ -162,6 +161,10 @@ Parameters:
 | `create` | `(options?: CanisterOptions<_SERVICE>) => GenesisTokenCanister` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/genesis_token.canister.ts#L14)
+
+#### Methods
+
+- [claimNeurons](#gear-claimneurons)
 
 ##### :gear: claimNeurons
 
@@ -175,9 +178,20 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L92)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
+
+##### :gear: create
+
+| Method   | Type                                                          |
+| -------- | ------------------------------------------------------------- |
+| `create` | `(options?: GovernanceCanisterOptions) => GovernanceCanister` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L107)
+
+#### Methods
+
 - [listNeurons](#gear-listneurons)
 - [listKnownNeurons](#gear-listknownneurons)
 - [getLastestRewardEvent](#gear-getlastestrewardevent)
@@ -210,14 +224,6 @@ Parameters:
 - [claimOrRefreshNeuron](#gear-claimorrefreshneuron)
 - [getNeuron](#gear-getneuron)
 - [getNetworkEconomicsParameters](#gear-getnetworkeconomicsparameters)
-
-##### :gear: create
-
-| Method   | Type                                                          |
-| -------- | ------------------------------------------------------------- |
-| `create` | `(options?: GovernanceCanisterOptions) => GovernanceCanister` |
-
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L107)
 
 ##### :gear: listNeurons
 
@@ -585,10 +591,9 @@ Return the [Network Economics](https://github.com/dfinity/ic/blob/d90e934eb440c7
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/sns_wasm.canister.ts#L10)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
-- [listSnses](#gear-listsnses)
 
 ##### :gear: create
 
@@ -597,6 +602,10 @@ Return the [Network Economics](https://github.com/dfinity/ic/blob/d90e934eb440c7
 | `create` | `(options?: CanisterOptions<_SERVICE>) => SnsWasmCanister` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/sns_wasm.canister.ts#L16)
+
+#### Methods
+
+- [listSnses](#gear-listsnses)
 
 ##### :gear: listSnses
 

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -102,9 +102,26 @@ Lookup for the canister ids of a Sns and initialize the wrapper to access its fe
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L65)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
+
+##### :gear: create
+
+Instantiate a canister to interact with the governance of a Sns project.
+
+| Method   | Type                                                               |
+| -------- | ------------------------------------------------------------------ |
+| `create` | `(options: SnsCanisterOptions<_SERVICE>) => SnsGovernanceCanister` |
+
+Parameters:
+
+- `options`: Miscellaneous options to initialize the canister. Its ID being the only mandatory parammeter.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L71)
+
+#### Methods
+
 - [listNeurons](#gear-listneurons)
 - [listProposals](#gear-listproposals)
 - [listTopics](#gear-listtopics)
@@ -130,20 +147,6 @@ Lookup for the canister ids of a Sns and initialize the wrapper to access its fe
 - [registerVote](#gear-registervote)
 - [refreshNeuron](#gear-refreshneuron)
 - [claimNeuron](#gear-claimneuron)
-
-##### :gear: create
-
-Instantiate a canister to interact with the governance of a Sns project.
-
-| Method   | Type                                                               |
-| -------- | ------------------------------------------------------------------ |
-| `create` | `(options: SnsCanisterOptions<_SERVICE>) => SnsGovernanceCanister` |
-
-Parameters:
-
-- `options`: Miscellaneous options to initialize the canister. Its ID being the only mandatory parammeter.
-
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L71)
 
 ##### :gear: listNeurons
 
@@ -416,10 +419,9 @@ Claim neuron
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/root.canister.ts#L10)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
-- [listSnsCanisters](#gear-listsnscanisters)
 
 ##### :gear: create
 
@@ -428,6 +430,10 @@ Claim neuron
 | `create` | `(options: SnsCanisterOptions<_SERVICE>) => SnsRootCanister` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/root.canister.ts#L11)
+
+#### Methods
+
+- [listSnsCanisters](#gear-listsnscanisters)
 
 ##### :gear: listSnsCanisters
 
@@ -449,9 +455,20 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L33)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
+
+##### :gear: create
+
+| Method   | Type                                                         |
+| -------- | ------------------------------------------------------------ |
+| `create` | `(options: SnsCanisterOptions<_SERVICE>) => SnsSwapCanister` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L34)
+
+#### Methods
+
 - [state](#gear-state)
 - [notifyPaymentFailure](#gear-notifypaymentfailure)
 - [notifyParticipation](#gear-notifyparticipation)
@@ -462,14 +479,6 @@ Parameters:
 - [newSaleTicket](#gear-newsaleticket)
 - [getLifecycle](#gear-getlifecycle)
 - [getFinalizationStatus](#gear-getfinalizationstatus)
-
-##### :gear: create
-
-| Method   | Type                                                         |
-| -------- | ------------------------------------------------------------ |
-| `create` | `(options: SnsCanisterOptions<_SERVICE>) => SnsSwapCanister` |
-
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/swap.canister.ts#L34)
 
 ##### :gear: state
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -556,12 +556,11 @@ Represents an amount of tokens.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L130)
 
-#### Methods
+#### Static Methods
 
 - [fromE8s](#gear-frome8s)
 - [fromString](#gear-fromstring)
 - [fromNumber](#gear-fromnumber)
-- [toE8s](#gear-toe8s)
 
 ##### :gear: fromE8s
 
@@ -614,6 +613,10 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L198)
 
+#### Methods
+
+- [toE8s](#gear-toe8s)
+
 ##### :gear: toE8s
 
 | Method  | Type           |
@@ -628,13 +631,11 @@ Represents an amount of tokens.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L236)
 
-#### Methods
+#### Static Methods
 
 - [fromUlps](#gear-fromulps)
 - [fromString](#gear-fromstring)
 - [fromNumber](#gear-fromnumber)
-- [toUlps](#gear-toulps)
-- [toE8s](#gear-toe8s)
 
 ##### :gear: fromUlps
 
@@ -687,6 +688,11 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/parser/token.ts#L294)
 
+#### Methods
+
+- [toUlps](#gear-toulps)
+- [toE8s](#gear-toe8s)
+
 ##### :gear: toUlps
 
 | Method   | Type           |
@@ -716,11 +722,9 @@ Provides functionality to create new agents, retrieve cached agents, and clear t
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L53)
 
-#### Methods
+#### Static Methods
 
 - [create](#gear-create)
-- [getAgent](#gear-getagent)
-- [clearAgents](#gear-clearagents)
 
 ##### :gear: create
 
@@ -740,6 +744,11 @@ Parameters:
 - `config.host`: - The host to connect to.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/agent.utils.ts#L69)
+
+#### Methods
+
+- [getAgent](#gear-getagent)
+- [clearAgents](#gear-clearagents)
 
 ##### :gear: getAgent
 


### PR DESCRIPTION
# Motivation

I created a new version of tsdoc-markdown ([v1.2.0](https://github.com/peterpeterparker/tsdoc-markdown/releases/tag/v1.2.0) which splits methods and proprerties in two sections: instances and statics.

# Changes

- Bump library
- Inherit updates of the documentation

