### PR TITLE
docs: jsdocs debounce utils

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -388,11 +388,22 @@ Parameters:
 
 #### :gear: debounce
 
+Creates a debounced version of the provided function.
+
+The debounced function postpones its execution until after a certain amount of time
+has elapsed since the last time it was invoked. This is useful for limiting the rate
+at which a function is called (e.g. in response to user input or events).
+
 | Function   | Type                                                                              |
 | ---------- | --------------------------------------------------------------------------------- |
 | `debounce` | `(func: Function, timeout?: number or undefined) => (...args: unknown[]) => void` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/debounce.utils.ts#L2)
+Parameters:
+
+- `func`: - The function to debounce. It will only be called after no new calls happen within the specified timeout.
+- `timeout`: - The debounce delay in milliseconds. Defaults to 300ms if not provided or invalid.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/debounce.utils.ts#L13)
 
 #### :gear: toNullable
 

--- a/packages/utils/src/utils/debounce.utils.ts
+++ b/packages/utils/src/utils/debounce.utils.ts
@@ -1,4 +1,15 @@
-/* eslint-disable-next-line @typescript-eslint/ban-types */
+/**
+ * Creates a debounced version of the provided function.
+ *
+ * The debounced function postpones its execution until after a certain amount of time
+ * has elapsed since the last time it was invoked. This is useful for limiting the rate
+ * at which a function is called (e.g. in response to user input or events).
+ *
+ * @param {Function} func - The function to debounce. It will only be called after no new calls happen within the specified timeout.
+ * @param {number} [timeout=300] - The debounce delay in milliseconds. Defaults to 300ms if not provided or invalid.
+ * @returns {(args: unknown[]) => void} A debounced version of the original function.
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
 export const debounce = (func: Function, timeout?: number) => {
   let timer: NodeJS.Timer | undefined;
 


### PR DESCRIPTION
# Motivation

I noticed the `debounce` utility was undocumented.

# Changes

- Provide JSDocs
