### PR TITLE
feat: separate error callback in queryAndUpdate service

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -162,16 +162,16 @@ The resolution can be:
 Once the call(s) are done, the response is handled by the `onLoad` callback.
 However, if an error occurs, it is handled by the error callbacks, if provided: one for the query call and one for the update call.
 
-| Function         | Type                                                                                                                                               |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `queryAndUpdate` | `<R, E = unknown>({ request, onLoad, onQueryError, onUpdateError, strategy, identity, resolution, }: QueryAndUpdateParams<R, E>) => Promise<void>` |
+| Function         | Type                                                                                                                                          |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `queryAndUpdate` | `<R, E = unknown>({ request, onLoad, onError, onUpdateError, strategy, identity, resolution, }: QueryAndUpdateParams<R, E>) => Promise<void>` |
 
 Parameters:
 
 - `params`: The parameters to perform the request.
 - `params.request`: The request to perform.
 - `params.onLoad`: The callback to handle the response of the request.
-- `params.onQueryError`: The callback to handle the error of the `query` request.
+- `params.onError`: The callback to handle the error of the `query` request.
 - `params.onUpdateError`: The callback to handle the error of the `update` request.
 - `params.strategy`: The strategy to use. Default is `query_and_update`.
 - `params.identity`: The identity to use for the request.

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -160,20 +160,19 @@ The resolution can be:
 - `race` waits for the first call to settle (typically, `query` is the fastest one).
 
 Once the call(s) are done, the response is handled by the `onLoad` callback.
-However, if an error occurs, it is handled by the `onError` callback, if provided.
-In addition, if the error is from the update call, the `onUpdateError` callback is called too, if provided.
+However, if an error occurs, it is handled by the error callbacks, if provided: one for the query call and one for the update call.
 
-| Function         | Type                                                                                                                                          |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `queryAndUpdate` | `<R, E = unknown>({ request, onLoad, onError, onUpdateError, strategy, identity, resolution, }: QueryAndUpdateParams<R, E>) => Promise<void>` |
+| Function         | Type                                                                                                                                               |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `queryAndUpdate` | `<R, E = unknown>({ request, onLoad, onQueryError, onUpdateError, strategy, identity, resolution, }: QueryAndUpdateParams<R, E>) => Promise<void>` |
 
 Parameters:
 
 - `params`: The parameters to perform the request.
 - `params.request`: The request to perform.
 - `params.onLoad`: The callback to handle the response of the request.
-- `params.onError`: The callback to handle the error of the request.
-- `params.onUpdateError`: The additional callback to handle the error of the update request.
+- `params.onQueryError`: The callback to handle the error of the `query` request.
+- `params.onUpdateError`: The callback to handle the error of the `update` request.
 - `params.strategy`: The strategy to use. Default is `query_and_update`.
 - `params.identity`: The identity to use for the request.
 - `params.resolution`: The resolution to use. Default is `race`.

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -160,25 +160,24 @@ The resolution can be:
 - `race` waits for the first call to settle (typically, `query` is the fastest one).
 
 Once the call(s) are done, the response is handled by the `onLoad` callback.
-However, if an error occurs, it is handled by the `onError` callback, if provided.
-In addition, if the error is from the update call, the `onCertifiedError` callback is called too, if provided.
+However, if an error occurs, it is handled by the error callbacks, if provided: one for the query call and one for the update call.
 
-| Function         | Type                                                                                                                                             |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `queryAndUpdate` | `<R, E = unknown>({ request, onLoad, onError, onCertifiedError, strategy, identity, resolution, }: QueryAndUpdateParams<R, E>) => Promise<void>` |
+| Function         | Type                                                                                                                                               |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `queryAndUpdate` | `<R, E = unknown>({ request, onLoad, onQueryError, onUpdateError, strategy, identity, resolution, }: QueryAndUpdateParams<R, E>) => Promise<void>` |
 
 Parameters:
 
 - `params`: The parameters to perform the request.
 - `params.request`: The request to perform.
 - `params.onLoad`: The callback to handle the response of the request.
-- `params.onError`: The callback to handle the error of the request.
-- `params.onCertifiedError`: The additional callback to handle the error of the update request.
+- `params.onQueryError`: The callback to handle the error of the `query` request.
+- `params.onUpdateError`: The callback to handle the error of the `update` request.
 - `params.strategy`: The strategy to use. Default is `query_and_update`.
 - `params.identity`: The identity to use for the request.
 - `params.resolution`: The resolution to use. Default is `race`.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/services/query.ts#L37)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/services/query.ts#L36)
 
 #### :gear: defaultAgent
 

