### PR TITLE
feat: add method status to class IcrcIndexNgCanister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Support `disburseMaturity` in `@dfinity/nns`.
 - Update `@dfinity/ic-management` to support optional new setting `wasm_memory_threshold` and return the new `memory_metrics`.
 - Add `neuronMinimumDissolveDelayToVoteSeconds` to nns `VotingPowerEconomics`.
+- Expose method `status` in class `IcrcIndexNgCanister`.
 
 # 2025.03.10-1330Z
 

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -411,7 +411,11 @@ Returns the status of the index canister.
 | -------- | ------------------------------------------ |
 | `status` | `(params: QueryParams) => Promise<Status>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L68)
+Parameters:
+
+- `params`: The parameters to get the status of the index canister.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L71)
 
 <!-- TSDOC_END -->
 

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -359,7 +359,7 @@ Returns the ledger canister ID related to the index canister.
 
 ### :factory: IcrcIndexNgCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L15)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L16)
 
 #### Static Methods
 
@@ -371,12 +371,13 @@ Returns the ledger canister ID related to the index canister.
 | -------- | ----------------------------------------------------------------------- |
 | `create` | `(options: IcrcLedgerCanisterOptions<_SERVICE>) => IcrcIndexNgCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L16)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L17)
 
 #### Methods
 
 - [getTransactions](#gear-gettransactions)
 - [ledgerId](#gear-ledgerid)
+- [status](#gear-status)
 
 ##### :gear: getTransactions
 
@@ -390,7 +391,7 @@ Parameters:
 
 - `params`: The parameters to get the transactions of an account.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L41)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L42)
 
 ##### :gear: ledgerId
 
@@ -400,7 +401,17 @@ Returns the ledger canister ID related to the index canister.
 | ---------- | --------------------------------------------- |
 | `ledgerId` | `(params: QueryParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L59)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L60)
+
+##### :gear: status
+
+Returns the status of the index canister.
+
+| Method   | Type                                       |
+| -------- | ------------------------------------------ |
+| `status` | `(params: QueryParams) => Promise<Status>` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L68)
 
 <!-- TSDOC_END -->
 

--- a/packages/ledger-icrc/src/index-ng.canister.spec.ts
+++ b/packages/ledger-icrc/src/index-ng.canister.spec.ts
@@ -12,9 +12,9 @@ import { IcrcIndexNgCanister } from "./index-ng.canister";
 import {
   indexCanisterIdMock,
   ledgerCanisterIdMock,
-  mockStatus,
 } from "./mocks/ledger.mock";
 import type { IcrcAccount } from "./types/ledger.responses";
+import type { Status } from "@dfinity/ledger-icp/candid";
 
 describe("Index canister", () => {
   afterEach(() => jest.clearAllMocks());
@@ -154,6 +154,10 @@ describe("Index canister", () => {
 
   describe("status", () => {
     it("should return the status of the index canister", async () => {
+       const mockStatus: Status = {
+        num_blocks_synced: 12_345n,
+      };
+
       const service = mock<ActorSubclass<IcrcIndexNgService>>();
       service.status.mockResolvedValue(mockStatus);
 

--- a/packages/ledger-icrc/src/index-ng.canister.spec.ts
+++ b/packages/ledger-icrc/src/index-ng.canister.spec.ts
@@ -9,7 +9,11 @@ import type {
 } from "../candid/icrc_index-ng";
 import { IndexError } from "./errors/index.errors";
 import { IcrcIndexNgCanister } from "./index-ng.canister";
-import { indexCanisterIdMock, ledgerCanisterIdMock } from "./mocks/ledger.mock";
+import {
+  indexCanisterIdMock,
+  ledgerCanisterIdMock,
+  mockStatus,
+} from "./mocks/ledger.mock";
 import type { IcrcAccount } from "./types/ledger.responses";
 
 describe("Index canister", () => {
@@ -101,7 +105,7 @@ describe("Index canister", () => {
       service.icrc1_balance_of.mockResolvedValue(balance);
 
       const canister = IcrcIndexNgCanister.create({
-        canisterId: ledgerCanisterIdMock,
+        canisterId: indexCanisterIdMock,
         certifiedServiceOverride: service,
       });
 
@@ -119,7 +123,7 @@ describe("Index canister", () => {
       service.icrc1_balance_of.mockResolvedValue(balance);
 
       const canister = IcrcIndexNgCanister.create({
-        canisterId: ledgerCanisterIdMock,
+        canisterId: indexCanisterIdMock,
         certifiedServiceOverride: service,
       });
 
@@ -134,17 +138,32 @@ describe("Index canister", () => {
   });
 
   describe("ledger_id", () => {
-    it("should return the balance of subaccount", async () => {
+    it("should return the ledger ID associated with the index canister", async () => {
       const service = mock<ActorSubclass<IcrcIndexNgService>>();
       service.ledger_id.mockResolvedValue(ledgerCanisterIdMock);
 
       const canister = IcrcIndexNgCanister.create({
-        canisterId: ledgerCanisterIdMock,
+        canisterId: indexCanisterIdMock,
         certifiedServiceOverride: service,
       });
 
       const res = await canister.ledgerId({});
       expect(res).toEqual(ledgerCanisterIdMock);
+    });
+  });
+
+  describe("status", () => {
+    it("should return the status of the index canister", async () => {
+      const service = mock<ActorSubclass<IcrcIndexNgService>>();
+      service.status.mockResolvedValue(mockStatus);
+
+      const canister = IcrcIndexNgCanister.create({
+        canisterId: indexCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+
+      const res = await canister.status({});
+      expect(res).toEqual(mockStatus);
     });
   });
 });

--- a/packages/ledger-icrc/src/index-ng.canister.spec.ts
+++ b/packages/ledger-icrc/src/index-ng.canister.spec.ts
@@ -1,4 +1,5 @@
 import type { ActorSubclass } from "@dfinity/agent";
+import type { Status } from "@dfinity/ledger-icp/candid";
 import { Principal } from "@dfinity/principal";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
@@ -9,12 +10,8 @@ import type {
 } from "../candid/icrc_index-ng";
 import { IndexError } from "./errors/index.errors";
 import { IcrcIndexNgCanister } from "./index-ng.canister";
-import {
-  indexCanisterIdMock,
-  ledgerCanisterIdMock,
-} from "./mocks/ledger.mock";
+import { indexCanisterIdMock, ledgerCanisterIdMock } from "./mocks/ledger.mock";
 import type { IcrcAccount } from "./types/ledger.responses";
-import type { Status } from "@dfinity/ledger-icp/candid";
 
 describe("Index canister", () => {
   afterEach(() => jest.clearAllMocks());
@@ -154,7 +151,7 @@ describe("Index canister", () => {
 
   describe("status", () => {
     it("should return the status of the index canister", async () => {
-       const mockStatus: Status = {
+      const mockStatus: Status = {
         num_blocks_synced: 12_345n,
       };
 

--- a/packages/ledger-icrc/src/index-ng.canister.ts
+++ b/packages/ledger-icrc/src/index-ng.canister.ts
@@ -3,6 +3,7 @@ import { createServices, type QueryParams } from "@dfinity/utils";
 import type {
   GetTransactions,
   _SERVICE as IcrcIndexNgService,
+  Status,
 } from "../candid/icrc_index-ng";
 import { idlFactory as certifiedIdlFactory } from "../candid/icrc_index-ng.certified.idl";
 import { idlFactory } from "../candid/icrc_index-ng.idl";
@@ -60,4 +61,10 @@ export class IcrcIndexNgCanister extends IcrcCanister<IcrcIndexNgService> {
     const { ledger_id } = this.caller(params);
     return ledger_id();
   };
+
+  /**
+   * Returns the status of the index canister.
+   */
+  status = (params: QueryParams): Promise<Status> =>
+    this.caller(params).status();
 }

--- a/packages/ledger-icrc/src/index-ng.canister.ts
+++ b/packages/ledger-icrc/src/index-ng.canister.ts
@@ -64,6 +64,9 @@ export class IcrcIndexNgCanister extends IcrcCanister<IcrcIndexNgService> {
 
   /**
    * Returns the status of the index canister.
+   *
+   * @param {QueryParams} params The parameters to get the status of the index canister.
+   * @returns {Promise<Status>} The status of the index canister.
    */
   status = (params: QueryParams): Promise<Status> =>
     this.caller(params).status();

--- a/packages/ledger-icrc/src/mocks/ledger.mock.ts
+++ b/packages/ledger-icrc/src/mocks/ledger.mock.ts
@@ -22,9 +22,6 @@ export const mockPrincipalText =
 
 export const mockPrincipal = Principal.fromText(mockPrincipalText);
 
-export const mockStatus: Status = {
-  num_blocks_synced: 12_345n,
-};
 
 export const ledgerCanisterIdMock: Principal = Principal.fromText(
   "ktxdj-qiaaa-aaaaa-aacqa-cai",

--- a/packages/ledger-icrc/src/mocks/ledger.mock.ts
+++ b/packages/ledger-icrc/src/mocks/ledger.mock.ts
@@ -1,4 +1,3 @@
-import type { Status } from "@dfinity/ledger-icp/candid";
 import { Principal } from "@dfinity/principal";
 import type { MetadataValue } from "../../candid/icrc_ledger";
 import { IcrcMetadataResponseEntries } from "../types/ledger.responses";
@@ -21,7 +20,6 @@ export const mockPrincipalText =
   "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe";
 
 export const mockPrincipal = Principal.fromText(mockPrincipalText);
-
 
 export const ledgerCanisterIdMock: Principal = Principal.fromText(
   "ktxdj-qiaaa-aaaaa-aacqa-cai",

--- a/packages/ledger-icrc/src/mocks/ledger.mock.ts
+++ b/packages/ledger-icrc/src/mocks/ledger.mock.ts
@@ -1,3 +1,4 @@
+import type { Status } from "@dfinity/ledger-icp/candid";
 import { Principal } from "@dfinity/principal";
 import type { MetadataValue } from "../../candid/icrc_ledger";
 import { IcrcMetadataResponseEntries } from "../types/ledger.responses";
@@ -20,6 +21,10 @@ export const mockPrincipalText =
   "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe";
 
 export const mockPrincipal = Principal.fromText(mockPrincipalText);
+
+export const mockStatus: Status = {
+  num_blocks_synced: 12_345n,
+};
 
 export const ledgerCanisterIdMock: Principal = Principal.fromText(
   "ktxdj-qiaaa-aaaaa-aacqa-cai",


### PR DESCRIPTION
# Motivation

We would like to expose method `status` in class `IcrcIndexNgCanister`.

# Changes

Included method `status` in `IcrcIndexNgCanister`.

# Tests

Included test for new method.
