### PR TITLE
feat(icrc): add method list subaccounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next version
+
+## Features
+
+- Expose method `listSubaccounts` in class `IcrcIndexNgCanister`.
+
 # v69
 
 ## Overview

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -374,7 +374,7 @@ Returns the ledger canister ID related to the index canister.
 
 ### :factory: IcrcIndexNgCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L16)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L23)
 
 #### Static Methods
 
@@ -386,13 +386,14 @@ Returns the ledger canister ID related to the index canister.
 | -------- | ----------------------------------------------------------------------- |
 | `create` | `(options: IcrcLedgerCanisterOptions<_SERVICE>) => IcrcIndexNgCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L17)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L24)
 
 #### Methods
 
 - [getTransactions](#gear-gettransactions)
 - [ledgerId](#gear-ledgerid)
 - [status](#gear-status)
+- [listSubaccounts](#gear-listsubaccounts)
 
 ##### :gear: getTransactions
 
@@ -406,7 +407,7 @@ Parameters:
 
 - `params`: The parameters to get the transactions of an account.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L42)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L49)
 
 ##### :gear: ledgerId
 
@@ -416,7 +417,7 @@ Returns the ledger canister ID related to the index canister.
 | ---------- | --------------------------------------------- |
 | `ledgerId` | `(params: QueryParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L60)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L67)
 
 ##### :gear: status
 
@@ -430,7 +431,21 @@ Parameters:
 
 - `params`: The parameters to get the status of the index canister.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L71)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L78)
+
+##### :gear: listSubaccounts
+
+Returns the list of subaccounts for a given Principal
+
+| Method            | Type                                                                       |
+| ----------------- | -------------------------------------------------------------------------- |
+| `listSubaccounts` | `({ certified, ...rest }: ListSubaccountsParams) => Promise<SubAccount[]>` |
+
+Parameters:
+
+- `params`: The parameters to get the list of subaccounts from principal.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L87)
 
 <!-- TSDOC_END -->
 

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -435,7 +435,7 @@ Parameters:
 
 ##### :gear: listSubaccounts
 
-Returns the list of subaccounts for a given owner
+Returns the list of subaccounts for a given owner.
 
 | Method            | Type                                                                       |
 | ----------------- | -------------------------------------------------------------------------- |

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -435,7 +435,7 @@ Parameters:
 
 ##### :gear: listSubaccounts
 
-Returns the list of subaccounts for a given Principal
+Returns the list of subaccounts for a given owner
 
 | Method            | Type                                                                       |
 | ----------------- | -------------------------------------------------------------------------- |
@@ -443,7 +443,7 @@ Returns the list of subaccounts for a given Principal
 
 Parameters:
 
-- `params`: The parameters to get the list of subaccounts from principal.
+- `params`: The parameters to get the list of subaccounts.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/index-ng.canister.ts#L87)
 

--- a/packages/ledger-icrc/src/converters/index.converters.ts
+++ b/packages/ledger-icrc/src/converters/index.converters.ts
@@ -3,7 +3,7 @@ import type {
   Account,
   GetAccountTransactionsArgs,
 } from "../../candid/icrc_index";
-import { ListSubaccountsArgs } from "../../candid/icrc_index-ng";
+import type { ListSubaccountsArgs } from "../../candid/icrc_index-ng";
 import type { ListSubaccountsParams } from "../types/index-ng.params";
 import type { GetAccountTransactionsParams } from "../types/index.params";
 import type { IcrcAccount } from "../types/ledger.responses";

--- a/packages/ledger-icrc/src/converters/index.converters.ts
+++ b/packages/ledger-icrc/src/converters/index.converters.ts
@@ -3,6 +3,8 @@ import type {
   Account,
   GetAccountTransactionsArgs,
 } from "../../candid/icrc_index";
+import { ListSubaccountsArgs } from "../../candid/icrc_index-ng";
+import type { ListSubaccountsParams } from "../types/index-ng.params";
 import type { GetAccountTransactionsParams } from "../types/index.params";
 import type { IcrcAccount } from "../types/ledger.responses";
 
