### PR TITLE
Expose sns topic types via root index

### DIFF
--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -8,6 +8,7 @@ export type {
   GetMetadataResponse as SnsGetMetadataResponse,
   ListNervousSystemFunctionsResponse as SnsListNervousSystemFunctionsResponse,
   ListProposalsResponse as SnsListProposalsResponse,
+  ListTopicsResponse as SnsListTopicsResponse,
   ManageNeuron as SnsManageNeuron,
   ManageNeuronResponse as SnsManageNeuronResponse,
   NervousSystemFunction as SnsNervousSystemFunction,
@@ -19,9 +20,9 @@ export type {
   ProposalData as SnsProposalData,
   ProposalId as SnsProposalId,
   Tally as SnsTally,
-  VotingRewardsParameters as SnsVotingRewardsParameters,
   Topic as SnsTopic,
   TopicInfo as SnsTopicInfo,
+  VotingRewardsParameters as SnsVotingRewardsParameters,
 } from "../candid/sns_governance";
 export type { CanisterStatusResultV2 as SnsCanisterStatus } from "../candid/sns_root";
 export type {

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -2,6 +2,8 @@ export type {
   Action as SnsAction,
   Ballot as SnsBallot,
   DefaultFollowees as SnsDefaultFollowees,
+  Followee as SnsFollowee,
+  FolloweesForTopic as SnsFolloweesForTopic,
   FunctionType as SnsFunctionType,
   GetMetadataResponse as SnsGetMetadataResponse,
   ListNervousSystemFunctionsResponse as SnsListNervousSystemFunctionsResponse,
@@ -18,6 +20,8 @@ export type {
   ProposalId as SnsProposalId,
   Tally as SnsTally,
   VotingRewardsParameters as SnsVotingRewardsParameters,
+  Topic as SnsTopic,
+  TopicInfo as SnsTopicInfo,
 } from "../candid/sns_governance";
 export type { CanisterStatusResultV2 as SnsCanisterStatus } from "../candid/sns_root";
 export type {


### PR DESCRIPTION
# Motivation

Currently, in the NNS-dapp, SNS topic-related types are imported from a long path like:
`import type { Topic } from "@dfinity/sns/dist/candid/sns_governance"`

It would be much cleaner to import them from the root of the SNS package, e.g.:
`import type { SnsTopic } from "@dfinity/sns"`.

# Changes

- Expose sns topic related types.

# Tests

- No.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.