### PR TITLE
refactor: rename onError to onQueryError in service queryAndUpdate

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -162,16 +162,16 @@ The resolution can be:
 Once the call(s) are done, the response is handled by the `onLoad` callback.
 However, if an error occurs, it is handled by the error callbacks, if provided: one for the query call and one for the update call.
 
-| Function         | Type                                                                                                                                          |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `queryAndUpdate` | `<R, E = unknown>({ request, onLoad, onError, onUpdateError, strategy, identity, resolution, }: QueryAndUpdateParams<R, E>) => Promise<void>` |
+| Function         | Type                                                                                                                                               |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `queryAndUpdate` | `<R, E = unknown>({ request, onLoad, onQueryError, onUpdateError, strategy, identity, resolution, }: QueryAndUpdateParams<R, E>) => Promise<void>` |
 
 Parameters:
 
 - `params`: The parameters to perform the request.
 - `params.request`: The request to perform.
 - `params.onLoad`: The callback to handle the response of the request.
-- `params.onError`: The callback to handle the error of the `query` request.
+- `params.onQueryError`: The callback to handle the error of the `query` request.
 - `params.onUpdateError`: The callback to handle the error of the `update` request.
 - `params.strategy`: The strategy to use. Default is `query_and_update`.
 - `params.identity`: The identity to use for the request.

