### PR TITLE
chore: eslint prefer-object-params on

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,6 @@ export default [
       // This rule is more appropriate in applications where null and undefined have distinct meanings.
       // That is why, for now, it's disabled in this repo.
       "local-rules/use-option-type-wrapper": "off",
-      "local-rules/prefer-object-params": "off",
     },
   },
   {

--- a/packages/cketh/src/utils/minter.utils.ts
+++ b/packages/cketh/src/utils/minter.utils.ts
@@ -20,10 +20,16 @@ export const encodePrincipalToEthAddress = (principal: Principal): string => {
  * @param {number} b A byte.
  * @return {string} An updated string.
  */
-const appendHexByte = (s: string, b: number): string => {
-  s += ((b >> 4) & 0x0f).toString(16);
-  s += (b & 0x0f).toString(16);
-  return s;
+const appendHexByte = ({
+  stringToAppend,
+  bytes,
+}: {
+  stringToAppend: string;
+  bytes: number;
+}): string => {
+  stringToAppend += ((bytes >> 4) & 0x0f).toString(16);
+  stringToAppend += (bytes & 0x0f).toString(16);
+  return stringToAppend;
 };
 
 /**
@@ -34,9 +40,9 @@ const appendHexByte = (s: string, b: number): string => {
 const bytes32Encode = (bytes: Uint8Array): string => {
   const n = bytes.length;
   let s = "0x";
-  s = appendHexByte(s, n);
+  s = appendHexByte({ stringToAppend: s, bytes: n });
   for (let i = 0; i < bytes.length; i++) {
-    s = appendHexByte(s, bytes[i]);
+    s = appendHexByte({ stringToAppend: s, bytes: bytes[i] });
   }
   for (let i = 0; i < 31 - bytes.length; i++) {
     s += "00";

--- a/packages/ic-management/src/utils/transform.utils.ts
+++ b/packages/ic-management/src/utils/transform.utils.ts
@@ -17,6 +17,7 @@ type QueryTransform = Required<ActorConfig>["queryTransform"];
  *
  * @link https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-effective-canister-id
  **/
+// eslint-disable-next-line local-rules/prefer-object-params
 export const transform: CallTransform | QueryTransform = (
   methodName: string,
   args: (Record<string, unknown> & {

--- a/packages/ledger-icp/src/utils/account_identifier.utils.ts
+++ b/packages/ledger-icp/src/utils/account_identifier.utils.ts
@@ -18,6 +18,7 @@ export const accountIdentifierFromBytes = (
   accountIdentifier: Uint8Array,
 ): AccountIdentifierHex => Buffer.from(accountIdentifier).toString("hex");
 
+// eslint-disable-next-line local-rules/prefer-object-params
 export const principalToAccountIdentifier = (
   principal: Principal,
   subAccount?: Uint8Array,

--- a/packages/ledger-icrc/src/utils/ledger.utils.spec.ts
+++ b/packages/ledger-icrc/src/utils/ledger.utils.spec.ts
@@ -173,6 +173,7 @@ describe("ledger-utils", () => {
 
     it.each(missingFieldCases)(
       "should return undefined for %s",
+      // eslint-disable-next-line local-rules/prefer-object-params
       (_, response) => {
         const result = mapTokenMetadata(response);
         expect(result).toBeUndefined();
@@ -216,6 +217,7 @@ describe("ledger-utils", () => {
 
     it.each(invalidFieldCases)(
       "should return undefined for %s",
+      // eslint-disable-next-line local-rules/prefer-object-params
       (_, response) => {
         const result = mapTokenMetadata(response);
         expect(result).toBeUndefined();

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -384,7 +384,7 @@ Set visibility of a neuron
 | --------------- | ------------------------------------------------------------------- |
 | `setVisibility` | `(neuronId: bigint, visibility: NeuronVisibility) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L525)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L526)
 
 ##### :gear: setNodeProviderAccount
 
@@ -395,7 +395,7 @@ Where the reward is paid to.
 | ------------------------ | ---------------------------------------------- |
 | `setNodeProviderAccount` | `(accountIdentifier: string) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L545)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L546)
 
 ##### :gear: mergeNeurons
 
@@ -405,7 +405,7 @@ Merge two neurons
 | -------------- | --------------------------------------------------------------------------------- |
 | `mergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L565)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L566)
 
 ##### :gear: simulateMergeNeurons
 
@@ -415,7 +415,7 @@ Simulate merging two neurons
 | ---------------------- | --------------------------------------------------------------------------------------- |
 | `simulateMergeNeurons` | `(request: { sourceNeuronId: bigint; targetNeuronId: bigint; }) => Promise<NeuronInfo>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L582)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L583)
 
 ##### :gear: splitNeuron
 
@@ -425,7 +425,7 @@ Splits a neuron creating a new one
 | ------------- | ----------------------------------------------------------------------------------- |
 | `splitNeuron` | `({ neuronId, amount, }: { neuronId: bigint; amount: bigint; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L627)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L628)
 
 ##### :gear: getProposal
 
@@ -438,7 +438,7 @@ it is fetched using a query call.
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `getProposal` | `({ proposalId, certified, }: { proposalId: bigint; certified?: boolean or undefined; }) => Promise<ProposalInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L667)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L668)
 
 ##### :gear: makeProposal
 
@@ -448,7 +448,7 @@ Create new proposal
 | -------------- | ---------------------------------------------------------------- |
 | `makeProposal` | `(request: MakeProposalRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L685)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L686)
 
 ##### :gear: registerVote
 
@@ -458,7 +458,7 @@ Registers vote for a proposal from the neuron passed.
 | -------------- | ----------------------------------------------------------------------------------------------------------- |
 | `registerVote` | `({ neuronId, vote, proposalId, }: { neuronId: bigint; vote: Vote; proposalId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L706)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L707)
 
 ##### :gear: setFollowees
 
@@ -468,7 +468,7 @@ Edit neuron followees per topic
 | -------------- | ------------------------------------------------- |
 | `setFollowees` | `(followRequest: FollowRequest) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L728)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L729)
 
 ##### :gear: disburse
 
@@ -478,7 +478,7 @@ Disburse neuron on Account
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `disburse` | `({ neuronId, toAccountId, amount, }: { neuronId: bigint; toAccountId?: string or undefined; amount?: bigint or undefined; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L743)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L744)
 
 ##### :gear: refreshVotingPower
 
@@ -490,7 +490,7 @@ parameter of the neuron to the current time).
 | -------------------- | --------------------------------------------------------- |
 | `refreshVotingPower` | `({ neuronId, }: { neuronId: bigint; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L779)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L780)
 
 ##### :gear: mergeMaturity
 
@@ -500,7 +500,7 @@ Merge Maturity of a neuron
 | --------------- | ------------------------------------------------------------------------------------------------------- |
 | `mergeMaturity` | `({ neuronId, percentageToMerge, }: { neuronId: bigint; percentageToMerge: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L801)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L802)
 
 ##### :gear: stakeMaturity
 
@@ -515,7 +515,7 @@ Parameters:
 - `neuronId`: The id of the neuron for which to stake the maturity
 - `percentageToStake`: Optional. Percentage of the current maturity to stake. If not provided, all of the neuron's current maturity will be staked.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L830)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L831)
 
 ##### :gear: spawnNeuron
 
@@ -525,7 +525,7 @@ Merge Maturity of a neuron
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `spawnNeuron` | `({ neuronId, percentageToSpawn, newController, nonce, }: { neuronId: bigint; percentageToSpawn?: number or undefined; newController?: Principal or undefined; nonce?: bigint or undefined; }) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L852)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L853)
 
 ##### :gear: addHotkey
 
@@ -535,7 +535,7 @@ Add hotkey to neuron
 | ----------- | ------------------------------------------------------------------------------------------ |
 | `addHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L899)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L900)
 
 ##### :gear: removeHotkey
 
@@ -545,7 +545,7 @@ Remove hotkey to neuron
 | -------------- | ------------------------------------------------------------------------------------------ |
 | `removeHotkey` | `({ neuronId, principal, }: { neuronId: bigint; principal: Principal; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L919)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L920)
 
 ##### :gear: claimOrRefreshNeuronFromAccount
 
@@ -555,7 +555,7 @@ Gets the NeuronID of a newly created neuron.
 | --------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `claimOrRefreshNeuronFromAccount` | `({ memo, controller, }: { memo: bigint; controller?: Principal or undefined; }) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L937)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L938)
 
 ##### :gear: claimOrRefreshNeuron
 
@@ -566,7 +566,7 @@ Uses query call only.
 | ---------------------- | ------------------------------------------------------------------------ |
 | `claimOrRefreshNeuron` | `(request: ClaimOrRefreshNeuronRequest) => Promise<bigint or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L968)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L969)
 
 ##### :gear: getNeuron
 
@@ -576,7 +576,7 @@ Return the data of the neuron provided as id.
 | ----------- | ----------------------------------------------------------------------------------------------------------- |
 | `getNeuron` | `({ certified, neuronId, }: { certified: boolean; neuronId: bigint; }) => Promise<NeuronInfo or undefined>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L993)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L994)
 
 ##### :gear: getNetworkEconomicsParameters
 
@@ -586,7 +586,7 @@ Return the [Network Economics](https://github.com/dfinity/ic/blob/d90e934eb440c7
 | ------------------------------- | ------------------------------------------------------------------------ |
 | `getNetworkEconomicsParameters` | `({ certified, }: { certified: boolean; }) => Promise<NetworkEconomics>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L1014)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L1015)
 
 ##### :gear: disburseMaturity
 
@@ -597,7 +597,7 @@ Reference: https://github.com/dfinity/ic/blob/ca2be53acf413bb92478ee7694ac0fb92a
 | ------------------ | ------------------------------------------------------------------------------------------------------------- |
 | `disburseMaturity` | `({ neuronId, percentageToDisburse, }: { neuronId: bigint; percentageToDisburse: number; }) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L1037)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/nns/src/governance.canister.ts#L1038)
 
 ### :factory: SnsWasmCanister
 

--- a/packages/nns/src/governance.canister.ts
+++ b/packages/nns/src/governance.canister.ts
@@ -522,6 +522,7 @@ export class GovernanceCanister {
    *
    * @throws {@link GovernanceError}
    */
+  // eslint-disable-next-line local-rules/prefer-object-params
   public setVisibility = async (
     neuronId: NeuronId,
     visibility: NeuronVisibility,

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -232,7 +232,7 @@ Parameters:
 | -------------- | ---------------------------------------------------------------- |
 | `asNonNullish` | `<T>(value: T, message?: string or undefined) => NonNullable<T>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/asserts.utils.ts#L16)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/asserts.utils.ts#L18)
 
 #### :gear: assertPercentageNumber
 
@@ -240,7 +240,7 @@ Parameters:
 | ------------------------ | ------------------------------ |
 | `assertPercentageNumber` | `(percentage: number) => void` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/asserts.utils.ts#L21)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/asserts.utils.ts#L23)
 
 #### :gear: uint8ArrayToBigInt
 
@@ -407,7 +407,7 @@ Parameters:
 - `_key`: - Ignored. Only provided for API compatibility.
 - `value`: - The value to transform before stringification.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/json.utils.ts#L21)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/json.utils.ts#L22)
 
 #### :gear: jsonReviver
 
@@ -430,7 +430,7 @@ Parameters:
 - `_key`: - Ignored but provided for API compatibility.
 - `value`: - The parsed value to transform.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/json.utils.ts#L51)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/json.utils.ts#L53)
 
 #### :gear: hashObject
 
@@ -490,7 +490,7 @@ Returns the current timestamp in nanoseconds as a `bigint`.
 | ------------------------ | -------------- |
 | `nowInBigIntNanoSeconds` | `() => bigint` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/date.utils.ts#L117)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/date.utils.ts#L123)
 
 #### :gear: toBigIntNanoSeconds
 
@@ -504,7 +504,7 @@ Parameters:
 
 - `date`: - The `Date` object to convert.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/date.utils.ts#L126)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/date.utils.ts#L132)
 
 #### :gear: debounce
 
@@ -611,7 +611,7 @@ Parameters:
 - `params.minVersion`: Ex: "1.0.0"
 - `params.currentVersion`: Ex: "2.0.0"
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/version.utils.ts#L28)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/version.utils.ts#L34)
 
 ### :wrench: Constants
 

--- a/packages/utils/src/utils/asserts.utils.ts
+++ b/packages/utils/src/utils/asserts.utils.ts
@@ -4,6 +4,7 @@ export class NullishError extends Error {}
 export const assertNonNullish: <T>(
   value: T,
   message?: string,
+  // eslint-disable-next-line local-rules/prefer-object-params
 ) => asserts value is NonNullable<T> = <T>(
   value: T,
   message?: string,
@@ -13,6 +14,7 @@ export const assertNonNullish: <T>(
   }
 };
 
+// eslint-disable-next-line local-rules/prefer-object-params
 export const asNonNullish = <T>(value: T, message?: string): NonNullable<T> => {
   assertNonNullish(value, message);
   return value;

--- a/packages/utils/src/utils/date.utils.spec.ts
+++ b/packages/utils/src/utils/date.utils.spec.ts
@@ -37,6 +37,7 @@ describe("date.utils", () => {
     second_plural: "secondes",
   };
 
+  // eslint-disable-next-line local-rules/prefer-object-params
   const test = (
     i18nResult: I18nSecondsToDuration,
     i18n?: I18nSecondsToDuration,

--- a/packages/utils/src/utils/date.utils.ts
+++ b/packages/utils/src/utils/date.utils.ts
@@ -59,12 +59,12 @@ export const secondsToDuration = ({
   days -= daysInYears(years);
 
   const periods = [
-    createLabel("year", years),
-    createLabel("day", days),
-    createLabel("hour", hours),
-    createLabel("minute", minutes),
+    createLabel({ labelKey: "year", amount: years }),
+    createLabel({ labelKey: "day", amount: days }),
+    createLabel({ labelKey: "hour", amount: hours }),
+    createLabel({ labelKey: "minute", amount: minutes }),
     ...(seconds > BigInt(0) && seconds < BigInt(60)
-      ? [createLabel("second", seconds)]
+      ? [createLabel({ labelKey: "second", amount: seconds })]
       : []),
   ];
 
@@ -102,7 +102,13 @@ type LabelInfo = {
   labelKey: LabelKey;
   amount: number;
 };
-const createLabel = (labelKey: LabelKey, amount: bigint): LabelInfo => ({
+const createLabel = ({
+  labelKey,
+  amount,
+}: {
+  labelKey: LabelKey;
+  amount: bigint;
+}): LabelInfo => ({
   labelKey,
   amount: Number(amount),
 });

--- a/packages/utils/src/utils/debounce.utils.ts
+++ b/packages/utils/src/utils/debounce.utils.ts
@@ -9,7 +9,7 @@
  * @param {number} [timeout=300] - The debounce delay in milliseconds. Defaults to 300ms if not provided or invalid.
  * @returns {(args: unknown[]) => void} A debounced version of the original function.
  */
-// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type, local-rules/prefer-object-params
 export const debounce = (func: Function, timeout?: number) => {
   let timer: NodeJS.Timer | undefined;
 

--- a/packages/utils/src/utils/json.utils.ts
+++ b/packages/utils/src/utils/json.utils.ts
@@ -18,6 +18,7 @@ const JSON_KEY_UINT8ARRAY = "__uint8array__";
  * @param {unknown} value - The value to transform before stringification.
  * @returns {unknown} The transformed value if it matches a known type, otherwise the original value.
  */
+// eslint-disable-next-line local-rules/prefer-object-params
 export const jsonReplacer = (_key: string, value: unknown): unknown => {
   if (typeof value === "bigint") {
     return { [JSON_KEY_BIGINT]: `${value}` };
@@ -48,6 +49,7 @@ export const jsonReplacer = (_key: string, value: unknown): unknown => {
  * @param {unknown} value - The parsed value to transform.
  * @returns {unknown} The reconstructed value if it matches a known type, otherwise the original value.
  */
+// eslint-disable-next-line local-rules/prefer-object-params
 export const jsonReviver = (_key: string, value: unknown): unknown => {
   const mapValue = <T>(key: string): T => (value as Record<string, T>)[key];
 

--- a/packages/utils/src/utils/version.utils.ts
+++ b/packages/utils/src/utils/version.utils.ts
@@ -1,5 +1,11 @@
 const AMOUNT_VERSION_PARTS = 3;
-const addZeros = (nums: number[], amountZeros: number): number[] =>
+const addZeros = ({
+  nums,
+  amountZeros,
+}: {
+  nums: number[];
+  amountZeros: number;
+}): number[] =>
   amountZeros > nums.length
     ? [...nums, ...[...Array(amountZeros - nums.length).keys()].map(() => 0)]
     : nums;
@@ -32,14 +38,14 @@ export const smallerVersion = ({
   minVersion: string;
   currentVersion: string;
 }): boolean => {
-  const minVersionStandarized = addZeros(
-    minVersion.split(".").map(convertToNumber),
-    AMOUNT_VERSION_PARTS,
-  ).join(".");
-  const currentVersionStandarized = addZeros(
-    currentVersion.split(".").map(convertToNumber),
-    AMOUNT_VERSION_PARTS,
-  ).join(".");
+  const minVersionStandarized = addZeros({
+    nums: minVersion.split(".").map(convertToNumber),
+    amountZeros: AMOUNT_VERSION_PARTS,
+  }).join(".");
+  const currentVersionStandarized = addZeros({
+    nums: currentVersion.split(".").map(convertToNumber),
+    amountZeros: AMOUNT_VERSION_PARTS,
+  }).join(".");
   // Versions need to have the same number of parts to be comparable
   // Source: https://stackoverflow.com/a/65687141
   return (


### PR DESCRIPTION
# Motivation

We want more restrictive eslint rules.

# Changes

- Toggle rule on
- Adapt some internal functions
- Add some exception either for functional reason, to avoid breaking change or simplity if test