@@ -18,5 +20,13 @@ export const toGetTransactionsArgs = ({
 }: GetAccountTransactionsParams): GetAccountTransactionsArgs => ({
   account: toCandidAccount(account),
   max_results,
+  start: toNullable(start),
+});
+
+export const toListSubaccountsParams = ({
+  owner,
+  start,
+}: ListSubaccountsParams): ListSubaccountsArgs => ({
+  owner,
   start: toNullable(start),
 });

--- a/packages/ledger-icrc/src/index-ng.canister.spec.ts
+++ b/packages/ledger-icrc/src/index-ng.canister.spec.ts
@@ -6,6 +6,7 @@ import { mock } from "jest-mock-extended";
 import type {
   Account,
   _SERVICE as IcrcIndexNgService,
+  SubAccount,
   Transaction,
 } from "../candid/icrc_index-ng";
 import { IndexError } from "./errors/index.errors";
@@ -165,6 +166,61 @@ describe("Index canister", () => {
 
       const res = await canister.status({});
       expect(res).toEqual(mockStatus);
+    });
+  });
+
+  describe("listSubaccounts", () => {
+    const mockSubaccounts: SubAccount[] = [
+      new Uint8Array([1, 2, 3, 4]),
+      new Uint8Array([5, 6, 7, 8]),
+    ];
+
+    it("should return the list of subaccounts for a Principal", async () => {
+      const service = mock<ActorSubclass<IcrcIndexNgService>>();
+      service.list_subaccounts.mockResolvedValue(mockSubaccounts);
+
+      const canister = IcrcIndexNgCanister.create({
+        canisterId: indexCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+
+      const owner = Principal.fromText("aaaaa-aa");
+      const res = await canister.listSubaccounts({
+        owner,
+      });
+
+      expect(service.list_subaccounts).toHaveBeenCalledTimes(1);
+      expect(service.list_subaccounts).toHaveBeenCalledWith({
+        owner,
+        start: [],
+      });
+      expect(res).toEqual(mockSubaccounts);
+    });
+
+    it("should pass the start parameter when provided", async () => {
+      const service = mock<ActorSubclass<IcrcIndexNgService>>();
+      service.list_subaccounts.mockResolvedValue(mockSubaccounts);
+
+      const canister = IcrcIndexNgCanister.create({
+        canisterId: indexCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+
+      const owner = Principal.fromText("aaaaa-aa");
+      const startSubaccount = new Uint8Array([1, 2, 3, 4]);
+
+      const res = await canister.listSubaccounts({
+        owner,
+        start: startSubaccount,
+        certified: true,
+      });
+
+      expect(service.list_subaccounts).toHaveBeenCalledTimes(1);
+      expect(service.list_subaccounts).toHaveBeenCalledWith({
+        owner,
+        start: [startSubaccount],
+      });
+      expect(res).toEqual(mockSubaccounts);
     });
   });
 });

--- a/packages/ledger-icrc/src/index-ng.canister.spec.ts
+++ b/packages/ledger-icrc/src/index-ng.canister.spec.ts
@@ -11,7 +11,11 @@ import type {
 } from "../candid/icrc_index-ng";
 import { IndexError } from "./errors/index.errors";
 import { IcrcIndexNgCanister } from "./index-ng.canister";
-import { indexCanisterIdMock, ledgerCanisterIdMock } from "./mocks/ledger.mock";
+import {
+  indexCanisterIdMock,
+  ledgerCanisterIdMock,
+  mockPrincipal,
+} from "./mocks/ledger.mock";
 import type { IcrcAccount } from "./types/ledger.responses";
 
 describe("Index canister", () => {
@@ -175,7 +179,7 @@ describe("Index canister", () => {
       new Uint8Array([5, 6, 7, 8]),
     ];
 
-    it("should return the list of subaccounts for a Principal", async () => {
+    it("should return the list of subaccounts for a owner", async () => {
       const service = mock<ActorSubclass<IcrcIndexNgService>>();
       service.list_subaccounts.mockResolvedValue(mockSubaccounts);
 
@@ -184,7 +188,7 @@ describe("Index canister", () => {
         certifiedServiceOverride: service,
       });
 
-      const owner = Principal.fromText("aaaaa-aa");
+      const owner = mockPrincipal;
       const res = await canister.listSubaccounts({
         owner,
       });
@@ -206,7 +210,7 @@ describe("Index canister", () => {
         certifiedServiceOverride: service,
       });
 
-      const owner = Principal.fromText("aaaaa-aa");
+      const owner = mockPrincipal;
       const startSubaccount = new Uint8Array([1, 2, 3, 4]);
 
       const res = await canister.listSubaccounts({

--- a/packages/ledger-icrc/src/index-ng.canister.spec.ts
+++ b/packages/ledger-icrc/src/index-ng.canister.spec.ts
@@ -179,7 +179,7 @@ describe("Index canister", () => {
       new Uint8Array([5, 6, 7, 8]),
     ];
 
-    it("should return the list of subaccounts for a owner", async () => {
+    it("should return the list of subaccounts for an owner", async () => {
       const service = mock<ActorSubclass<IcrcIndexNgService>>();
       service.list_subaccounts.mockResolvedValue(mockSubaccounts);
 

--- a/packages/ledger-icrc/src/index-ng.canister.ts
+++ b/packages/ledger-icrc/src/index-ng.canister.ts
@@ -79,10 +79,10 @@ export class IcrcIndexNgCanister extends IcrcCanister<IcrcIndexNgService> {
     this.caller(params).status();
 
   /**
-   * Returns the list of subaccounts for a given owner
+   * Returns the list of subaccounts for a given owner.
    *
    * @param {ListSubaccountsParams} params The parameters to get the list of subaccounts.
-   * @returns {Promise<Array<SubAccount>>} The list of subaccounts
+   * @returns {Promise<Array<SubAccount>>} The list of subaccounts.
    */
   listSubaccounts = ({
     certified,

--- a/packages/ledger-icrc/src/index-ng.canister.ts
+++ b/packages/ledger-icrc/src/index-ng.canister.ts
@@ -1,6 +1,6 @@
 import type { Principal } from "@dfinity/principal";
 import { createServices, type QueryParams } from "@dfinity/utils";
-import { SubAccount } from "../candid/icrc_index";
+import type { SubAccount } from "../candid/icrc_index";
 import type {
   GetTransactions,
   _SERVICE as IcrcIndexNgService,

--- a/packages/ledger-icrc/src/index-ng.canister.ts
+++ b/packages/ledger-icrc/src/index-ng.canister.ts
@@ -79,9 +79,9 @@ export class IcrcIndexNgCanister extends IcrcCanister<IcrcIndexNgService> {
     this.caller(params).status();
 
   /**
-   * Returns the list of subaccounts for a given Principal
+   * Returns the list of subaccounts for a given owner
    *
-   * @param {ListSubaccountsParams} params The parameters to get the list of subaccounts from principal.
+   * @param {ListSubaccountsParams} params The parameters to get the list of subaccounts.
    * @returns {Promise<Array<SubAccount>>} The list of subaccounts
    */
   listSubaccounts = ({

--- a/packages/ledger-icrc/src/index-ng.canister.ts
+++ b/packages/ledger-icrc/src/index-ng.canister.ts
@@ -1,5 +1,6 @@
 import type { Principal } from "@dfinity/principal";
 import { createServices, type QueryParams } from "@dfinity/utils";
+import { SubAccount } from "../candid/icrc_index";
 import type {
   GetTransactions,
   _SERVICE as IcrcIndexNgService,
@@ -8,10 +9,16 @@ import type {
 import { idlFactory as certifiedIdlFactory } from "../candid/icrc_index-ng.certified.idl";
 import { idlFactory } from "../candid/icrc_index-ng.idl";
 import { IcrcCanister } from "./canister";
-import { toGetTransactionsArgs } from "./converters/index.converters";
+import {
+  toGetTransactionsArgs,
+  toListSubaccountsParams,
+} from "./converters/index.converters";
 import { IndexError } from "./errors/index.errors";
 import type { IcrcLedgerCanisterOptions } from "./types/canister.options";
-import type { GetIndexNgAccountTransactionsParams } from "./types/index-ng.params";
+import type {
+  GetIndexNgAccountTransactionsParams,
+  ListSubaccountsParams,
+} from "./types/index-ng.params";
 
 export class IcrcIndexNgCanister extends IcrcCanister<IcrcIndexNgService> {
   static create(options: IcrcLedgerCanisterOptions<IcrcIndexNgService>) {
@@ -70,4 +77,16 @@ export class IcrcIndexNgCanister extends IcrcCanister<IcrcIndexNgService> {
    */
   status = (params: QueryParams): Promise<Status> =>
     this.caller(params).status();
+
+  /**
+   * Returns the list of subaccounts for a given Principal
+   *
+   * @param {ListSubaccountsParams} params The parameters to get the list of subaccounts from principal.
+   * @returns {Promise<Array<SubAccount>>} The list of subaccounts
+   */
+  listSubaccounts = ({
+    certified,
+    ...rest
+  }: ListSubaccountsParams): Promise<Array<SubAccount>> =>
+    this.caller({ certified }).list_subaccounts(toListSubaccountsParams(rest));
 }

--- a/packages/ledger-icrc/src/types/index-ng.params.ts
+++ b/packages/ledger-icrc/src/types/index-ng.params.ts
@@ -1,6 +1,6 @@
-import { Principal } from "@dfinity/principal";
+import type { Principal } from "@dfinity/principal";
 import type { QueryParams } from "@dfinity/utils";
-import { Subaccount } from "../../candid/icrc_ledger";
+import type { Subaccount } from "../../candid/icrc_ledger";
 import type { IcrcNgTxId } from "./index-ng.types";
 import type { IcrcAccount } from "./ledger.responses";
 

--- a/packages/ledger-icrc/src/types/index-ng.params.ts
+++ b/packages/ledger-icrc/src/types/index-ng.params.ts
@@ -1,4 +1,3 @@
-import type { Principal } from "@dfinity/principal";
 import type { QueryParams } from "@dfinity/utils";
 import type { Subaccount } from "../../candid/icrc_ledger";
 import type { IcrcNgTxId } from "./index-ng.types";
@@ -11,6 +10,6 @@ export type GetIndexNgAccountTransactionsParams = {
 } & QueryParams;
 
 export type ListSubaccountsParams = {
-  owner: Principal;
   start?: Subaccount;
-} & QueryParams;
+} & Pick<IcrcAccount, "owner"> &
+  QueryParams;

--- a/packages/ledger-icrc/src/types/index-ng.params.ts
+++ b/packages/ledger-icrc/src/types/index-ng.params.ts
@@ -1,4 +1,6 @@
+import { Principal } from "@dfinity/principal";
 import type { QueryParams } from "@dfinity/utils";
+import { Subaccount } from "../../candid/icrc_ledger";
 import type { IcrcNgTxId } from "./index-ng.types";
 import type { IcrcAccount } from "./ledger.responses";
 
@@ -6,4 +8,9 @@ export type GetIndexNgAccountTransactionsParams = {
   max_results: bigint;
   start?: IcrcNgTxId;
   account: IcrcAccount;
+} & QueryParams;
+
+export type ListSubaccountsParams = {
+  owner: Principal;
+  start?: Subaccount;
 } & QueryParams;


### PR DESCRIPTION
# Motivation

We aim to introduce a new method, [listSubaccounts](https://github.com/dfinity/ic/blob/12ade05922581a5c95de05b63456655eacc6e2af/rs/ledger_suite/icrc1/index-ng/src/main.rs#L1056), in the `IcrcIndexNgCanister` class.

# Changes

- Added the `listSubaccounts` method to the `IcrcIndexNgCanister` class.

# Tests

- Created tests for the new method.

# Todos

- [x] Add entry to changelog (if necessary).
