### PR TITLE
refactor: rename onCertifiedError to onUpdateError in service queryAndUpdate

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -161,11 +161,11 @@ The resolution can be:
 
 Once the call(s) are done, the response is handled by the `onLoad` callback.
 However, if an error occurs, it is handled by the `onError` callback, if provided.
-In addition, if the error is from the update call, the `onCertifiedError` callback is called too, if provided.
+In addition, if the error is from the update call, the `onUpdateError` callback is called too, if provided.
 
-| Function         | Type                                                                                                                                             |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `queryAndUpdate` | `<R, E = unknown>({ request, onLoad, onError, onCertifiedError, strategy, identity, resolution, }: QueryAndUpdateParams<R, E>) => Promise<void>` |
+| Function         | Type                                                                                                                                          |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `queryAndUpdate` | `<R, E = unknown>({ request, onLoad, onError, onUpdateError, strategy, identity, resolution, }: QueryAndUpdateParams<R, E>) => Promise<void>` |
 
 Parameters:
 
@@ -173,7 +173,7 @@ Parameters:
 - `params.request`: The request to perform.
 - `params.onLoad`: The callback to handle the response of the request.
 - `params.onError`: The callback to handle the error of the request.
-- `params.onCertifiedError`: The additional callback to handle the error of the update request.
+- `params.onUpdateError`: The additional callback to handle the error of the update request.
 - `params.strategy`: The strategy to use. Default is `query_and_update`.
 - `params.identity`: The identity to use for the request.
 - `params.resolution`: The resolution to use. Default is `race`.

