### PR TITLE
chore: use isNullish in governance service

### DIFF
--- a/packages/nns/src/canisters/governance/services.ts
+++ b/packages/nns/src/canisters/governance/services.ts
@@ -1,3 +1,4 @@
+import { isNullish } from "@dfinity/utils";
 import type {
   Command_1,
   _SERVICE as GovernanceService,
@@ -5,7 +6,6 @@ import type {
   ManageNeuronResponse,
 } from "../../../candid/governance";
 import { GovernanceError } from "../../errors/governance.errors";
-import { isNullish } from "@dfinity/utils";
 
 /**
  * Checks a Manage Neuron Response for error and returns successful response data.

--- a/packages/nns/src/canisters/governance/services.ts
+++ b/packages/nns/src/canisters/governance/services.ts
@@ -5,6 +5,7 @@ import type {
   ManageNeuronResponse,
 } from "../../../candid/governance";
 import { GovernanceError } from "../../errors/governance.errors";
+import { isNullish } from "@dfinity/utils";
 
 /**
  * Checks a Manage Neuron Response for error and returns successful response data.
@@ -16,7 +17,7 @@ export const getSuccessfulCommandFromResponse = (
 ): Command_1 => {
   const { command } = response;
   const data = command[0];
-  if (!data) {
+  if (isNullish(data)) {
     throw new GovernanceError({
       error_message: "Error updating neuron",
       error_type: 0,


### PR DESCRIPTION
# Motivation

Randomly spotted the usage of a `!` null check which can be replaced by `isNullish` for consistency reasons.
