### PR TITLE
build: increase size limit of utils package

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     {
       "name": "@dfinity/utils",
       "path": "./packages/utils/dist/index.js",
-      "limit": "5 kB",
+      "limit": "10 kB",
       "gzip": true,
       "ignore": [
         "@dfinity/agent",


### PR DESCRIPTION
# Motivation

The size limit of `@dfinity/utils` is being breached with PR https://github.com/dfinity/ic-js/pull/871 (see [CI results](https://github.com/dfinity/ic-js/actions/runs/14072188427/job/39425223731)).

So we increase the size limit from `5 kb` to `10 kb`.