### PR TITLE
feat: add support for wasm_memory_threshold and  memory_metrics to ic-mgmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - Add utility `isIcpAccountIdentifier` to check if a string is a valid ICP account identifier.
+- Update `@dfinity/ic-management` to support optional new setting `wasm_memory_threshold` and return the new `memory_metrics`.
 
 # 2025.03.10-1330Z
 

--- a/packages/ic-management/candid/ic-management.certified.idl.js
+++ b/packages/ic-management/candid/ic-management.certified.idl.js
@@ -113,6 +113,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const definite_canister_settings = IDL.Record({
     'freezing_threshold' : IDL.Nat,
+    'wasm_memory_threshold' : IDL.Nat,
     'controllers' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Nat,
     'log_visibility' : log_visibility,
@@ -121,6 +122,16 @@ export const idlFactory = ({ IDL }) => {
     'compute_allocation' : IDL.Nat,
   });
   const canister_status_result = IDL.Record({
+    'memory_metrics' : IDL.Record({
+      'wasm_binary_size' : IDL.Nat,
+      'wasm_chunk_store_size' : IDL.Nat,
+      'canister_history_size' : IDL.Nat,
+      'stable_memory_size' : IDL.Nat,
+      'snapshots_size' : IDL.Nat,
+      'wasm_memory_size' : IDL.Nat,
+      'global_memory_size' : IDL.Nat,
+      'custom_sections_size' : IDL.Nat,
+    }),
     'status' : IDL.Variant({
       'stopped' : IDL.Null,
       'stopping' : IDL.Null,
@@ -142,6 +153,7 @@ export const idlFactory = ({ IDL }) => {
   const clear_chunk_store_args = IDL.Record({ 'canister_id' : canister_id });
   const canister_settings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat),
     'controllers' : IDL.Opt(IDL.Vec(IDL.Principal)),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat),
     'log_visibility' : IDL.Opt(log_visibility),

--- a/packages/ic-management/candid/ic-management.d.ts
+++ b/packages/ic-management/candid/ic-management.d.ts
@@ -78,6 +78,7 @@ export interface canister_log_record {
 }
 export interface canister_settings {
   freezing_threshold: [] | [bigint];
+  wasm_memory_threshold: [] | [bigint];
   controllers: [] | [Array<Principal>];
   reserved_cycles_limit: [] | [bigint];
   log_visibility: [] | [log_visibility];
@@ -89,6 +90,16 @@ export interface canister_status_args {
   canister_id: canister_id;
 }
 export interface canister_status_result {
+  memory_metrics: {
+    wasm_binary_size: bigint;
+    wasm_chunk_store_size: bigint;
+    canister_history_size: bigint;
+    stable_memory_size: bigint;
+    snapshots_size: bigint;
+    wasm_memory_size: bigint;
+    global_memory_size: bigint;
+    custom_sections_size: bigint;
+  };
   status: { stopped: null } | { stopping: null } | { running: null };
   memory_size: bigint;
   cycles: bigint;
@@ -151,6 +162,7 @@ export interface create_canister_result {
 }
 export interface definite_canister_settings {
   freezing_threshold: bigint;
+  wasm_memory_threshold: bigint;
   controllers: Array<Principal>;
   reserved_cycles_limit: bigint;
   log_visibility: log_visibility;

--- a/packages/ic-management/candid/ic-management.did
+++ b/packages/ic-management/candid/ic-management.did
@@ -1,4 +1,4 @@
-// Generated from dfinity/portal commit aed4ac730cc662713c0353609af96bbb2cd3a8ca for file 'docs/references/_attachments/ic.did'
+// Generated from dfinity/portal commit 39bbfcbae104623ffca6743ed139f851bf7561de for file 'docs/references/_attachments/ic.did'
 type canister_id = principal;
 type wasm_module = blob;
 type snapshot_id = blob;
@@ -17,6 +17,7 @@ type canister_settings = record {
     reserved_cycles_limit : opt nat;
     log_visibility : opt log_visibility;
     wasm_memory_limit : opt nat;
+    wasm_memory_threshold : opt nat;
 };
 
 type definite_canister_settings = record {
@@ -27,6 +28,7 @@ type definite_canister_settings = record {
     reserved_cycles_limit : nat;
     log_visibility : log_visibility;
     wasm_memory_limit : nat;
+    wasm_memory_threshold: nat;
 };
 
 type change_origin = variant {
@@ -249,6 +251,16 @@ type canister_status_result = record {
     settings : definite_canister_settings;
     module_hash : opt blob;
     memory_size : nat;
+    memory_metrics : record {
+        wasm_memory_size : nat;
+        stable_memory_size : nat;
+        global_memory_size : nat;
+        wasm_binary_size : nat;
+        custom_sections_size : nat;
+        canister_history_size : nat;
+        wasm_chunk_store_size : nat;
+        snapshots_size : nat;
+    };
     cycles : nat;
     reserved_cycles : nat;
     idle_cycles_burned_per_day : nat;

--- a/packages/ic-management/candid/ic-management.idl.js
+++ b/packages/ic-management/candid/ic-management.idl.js
@@ -113,6 +113,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const definite_canister_settings = IDL.Record({
     'freezing_threshold' : IDL.Nat,
+    'wasm_memory_threshold' : IDL.Nat,
     'controllers' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Nat,
     'log_visibility' : log_visibility,
@@ -121,6 +122,16 @@ export const idlFactory = ({ IDL }) => {
     'compute_allocation' : IDL.Nat,
   });
   const canister_status_result = IDL.Record({
+    'memory_metrics' : IDL.Record({
+      'wasm_binary_size' : IDL.Nat,
+      'wasm_chunk_store_size' : IDL.Nat,
+      'canister_history_size' : IDL.Nat,
+      'stable_memory_size' : IDL.Nat,
+      'snapshots_size' : IDL.Nat,
+      'wasm_memory_size' : IDL.Nat,
+      'global_memory_size' : IDL.Nat,
+      'custom_sections_size' : IDL.Nat,
+    }),
     'status' : IDL.Variant({
       'stopped' : IDL.Null,
       'stopping' : IDL.Null,
@@ -142,6 +153,7 @@ export const idlFactory = ({ IDL }) => {
   const clear_chunk_store_args = IDL.Record({ 'canister_id' : canister_id });
   const canister_settings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat),
+    'wasm_memory_threshold' : IDL.Opt(IDL.Nat),
     'controllers' : IDL.Opt(IDL.Vec(IDL.Principal)),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat),
     'log_visibility' : IDL.Opt(log_visibility),

--- a/packages/ic-management/src/ic-management.canister.spec.ts
+++ b/packages/ic-management/src/ic-management.canister.spec.ts
@@ -167,6 +167,7 @@ describe("ICManagementCanister", () => {
           reserved_cycles_limit: [],
           log_visibility: [],
           wasm_memory_limit: [],
+          wasm_memory_threshold: [],
         },
       });
     });
@@ -393,6 +394,7 @@ describe("ICManagementCanister", () => {
         reserved_cycles_limit: BigInt(11),
         log_visibility: { controllers: null },
         wasm_memory_limit: BigInt(500_00),
+        wasm_memory_threshold: BigInt(100),
       };
       const response: CanisterStatusResponse = {
         status: { running: null },
@@ -407,6 +409,16 @@ describe("ICManagementCanister", () => {
           num_instructions_total: 100_000n,
           response_payload_bytes_total: 200n,
           request_payload_bytes_total: 300n,
+        },
+        memory_metrics: {
+          wasm_binary_size: BigInt(2_000_900),
+          wasm_chunk_store_size: BigInt(2_100_800),
+          canister_history_size: BigInt(2_200_700),
+          stable_memory_size: BigInt(2_300_600),
+          snapshots_size: BigInt(2_400_500),
+          wasm_memory_size: BigInt(2_500_400),
+          global_memory_size: BigInt(2_600_300),
+          custom_sections_size: BigInt(2_700_200),
         },
       };
       const service = mock<IcManagementService>();

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -21,6 +21,7 @@ export interface CanisterSettings {
   reservedCyclesLimit?: bigint;
   logVisibility?: LogVisibility;
   wasmMemoryLimit?: bigint;
+  wasmMemoryThreshold?: bigint;
 }
 
 export class UnsupportedLogVisibility extends Error {}
@@ -33,6 +34,7 @@ export const toCanisterSettings = ({
   reservedCyclesLimit,
   logVisibility,
   wasmMemoryLimit,
+  wasmMemoryThreshold,
 }: CanisterSettings = {}): canister_settings => {
   const toLogVisibility = (): log_visibility => {
     switch (logVisibility) {
@@ -53,6 +55,7 @@ export const toCanisterSettings = ({
     reserved_cycles_limit: toNullable(reservedCyclesLimit),
     log_visibility: isNullish(logVisibility) ? [] : [toLogVisibility()],
     wasm_memory_limit: toNullable(wasmMemoryLimit),
+    wasm_memory_threshold: toNullable(wasmMemoryThreshold),
   };
 };
 


### PR DESCRIPTION
# Motivation

New fields  `wasm_memory_threshold` and `memory_metrics` have been added to the IC spec (provided in Candid PR #864).

# Changes

- Update did files as in #864
- Adapt test accordingly
- Add field `wasMemoryThreshold` to parameters
