### PR TITLE
chore: update sns Candid files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next Version
+
+## Features
+
+- Updated `@dfinity/sns` to add support for filtering SNS proposals by topics
+
 # v68
 
 ## Overview

--- a/packages/sns/candid/sns_governance.certified.idl.js
+++ b/packages/sns/candid/sns_governance.certified.idl.js
@@ -627,16 +627,19 @@ export const idlFactory = ({ IDL }) => {
     'start_page_at' : IDL.Opt(NeuronId),
   });
   const ListNeuronsResponse = IDL.Record({ 'neurons' : IDL.Vec(Neuron) });
+  const TopicSelector = IDL.Record({ 'topic' : IDL.Opt(Topic) });
   const ListProposals = IDL.Record({
     'include_reward_status' : IDL.Vec(IDL.Int32),
     'before_proposal' : IDL.Opt(ProposalId),
     'limit' : IDL.Nat32,
     'exclude_type' : IDL.Vec(IDL.Nat64),
+    'include_topics' : IDL.Opt(IDL.Vec(TopicSelector)),
     'include_status' : IDL.Vec(IDL.Int32),
   });
   const ListProposalsResponse = IDL.Record({
     'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
+    'include_topic_filtering' : IDL.Opt(IDL.Bool),
   });
   const ListTopicsRequest = IDL.Record({});
   const TopicInfo = IDL.Record({

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -339,11 +339,13 @@ export interface ListProposals {
   before_proposal: [] | [ProposalId];
   limit: number;
   exclude_type: BigUint64Array | bigint[];
+  include_topics: [] | [Array<TopicSelector>];
   include_status: Int32Array | number[];
 }
 export interface ListProposalsResponse {
   include_ballots_by_caller: [] | [boolean];
   proposals: Array<ProposalData>;
+  include_topic_filtering: [] | [boolean];
 }
 export type ListTopicsRequest = {};
 export interface ListTopicsResponse {
@@ -651,6 +653,9 @@ export interface TopicInfo {
   name: [] | [string];
   description: [] | [string];
   custom_functions: [] | [Array<NervousSystemFunction>];
+}
+export interface TopicSelector {
+  topic: [] | [Topic];
 }
 export interface TransferSnsTreasuryFunds {
   from_treasury: number;

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 148ccc9 (2025-04-04 tags: rosetta-icrc-release-1.2.0) 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 579b8ba3a3 (2025-04-11 tags: release-2025-04-11_13-20-base) 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -372,10 +372,16 @@ type ListProposals = record {
   limit : nat32;
   exclude_type : vec nat64;
   include_status : vec int32;
+  include_topics : opt vec TopicSelector;
+};
+
+type TopicSelector = record {
+  topic : opt Topic;
 };
 
 type ListProposalsResponse = record {
   include_ballots_by_caller : opt bool;
+  include_topic_filtering : opt bool;
   proposals : vec ProposalData;
 };
 

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -627,16 +627,19 @@ export const idlFactory = ({ IDL }) => {
     'start_page_at' : IDL.Opt(NeuronId),
   });
   const ListNeuronsResponse = IDL.Record({ 'neurons' : IDL.Vec(Neuron) });
+  const TopicSelector = IDL.Record({ 'topic' : IDL.Opt(Topic) });
   const ListProposals = IDL.Record({
     'include_reward_status' : IDL.Vec(IDL.Int32),
     'before_proposal' : IDL.Opt(ProposalId),
     'limit' : IDL.Nat32,
     'exclude_type' : IDL.Vec(IDL.Nat64),
+    'include_topics' : IDL.Opt(IDL.Vec(TopicSelector)),
     'include_status' : IDL.Vec(IDL.Int32),
   });
   const ListProposalsResponse = IDL.Record({
     'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
+    'include_topic_filtering' : IDL.Opt(IDL.Bool),
   });
   const ListTopicsRequest = IDL.Record({});
   const TopicInfo = IDL.Record({

--- a/packages/sns/candid/sns_governance_test.certified.idl.js
+++ b/packages/sns/candid/sns_governance_test.certified.idl.js
@@ -638,16 +638,19 @@ export const idlFactory = ({ IDL }) => {
     'start_page_at' : IDL.Opt(NeuronId),
   });
   const ListNeuronsResponse = IDL.Record({ 'neurons' : IDL.Vec(Neuron) });
+  const TopicSelector = IDL.Record({ 'topic' : IDL.Opt(Topic) });
   const ListProposals = IDL.Record({
     'include_reward_status' : IDL.Vec(IDL.Int32),
     'before_proposal' : IDL.Opt(ProposalId),
     'limit' : IDL.Nat32,
     'exclude_type' : IDL.Vec(IDL.Nat64),
+    'include_topics' : IDL.Opt(IDL.Vec(TopicSelector)),
     'include_status' : IDL.Vec(IDL.Int32),
   });
   const ListProposalsResponse = IDL.Record({
     'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
+    'include_topic_filtering' : IDL.Opt(IDL.Bool),
   });
   const ListTopicsRequest = IDL.Record({});
   const TopicInfo = IDL.Record({

--- a/packages/sns/candid/sns_governance_test.d.ts
+++ b/packages/sns/candid/sns_governance_test.d.ts
@@ -350,11 +350,13 @@ export interface ListProposals {
   before_proposal: [] | [ProposalId];
   limit: number;
   exclude_type: BigUint64Array | bigint[];
+  include_topics: [] | [Array<TopicSelector>];
   include_status: Int32Array | number[];
 }
 export interface ListProposalsResponse {
   include_ballots_by_caller: [] | [boolean];
   proposals: Array<ProposalData>;
+  include_topic_filtering: [] | [boolean];
 }
 export type ListTopicsRequest = {};
 export interface ListTopicsResponse {
@@ -666,6 +668,9 @@ export interface TopicInfo {
   name: [] | [string];
   description: [] | [string];
   custom_functions: [] | [Array<NervousSystemFunction>];
+}
+export interface TopicSelector {
+  topic: [] | [Topic];
 }
 export interface TransferSnsTreasuryFunds {
   from_treasury: number;

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 148ccc9 (2025-04-04 tags: rosetta-icrc-release-1.2.0) 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 579b8ba3a3 (2025-04-11 tags: release-2025-04-11_13-20-base) 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -381,10 +381,16 @@ type ListProposals = record {
   limit : nat32;
   exclude_type : vec nat64;
   include_status : vec int32;
+  include_topics : opt vec TopicSelector;
+};
+
+type TopicSelector = record {
+  topic : opt Topic;
 };
 
 type ListProposalsResponse = record {
   include_ballots_by_caller : opt bool;
+  include_topic_filtering : opt bool;
   proposals : vec ProposalData;
 };
 

--- a/packages/sns/candid/sns_governance_test.idl.js
+++ b/packages/sns/candid/sns_governance_test.idl.js
@@ -638,16 +638,19 @@ export const idlFactory = ({ IDL }) => {
     'start_page_at' : IDL.Opt(NeuronId),
   });
   const ListNeuronsResponse = IDL.Record({ 'neurons' : IDL.Vec(Neuron) });
+  const TopicSelector = IDL.Record({ 'topic' : IDL.Opt(Topic) });
   const ListProposals = IDL.Record({
     'include_reward_status' : IDL.Vec(IDL.Int32),
     'before_proposal' : IDL.Opt(ProposalId),
     'limit' : IDL.Nat32,
     'exclude_type' : IDL.Vec(IDL.Nat64),
+    'include_topics' : IDL.Opt(IDL.Vec(TopicSelector)),
     'include_status' : IDL.Vec(IDL.Int32),
   });
   const ListProposalsResponse = IDL.Record({
     'include_ballots_by_caller' : IDL.Opt(IDL.Bool),
     'proposals' : IDL.Vec(ProposalData),
+    'include_topic_filtering' : IDL.Opt(IDL.Bool),
   });
   const ListTopicsRequest = IDL.Record({});
   const TopicInfo = IDL.Record({

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 148ccc9 (2025-04-04 tags: rosetta-icrc-release-1.2.0) 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit 579b8ba3a3 (2025-04-11 tags: release-2025-04-11_13-20-base) 'rs/sns/root/canister/root.did' by import-candid
 type CanisterCallError = record {
   code : opt int32;
   description : text;

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 148ccc9 (2025-04-04 tags: rosetta-icrc-release-1.2.0) 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 579b8ba3a3 (2025-04-11 tags: release-2025-04-11_13-20-base) 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;

--- a/packages/sns/src/converters/governance.converters.ts
+++ b/packages/sns/src/converters/governance.converters.ts
@@ -318,12 +318,18 @@ export const toListProposalRequest = ({
   includeRewardStatus,
   includeStatus,
   limit,
+  includeTopics,
 }: SnsListProposalsParams): ListProposals => ({
   exclude_type: BigUint64Array.from(excludeType ?? []),
   before_proposal: toNullable(beforeProposal),
   include_reward_status: Int32Array.from(includeRewardStatus ?? []),
   include_status: Int32Array.from(includeStatus ?? []),
   limit: limit ?? DEFAULT_PROPOSALS_LIMIT,
+  include_topics: toNullable(
+    includeTopics?.map((topic) => ({
+      topic: toNullable(topic),
+    })) ?? [],
+  ),
 });
 
 export const fromCandidAction = (action: ActionCandid): Action => {

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -112,6 +112,7 @@ describe("Governance canister", () => {
       const mockListProposals = service.list_proposals.mockResolvedValue({
         proposals: proposalsMock,
         include_ballots_by_caller: [],
+        include_topic_filtering: [],
       });
 
       const canister = SnsGovernanceCanister.create({
@@ -145,6 +146,7 @@ describe("Governance canister", () => {
       const mockListProposals = service.list_proposals.mockResolvedValue({
         proposals: proposalsMock,
         include_ballots_by_caller: [],
+        include_topic_filtering: [],
       });
 
       const canister = SnsGovernanceCanister.create({
@@ -167,6 +169,7 @@ describe("Governance canister", () => {
       const mockListProposals = service.list_proposals.mockResolvedValue({
         proposals: proposalsMock,
         include_ballots_by_caller: [],
+        include_topic_filtering: [],
       });
 
       const canister = SnsGovernanceCanister.create({
@@ -198,6 +201,7 @@ describe("Governance canister", () => {
       const mockListProposals = service.list_proposals.mockResolvedValue({
         proposals: proposalsMock,
         include_ballots_by_caller: [],
+        include_topic_filtering: [],
       });
 
       const canister = SnsGovernanceCanister.create({

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -161,6 +161,7 @@ describe("Governance canister", () => {
         include_reward_status: Int32Array.from([]),
         include_status: Int32Array.from([]),
         limit: DEFAULT_PROPOSALS_LIMIT,
+        include_topics: [[]],
       });
     });
 
@@ -193,6 +194,7 @@ describe("Governance canister", () => {
         include_reward_status: Int32Array.from(params.includeRewardStatus),
         include_status: Int32Array.from(params.includeStatus),
         limit: DEFAULT_PROPOSALS_LIMIT,
+        include_topics: [[]],
       });
     });
 
@@ -220,6 +222,46 @@ describe("Governance canister", () => {
         include_reward_status: Int32Array.from([]),
         include_status: Int32Array.from([]),
         limit: params.limit,
+        include_topics: [[]],
+      });
+    });
+
+    it("should use include topics params", async () => {
+      const service = mock<ActorSubclass<SnsGovernanceService>>();
+      const mockListProposals = service.list_proposals.mockResolvedValue({
+        proposals: proposalsMock,
+        include_ballots_by_caller: [],
+        include_topic_filtering: [true],
+      });
+
+      const canister = SnsGovernanceCanister.create({
+        canisterId: rootCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+
+      const params = {
+        limit: 100,
+        beforeProposal: { id: BigInt(2) },
+        includeTopics: [
+          { DappCanisterManagement: null },
+          { SnsFrameworkManagement: null },
+        ],
+      };
+
+      await canister.listProposals(params);
+
+      expect(mockListProposals).toBeCalledWith({
+        exclude_type: BigUint64Array.from([]),
+        before_proposal: [params.beforeProposal],
+        include_reward_status: Int32Array.from([]),
+        include_status: Int32Array.from([]),
+        limit: params.limit,
+        include_topics: [
+          [
+            { topic: [{ DappCanisterManagement: null }] },
+            { topic: [{ SnsFrameworkManagement: null }] },
+          ],
+        ],
       });
     });
 

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -245,6 +245,7 @@ describe("Governance canister", () => {
         includeTopics: [
           { DappCanisterManagement: null },
           { SnsFrameworkManagement: null },
+          null,
         ],
       };
 
@@ -260,6 +261,7 @@ describe("Governance canister", () => {
           [
             { topic: [{ DappCanisterManagement: null }] },
             { topic: [{ SnsFrameworkManagement: null }] },
+            { topic: [] },
           ],
         ],
       });

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -55,7 +55,9 @@ export interface SnsListProposalsParams extends QueryParams {
   // that have one of the define topics should be included
   // in the list.
   // If this list is empty, no restriction is applied.
-  includeTopics?: Topic[];
+  // If there is null, then proposals without a topic are included.
+  // Ref: https://github.com/dfinity/ic/blob/23abac5891de0ebde5c49c0fe91a1aab39c6241f/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs#L2140
+  includeTopics?: Array<Topic | null>;
 }
 
 export interface SnsListTopicsParams extends QueryParams {}

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -45,11 +45,17 @@ export interface SnsListProposalsParams extends QueryParams {
   // A list of proposal types, specifying that proposals of the given
   // types should be excluded in this list.
   excludeType?: bigint[];
-  // A list of proposal decision statuses, specifying that only proposals that
+  // A list of proposal decision statuses, specifying that only proposals
   // that have one of the define decision statuses should be included
   // in the list.
   // If this list is empty, no restriction is applied.
   includeStatus?: SnsProposalDecisionStatus[];
+
+  // A list of proposal topics, specifying that only proposals
+  // that have one of the define topics should be included
+  // in the list.
+  // If this list is empty, no restriction is applied.
+  includeTopics?: Topic[];
 }
 
 export interface SnsListTopicsParams extends QueryParams {}

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -52,7 +52,7 @@ export interface SnsListProposalsParams extends QueryParams {
   includeStatus?: SnsProposalDecisionStatus[];
 
   // A list of proposal topics, specifying that only proposals
-  // that have one of the define topics should be included
+  // that have one of the defined topics should be included
   // in the list.
   // If this list is empty, no restriction is applied.
   // If there is null, then proposals without a topic are included.


### PR DESCRIPTION
# Motivation

#885 is attempting to upgrade the Candid files but cannot do so because new fields are required in the test cases, causing the pipeline to fail.

This PR fixes the issues updating sns candid files by:
* adds support for the new field in `list_proposals`.
* fixes existing tests that require the new property `include_topic_filtering` in the mocked response.

# Changes

- Checkout ic at `579b8ba`
- Ran `./scripts/import-candid ../ic` from ic-js root folder 
- Ran `./scripts/compile-idl-js` from ic-js root folder 
- Revert changes not related to the `sns` package
- Exposes the `include_topics` property in `list_proposals` to filter proposals by topics.

# Tests

- Adds unit tests for the new field in `list_proposals`.
- Fixes existing tests by providing a default value for `include_topic_filtering` in mock responses.

# Todos

- [x] Add entry to changelog (if necessary).
