### PR TITLE
feat: add hashToHex utility for computing SHA-256 as hex

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -53,12 +53,12 @@ npm i @dfinity/agent @dfinity/candid @dfinity/principal
 - [hexStringToUint8Array](#gear-hexstringtouint8array)
 - [uint8ArrayToHexString](#gear-uint8arraytohexstring)
 - [candidNumberArrayToBigInt](#gear-candidnumberarraytobigint)
-- [hexToString](#gear-hashtohex)
 - [encodeBase32](#gear-encodebase32)
 - [decodeBase32](#gear-decodebase32)
 - [uint8ArrayToBase64](#gear-uint8arraytobase64)
 - [base64ToUint8Array](#gear-base64touint8array)
 - [bigEndianCrc32](#gear-bigendiancrc32)
+- [hashToHex](#gear-hashtohex)
 - [secondsToDuration](#gear-secondstoduration)
 - [nowInBigIntNanoSeconds](#gear-nowinbigintnanoseconds)
 - [toBigIntNanoSeconds](#gear-tobigintnanoseconds)
@@ -321,14 +321,6 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/arrays.utils.ts#L70)
 
-#### :gear: hashToHex
-
-| Function      | Type                               |
-| ------------- | ---------------------------------- |
-| `hextostring` | `(input: string): Promise<string>` |
-
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/crypto.utils.ts#L23)
-
 #### :gear: encodeBase32
 
 Encode an Uint8Array to a base32 string.
@@ -393,6 +385,20 @@ Parameters:
 | `bigEndianCrc32` | `(bytes: Uint8Array) => Uint8Array` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/crc.utils.ts#L61)
+
+#### :gear: hashToHex
+
+Computes the SHA-256 hash of a UTF-8 string and encodes the result as a hexadecimal string.
+
+| Function    | Type                                 |
+| ----------- | ------------------------------------ |
+| `hashToHex` | `(input: string) => Promise<string>` |
+
+Parameters:
+
+- `input`: - A UTF-8 encoded string to hash.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/crypto.utils.ts#L23)
 
 #### :gear: secondsToDuration
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -53,6 +53,7 @@ npm i @dfinity/agent @dfinity/candid @dfinity/principal
 - [hexStringToUint8Array](#gear-hexstringtouint8array)
 - [uint8ArrayToHexString](#gear-uint8arraytohexstring)
 - [candidNumberArrayToBigInt](#gear-candidnumberarraytobigint)
+- [hexToString](#gear-hashtohex)
 - [encodeBase32](#gear-encodebase32)
 - [decodeBase32](#gear-decodebase32)
 - [uint8ArrayToBase64](#gear-uint8arraytobase64)
@@ -319,6 +320,14 @@ Parameters:
 | `candidNumberArrayToBigInt` | `(array: number[]) => bigint` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/arrays.utils.ts#L70)
+
+#### :gear: hashToHex
+
+| Function      | Type                               |
+| ------------- | ---------------------------------- |
+| `hextostring` | `(input: string): Promise<string>` |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/crypto.utils.ts#L23)
 
 #### :gear: encodeBase32
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -14,6 +14,7 @@ export * from "./utils/asserts.utils";
 export * from "./utils/base32.utils";
 export * from "./utils/base64.utils";
 export * from "./utils/crc.utils";
+export * from "./utils/crypto.utils";
 export * from "./utils/date.utils";
 export * from "./utils/debounce.utils";
 export * from "./utils/did.utils";

--- a/packages/utils/src/utils/crypto.utils.spec.ts
+++ b/packages/utils/src/utils/crypto.utils.spec.ts
@@ -1,0 +1,64 @@
+import { hashToHex } from "./crypto.utils";
+
+describe("hashToHex", () => {
+  const hexRegex = /^[0-9a-f]{64}$/;
+
+  it("returns a valid 64-character hex string", async () => {
+    const hash = await hashToHex("input");
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(hexRegex);
+  });
+
+  it("returns different hashes for different inputs", async () => {
+    const hash1 = await hashToHex("first");
+    const hash2 = await hashToHex("second");
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it("returns the same hash for the same input", async () => {
+    const input = "test";
+    const hash1 = await hashToHex(input);
+    const hash2 = await hashToHex(input);
+
+    expect(hash1).toBe(hash2);
+  });
+
+  it('returns correct hash for "input"', async () => {
+    const hash = await hashToHex("input");
+    expect(hash).toEqual(
+      "c96c6d5be8d08a12e7b5cdc1b207fa6b2430974c86803d8891675e76fd992c20",
+    );
+  });
+
+  it("returns correct hash for empty string", async () => {
+    const hash = await hashToHex("");
+    expect(hash).toEqual(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+  });
+
+  it("handles long strings correctly", async () => {
+    const longString = "test".repeat(10_000);
+    const hash = await hashToHex(longString);
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(hexRegex);
+  });
+
+  it("treats different whitespace as different input", async () => {
+    const a = await hashToHex("test");
+    const b = await hashToHex(" test ");
+    expect(a).not.toBe(b);
+  });
+
+  it("treats uppercase and lowercase input as different", async () => {
+    const lower = await hashToHex("input");
+    const upper = await hashToHex("INPUT");
+    expect(lower).not.toBe(upper);
+  });
+
+  it("works with symbols and punctuation", async () => {
+    const hash = await hashToHex("!@#$/\\()[]{}<>&?*=+-~");
+    expect(hash).toMatch(hexRegex);
+  });
+});

--- a/packages/utils/src/utils/crypto.utils.ts
+++ b/packages/utils/src/utils/crypto.utils.ts
@@ -1,0 +1,26 @@
+import { uint8ArrayToHexString } from "./arrays.utils";
+
+/**
+ * Computes the SHA-256 hash of a UTF-8 string.
+ *
+ * @param input - A UTF-8 encoded string to hash.
+ * @returns A promise that resolves to a 32-byte SHA-256 hash as an ArrayBuffer.
+ *
+ * @internal
+ */
+
+const computeSha256 = async (input: string): Promise<ArrayBuffer> => {
+  const encoded = new TextEncoder().encode(input);
+  return crypto.subtle.digest("SHA-256", encoded);
+};
+
+/**
+ * Computes the SHA-256 hash of a UTF-8 string and encodes the result as a hexadecimal string.
+ *
+ * @param input - A UTF-8 encoded string to hash.
+ * @returns A promise that resolves to the 64-character lowercase hexadecimal hash.
+ */
+export const hashToHex = async (input: string): Promise<string> => {
+  const hashBuffer = await computeSha256(input);
+  return uint8ArrayToHexString(new Uint8Array(hashBuffer));
+};


### PR DESCRIPTION
# Motivation

Add a  utility for computing SHA-256 hashes and returning them as hexadecimal strings.  
This is commonly needed for generating deterministic IDs, cache keys.

The logic will be reused across:
- `oisy-wallet`
- `oisy-wallet-signer`

Also add intenal `computeSha256` logic as an helper for reusability for crypto utils.

# Changes

- Added `computeSha256(input: string): Promise<ArrayBuffer>` (internal helper)
- Added `hashToHex(input: string): Promise<string>`

# Tests

- Added unit tests for `hashToHex`
- Covered edge cases like empty string, long input, case sensitivity
