### PR TITLE
chore: eslint keep local-rules/use-option-type-wrapper off

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,9 @@ export default [
       "require-await": "off",
       "@typescript-eslint/no-empty-object-type": "off",
       "import/no-relative-parent-imports": "off",
+      // Enforcing Option<Type> for nullish values would require every library to define or depend on such a wrapper.
+      // This rule is more appropriate in applications where null and undefined have distinct meanings.
+      // That is why, for now, it's disabled in this repo.
       "local-rules/use-option-type-wrapper": "off",
       "@typescript-eslint/no-unused-vars": "off",
       "arrow-body-style": "off",


### PR DESCRIPTION
# Motivation

Add a comment on why it makes sense to keep `local-rules/use-option-type-wrapper` disabled here.