--- a/packages/utils/src/services/query.spec.ts
+++ b/packages/utils/src/services/query.spec.ts
@@ -33,7 +33,7 @@ describe("query", () => {
       mockParams: QueryAndUpdateParams<string>;
       requestMock: jest.Mock;
       onLoadMock: jest.Mock;
-      onErrorMock: jest.Mock;
+      onQueryErrorMock: jest.Mock;
       onUpdateErrorMock: jest.Mock;
     } => {
       const {
@@ -49,7 +49,7 @@ describe("query", () => {
         .fn()
         .mockResolvedValue(requestResponse);
       const onLoadMock: jest.Mock = jest.fn();
-      const onErrorMock: jest.Mock = jest.fn();
+      const onQueryErrorMock: jest.Mock = jest.fn();
       const onUpdateErrorMock: jest.Mock = jest.fn();
 
       const mockQueryResult: jest.Mock = jest
@@ -97,7 +97,7 @@ describe("query", () => {
       const mockParams: QueryAndUpdateParams<string> = {
         request: requestMock,
         onLoad: onLoadMock,
-        onError: onErrorMock,
+        onQueryError: onQueryErrorMock,
         onUpdateError: onUpdateErrorMock,
         identity: mockIdentity,
         resolution,
@@ -108,7 +108,7 @@ describe("query", () => {
         mockParams,
         requestMock,
         onLoadMock,
-        onErrorMock,
+        onQueryErrorMock,
         onUpdateErrorMock,
       };
     };
@@ -182,12 +182,12 @@ describe("query", () => {
       });
 
       describe("when both requests succeed", () => {
-        it("should not call `onError`", async () => {
-          const { mockParams, onErrorMock } = createMockParams();
+        it("should not call `onQueryError`", async () => {
+          const { mockParams, onQueryErrorMock } = createMockParams();
 
           await queryAndUpdate(mockParams);
 
-          expect(onErrorMock).not.toHaveBeenCalled();
+          expect(onQueryErrorMock).not.toHaveBeenCalled();
         });
 
         it("should not call `onUpdateError`", async () => {
@@ -262,12 +262,12 @@ describe("query", () => {
               });
             });
 
-            it("should not call `onError`", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should not call `onQueryError`", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).not.toHaveBeenCalled();
+              expect(onQueryErrorMock).not.toHaveBeenCalled();
             });
 
             it("should ignore `update` error and not call `onUpdateError`", async () => {
@@ -304,13 +304,13 @@ describe("query", () => {
               expect(onLoadMock).not.toHaveBeenCalled();
             });
 
-            it("should ignore `update` response and call `onError` with query error", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should ignore `update` response and call `onQueryError` with query error", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(1);
-              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
+              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
                 identity: mockIdentity,
               });
@@ -347,13 +347,13 @@ describe("query", () => {
               };
             });
 
-            it("should call `onError` with `query` error", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should call `onQueryError` with `query` error", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(1);
-              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
+              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
                 identity: mockIdentity,
               });
@@ -433,12 +433,12 @@ describe("query", () => {
               });
             });
 
-            it("should not call `onError", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should not call `onQueryError", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).not.toHaveBeenCalled();
+              expect(onQueryErrorMock).not.toHaveBeenCalled();
             });
 
             it("should call `onUpdateError` with `update` error", async () => {
@@ -495,13 +495,13 @@ describe("query", () => {
               });
             });
 
-            it("should call `onError` with `query` error", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should call `onQueryError` with `query` error", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(1);
-              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
+              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
                 identity: mockIdentity,
               });
@@ -546,13 +546,13 @@ describe("query", () => {
               };
             });
 
-            it("should call `onError` with `query` error", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should call `onQueryError` with `query` error", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(1);
-              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
+              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
                 identity: mockIdentity,
               });
@@ -631,12 +631,12 @@ describe("query", () => {
               expect(onLoadMock).not.toHaveBeenCalled();
             });
 
-            it("should not call `onError`", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should not call `onQueryError`", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).not.toHaveBeenCalled();
+              expect(onQueryErrorMock).not.toHaveBeenCalled();
             });
 
             it("should ignore `query` response and call `onUpdateError` with `update` error", async () => {
@@ -693,12 +693,12 @@ describe("query", () => {
               });
             });
 
-            it("should ignore `query` error and not call `onError`", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should ignore `query` error and not call `onQueryError`", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).not.toHaveBeenCalled();
+              expect(onQueryErrorMock).not.toHaveBeenCalled();
             });
 
             it("should ignore `query` error and not log the console error", async () => {
@@ -720,12 +720,12 @@ describe("query", () => {
               };
             });
 
-            it("should ignore `query` error and not call `onError`", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should ignore `query` error and not call `onQueryError`", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).not.toHaveBeenCalled();
+              expect(onQueryErrorMock).not.toHaveBeenCalled();
             });
 
             it("should call `onUpdateError` with `update` error", async () => {
@@ -798,12 +798,12 @@ describe("query", () => {
               expect(onLoadMock).not.toHaveBeenCalled();
             });
 
-            it("should not call `onError`", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should not call `onQueryError`", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).not.toHaveBeenCalled();
+              expect(onQueryErrorMock).not.toHaveBeenCalled();
             });
 
             it("should call `onUpdateError` with `update` error", async () => {
@@ -860,13 +860,13 @@ describe("query", () => {
               });
             });
 
-            it("should call `onError` with `query` error", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should call `onQueryError` with `query` error", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(1);
-              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
+              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
                 identity: mockIdentity,
               });
@@ -899,13 +899,13 @@ describe("query", () => {
               };
             });
 
-            it("should call `onError` with `query` error", async () => {
-              const { mockParams, onErrorMock } = createMockParams();
+            it("should call `onQueryError` with `query` error", async () => {
+              const { mockParams, onQueryErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(1);
-              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
+              expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
                 error: queryErrorObj,
                 identity: mockIdentity,
               });
@@ -978,15 +978,15 @@ describe("query", () => {
         });
       });
 
-      it("should call `onError` if `query` fails", async () => {
+      it("should call `onQueryError` if `query` fails", async () => {
         params = { ...params, requestError: true };
 
-        const { mockParams, onErrorMock } = createMockParams();
+        const { mockParams, onQueryErrorMock } = createMockParams();
 
         await queryAndUpdate(mockParams);
 
-        expect(onErrorMock).toHaveBeenCalledTimes(1);
-        expect(onErrorMock).toHaveBeenNthCalledWith(1, {
+        expect(onQueryErrorMock).toHaveBeenCalledTimes(1);
+        expect(onQueryErrorMock).toHaveBeenNthCalledWith(1, {
           error: requestErrorObj,
           identity: mockIdentity,
         });
@@ -1058,14 +1058,14 @@ describe("query", () => {
         });
       });
 
-      it("should not call `onError` if `update` fails", async () => {
+      it("should not call `onQueryError` if `update` fails", async () => {
         params = { ...params, requestError: true };
 
-        const { mockParams, onErrorMock } = createMockParams();
+        const { mockParams, onQueryErrorMock } = createMockParams();
 
         await queryAndUpdate(mockParams);
 
-        expect(onErrorMock).not.toHaveBeenCalled();
+        expect(onQueryErrorMock).not.toHaveBeenCalled();
       });
 
       it("should call `onUpdateError` if `update` fails", async () => {

--- a/packages/utils/src/services/query.ts
+++ b/packages/utils/src/services/query.ts
@@ -22,7 +22,7 @@ import { isNullish } from "../utils/nullish.utils";
  * @param {QueryAndUpdateParams<R, E>} params The parameters to perform the request.
  * @param {QueryAndUpdateRequest<R>} params.request The request to perform.
  * @param {QueryAndUpdateOnResponse<R>} params.onLoad The callback to handle the response of the request.
- * @param {QueryAndUpdateOnError<E>} [params.onError] The callback to handle the error of the `query` request.
+ * @param {QueryAndUpdateOnQueryError<E>} [params.onQueryError] The callback to handle the error of the `query` request.
  * @param {QueryAndUpdateOnUpdateError<E>} [params.onUpdateError] The callback to handle the error of the `update` request.
  * @param {QueryAndUpdateStrategy} [params.strategy="query_and_update"] The strategy to use. Default is `query_and_update`.
  * @param {QueryAndUpdateIdentity} params.identity The identity to use for the request.
@@ -36,7 +36,7 @@ import { isNullish } from "../utils/nullish.utils";
 export const queryAndUpdate = async <R, E = unknown>({
   request,
   onLoad,
-  onError,
+  onQueryError,
   onUpdateError,
   strategy = "query_and_update",
   identity,
@@ -55,7 +55,7 @@ export const queryAndUpdate = async <R, E = unknown>({
       })
       .catch((error: E) => {
         if (!certified) {
-          onError?.({ error, identity });
+          onQueryError?.({ error, identity });
         }
 
         if (certifiedDone) {

--- a/packages/utils/src/types/query-and-update.params.ts
+++ b/packages/utils/src/types/query-and-update.params.ts
@@ -26,9 +26,9 @@ type QueryAndUpdateOnError<E = unknown> = (
   options: QueryAndUpdateOnErrorOptions<E>,
 ) => void;
 
-export type QueryAndUpdateOnQueryError<E = unknown> = QueryAndUpdateOnError<E>
+export type QueryAndUpdateOnQueryError<E = unknown> = QueryAndUpdateOnError<E>;
 
-export type QueryAndUpdateOnUpdateError<E = unknown> = QueryAndUpdateOnError<E>
+export type QueryAndUpdateOnUpdateError<E = unknown> = QueryAndUpdateOnError<E>;
 
 export type QueryAndUpdateStrategy = "query_and_update" | "query" | "update";
 

--- a/packages/utils/src/types/query-and-update.params.ts
+++ b/packages/utils/src/types/query-and-update.params.ts
@@ -22,13 +22,13 @@ export interface QueryAndUpdateOnErrorOptions<E = unknown> {
   identity: QueryAndUpdateIdentity;
 }
 
-export type QueryAndUpdateOnError<E = unknown> = (
+type QueryAndUpdateOnError<E = unknown> = (
   options: QueryAndUpdateOnErrorOptions<E>,
 ) => void;
 
-export type QueryAndUpdateOnUpdateError<E = unknown> = (
-  options: QueryAndUpdateOnErrorOptions<E>,
-) => void;
+export type QueryAndUpdateOnQueryError<E = unknown> = QueryAndUpdateOnError<E>
+
+export type QueryAndUpdateOnUpdateError<E = unknown> = QueryAndUpdateOnError<E>
 
 export type QueryAndUpdateStrategy = "query_and_update" | "query" | "update";
 
@@ -37,7 +37,7 @@ export type QueryAndUpdatePromiseResolution = "all_settled" | "race";
 export interface QueryAndUpdateParams<R, E = unknown> {
   request: QueryAndUpdateRequest<R>;
   onLoad: QueryAndUpdateOnResponse<R>;
-  onError?: QueryAndUpdateOnError<E>;
+  onQueryError?: QueryAndUpdateOnQueryError<E>;
   onUpdateError?: QueryAndUpdateOnUpdateError<E>;
   strategy?: QueryAndUpdateStrategy;
   identity: QueryAndUpdateIdentity;


### PR DESCRIPTION
# Motivation

It makes more sense to rename the `onError` parameters of service `queryAndUpdate` to `onQueryError`, since it is called only for non-certified calls (query) after PR https://github.com/dfinity/ic-js/pull/875 .