### PR TITLE
feat: add type assertion to notEmptyString util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - Add utility `isIcpAccountIdentifier` to check if a string is a valid ICP account identifier.
+- Utility `notEmptyString` to use a type predicate, ensuring that the input is a string type type when it returns true.
 
 # 2025.03.10-1330Z
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Features
 
 - Add utility `isIcpAccountIdentifier` to check if a string is a valid ICP account identifier.
-- Utility `notEmptyString` to use a type predicate, ensuring that the input is a string type type when it returns true.
+- Utility `notEmptyString` to use a type predicate, ensuring that the input is a string type when it returns true.
 
 # 2025.03.10-1330Z
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -116,9 +116,9 @@ Parameters:
 
 Checks if a given value is not null, not undefined, and not an empty string.
 
-| Function         | Type                                              |
-| ---------------- | ------------------------------------------------- |
-| `notEmptyString` | `(value: string or null or undefined) => boolean` |
+| Function         | Type                                                      |
+| ---------------- | --------------------------------------------------------- |
+| `notEmptyString` | `(value: string or null or undefined) => value is string` |
 
 Parameters:
 
@@ -138,7 +138,7 @@ Parameters:
 
 - `value`: - The value to check.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/nullish.utils.ts#L38)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/nullish.utils.ts#L39)
 
 #### :gear: defaultAgent
 

--- a/packages/utils/src/utils/nullish.utils.ts
+++ b/packages/utils/src/utils/nullish.utils.ts
@@ -26,8 +26,9 @@ export const nonNullish = <T>(
  * @param {string | undefined | null} value - The value to check.
  * @returns {boolean} `true` if the value is not null, not undefined, and not an empty string; otherwise, `false`.
  */
-export const notEmptyString = (value: string | undefined | null): boolean =>
-  nonNullish(value) && value !== "";
+export const notEmptyString = (
+  value: string | undefined | null,
+): value is string => nonNullish(value) && value !== "";
 
 /**
  * Checks if a given value is null, undefined, or an empty string.


### PR DESCRIPTION
# Motivation

It seems coherent that the util `notEmptyString` will define the type of the input as string, in case of positive results.

