### PR TITLE
feat: add type predicate in util isEmptyString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Expose method `status` in class `IcrcIndexNgCanister`.
 - Expose method `icrc3_get_blocks` in class `IcrcLedgerCanister`.
 - New service util `queryAndUpdate` that aids in executing a request and handling the results, for both type of calls.
+- Added type predicate to narrow value to `undefined`, `null`, or empty string in type guards in util `isEmptyString`.
 
 # 2025.03.10-1330Z
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -131,9 +131,9 @@ Parameters:
 
 Checks if a given value is null, undefined, or an empty string.
 
-| Function        | Type                                              |
-| --------------- | ------------------------------------------------- |
-| `isEmptyString` | `(value: string or null or undefined) => boolean` |
+| Function        | Type                                                                       |
+| --------------- | -------------------------------------------------------------------------- |
+| `isEmptyString` | `(value: string or null or undefined) => value is "" or null or undefined` |
 
 Parameters:
 

--- a/packages/utils/src/utils/nullish.utils.ts
+++ b/packages/utils/src/utils/nullish.utils.ts
@@ -36,5 +36,6 @@ export const notEmptyString = (
  * @param {string | undefined | null} value - The value to check.
  * @returns {boolean} `true` if the value is null, undefined, or an empty string; otherwise, `false`.
  */
-export const isEmptyString = (value: string | undefined | null): value is undefined | null | '' =>
-  !notEmptyString(value);
+export const isEmptyString = (
+  value: string | undefined | null,
+): value is undefined | null | "" => !notEmptyString(value);

--- a/packages/utils/src/utils/nullish.utils.ts
+++ b/packages/utils/src/utils/nullish.utils.ts
@@ -36,5 +36,5 @@ export const notEmptyString = (
  * @param {string | undefined | null} value - The value to check.
  * @returns {boolean} `true` if the value is null, undefined, or an empty string; otherwise, `false`.
  */
-export const isEmptyString = (value: string | undefined | null): boolean =>
+export const isEmptyString = (value: string | undefined | null): value is undefined | null | '' =>
   !notEmptyString(value);

--- a/packages/utils/src/utils/nullish.utils.ts
+++ b/packages/utils/src/utils/nullish.utils.ts
@@ -34,7 +34,7 @@ export const notEmptyString = (
  * Checks if a given value is null, undefined, or an empty string.
  *
  * @param {string | undefined | null} value - The value to check.
- * @returns {boolean} `true` if the value is null, undefined, or an empty string; otherwise, `false`.
+ * @returns {value is undefined | null | ""} Type predicate indicating if the value is null, undefined, or an empty string.
  */
 export const isEmptyString = (
   value: string | undefined | null,


### PR DESCRIPTION
# Motivation

Just for completion, it would be useful to have a type predicate in util `isEmptyString` that defines the input as either nullish value or empty string.