### PR TITLE
chore: eslint no-empty-object-type on

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,6 @@ export default [
   {
     rules: {
       "require-await": "off",
-      "@typescript-eslint/no-empty-object-type": "off",
       "import/no-relative-parent-imports": "off",
       "local-rules/use-option-type-wrapper": "off",
       "@typescript-eslint/no-unused-vars": "off",

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -127,6 +127,7 @@ export type ManageNeuronCommandRequest =
 export interface Configure {
   operation: Option<Operation>;
 }
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface RefreshVotingPower {
   // Intentionally left blank.
 }

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -173,9 +173,9 @@ List the proposals of the Sns
 
 List the topics of the Sns
 
-| Method       | Type                                                           |
-| ------------ | -------------------------------------------------------------- |
-| `listTopics` | `(params: SnsListTopicsParams) => Promise<ListTopicsResponse>` |
+| Method       | Type                                                   |
+| ------------ | ------------------------------------------------------ |
+| `listTopics` | `(params: QueryParams) => Promise<ListTopicsResponse>` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/sns/src/governance.canister.ts#L116)
 

--- a/packages/sns/src/types/governance.params.ts
+++ b/packages/sns/src/types/governance.params.ts
@@ -60,7 +60,7 @@ export interface SnsListProposalsParams extends QueryParams {
   includeTopics?: Array<Topic | null>;
 }
 
-export interface SnsListTopicsParams extends QueryParams {}
+export type SnsListTopicsParams = QueryParams;
 
 /**
  * The parameters to get an sns proposal


### PR DESCRIPTION
# Motivation

We want more restrictive eslint rules.

# Changes

- Remove exception and fix code.
