### PR TITLE
refactor: rename generateHash to hashObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Features
 
 - Updated `@dfinity/sns` to add support for filtering SNS proposals by topics.
-- Add `generateHash` utility to generate a SHA-256 hash from the given object.
+- Add `generateHashObject` utility to generate a SHA-256 hash from the given object.
 
 # v68
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Features
 
 - Updated `@dfinity/sns` to add support for filtering SNS proposals by topics.
-- Add `generateHashObject` utility to generate a SHA-256 hash from the given object.
+- Add `hashObject` utility to generate a SHA-256 hash from the given object.
 
 # v68
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Features
 
-- Updated `@dfinity/sns` to add support for filtering SNS proposals by topics
+- Updated `@dfinity/sns` to add support for filtering SNS proposals by topics.
+- Add `generateHash` utility to generate a SHA-256 hash from the given object.
 
 # v68
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -60,7 +60,7 @@ npm i @dfinity/agent @dfinity/candid @dfinity/principal
 - [bigEndianCrc32](#gear-bigendiancrc32)
 - [jsonReplacer](#gear-jsonreplacer)
 - [jsonReviver](#gear-jsonreviver)
-- [generateHash](#gear-generatehash)
+- [hashObject](#gear-hashobject)
 - [hashText](#gear-hashtext)
 - [secondsToDuration](#gear-secondstoduration)
 - [nowInBigIntNanoSeconds](#gear-nowinbigintnanoseconds)
@@ -432,16 +432,16 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/json.utils.ts#L51)
 
-#### :gear: generateHash
+#### :gear: hashObject
 
 Generates a SHA-256 hash from the given object.
 
 The object is first stringified using a custom `jsonReplacer`, then
 hashed using the SubtleCrypto API. The resulting hash is returned as a hex string.
 
-| Function       | Type                                               |
-| -------------- | -------------------------------------------------- |
-| `generateHash` | `<T extends object>(params: T) => Promise<string>` |
+| Function     | Type                                               |
+| ------------ | -------------------------------------------------- |
+| `hashObject` | `<T extends object>(params: T) => Promise<string>` |
 
 Parameters:
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -60,7 +60,7 @@ npm i @dfinity/agent @dfinity/candid @dfinity/principal
 - [bigEndianCrc32](#gear-bigendiancrc32)
 - [jsonReplacer](#gear-jsonreplacer)
 - [jsonReviver](#gear-jsonreviver)
-- [generateHashObject](#gear-generatehashobject)
+- [hashObject](#gear-hashobject)
 - [secondsToDuration](#gear-secondstoduration)
 - [nowInBigIntNanoSeconds](#gear-nowinbigintnanoseconds)
 - [toBigIntNanoSeconds](#gear-tobigintnanoseconds)
@@ -431,16 +431,16 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/json.utils.ts#L51)
 
-#### :gear: generateHashObject
+#### :gear: hashObject
 
 Generates a SHA-256 hash from the given object.
 
 The object is first stringified using a custom `jsonReplacer`, then
 hashed using the SubtleCrypto API. The resulting hash is returned as a hex string.
 
-| Function             | Type                                               |
-| -------------------- | -------------------------------------------------- |
-| `generateHashObject` | `<T extends object>(params: T) => Promise<string>` |
+| Function     | Type                                               |
+| ------------ | -------------------------------------------------- |
+| `hashObject` | `<T extends object>(params: T) => Promise<string>` |
 
 Parameters:
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -58,6 +58,9 @@ npm i @dfinity/agent @dfinity/candid @dfinity/principal
 - [uint8ArrayToBase64](#gear-uint8arraytobase64)
 - [base64ToUint8Array](#gear-base64touint8array)
 - [bigEndianCrc32](#gear-bigendiancrc32)
+- [jsonReplacer](#gear-jsonreplacer)
+- [jsonReviver](#gear-jsonreviver)
+- [generateHash](#gear-generatehash)
 - [secondsToDuration](#gear-secondstoduration)
 - [nowInBigIntNanoSeconds](#gear-nowinbigintnanoseconds)
 - [toBigIntNanoSeconds](#gear-tobigintnanoseconds)
@@ -66,8 +69,6 @@ npm i @dfinity/agent @dfinity/candid @dfinity/principal
 - [fromNullable](#gear-fromnullable)
 - [fromDefinedNullable](#gear-fromdefinednullable)
 - [fromNullishNullable](#gear-fromnullishnullable)
-- [jsonReplacer](#gear-jsonreplacer)
-- [jsonReviver](#gear-jsonreviver)
 - [principalToSubAccount](#gear-principaltosubaccount)
 - [smallerVersion](#gear-smallerversion)
 
@@ -385,6 +386,68 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/crc.utils.ts#L61)
 
+#### :gear: jsonReplacer
+
+A custom replacer for `JSON.stringify` that converts specific types not natively supported
+by the API into JSON-compatible formats.
+
+Supported conversions:
+
+- `BigInt` → `{ "__bigint__": string }`
+- `Principal` → `{ "__principal__": string }`
+- `Uint8Array` → `{ "__uint8array__": number[] }`
+
+| Function       | Type                                        |
+| -------------- | ------------------------------------------- |
+| `jsonReplacer` | `(_key: string, value: unknown) => unknown` |
+
+Parameters:
+
+- `_key`: - Ignored. Only provided for API compatibility.
+- `value`: - The value to transform before stringification.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/json.utils.ts#L21)
+
+#### :gear: jsonReviver
+
+A custom reviver for `JSON.parse` that reconstructs specific types from their JSON-encoded representations.
+
+This reverses the transformations applied by `jsonReplacer`, restoring the original types.
+
+Supported conversions:
+
+- `{ "__bigint__": string }` → `BigInt`
+- `{ "__principal__": string }` → `Principal`
+- `{ "__uint8array__": number[] }` → `Uint8Array`
+
+| Function      | Type                                        |
+| ------------- | ------------------------------------------- |
+| `jsonReviver` | `(_key: string, value: unknown) => unknown` |
+
+Parameters:
+
+- `_key`: - Ignored but provided for API compatibility.
+- `value`: - The parsed value to transform.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/json.utils.ts#L51)
+
+#### :gear: generateHash
+
+Generates a SHA-256 hash from the given object.
+
+The object is first stringified using a custom `jsonReplacer`, then
+hashed using the SubtleCrypto API. The resulting hash is returned as a hex string.
+
+| Function       | Type                                               |
+| -------------- | -------------------------------------------------- |
+| `generateHash` | `<T extends object>(params: T) => Promise<string>` |
+
+Parameters:
+
+- `params`: - The object to hash.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/crypto.utils.ts#L14)
+
 #### :gear: secondsToDuration
 
 Convert seconds to a human-readable duration, such as "6 days, 10 hours."
@@ -500,51 +563,6 @@ Parameters:
 - `value`: - A Candid-style variant or `undefined`.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/did.utils.ts#L50)
-
-#### :gear: jsonReplacer
-
-A custom replacer for `JSON.stringify` that converts specific types not natively supported
-by the API into JSON-compatible formats.
-
-Supported conversions:
-
-- `BigInt` → `{ "__bigint__": string }`
-- `Principal` → `{ "__principal__": string }`
-- `Uint8Array` → `{ "__uint8array__": number[] }`
-
-| Function       | Type                                        |
-| -------------- | ------------------------------------------- |
-| `jsonReplacer` | `(_key: string, value: unknown) => unknown` |
-
-Parameters:
-
-- `_key`: - Ignored. Only provided for API compatibility.
-- `value`: - The value to transform before stringification.
-
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/json.utils.ts#L21)
-
-#### :gear: jsonReviver
-
-A custom reviver for `JSON.parse` that reconstructs specific types from their JSON-encoded representations.
-
-This reverses the transformations applied by `jsonReplacer`, restoring the original types.
-
-Supported conversions:
-
-- `{ "__bigint__": string }` → `BigInt`
-- `{ "__principal__": string }` → `Principal`
-- `{ "__uint8array__": number[] }` → `Uint8Array`
-
-| Function      | Type                                        |
-| ------------- | ------------------------------------------- |
-| `jsonReviver` | `(_key: string, value: unknown) => unknown` |
-
-Parameters:
-
-- `_key`: - Ignored but provided for API compatibility.
-- `value`: - The parsed value to transform.
-
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/json.utils.ts#L51)
 
 #### :gear: principalToSubAccount
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -14,6 +14,7 @@ export * from "./utils/asserts.utils";
 export * from "./utils/base32.utils";
 export * from "./utils/base64.utils";
 export * from "./utils/crc.utils";
+export * from "./utils/crypto.utils";
 export * from "./utils/date.utils";
 export * from "./utils/debounce.utils";
 export * from "./utils/did.utils";

--- a/packages/utils/src/utils/crypto.utils.spec.ts
+++ b/packages/utils/src/utils/crypto.utils.spec.ts
@@ -1,8 +1,8 @@
 import { Expiry, SubmitRequestType } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
-import { generateHash } from "./crypto.utils";
+import { generateHashObject } from "./crypto.utils";
 
-describe("generateHash", () => {
+describe("generateHashObject", () => {
   const mockCanisterId = "doked-biaaa-aaaar-qag2a-cai";
 
   const mockPrincipalText =
@@ -12,7 +12,7 @@ describe("generateHash", () => {
 
   it("returns a valid 64-character hex string for basic string params", async () => {
     const params = { key1: "value1", key2: "value2" };
-    const hash = await generateHash(params);
+    const hash = await generateHashObject(params);
 
     expect(hash).toHaveLength(64);
     expect(hash).toMatch(hexRegex);
@@ -22,22 +22,22 @@ describe("generateHash", () => {
     const hashInput1 = { key: "value1" };
     const hashInput2 = { key: "value2" };
 
-    const hash1 = await generateHash(hashInput1);
-    const hash2 = await generateHash(hashInput2);
+    const hash1 = await generateHashObject(hashInput1);
+    const hash2 = await generateHashObject(hashInput2);
 
     expect(hash1).not.toBe(hash2);
   });
 
   it("returns the same hash for the same input object", async () => {
     const input = { a: "1", b: "2" };
-    const hash1 = await generateHash(input);
-    const hash2 = await generateHash(input);
+    const hash1 = await generateHashObject(input);
+    const hash2 = await generateHashObject(input);
 
     expect(hash1).toBe(hash2);
   });
 
   it("returns the expected hash for simple value", async () => {
-    const hash = await generateHash({ a: 123 });
+    const hash = await generateHashObject({ a: 123 });
     expect(hash).toEqual(
       "917cbcf20ffdb44b525db310004af7597b512c57cf37ad585d9b37b5e6617cca",
     );
@@ -50,7 +50,7 @@ describe("generateHash", () => {
       key: new Uint8Array([1, 2, 3, 4]),
     };
 
-    const hash = await generateHash(payload);
+    const hash = await generateHashObject(payload);
 
     expect(hash).toEqual(
       "7809e083f1e990698332f9328280d37d0d6b4637d2a2d8e2fdce0ccf13d9a40e",
@@ -59,8 +59,8 @@ describe("generateHash", () => {
 
   describe("handles complex value types", () => {
     it("handles BigInt values and distinguishes them correctly", async () => {
-      const hash1 = await generateHash({ amount: 123n });
-      const hash2 = await generateHash({ amount: 456n });
+      const hash1 = await generateHashObject({ amount: 123n });
+      const hash2 = await generateHashObject({ amount: 456n });
 
       expect(hash1).not.toBe(hash2);
       expect(hash1).toMatch(hexRegex);
@@ -72,15 +72,15 @@ describe("generateHash", () => {
         "ids2f-skxn7-4uwrl-lgtdm-mcv3m-m324f-vjn73-xg6xq-uea7b-37klk-nqe",
       );
 
-      const hashA = await generateHash({ user: principalA });
-      const hashB = await generateHash({ user: principalB });
+      const hashA = await generateHashObject({ user: principalA });
+      const hashB = await generateHashObject({ user: principalB });
 
       expect(hashA).not.toBe(hashB);
       expect(hashA).toMatch(hexRegex);
     });
 
     it("handles Uint8Array values correctly", async () => {
-      const hash = await generateHash({
+      const hash = await generateHashObject({
         key: new Uint8Array([1, 2, 3, 4]),
       });
 
@@ -92,7 +92,7 @@ describe("generateHash", () => {
         constructor(private value: number) {}
       }
 
-      const hash = await generateHash({
+      const hash = await generateHashObject({
         expiry: new Tmp(1_000_000),
       });
 
@@ -110,7 +110,7 @@ describe("generateHash", () => {
         request_type: SubmitRequestType.Call,
       };
 
-      const hash = await generateHash(complexPayload);
+      const hash = await generateHashObject(complexPayload);
       expect(hash).toMatch(hexRegex);
     });
   });

--- a/packages/utils/src/utils/crypto.utils.spec.ts
+++ b/packages/utils/src/utils/crypto.utils.spec.ts
@@ -1,0 +1,117 @@
+import { Expiry, SubmitRequestType } from "@dfinity/agent";
+import { Principal } from "@dfinity/principal";
+import { generateHash } from "./crypto.utils";
+
+describe("generateHash", () => {
+  const mockCanisterId = "doked-biaaa-aaaar-qag2a-cai";
+
+  const mockPrincipalText =
+    "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe";
+
+  const hexRegex = /^[0-9a-fA-F]{64}$/;
+
+  it("returns a valid 64-character hex string for basic string params", async () => {
+    const params = { key1: "value1", key2: "value2" };
+    const hash = await generateHash(params);
+
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(hexRegex);
+  });
+
+  it("returns different hashes for different input values", async () => {
+    const hashInput1 = { key: "value1" };
+    const hashInput2 = { key: "value2" };
+
+    const hash1 = await generateHash(hashInput1);
+    const hash2 = await generateHash(hashInput2);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it("returns the same hash for the same input object", async () => {
+    const input = { a: "1", b: "2" };
+    const hash1 = await generateHash(input);
+    const hash2 = await generateHash(input);
+
+    expect(hash1).toBe(hash2);
+  });
+
+  it("returns the expected hash for simple value", async () => {
+    const hash = await generateHash({ a: 123 });
+    expect(hash).toEqual(
+      "917cbcf20ffdb44b525db310004af7597b512c57cf37ad585d9b37b5e6617cca",
+    );
+  });
+
+  it("generates the expected hash for a complex payload", async () => {
+    const payload = {
+      amount: 987654321n,
+      user: Principal.fromText("aaaaa-aa"),
+      key: new Uint8Array([1, 2, 3, 4]),
+    };
+
+    const hash = await generateHash(payload);
+
+    expect(hash).toEqual(
+      "7809e083f1e990698332f9328280d37d0d6b4637d2a2d8e2fdce0ccf13d9a40e",
+    );
+  });
+
+  describe("handles complex value types", () => {
+    it("handles BigInt values and distinguishes them correctly", async () => {
+      const hash1 = await generateHash({ amount: 123n });
+      const hash2 = await generateHash({ amount: 456n });
+
+      expect(hash1).not.toBe(hash2);
+      expect(hash1).toMatch(hexRegex);
+    });
+
+    it("handles Principal values correctly", async () => {
+      const principalA = Principal.fromText("v7iq7-yiaaa-aaaan-qmrtq-cai");
+      const principalB = Principal.fromText(
+        "ids2f-skxn7-4uwrl-lgtdm-mcv3m-m324f-vjn73-xg6xq-uea7b-37klk-nqe",
+      );
+
+      const hashA = await generateHash({ user: principalA });
+      const hashB = await generateHash({ user: principalB });
+
+      expect(hashA).not.toBe(hashB);
+      expect(hashA).toMatch(hexRegex);
+    });
+
+    it("handles Uint8Array values correctly", async () => {
+      const hash = await generateHash({
+        key: new Uint8Array([1, 2, 3, 4]),
+      });
+
+      expect(hash).toMatch(hexRegex);
+    });
+
+    it("handles Object values safely", async () => {
+      class Tmp {
+        constructor(private value: number) {}
+      }
+
+      const hash = await generateHash({
+        expiry: new Tmp(1_000_000),
+      });
+
+      expect(hash).toMatch(hexRegex);
+    });
+
+    it("handles a combination of all supported types in a single payload", async () => {
+      const complexPayload = {
+        canister_id: Principal.fromText(mockCanisterId),
+        sender: Principal.fromText(mockPrincipalText),
+        method_name: "test-method",
+        arg: new Uint8Array([68, 73, 68, 76]),
+        nonce: new Uint8Array([1, 2, 3]).buffer,
+        ingress_expiry: new Expiry(5 * 60 * 1000),
+        request_type: SubmitRequestType.Call,
+      };
+
+      const hash = await generateHash(complexPayload);
+      expect(hash).toMatch(hexRegex);
+    });
+  });
+});

--- a/packages/utils/src/utils/crypto.utils.spec.ts
+++ b/packages/utils/src/utils/crypto.utils.spec.ts
@@ -1,8 +1,8 @@
 import { Expiry, SubmitRequestType } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
-import { generateHashObject } from "./crypto.utils";
+import { hashObject } from "./crypto.utils";
 
-describe("generateHashObject", () => {
+describe("hashObject", () => {
   const mockCanisterId = "doked-biaaa-aaaar-qag2a-cai";
 
   const mockPrincipalText =
@@ -12,7 +12,7 @@ describe("generateHashObject", () => {
 
   it("returns a valid 64-character hex string for basic string params", async () => {
     const params = { key1: "value1", key2: "value2" };
-    const hash = await generateHashObject(params);
+    const hash = await hashObject(params);
 
     expect(hash).toHaveLength(64);
     expect(hash).toMatch(hexRegex);
@@ -22,22 +22,22 @@ describe("generateHashObject", () => {
     const hashInput1 = { key: "value1" };
     const hashInput2 = { key: "value2" };
 
-    const hash1 = await generateHashObject(hashInput1);
-    const hash2 = await generateHashObject(hashInput2);
+    const hash1 = await hashObject(hashInput1);
+    const hash2 = await hashObject(hashInput2);
 
     expect(hash1).not.toBe(hash2);
   });
 
   it("returns the same hash for the same input object", async () => {
     const input = { a: "1", b: "2" };
-    const hash1 = await generateHashObject(input);
-    const hash2 = await generateHashObject(input);
+    const hash1 = await hashObject(input);
+    const hash2 = await hashObject(input);
 
     expect(hash1).toBe(hash2);
   });
 
   it("returns the expected hash for simple value", async () => {
-    const hash = await generateHashObject({ a: 123 });
+    const hash = await hashObject({ a: 123 });
     expect(hash).toEqual(
       "917cbcf20ffdb44b525db310004af7597b512c57cf37ad585d9b37b5e6617cca",
     );
@@ -50,7 +50,7 @@ describe("generateHashObject", () => {
       key: new Uint8Array([1, 2, 3, 4]),
     };
 
-    const hash = await generateHashObject(payload);
+    const hash = await hashObject(payload);
 
     expect(hash).toEqual(
       "7809e083f1e990698332f9328280d37d0d6b4637d2a2d8e2fdce0ccf13d9a40e",
@@ -59,8 +59,8 @@ describe("generateHashObject", () => {
 
   describe("handles complex value types", () => {
     it("handles BigInt values and distinguishes them correctly", async () => {
-      const hash1 = await generateHashObject({ amount: 123n });
-      const hash2 = await generateHashObject({ amount: 456n });
+      const hash1 = await hashObject({ amount: 123n });
+      const hash2 = await hashObject({ amount: 456n });
 
       expect(hash1).not.toBe(hash2);
       expect(hash1).toMatch(hexRegex);
@@ -72,15 +72,15 @@ describe("generateHashObject", () => {
         "ids2f-skxn7-4uwrl-lgtdm-mcv3m-m324f-vjn73-xg6xq-uea7b-37klk-nqe",
       );
 
-      const hashA = await generateHashObject({ user: principalA });
-      const hashB = await generateHashObject({ user: principalB });
+      const hashA = await hashObject({ user: principalA });
+      const hashB = await hashObject({ user: principalB });
 
       expect(hashA).not.toBe(hashB);
       expect(hashA).toMatch(hexRegex);
     });
 
     it("handles Uint8Array values correctly", async () => {
-      const hash = await generateHashObject({
+      const hash = await hashObject({
         key: new Uint8Array([1, 2, 3, 4]),
       });
 
@@ -92,7 +92,7 @@ describe("generateHashObject", () => {
         constructor(private value: number) {}
       }
 
-      const hash = await generateHashObject({
+      const hash = await hashObject({
         expiry: new Tmp(1_000_000),
       });
 
@@ -110,7 +110,7 @@ describe("generateHashObject", () => {
         request_type: SubmitRequestType.Call,
       };
 
-      const hash = await generateHashObject(complexPayload);
+      const hash = await hashObject(complexPayload);
       expect(hash).toMatch(hexRegex);
     });
   });

--- a/packages/utils/src/utils/crypto.utils.ts
+++ b/packages/utils/src/utils/crypto.utils.ts
@@ -1,0 +1,22 @@
+import { uint8ArrayToHexString } from "./arrays.utils";
+import { jsonReplacer } from "./json.utils";
+
+/**
+ * Generates a SHA-256 hash from the given object.
+ *
+ * The object is first stringified using a custom `jsonReplacer`, then
+ * hashed using the SubtleCrypto API. The resulting hash is returned as a hex string.
+ *
+ * @template T - The type of the input object.
+ * @param {T} params - The object to hash.
+ * @returns {Promise<string>} A promise that resolves to the hex string of the SHA-256 hash.
+ */
+export const generateHash = async <T extends object>(
+  params: T,
+): Promise<string> => {
+  const jsonString = JSON.stringify(params, jsonReplacer);
+  const dataBuffer = new TextEncoder().encode(jsonString);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", dataBuffer);
+
+  return uint8ArrayToHexString(new Uint8Array(hashBuffer));
+};

--- a/packages/utils/src/utils/crypto.utils.ts
+++ b/packages/utils/src/utils/crypto.utils.ts
@@ -11,7 +11,7 @@ import { jsonReplacer } from "./json.utils";
  * @param {T} params - The object to hash.
  * @returns {Promise<string>} A promise that resolves to the hex string of the SHA-256 hash.
  */
-export const generateHash = async <T extends object>(
+export const generateHashObject = async <T extends object>(
   params: T,
 ): Promise<string> => {
   const jsonString = JSON.stringify(params, jsonReplacer);

--- a/packages/utils/src/utils/crypto.utils.ts
+++ b/packages/utils/src/utils/crypto.utils.ts
@@ -11,7 +11,7 @@ import { jsonReplacer } from "./json.utils";
  * @param {T} params - The object to hash.
  * @returns {Promise<string>} A promise that resolves to the hex string of the SHA-256 hash.
  */
-export const generateHashObject = async <T extends object>(
+export const hashObject = async <T extends object>(
   params: T,
 ): Promise<string> => {
   const jsonString = JSON.stringify(params, jsonReplacer);


### PR DESCRIPTION
# Motivation

Since we introduce a `hashText` #890 in PR we can rename `generateHash` to `hashObject`.

# Notes

At first I went for `generateHashObject` but thought we could even shorten a bit.