--- a/packages/utils/src/services/query.spec.ts
+++ b/packages/utils/src/services/query.spec.ts
@@ -33,7 +33,7 @@ describe("query", () => {
       mockParams: QueryAndUpdateParams<string>;
       requestMock: jest.Mock;
       onLoadMock: jest.Mock;
-      onQueryErrorMock: jest.Mock;
+      onErrorMock: jest.Mock;
       onUpdateErrorMock: jest.Mock;
     } => {
       const {
@@ -49,7 +49,7 @@ describe("query", () => {
         .fn()
         .mockResolvedValue(requestResponse);
       const onLoadMock: jest.Mock = jest.fn();
-      const onQueryErrorMock: jest.Mock = jest.fn();
+      const onErrorMock: jest.Mock = jest.fn();
       const onUpdateErrorMock: jest.Mock = jest.fn();
 
       const mockQueryResult: jest.Mock = jest
@@ -97,7 +97,7 @@ describe("query", () => {
       const mockParams: QueryAndUpdateParams<string> = {
         request: requestMock,
         onLoad: onLoadMock,
-        onQueryError: onQueryErrorMock,
+        onError: onErrorMock,
         onUpdateError: onUpdateErrorMock,
         identity: mockIdentity,
         resolution,
@@ -108,7 +108,7 @@ describe("query", () => {
         mockParams,
         requestMock,
         onLoadMock,
-        onQueryErrorMock,
+        onErrorMock,
         onUpdateErrorMock,
       };
     };
@@ -182,12 +182,12 @@ describe("query", () => {
       });
 
       describe("when both requests succeed", () => {
-        it("should not call `onQueryError`", async () => {
-          const { mockParams, onQueryErrorMock } = createMockParams();
+        it("should not call `onError`", async () => {
+          const { mockParams, onErrorMock } = createMockParams();
 
           await queryAndUpdate(mockParams);
 
-          expect(onQueryErrorMock).not.toHaveBeenCalled();
+          expect(onErrorMock).not.toHaveBeenCalled();
         });
 
         it("should not call `onUpdateError`", async () => {
@@ -262,12 +262,12 @@ describe("query", () => {
               });
             });
 
-            it("should not call `onQueryError`", async () => {
-              const { mockParams, onQueryErrorMock } = createMockParams();
+            it("should not call `onError`", async () => {
+              const { mockParams, onErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onQueryErrorMock).not.toHaveBeenCalled();
+              expect(onErrorMock).not.toHaveBeenCalled();
             });
 
             it("should ignore `update` error and not call `onUpdateError`", async () => {
@@ -304,13 +304,13 @@ describe("query", () => {
               expect(onLoadMock).not.toHaveBeenCalled();
             });
 
-            it("should ignore `update` response and call `onQueryError` with query error", async () => {
-              const { mockParams, onQueryErrorMock } = createMockParams();
+            it("should ignore `update` response and call `onError` with query error", async () => {
+              const { mockParams, onErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
-              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onErrorMock).toHaveBeenCalledTimes(1);
+              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
                 identity: mockIdentity,
               });
@@ -347,13 +347,13 @@ describe("query", () => {
               };
             });
 
-            it("should call `onQueryError` only with `query` error", async () => {
-              const { mockParams, onQueryErrorMock } = createMockParams();
+            it("should call `onError` only with `query` error", async () => {
+              const { mockParams, onErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
-              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onErrorMock).toHaveBeenCalledTimes(1);
+              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
                 identity: mockIdentity,
               });
@@ -433,12 +433,12 @@ describe("query", () => {
               });
             });
 
-            it("should not call `onQueryError", async () => {
-              const { mockParams, onQueryErrorMock } = createMockParams();
+            it("should not call `onError", async () => {
+              const { mockParams, onErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onQueryErrorMock).not.toHaveBeenCalled();
+              expect(onErrorMock).not.toHaveBeenCalled();
             });
 
             it("should call `onUpdateError` with `update` error", async () => {
@@ -495,13 +495,13 @@ describe("query", () => {
               });
             });
 
-            it("should call `onQueryError` with `query` error", async () => {
-              const { mockParams, onQueryErrorMock } = createMockParams();
+            it("should call `onError` with `query` error", async () => {
+              const { mockParams, onErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
-              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onErrorMock).toHaveBeenCalledTimes(1);
+              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
                 identity: mockIdentity,
               });
@@ -546,13 +546,13 @@ describe("query", () => {
               };
             });
 
-            it("should call `onQueryError` with `query` error", async () => {
-              const { mockParams, onQueryErrorMock } = createMockParams();
+            it("should call `onError` with `query` error", async () => {
+              const { mockParams, onErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
-              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onErrorMock).toHaveBeenCalledTimes(1);
+              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
                 identity: mockIdentity,
               });
@@ -631,12 +631,12 @@ describe("query", () => {
               expect(onLoadMock).not.toHaveBeenCalled();
             });
 
-            it("should not call `onQueryError`", async () => {
-              const { mockParams, onQueryErrorMock } = createMockParams();
+            it("should not call `onError`", async () => {
+              const { mockParams, onErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onQueryErrorMock).not.toHaveBeenCalled();
+              expect(onErrorMock).not.toHaveBeenCalled();
             });
 
             it("should ignore `query` response and call `onUpdateError` with `update` error", async () => {
@@ -693,12 +693,12 @@ describe("query", () => {
               });
             });
 
-            it("should ignore `query` error and not call `onQueryError`", async () => {
-              const { mockParams, onQueryErrorMock } = createMockParams();
+            it("should ignore `query` error and not call `onError`", async () => {
+              const { mockParams, onErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onQueryErrorMock).not.toHaveBeenCalled();
+              expect(onErrorMock).not.toHaveBeenCalled();
             });
 
             it("should ignore `query` error and not log the console error", async () => {
@@ -720,12 +720,12 @@ describe("query", () => {
               };
             });
 
-            it("should ignore `query` error and not call `onQueryError`", async () => {
-              const { mockParams, onQueryErrorMock } = createMockParams();
+            it("should ignore `query` error and not call `onError`", async () => {
+              const { mockParams, onErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onQueryErrorMock).not.toHaveBeenCalled();
+              expect(onErrorMock).not.toHaveBeenCalled();
             });
 
             it("should call `onUpdateError` with `update` error", async () => {
@@ -798,12 +798,12 @@ describe("query", () => {
               expect(onLoadMock).not.toHaveBeenCalled();
             });
 
-            it("should not call `onQueryError`", async () => {
-              const { mockParams, onQueryErrorMock } = createMockParams();
+            it("should not call `onError`", async () => {
+              const { mockParams, onErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onQueryErrorMock).not.toHaveBeenCalled();
+              expect(onErrorMock).not.toHaveBeenCalled();
             });
 
             it("should call `onUpdateError` with `update` error", async () => {
@@ -860,13 +860,13 @@ describe("query", () => {
               });
             });
 
-            it("should call `onQueryError` with `query` error", async () => {
-              const { mockParams, onQueryErrorMock } = createMockParams();
+            it("should call `onError` with `query` error", async () => {
+              const { mockParams, onErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
-              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onErrorMock).toHaveBeenCalledTimes(1);
+              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
                 identity: mockIdentity,
               });
@@ -899,18 +899,13 @@ describe("query", () => {
               };
             });
 
-            it("should call `onQueryError` with `query` error", async () => {
-              const { mockParams, onQueryErrorMock } = createMockParams();
+            it("should call `onError` with `query` error", async () => {
+              const { mockParams, onErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
-              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
-                error: queryErrorObj,
-                identity: mockIdentity,
-              });
-              expect(onErrorMock).toHaveBeenNthCalledWith(2, {
-                certified: false,
+              expect(onErrorMock).toHaveBeenCalledTimes(1);
+              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
                 identity: mockIdentity,
               });
@@ -983,15 +978,15 @@ describe("query", () => {
         });
       });
 
-      it("should call `onQueryError` if `query` fails", async () => {
+      it("should call `onError` if `query` fails", async () => {
         params = { ...params, requestError: true };
 
-        const { mockParams, onQueryErrorMock } = createMockParams();
+        const { mockParams, onErrorMock } = createMockParams();
 
         await queryAndUpdate(mockParams);
 
-        expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
-        expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
+        expect(onErrorMock).toHaveBeenCalledTimes(1);
+        expect(onErrorMock).toHaveBeenNthCalledWith(1, {
           error: requestErrorObj,
           identity: mockIdentity,
         });
@@ -1063,14 +1058,14 @@ describe("query", () => {
         });
       });
 
-      it("should not call `onQueryError` if `update` fails", async () => {
+      it("should not call `onError` if `update` fails", async () => {
         params = { ...params, requestError: true };
 
-        const { mockParams, onQueryErrorMock } = createMockParams();
+        const { mockParams, onErrorMock } = createMockParams();
 
         await queryAndUpdate(mockParams);
 
-        expect(onQueryErrorMock).not.toHaveBeenCalled();
+        expect(onErrorMock).not.toHaveBeenCalled();
       });
 
       it("should call `onUpdateError` if `update` fails", async () => {

--- a/packages/utils/src/services/query.spec.ts
+++ b/packages/utils/src/services/query.spec.ts
@@ -860,12 +860,16 @@ describe("query", () => {
               });
             });
 
-            it("should ignore `query` error and not call `onQueryError`", async () => {
+            it("should call `onQueryError` with `query` error", async () => {
               const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onQueryErrorMock).not.toHaveBeenCalled();
+              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
+              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
+                error: queryErrorObj,
+                identity: mockIdentity,
+              });
             });
 
             it("should not call `onUpdateError`", async () => {
@@ -895,12 +899,16 @@ describe("query", () => {
               };
             });
 
-            it("should ignore `query` error and not call `onQueryError`", async () => {
+            it("should call `onQueryError` with `query` error", async () => {
               const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onQueryErrorMock).not.toHaveBeenCalled();
+              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
+              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
+                error: queryErrorObj,
+                identity: mockIdentity,
+              });
             });
 
             it("should call `onUpdateError` with `update` error", async () => {

--- a/packages/utils/src/services/query.spec.ts
+++ b/packages/utils/src/services/query.spec.ts
@@ -33,8 +33,8 @@ describe("query", () => {
       mockParams: QueryAndUpdateParams<string>;
       requestMock: jest.Mock;
       onLoadMock: jest.Mock;
-      onErrorMock: jest.Mock;
-      onCertifiedErrorMock: jest.Mock;
+      onQueryErrorMock: jest.Mock;
+      onUpdateErrorMock: jest.Mock;
     } => {
       const {
         faster,
@@ -49,8 +49,8 @@ describe("query", () => {
         .fn()
         .mockResolvedValue(requestResponse);
       const onLoadMock: jest.Mock = jest.fn();
-      const onErrorMock: jest.Mock = jest.fn();
-      const onCertifiedErrorMock: jest.Mock = jest.fn();
+      const onQueryErrorMock: jest.Mock = jest.fn();
+      const onUpdateErrorMock: jest.Mock = jest.fn();
 
       const mockQueryResult: jest.Mock = jest
         .fn()
@@ -97,8 +97,8 @@ describe("query", () => {
       const mockParams: QueryAndUpdateParams<string> = {
         request: requestMock,
         onLoad: onLoadMock,
-        onError: onErrorMock,
-        onCertifiedError: onCertifiedErrorMock,
+        onQueryError: onQueryErrorMock,
+        onUpdateError: onUpdateErrorMock,
         identity: mockIdentity,
         resolution,
         strategy,
@@ -108,8 +108,8 @@ describe("query", () => {
         mockParams,
         requestMock,
         onLoadMock,
-        onErrorMock,
-        onCertifiedErrorMock,
+        onQueryErrorMock,
+        onUpdateErrorMock,
       };
     };
 
@@ -182,20 +182,20 @@ describe("query", () => {
       });
 
       describe("when both requests succeed", () => {
-        it("should not call `onError`", async () => {
-          const { mockParams, onErrorMock } = createMockParams();
+        it("should not call `onQueryError`", async () => {
+          const { mockParams, onQueryErrorMock } = createMockParams();
 
           await queryAndUpdate(mockParams);
 
-          expect(onErrorMock).not.toHaveBeenCalled();
+          expect(onQueryErrorMock).not.toHaveBeenCalled();
         });
 
-        it("should not call `onCertifiedError`", async () => {
-          const { mockParams, onCertifiedErrorMock } = createMockParams();
+        it("should not call `onUpdateError`", async () => {
+          const { mockParams, onUpdateErrorMock } = createMockParams();
 
           await queryAndUpdate(mockParams);
 
-          expect(onCertifiedErrorMock).not.toHaveBeenCalled();
+          expect(onUpdateErrorMock).not.toHaveBeenCalled();
         });
 
         it("should not log the console error", async () => {
@@ -262,20 +262,20 @@ describe("query", () => {
               });
             });
 
-            it("should ignore `update` error and not call `onError`", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should not call `onQueryError`", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).not.toHaveBeenCalled();
+              expect(onQueryErrorMock).not.toHaveBeenCalled();
             });
 
-            it("should ignore `update` error and not call `onCertifiedError`", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should ignore `update` error and not call `onUpdateError`", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).not.toHaveBeenCalled();
+              expect(onUpdateErrorMock).not.toHaveBeenCalled();
             });
 
             it("should ignore `update` error and not log the console error", async () => {
@@ -304,14 +304,13 @@ describe("query", () => {
               expect(onLoadMock).not.toHaveBeenCalled();
             });
 
-            it("should ignore `update` response and call `onError` with query error", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should ignore `update` response and call `onQueryError` with query error", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(1);
-              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
-                certified: false,
+              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
+              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
                 identity: mockIdentity,
               });
@@ -326,12 +325,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, queryErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -348,25 +347,24 @@ describe("query", () => {
               };
             });
 
-            it("should call `onError` only with `query` error", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should call `onQueryError` only with `query` error", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(1);
-              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
-                certified: false,
+              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
+              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
                 identity: mockIdentity,
               });
             });
 
-            it("should not call `onCertifiedError`", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should ignore `update` error and not call `onUpdateError`", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).not.toHaveBeenCalled();
+              expect(onUpdateErrorMock).not.toHaveBeenCalled();
             });
 
             it("should log the console error only with `query` error", async () => {
@@ -378,12 +376,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, queryErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -435,26 +433,21 @@ describe("query", () => {
               });
             });
 
-            it("should call `onError` with `update` error", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should not call `onQueryError", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(1);
-              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
-                certified: true,
-                error: updateErrorObj,
-                identity: mockIdentity,
-              });
+              expect(onQueryErrorMock).not.toHaveBeenCalled();
             });
 
-            it("should call `onCertifiedError` with `update` error", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should call `onUpdateError` with `update` error", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).toHaveBeenCalledTimes(1);
-              expect(onCertifiedErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onUpdateErrorMock).toHaveBeenCalledTimes(1);
+              expect(onUpdateErrorMock).toHaveBeenNthCalledWith(1, {
                 error: updateErrorObj,
                 identity: mockIdentity,
               });
@@ -469,12 +462,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, updateErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -502,25 +495,24 @@ describe("query", () => {
               });
             });
 
-            it("should call `onError` with `query` error", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should call `onQueryError` with `query` error", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(1);
-              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
-                certified: false,
+              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
+              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
                 identity: mockIdentity,
               });
             });
 
-            it("should not call `onCertifiedError`", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should not call `onUpdateError`", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).not.toHaveBeenCalled();
+              expect(onUpdateErrorMock).not.toHaveBeenCalled();
             });
 
             it("should log the console error with `query` error", async () => {
@@ -532,12 +524,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, queryErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -554,31 +546,25 @@ describe("query", () => {
               };
             });
 
-            it("should call `onError` with both errors", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should call `onQueryError` with `query` error", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(2);
-              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
-                certified: false,
+              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
+              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
-                identity: mockIdentity,
-              });
-              expect(onErrorMock).toHaveBeenNthCalledWith(2, {
-                certified: true,
-                error: updateErrorObj,
                 identity: mockIdentity,
               });
             });
 
-            it("should call `onCertifiedError` with `update` error", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should call `onUpdateError` with `update` error", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).toHaveBeenCalledTimes(1);
-              expect(onCertifiedErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onUpdateErrorMock).toHaveBeenCalledTimes(1);
+              expect(onUpdateErrorMock).toHaveBeenNthCalledWith(1, {
                 error: updateErrorObj,
                 identity: mockIdentity,
               });
@@ -594,12 +580,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(2, updateErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -645,26 +631,21 @@ describe("query", () => {
               expect(onLoadMock).not.toHaveBeenCalled();
             });
 
-            it("should ignore `query` response and call `onError` with `update` error", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should not call `onQueryError`", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(1);
-              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
-                certified: true,
-                error: updateErrorObj,
-                identity: mockIdentity,
-              });
+              expect(onQueryErrorMock).not.toHaveBeenCalled();
             });
 
-            it("should ignore `query` response and call `onCertifiedError` with `update` error", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should ignore `query` response and call `onUpdateError` with `update` error", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).toHaveBeenCalledTimes(1);
-              expect(onCertifiedErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onUpdateErrorMock).toHaveBeenCalledTimes(1);
+              expect(onUpdateErrorMock).toHaveBeenNthCalledWith(1, {
                 error: updateErrorObj,
                 identity: mockIdentity,
               });
@@ -679,12 +660,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, updateErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -712,12 +693,12 @@ describe("query", () => {
               });
             });
 
-            it("should ignore `query` error and not call `onError`", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should ignore `query` error and not call `onQueryError`", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).not.toHaveBeenCalled();
+              expect(onQueryErrorMock).not.toHaveBeenCalled();
             });
 
             it("should ignore `query` error and not log the console error", async () => {
@@ -739,26 +720,21 @@ describe("query", () => {
               };
             });
 
-            it("should call `onError` only with `update` error", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should ignore `query` error and not call `onQueryError`", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(1);
-              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
-                certified: true,
-                error: updateErrorObj,
-                identity: mockIdentity,
-              });
+              expect(onQueryErrorMock).not.toHaveBeenCalled();
             });
 
-            it("should call `onCertifiedError` with `update` error", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should call `onUpdateError` with `update` error", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).toHaveBeenCalledTimes(1);
-              expect(onCertifiedErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onUpdateErrorMock).toHaveBeenCalledTimes(1);
+              expect(onUpdateErrorMock).toHaveBeenNthCalledWith(1, {
                 error: updateErrorObj,
                 identity: mockIdentity,
               });
@@ -773,12 +749,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, updateErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -822,26 +798,21 @@ describe("query", () => {
               expect(onLoadMock).not.toHaveBeenCalled();
             });
 
-            it("should call `onError` with `update` error", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should not call `onQueryError`", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(1);
-              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
-                certified: true,
-                error: updateErrorObj,
-                identity: mockIdentity,
-              });
+              expect(onQueryErrorMock).not.toHaveBeenCalled();
             });
 
-            it("should call `onCertifiedError` with `update` error", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should call `onUpdateError` with `update` error", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).toHaveBeenCalledTimes(1);
-              expect(onCertifiedErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onUpdateErrorMock).toHaveBeenCalledTimes(1);
+              expect(onUpdateErrorMock).toHaveBeenNthCalledWith(1, {
                 error: updateErrorObj,
                 identity: mockIdentity,
               });
@@ -856,12 +827,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, updateErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -889,20 +860,20 @@ describe("query", () => {
               });
             });
 
-            it("should ignore `query` error and not call `onError`", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should ignore `query` error and not call `onQueryError`", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).not.toHaveBeenCalled();
+              expect(onQueryErrorMock).not.toHaveBeenCalled();
             });
 
-            it("should not call `onCertifiedError`", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should not call `onUpdateError`", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).not.toHaveBeenCalled();
+              expect(onUpdateErrorMock).not.toHaveBeenCalled();
             });
 
             it("should ignore `query` error and not log the console error", async () => {
@@ -924,26 +895,21 @@ describe("query", () => {
               };
             });
 
-            it("should call `onError` only with `update` error", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should ignore `query` error and not call `onQueryError`", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(1);
-              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
-                certified: true,
-                error: updateErrorObj,
-                identity: mockIdentity,
-              });
+              expect(onQueryErrorMock).not.toHaveBeenCalled();
             });
 
-            it("should call `onCertifiedError` with `update` error", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should call `onUpdateError` with `update` error", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).toHaveBeenCalledTimes(1);
-              expect(onCertifiedErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onUpdateErrorMock).toHaveBeenCalledTimes(1);
+              expect(onUpdateErrorMock).toHaveBeenNthCalledWith(1, {
                 error: updateErrorObj,
                 identity: mockIdentity,
               });
@@ -958,12 +924,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, updateErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -1004,29 +970,28 @@ describe("query", () => {
         });
       });
 
-      it("should call `onError` if `query` fails", async () => {
+      it("should call `onQueryError` if `query` fails", async () => {
         params = { ...params, requestError: true };
 
-        const { mockParams, onErrorMock } = createMockParams();
+        const { mockParams, onQueryErrorMock } = createMockParams();
 
         await queryAndUpdate(mockParams);
 
-        expect(onErrorMock).toHaveBeenCalledTimes(1);
-        expect(onErrorMock).toHaveBeenNthCalledWith(1, {
-          certified: false,
+        expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
+        expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
           error: requestErrorObj,
           identity: mockIdentity,
         });
       });
 
-      it("should not call `onCertifiedError` if `query` fails", async () => {
+      it("should not call `onUpdateError` if `query` fails", async () => {
         params = { ...params, requestError: true };
 
-        const { mockParams, onCertifiedErrorMock } = createMockParams();
+        const { mockParams, onUpdateErrorMock } = createMockParams();
 
         await queryAndUpdate(mockParams);
 
-        expect(onCertifiedErrorMock).not.toHaveBeenCalled();
+        expect(onUpdateErrorMock).not.toHaveBeenCalled();
       });
 
       it("should log the console error if `query` fails", async () => {
@@ -1040,14 +1005,14 @@ describe("query", () => {
         expect(console.error).toHaveBeenNthCalledWith(1, requestErrorObj);
       });
 
-      it("should not log the console error when `onCertifiedError` is nullish", async () => {
+      it("should not log the console error when `onUpdateError` is nullish", async () => {
         params = { ...params, requestError: true };
 
         const { mockParams } = createMockParams();
 
         await queryAndUpdate({
           ...mockParams,
-          onCertifiedError: undefined,
+          onUpdateError: undefined,
         });
 
         expect(console.error).not.toHaveBeenCalled();
@@ -1085,30 +1050,25 @@ describe("query", () => {
         });
       });
 
-      it("should call `onError` if `update` fails", async () => {
+      it("should not call `onQueryError` if `update` fails", async () => {
         params = { ...params, requestError: true };
 
-        const { mockParams, onErrorMock } = createMockParams();
+        const { mockParams, onQueryErrorMock } = createMockParams();
 
         await queryAndUpdate(mockParams);
 
-        expect(onErrorMock).toHaveBeenCalledTimes(1);
-        expect(onErrorMock).toHaveBeenNthCalledWith(1, {
-          certified: true,
-          error: requestErrorObj,
-          identity: mockIdentity,
-        });
+        expect(onQueryErrorMock).not.toHaveBeenCalled();
       });
 
-      it("should call `onCertifiedError` if `update` fails", async () => {
+      it("should call `onUpdateError` if `update` fails", async () => {
         params = { ...params, requestError: true };
 
-        const { mockParams, onCertifiedErrorMock } = createMockParams();
+        const { mockParams, onUpdateErrorMock } = createMockParams();
 
         await queryAndUpdate(mockParams);
 
-        expect(onCertifiedErrorMock).toHaveBeenCalledTimes(1);
-        expect(onCertifiedErrorMock).toHaveBeenNthCalledWith(1, {
+        expect(onUpdateErrorMock).toHaveBeenCalledTimes(1);
+        expect(onUpdateErrorMock).toHaveBeenNthCalledWith(1, {
           error: requestErrorObj,
           identity: mockIdentity,
         });
@@ -1125,14 +1085,14 @@ describe("query", () => {
         expect(console.error).toHaveBeenNthCalledWith(1, requestErrorObj);
       });
 
-      it("should not log the console error when `onCertifiedError` is nullish", async () => {
+      it("should not log the console error when `onUpdateError` is nullish", async () => {
         params = { ...params, requestError: true };
 
         const { mockParams } = createMockParams();
 
         await queryAndUpdate({
           ...mockParams,
-          onCertifiedError: undefined,
+          onUpdateError: undefined,
         });
 
         expect(console.error).not.toHaveBeenCalled();

--- a/packages/utils/src/services/query.spec.ts
+++ b/packages/utils/src/services/query.spec.ts
@@ -347,7 +347,7 @@ describe("query", () => {
               };
             });
 
-            it("should call `onError` only with `query` error", async () => {
+            it("should call `onError` with `query` error", async () => {
               const { mockParams, onErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);

--- a/packages/utils/src/services/query.ts
+++ b/packages/utils/src/services/query.ts
@@ -22,7 +22,7 @@ import { isNullish } from "../utils/nullish.utils";
  * @param {QueryAndUpdateParams<R, E>} params The parameters to perform the request.
  * @param {QueryAndUpdateRequest<R>} params.request The request to perform.
  * @param {QueryAndUpdateOnResponse<R>} params.onLoad The callback to handle the response of the request.
- * @param {QueryAndUpdateOnQueryError<E>} [params.onQueryError] The callback to handle the error of the `query` request.
+ * @param {QueryAndUpdateOnError<E>} [params.onError] The callback to handle the error of the `query` request.
  * @param {QueryAndUpdateOnUpdateError<E>} [params.onUpdateError] The callback to handle the error of the `update` request.
  * @param {QueryAndUpdateStrategy} [params.strategy="query_and_update"] The strategy to use. Default is `query_and_update`.
  * @param {QueryAndUpdateIdentity} params.identity The identity to use for the request.
@@ -36,7 +36,7 @@ import { isNullish } from "../utils/nullish.utils";
 export const queryAndUpdate = async <R, E = unknown>({
   request,
   onLoad,
-  onQueryError,
+  onError,
   onUpdateError,
   strategy = "query_and_update",
   identity,
@@ -55,7 +55,7 @@ export const queryAndUpdate = async <R, E = unknown>({
       })
       .catch((error: E) => {
         if (!certified) {
-          onQueryError?.({ error, identity });
+          onError?.({ error, identity });
         }
 
         if (certifiedDone) {

--- a/packages/utils/src/services/query.ts
+++ b/packages/utils/src/services/query.ts
@@ -72,7 +72,7 @@ export const queryAndUpdate = async <R, E = unknown>({
           return;
         }
 
-        onUpdateError?.({ error, identity });
+        onUpdateError({ error, identity });
       })
       .finally(() => (certifiedDone = certifiedDone || certified));
 

--- a/packages/utils/src/services/query.ts
+++ b/packages/utils/src/services/query.ts
@@ -62,7 +62,6 @@ export const queryAndUpdate = async <R, E = unknown>({
           onQueryError?.({ error, identity });
         }
 
-        // Handling certified is handled as: just console error query error and do something with the update error
         if (isNullish(onUpdateError)) {
           return;
         }

--- a/packages/utils/src/services/query.ts
+++ b/packages/utils/src/services/query.ts
@@ -17,14 +17,13 @@ import { isNullish } from "../utils/nullish.utils";
  * - `race` waits for the first call to settle (typically, `query` is the fastest one).
  *
  * Once the call(s) are done, the response is handled by the `onLoad` callback.
- * However, if an error occurs, it is handled by the `onError` callback, if provided.
- * In addition, if the error is from the update call, the `onCertifiedError` callback is called too, if provided.
+ * However, if an error occurs, it is handled by the error callbacks, if provided: one for the query call and one for the update call.
  *
  * @param {QueryAndUpdateParams<R, E>} params The parameters to perform the request.
  * @param {QueryAndUpdateRequest<R>} params.request The request to perform.
  * @param {QueryAndUpdateOnResponse<R>} params.onLoad The callback to handle the response of the request.
- * @param {QueryAndUpdateOnError<E>} [params.onError] The callback to handle the error of the request.
- * @param {QueryAndUpdateOnCertifiedError<E>} [params.onCertifiedError] The additional callback to handle the error of the update request.
+ * @param {QueryAndUpdateOnQueryError<E>} [params.onQueryError] The callback to handle the error of the `query` request.
+ * @param {QueryAndUpdateOnUpdateError<E>} [params.onUpdateError] The callback to handle the error of the `update` request.
  * @param {QueryAndUpdateStrategy} [params.strategy="query_and_update"] The strategy to use. Default is `query_and_update`.
  * @param {QueryAndUpdateIdentity} params.identity The identity to use for the request.
  * @param {QueryAndUpdatePromiseResolution} [params.resolution="race"] The resolution to use. Default is `race`.
@@ -37,8 +36,8 @@ import { isNullish } from "../utils/nullish.utils";
 export const queryAndUpdate = async <R, E = unknown>({
   request,
   onLoad,
-  onError,
-  onCertifiedError,
+  onQueryError,
+  onUpdateError,
   strategy = "query_and_update",
   identity,
   resolution = "race",
@@ -59,10 +58,12 @@ export const queryAndUpdate = async <R, E = unknown>({
           return;
         }
 
-        onError?.({ certified, error, identity });
+        if (!certified) {
+          onQueryError?.({ error, identity });
+        }
 
         // Handling certified is handled as: just console error query error and do something with the update error
-        if (isNullish(onCertifiedError)) {
+        if (isNullish(onUpdateError)) {
           return;
         }
 
@@ -72,7 +73,7 @@ export const queryAndUpdate = async <R, E = unknown>({
           return;
         }
 
-        onCertifiedError?.({ error, identity });
+        onUpdateError?.({ error, identity });
       })
       .finally(() => (certifiedDone = certifiedDone || certified));
 

--- a/packages/utils/src/services/query.ts
+++ b/packages/utils/src/services/query.ts
@@ -54,12 +54,12 @@ export const queryAndUpdate = async <R, E = unknown>({
         onLoad({ certified, response });
       })
       .catch((error: E) => {
-        if (certifiedDone) {
-          return;
-        }
-
         if (!certified) {
           onQueryError?.({ error, identity });
+        }
+
+        if (certifiedDone) {
+          return;
         }
 
         if (isNullish(onUpdateError)) {

--- a/packages/utils/src/types/query-and-update.params.ts
+++ b/packages/utils/src/types/query-and-update.params.ts
@@ -22,15 +22,13 @@ export interface QueryAndUpdateOnErrorOptions<E = unknown> {
   identity: QueryAndUpdateIdentity;
 }
 
-export type QueryAndUpdateOnError<E = unknown> = (
-  options: {
-    certified: boolean;
-  } & QueryAndUpdateOnErrorOptions<E>,
-) => void;
-
-export type QueryAndUpdateOnCertifiedError<E = unknown> = (
+type QueryAndUpdateOnError<E = unknown> = (
   options: QueryAndUpdateOnErrorOptions<E>,
 ) => void;
+
+export type QueryAndUpdateOnQueryError<E = unknown> = QueryAndUpdateOnError<E>;
+
+export type QueryAndUpdateOnUpdateError<E = unknown> = QueryAndUpdateOnError<E>;
 
 export type QueryAndUpdateStrategy = "query_and_update" | "query" | "update";
 
@@ -39,8 +37,8 @@ export type QueryAndUpdatePromiseResolution = "all_settled" | "race";
 export interface QueryAndUpdateParams<R, E = unknown> {
   request: QueryAndUpdateRequest<R>;
   onLoad: QueryAndUpdateOnResponse<R>;
-  onError?: QueryAndUpdateOnError<E>;
-  onCertifiedError?: QueryAndUpdateOnCertifiedError<E>;
+  onQueryError?: QueryAndUpdateOnQueryError<E>;
+  onUpdateError?: QueryAndUpdateOnUpdateError<E>;
   strategy?: QueryAndUpdateStrategy;
   identity: QueryAndUpdateIdentity;
   resolution?: QueryAndUpdatePromiseResolution;

--- a/packages/utils/src/types/query-and-update.params.ts
+++ b/packages/utils/src/types/query-and-update.params.ts
@@ -22,13 +22,14 @@ export interface QueryAndUpdateOnErrorOptions<E = unknown> {
   identity: QueryAndUpdateIdentity;
 }
 
-type QueryAndUpdateOnError<E = unknown> = (
+
+export type QueryAndUpdateOnError<E = unknown> = (
   options: QueryAndUpdateOnErrorOptions<E>,
 ) => void;
 
-export type QueryAndUpdateOnQueryError<E = unknown> = QueryAndUpdateOnError<E>;
-
-export type QueryAndUpdateOnUpdateError<E = unknown> = QueryAndUpdateOnError<E>;
+export type QueryAndUpdateOnUpdateError<E = unknown> = (
+  options: QueryAndUpdateOnErrorOptions<E>,
+) => void;
 
 export type QueryAndUpdateStrategy = "query_and_update" | "query" | "update";
 
@@ -37,7 +38,7 @@ export type QueryAndUpdatePromiseResolution = "all_settled" | "race";
 export interface QueryAndUpdateParams<R, E = unknown> {
   request: QueryAndUpdateRequest<R>;
   onLoad: QueryAndUpdateOnResponse<R>;
-  onQueryError?: QueryAndUpdateOnQueryError<E>;
+  onError?: QueryAndUpdateOnError<E>;
   onUpdateError?: QueryAndUpdateOnUpdateError<E>;
   strategy?: QueryAndUpdateStrategy;
   identity: QueryAndUpdateIdentity;

--- a/packages/utils/src/types/query-and-update.params.ts
+++ b/packages/utils/src/types/query-and-update.params.ts
@@ -22,7 +22,6 @@ export interface QueryAndUpdateOnErrorOptions<E = unknown> {
   identity: QueryAndUpdateIdentity;
 }
 
-
 export type QueryAndUpdateOnError<E = unknown> = (
   options: QueryAndUpdateOnErrorOptions<E>,
 ) => void;


### PR DESCRIPTION
# Motivation

As discussed in https://github.com/dfinity/ic-js/pull/871#discussion_r2015855642 , with this PR, we aim to modify service util `queryAndUpdate` to have separate error callbacks: one for `query` and one for `update`.

# Changes

- Modify `queryAndUpdate` logic to call only `onError` for `query` calls and only `onUpdateError` for `update` calls.
- Remove unnecessary `certified` parameter from `onError` function, since it will always be called for `certified: false`

# Tests

Adapt tests.
