### PR TITLE
feat: service queryAndUpdate will always call error callback

### DIFF
--- a/packages/utils/src/services/query.spec.ts
+++ b/packages/utils/src/services/query.spec.ts
@@ -889,12 +889,17 @@ describe("query", () => {
               });
             });
 
-            it("should ignore `query` error and not call `onError`", async () => {
+            it("should call `onError` only with `query` error", async () => {
               const { mockParams, onErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).not.toHaveBeenCalled();
+              expect(onErrorMock).toHaveBeenCalledTimes(1);
+              expect(onErrorMock).toHaveBeenNthCalledWith(1, {
+                certified: false,
+                error: queryErrorObj,
+                identity: mockIdentity,
+              });
             });
 
             it("should not call `onCertifiedError`", async () => {
@@ -924,15 +929,20 @@ describe("query", () => {
               };
             });
 
-            it("should call `onError` only with `update` error", async () => {
+            it("should call `onError` first with `update` error and then with `query` error", async () => {
               const { mockParams, onErrorMock } = createMockParams();
 
               await queryAndUpdate(mockParams);
 
-              expect(onErrorMock).toHaveBeenCalledTimes(1);
+              expect(onErrorMock).toHaveBeenCalledTimes(2);
               expect(onErrorMock).toHaveBeenNthCalledWith(1, {
                 certified: true,
                 error: updateErrorObj,
+                identity: mockIdentity,
+              });
+              expect(onErrorMock).toHaveBeenNthCalledWith(2, {
+                certified: false,
+                error: queryErrorObj,
                 identity: mockIdentity,
               });
             });

--- a/packages/utils/src/services/query.ts
+++ b/packages/utils/src/services/query.ts
@@ -55,11 +55,11 @@ export const queryAndUpdate = async <R, E = unknown>({
         onLoad({ certified, response });
       })
       .catch((error: E) => {
+        onError?.({ certified, error, identity });
+
         if (certifiedDone) {
           return;
         }
-
-        onError?.({ certified, error, identity });
 
         // Handling certified is handled as: just console error query error and do something with the update error
         if (isNullish(onCertifiedError)) {


### PR DESCRIPTION
# Motivation

The current implementation of `queryAndUpdate` does not call the `onError` callback in the unlikely scenario when the `update` call is faster than the `query` calls and the latter fails.

However, it is useful to have it called either way, even when the `query` calls fails after the `update` calls.

# Changes

Move the error callback before the check to see if the `update` calls was already executed.

# Tests

Test adjusted.