--- a/packages/utils/src/services/query.spec.ts
+++ b/packages/utils/src/services/query.spec.ts
@@ -34,7 +34,7 @@ describe("query", () => {
       requestMock: jest.Mock;
       onLoadMock: jest.Mock;
       onErrorMock: jest.Mock;
-      onCertifiedErrorMock: jest.Mock;
+      onUpdateErrorMock: jest.Mock;
     } => {
       const {
         faster,
@@ -50,7 +50,7 @@ describe("query", () => {
         .mockResolvedValue(requestResponse);
       const onLoadMock: jest.Mock = jest.fn();
       const onErrorMock: jest.Mock = jest.fn();
-      const onCertifiedErrorMock: jest.Mock = jest.fn();
+      const onUpdateErrorMock: jest.Mock = jest.fn();
 
       const mockQueryResult: jest.Mock = jest
         .fn()
@@ -98,7 +98,7 @@ describe("query", () => {
         request: requestMock,
         onLoad: onLoadMock,
         onError: onErrorMock,
-        onCertifiedError: onCertifiedErrorMock,
+        onUpdateError: onUpdateErrorMock,
         identity: mockIdentity,
         resolution,
         strategy,
@@ -109,7 +109,7 @@ describe("query", () => {
         requestMock,
         onLoadMock,
         onErrorMock,
-        onCertifiedErrorMock,
+        onUpdateErrorMock,
       };
     };
 
@@ -190,12 +190,12 @@ describe("query", () => {
           expect(onErrorMock).not.toHaveBeenCalled();
         });
 
-        it("should not call `onCertifiedError`", async () => {
-          const { mockParams, onCertifiedErrorMock } = createMockParams();
+        it("should not call `onUpdateError`", async () => {
+          const { mockParams, onUpdateErrorMock } = createMockParams();
 
           await queryAndUpdate(mockParams);
 
-          expect(onCertifiedErrorMock).not.toHaveBeenCalled();
+          expect(onUpdateErrorMock).not.toHaveBeenCalled();
         });
 
         it("should not log the console error", async () => {
@@ -270,12 +270,12 @@ describe("query", () => {
               expect(onErrorMock).not.toHaveBeenCalled();
             });
 
-            it("should ignore `update` error and not call `onCertifiedError`", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should ignore `update` error and not call `onUpdateError`", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).not.toHaveBeenCalled();
+              expect(onUpdateErrorMock).not.toHaveBeenCalled();
             });
 
             it("should ignore `update` error and not log the console error", async () => {
@@ -326,12 +326,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, queryErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -361,12 +361,12 @@ describe("query", () => {
               });
             });
 
-            it("should not call `onCertifiedError`", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should not call `onUpdateError`", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).not.toHaveBeenCalled();
+              expect(onUpdateErrorMock).not.toHaveBeenCalled();
             });
 
             it("should log the console error only with `query` error", async () => {
@@ -378,12 +378,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, queryErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -448,13 +448,13 @@ describe("query", () => {
               });
             });
 
-            it("should call `onCertifiedError` with `update` error", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should call `onUpdateError` with `update` error", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).toHaveBeenCalledTimes(1);
-              expect(onCertifiedErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onUpdateErrorMock).toHaveBeenCalledTimes(1);
+              expect(onUpdateErrorMock).toHaveBeenNthCalledWith(1, {
                 error: updateErrorObj,
                 identity: mockIdentity,
               });
@@ -469,12 +469,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, updateErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -515,12 +515,12 @@ describe("query", () => {
               });
             });
 
-            it("should not call `onCertifiedError`", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should not call `onUpdateError`", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).not.toHaveBeenCalled();
+              expect(onUpdateErrorMock).not.toHaveBeenCalled();
             });
 
             it("should log the console error with `query` error", async () => {
@@ -532,12 +532,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, queryErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -572,13 +572,13 @@ describe("query", () => {
               });
             });
 
-            it("should call `onCertifiedError` with `update` error", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should call `onUpdateError` with `update` error", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).toHaveBeenCalledTimes(1);
-              expect(onCertifiedErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onUpdateErrorMock).toHaveBeenCalledTimes(1);
+              expect(onUpdateErrorMock).toHaveBeenNthCalledWith(1, {
                 error: updateErrorObj,
                 identity: mockIdentity,
               });
@@ -594,12 +594,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(2, updateErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -658,13 +658,13 @@ describe("query", () => {
               });
             });
 
-            it("should ignore `query` response and call `onCertifiedError` with `update` error", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should ignore `query` response and call `onUpdateError` with `update` error", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).toHaveBeenCalledTimes(1);
-              expect(onCertifiedErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onUpdateErrorMock).toHaveBeenCalledTimes(1);
+              expect(onUpdateErrorMock).toHaveBeenNthCalledWith(1, {
                 error: updateErrorObj,
                 identity: mockIdentity,
               });
@@ -679,12 +679,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, updateErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -752,13 +752,13 @@ describe("query", () => {
               });
             });
 
-            it("should call `onCertifiedError` with `update` error", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should call `onUpdateError` with `update` error", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).toHaveBeenCalledTimes(1);
-              expect(onCertifiedErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onUpdateErrorMock).toHaveBeenCalledTimes(1);
+              expect(onUpdateErrorMock).toHaveBeenNthCalledWith(1, {
                 error: updateErrorObj,
                 identity: mockIdentity,
               });
@@ -773,12 +773,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, updateErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -835,13 +835,13 @@ describe("query", () => {
               });
             });
 
-            it("should call `onCertifiedError` with `update` error", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should call `onUpdateError` with `update` error", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).toHaveBeenCalledTimes(1);
-              expect(onCertifiedErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onUpdateErrorMock).toHaveBeenCalledTimes(1);
+              expect(onUpdateErrorMock).toHaveBeenNthCalledWith(1, {
                 error: updateErrorObj,
                 identity: mockIdentity,
               });
@@ -856,12 +856,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, updateErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -897,12 +897,12 @@ describe("query", () => {
               expect(onErrorMock).not.toHaveBeenCalled();
             });
 
-            it("should not call `onCertifiedError`", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should not call `onUpdateError`", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).not.toHaveBeenCalled();
+              expect(onUpdateErrorMock).not.toHaveBeenCalled();
             });
 
             it("should ignore `query` error and not log the console error", async () => {
@@ -937,13 +937,13 @@ describe("query", () => {
               });
             });
 
-            it("should call `onCertifiedError` with `update` error", async () => {
-              const { mockParams, onCertifiedErrorMock } = createMockParams();
+            it("should call `onUpdateError` with `update` error", async () => {
+              const { mockParams, onUpdateErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onCertifiedErrorMock).toHaveBeenCalledTimes(1);
-              expect(onCertifiedErrorMock).toHaveBeenNthCalledWith(1, {
+              expect(onUpdateErrorMock).toHaveBeenCalledTimes(1);
+              expect(onUpdateErrorMock).toHaveBeenNthCalledWith(1, {
                 error: updateErrorObj,
                 identity: mockIdentity,
               });
@@ -958,12 +958,12 @@ describe("query", () => {
               expect(console.error).toHaveBeenNthCalledWith(1, updateErrorObj);
             });
 
-            it("should not log the console error when `onCertifiedError` is nullish", async () => {
+            it("should not log the console error when `onUpdateError` is nullish", async () => {
               const { mockParams } = createMockParams();
 
               await queryAndUpdate({
                 ...mockParams,
-                onCertifiedError: undefined,
+                onUpdateError: undefined,
               });
 
               expect(console.error).not.toHaveBeenCalled();
@@ -1019,14 +1019,14 @@ describe("query", () => {
         });
       });
 
-      it("should not call `onCertifiedError` if `query` fails", async () => {
+      it("should not call `onUpdateError` if `query` fails", async () => {
         params = { ...params, requestError: true };
 
-        const { mockParams, onCertifiedErrorMock } = createMockParams();
+        const { mockParams, onUpdateErrorMock } = createMockParams();
 
         await queryAndUpdate(mockParams);
 
-        expect(onCertifiedErrorMock).not.toHaveBeenCalled();
+        expect(onUpdateErrorMock).not.toHaveBeenCalled();
       });
 
       it("should log the console error if `query` fails", async () => {
@@ -1040,14 +1040,14 @@ describe("query", () => {
         expect(console.error).toHaveBeenNthCalledWith(1, requestErrorObj);
       });
 
-      it("should not log the console error when `onCertifiedError` is nullish", async () => {
+      it("should not log the console error when `onUpdateError` is nullish", async () => {
         params = { ...params, requestError: true };
 
         const { mockParams } = createMockParams();
 
         await queryAndUpdate({
           ...mockParams,
-          onCertifiedError: undefined,
+          onUpdateError: undefined,
         });
 
         expect(console.error).not.toHaveBeenCalled();
@@ -1100,15 +1100,15 @@ describe("query", () => {
         });
       });
 
-      it("should call `onCertifiedError` if `update` fails", async () => {
+      it("should call `onUpdateError` if `update` fails", async () => {
         params = { ...params, requestError: true };
 
-        const { mockParams, onCertifiedErrorMock } = createMockParams();
+        const { mockParams, onUpdateErrorMock } = createMockParams();
 
         await queryAndUpdate(mockParams);
 
-        expect(onCertifiedErrorMock).toHaveBeenCalledTimes(1);
-        expect(onCertifiedErrorMock).toHaveBeenNthCalledWith(1, {
+        expect(onUpdateErrorMock).toHaveBeenCalledTimes(1);
+        expect(onUpdateErrorMock).toHaveBeenNthCalledWith(1, {
           error: requestErrorObj,
           identity: mockIdentity,
         });
@@ -1125,14 +1125,14 @@ describe("query", () => {
         expect(console.error).toHaveBeenNthCalledWith(1, requestErrorObj);
       });
 
-      it("should not log the console error when `onCertifiedError` is nullish", async () => {
+      it("should not log the console error when `onUpdateError` is nullish", async () => {
         params = { ...params, requestError: true };
 
         const { mockParams } = createMockParams();
 
         await queryAndUpdate({
           ...mockParams,
-          onCertifiedError: undefined,
+          onUpdateError: undefined,
         });
 
         expect(console.error).not.toHaveBeenCalled();

--- a/packages/utils/src/services/query.ts
+++ b/packages/utils/src/services/query.ts
@@ -18,13 +18,13 @@ import { isNullish } from "../utils/nullish.utils";
  *
  * Once the call(s) are done, the response is handled by the `onLoad` callback.
  * However, if an error occurs, it is handled by the `onError` callback, if provided.
- * In addition, if the error is from the update call, the `onCertifiedError` callback is called too, if provided.
+ * In addition, if the error is from the update call, the `onUpdateError` callback is called too, if provided.
  *
  * @param {QueryAndUpdateParams<R, E>} params The parameters to perform the request.
  * @param {QueryAndUpdateRequest<R>} params.request The request to perform.
  * @param {QueryAndUpdateOnResponse<R>} params.onLoad The callback to handle the response of the request.
  * @param {QueryAndUpdateOnError<E>} [params.onError] The callback to handle the error of the request.
- * @param {QueryAndUpdateOnCertifiedError<E>} [params.onCertifiedError] The additional callback to handle the error of the update request.
+ * @param {QueryAndUpdateOnUpdateError<E>} [params.onUpdateError] The additional callback to handle the error of the update request.
  * @param {QueryAndUpdateStrategy} [params.strategy="query_and_update"] The strategy to use. Default is `query_and_update`.
  * @param {QueryAndUpdateIdentity} params.identity The identity to use for the request.
  * @param {QueryAndUpdatePromiseResolution} [params.resolution="race"] The resolution to use. Default is `race`.
@@ -38,7 +38,7 @@ export const queryAndUpdate = async <R, E = unknown>({
   request,
   onLoad,
   onError,
-  onCertifiedError,
+  onUpdateError,
   strategy = "query_and_update",
   identity,
   resolution = "race",
@@ -62,7 +62,7 @@ export const queryAndUpdate = async <R, E = unknown>({
         onError?.({ certified, error, identity });
 
         // Handling certified is handled as: just console error query error and do something with the update error
-        if (isNullish(onCertifiedError)) {
+        if (isNullish(onUpdateError)) {
           return;
         }
 
@@ -72,7 +72,7 @@ export const queryAndUpdate = async <R, E = unknown>({
           return;
         }
 
-        onCertifiedError?.({ error, identity });
+        onUpdateError?.({ error, identity });
       })
       .finally(() => (certifiedDone = certifiedDone || certified));
 

--- a/packages/utils/src/types/query-and-update.params.ts
+++ b/packages/utils/src/types/query-and-update.params.ts
@@ -28,7 +28,7 @@ export type QueryAndUpdateOnError<E = unknown> = (
   } & QueryAndUpdateOnErrorOptions<E>,
 ) => void;
 
-export type QueryAndUpdateOnCertifiedError<E = unknown> = (
+export type QueryAndUpdateOnUpdateError<E = unknown> = (
   options: QueryAndUpdateOnErrorOptions<E>,
 ) => void;
 
@@ -40,7 +40,7 @@ export interface QueryAndUpdateParams<R, E = unknown> {
   request: QueryAndUpdateRequest<R>;
   onLoad: QueryAndUpdateOnResponse<R>;
   onError?: QueryAndUpdateOnError<E>;
-  onCertifiedError?: QueryAndUpdateOnCertifiedError<E>;
+  onUpdateError?: QueryAndUpdateOnUpdateError<E>;
   strategy?: QueryAndUpdateStrategy;
   identity: QueryAndUpdateIdentity;
   resolution?: QueryAndUpdatePromiseResolution;


### PR DESCRIPTION
# Motivation

It makes more sense to rename the `onCertifiedError` parameters of service `queryAndUpdate` to `onUpdateError`, as suggested in https://github.com/dfinity/ic-js/pull/871#discussion_r2015855642


