### PR TITLE
chore: Await all rejects promises in tests

### DIFF
--- a/packages/ckbtc/src/bitcoin.canister.spec.ts
+++ b/packages/ckbtc/src/bitcoin.canister.spec.ts
@@ -117,7 +117,7 @@ describe("BitcoinCanister", () => {
       });
     });
 
-    it("throws Error", () => {
+    it("throws Error", async () => {
       const error = new Error("Test");
       const service = mock<ActorSubclass<BitcoinService>>();
       service.bitcoin_get_utxos_query.mockRejectedValue(error);
@@ -131,7 +131,7 @@ describe("BitcoinCanister", () => {
           ...params,
         });
 
-      expect(call).rejects.toThrowError(Error);
+      await expect(call).rejects.toThrowError(Error);
     });
 
     it("should not call certified end point", async () => {
@@ -179,7 +179,7 @@ describe("BitcoinCanister", () => {
       });
     });
 
-    it("throws Error", () => {
+    it("throws Error", async () => {
       const error = new Error("Test");
       const service = mock<ActorSubclass<BitcoinService>>();
       service.bitcoin_get_balance_query.mockRejectedValue(error);
@@ -193,7 +193,7 @@ describe("BitcoinCanister", () => {
           ...params,
         });
 
-      expect(call).rejects.toThrowError(Error);
+      await expect(call).rejects.toThrowError(Error);
     });
 
     it("should not call certified end point", async () => {

--- a/packages/cmc/src/cmc.canister.spec.ts
+++ b/packages/cmc/src/cmc.canister.spec.ts
@@ -133,7 +133,7 @@ describe("CyclesMintingCanister", () => {
           settings: [],
         });
 
-      expect(call).rejects.toThrowError(RefundedError);
+      await expect(call).rejects.toThrowError(RefundedError);
     });
 
     it("throws InvalidaTransactionError error", async () => {
@@ -154,7 +154,7 @@ describe("CyclesMintingCanister", () => {
           settings: [],
         });
 
-      expect(call).rejects.toThrowError(InvalidaTransactionError);
+      await expect(call).rejects.toThrowError(InvalidaTransactionError);
     });
 
     it("throws ProcessingError error", async () => {
@@ -175,7 +175,7 @@ describe("CyclesMintingCanister", () => {
           settings: [],
         });
 
-      expect(call).rejects.toThrowError(ProcessingError);
+      await expect(call).rejects.toThrowError(ProcessingError);
     });
 
     it("throws TransactionTooOldError error", async () => {
@@ -196,7 +196,7 @@ describe("CyclesMintingCanister", () => {
           settings: [],
         });
 
-      expect(call).rejects.toThrowError(TransactionTooOldError);
+      await expect(call).rejects.toThrowError(TransactionTooOldError);
     });
 
     it("throws CMCError error", async () => {
@@ -217,7 +217,7 @@ describe("CyclesMintingCanister", () => {
           settings: [],
         });
 
-      expect(call).rejects.toThrowError(CMCError);
+      await expect(call).rejects.toThrowError(CMCError);
     });
   });
 
@@ -254,7 +254,7 @@ describe("CyclesMintingCanister", () => {
           block_index: BigInt(10),
         });
 
-      expect(call).rejects.toThrowError(RefundedError);
+      await expect(call).rejects.toThrowError(RefundedError);
     });
 
     it("throws InvalidaTransactionError error", async () => {
@@ -272,7 +272,7 @@ describe("CyclesMintingCanister", () => {
           block_index: BigInt(10),
         });
 
-      expect(call).rejects.toThrowError(InvalidaTransactionError);
+      await expect(call).rejects.toThrowError(InvalidaTransactionError);
     });
 
     it("throws ProcessingError error", async () => {
@@ -290,7 +290,7 @@ describe("CyclesMintingCanister", () => {
           block_index: BigInt(10),
         });
 
-      expect(call).rejects.toThrowError(ProcessingError);
+      await expect(call).rejects.toThrowError(ProcessingError);
     });
 
     it("throws TransactionTooOldError error", async () => {
@@ -308,7 +308,7 @@ describe("CyclesMintingCanister", () => {
           block_index: BigInt(10),
         });
 
-      expect(call).rejects.toThrowError(TransactionTooOldError);
+      await expect(call).rejects.toThrowError(TransactionTooOldError);
     });
 
     it("throws CMCError error", async () => {
@@ -326,7 +326,7 @@ describe("CyclesMintingCanister", () => {
           block_index: BigInt(10),
         });
 
-      expect(call).rejects.toThrowError(CMCError);
+      await expect(call).rejects.toThrowError(CMCError);
     });
   });
 

--- a/packages/ledger-icp/src/index.canister.spec.ts
+++ b/packages/ledger-icp/src/index.canister.spec.ts
@@ -213,7 +213,7 @@ describe("IndexCanister", () => {
       });
     });
 
-    it("throws errors", () => {
+    it("throws errors", async () => {
       const transactionsErrorMock = {
         Err: {
           message: "Test error",
@@ -228,7 +228,7 @@ describe("IndexCanister", () => {
         serviceOverride: service,
       });
 
-      expect(() =>
+      await expect(() =>
         index.getTransactions({
           accountIdentifier: mockAccountIdentifier.toHex(),
           certified: false,
@@ -237,7 +237,7 @@ describe("IndexCanister", () => {
       ).rejects.toThrowError();
     });
 
-    it("should bubble errors", () => {
+    it("should bubble errors", async () => {
       const service = mock<ActorSubclass<IndexService>>();
       service.get_account_identifier_transactions.mockImplementation(() => {
         throw new Error();
@@ -247,7 +247,7 @@ describe("IndexCanister", () => {
         serviceOverride: service,
       });
 
-      expect(() =>
+      await expect(() =>
         index.getTransactions({
           accountIdentifier: mockAccountIdentifier.toHex(),
           certified: false,

--- a/packages/ledger-icp/src/ledger.canister.spec.ts
+++ b/packages/ledger-icp/src/ledger.canister.spec.ts
@@ -290,7 +290,7 @@ describe("LedgerCanister", () => {
         });
       });
 
-      it("handles duplicate transaction", () => {
+      it("handles duplicate transaction", async () => {
         const service = mock<ActorSubclass<LedgerService>>();
         service.transfer.mockResolvedValue({
           Err: {
@@ -310,10 +310,10 @@ describe("LedgerCanister", () => {
             fee: BigInt(10_000),
           });
 
-        expect(call).rejects.toThrowError(TxDuplicateError);
+        await expect(call).rejects.toThrowError(TxDuplicateError);
       });
 
-      it("handles insufficient balance", () => {
+      it("handles insufficient balance", async () => {
         const service = mock<ActorSubclass<LedgerService>>();
         service.transfer.mockResolvedValue({
           Err: {
@@ -335,10 +335,10 @@ describe("LedgerCanister", () => {
             fee: BigInt(10_000),
           });
 
-        expect(call).rejects.toThrowError(InsufficientFundsError);
+        await expect(call).rejects.toThrowError(InsufficientFundsError);
       });
 
-      it("handles old tx", () => {
+      it("handles old tx", async () => {
         const service = mock<ActorSubclass<LedgerService>>();
         service.transfer.mockResolvedValue({
           Err: {
@@ -358,10 +358,10 @@ describe("LedgerCanister", () => {
             fee: BigInt(10_000),
           });
 
-        expect(call).rejects.toThrowError(TxTooOldError);
+        await expect(call).rejects.toThrowError(TxTooOldError);
       });
 
-      it("handles bad fee", () => {
+      it("handles bad fee", async () => {
         const service = mock<ActorSubclass<LedgerService>>();
         service.transfer.mockResolvedValue({
           Err: {
@@ -383,10 +383,10 @@ describe("LedgerCanister", () => {
             fee: BigInt(10_000),
           });
 
-        expect(call).rejects.toThrowError(BadFeeError);
+        await expect(call).rejects.toThrowError(BadFeeError);
       });
 
-      it("handles transaction created in the future", () => {
+      it("handles transaction created in the future", async () => {
         const service = mock<ActorSubclass<LedgerService>>();
         service.transfer.mockResolvedValue({
           Err: {
@@ -404,7 +404,7 @@ describe("LedgerCanister", () => {
             fee: BigInt(10_000),
           });
 
-        expect(call).rejects.toThrowError(TxCreatedInFutureError);
+        await expect(call).rejects.toThrowError(TxCreatedInFutureError);
       });
     });
   });

--- a/packages/ledger-icrc/src/index-ng.canister.spec.ts
+++ b/packages/ledger-icrc/src/index-ng.canister.spec.ts
@@ -79,7 +79,7 @@ describe("Index canister", () => {
       expect(res.transactions).toEqual([transactionWithId]);
     });
 
-    it("raises error when Err in response", () => {
+    it("raises error when Err in response", async () => {
       const service = mock<ActorSubclass<IcrcIndexNgService>>();
       service.get_account_transactions.mockResolvedValue({
         Err: {
@@ -96,7 +96,7 @@ describe("Index canister", () => {
           account: fakeSnsAccount,
           max_results: BigInt(10),
         });
-      expect(call).rejects.toThrowError(IndexError);
+      await expect(call).rejects.toThrowError(IndexError);
     });
   });
 

--- a/packages/ledger-icrc/src/index.canister.spec.ts
+++ b/packages/ledger-icrc/src/index.canister.spec.ts
@@ -71,7 +71,7 @@ describe("Index canister", () => {
       expect(res.transactions).toEqual([transactionWithId]);
     });
 
-    it("raises error when Err in response", () => {
+    it("raises error when Err in response", async () => {
       const service = mock<ActorSubclass<IcrcIndexService>>();
       service.get_account_transactions.mockResolvedValue({
         Err: {
@@ -88,7 +88,7 @@ describe("Index canister", () => {
           account: fakeSnsAccount,
           max_results: BigInt(10),
         });
-      expect(call).rejects.toThrowError(IndexError);
+      await expect(call).rejects.toThrowError(IndexError);
     });
   });
 

--- a/packages/ledger-icrc/src/ledger.canister.spec.ts
+++ b/packages/ledger-icrc/src/ledger.canister.spec.ts
@@ -148,7 +148,7 @@ describe("Ledger canister", () => {
       expect(service.icrc1_transfer).toBeCalledWith(transferArg);
     });
 
-    it("should raise IcrcTransferError error", () => {
+    it("should raise IcrcTransferError error", async () => {
       const service = mock<ActorSubclass<IcrcLedgerService>>();
       const errorResponse = {
         Err: {
@@ -165,7 +165,7 @@ describe("Ledger canister", () => {
       });
 
       const call = () => canister.transfer(transferParams);
-      expect(call).rejects.toThrow(IcrcTransferError);
+      await expect(call).rejects.toThrow(IcrcTransferError);
     });
   });
 
@@ -211,7 +211,7 @@ describe("Ledger canister", () => {
       expect(service.icrc2_transfer_from).toBeCalledWith(transferArg);
     });
 
-    it("should raise IcrcTransferError error", () => {
+    it("should raise IcrcTransferError error", async () => {
       const service = mock<ActorSubclass<IcrcLedgerService>>();
       const errorResponse = {
         Err: {
@@ -228,7 +228,7 @@ describe("Ledger canister", () => {
       });
 
       const call = () => canister.transferFrom(transferParams);
-      expect(call).rejects.toThrow(IcrcTransferError);
+      await expect(call).rejects.toThrow(IcrcTransferError);
     });
   });
 
@@ -269,7 +269,7 @@ describe("Ledger canister", () => {
       expect(service.icrc2_approve).toBeCalledWith(approveArg);
     });
 
-    it("should raise IcrcTransferError error", () => {
+    it("should raise IcrcTransferError error", async () => {
       const service = mock<ActorSubclass<IcrcLedgerService>>();
       const errorResponse = {
         Err: {
@@ -286,7 +286,7 @@ describe("Ledger canister", () => {
       });
 
       const call = () => canister.approve(approveParams);
-      expect(call).rejects.toThrow(IcrcTransferError);
+      await expect(call).rejects.toThrow(IcrcTransferError);
     });
   });
 

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -1140,7 +1140,7 @@ describe("GovernanceCanister", () => {
       expect(response).toBe(neuronId);
     });
 
-    it("throws in unexpected response", () => {
+    it("throws in unexpected response", async () => {
       const serviceResponse: ManageNeuronResponse = {
         command: [{ Configure: {} }],
       };
@@ -1156,7 +1156,7 @@ describe("GovernanceCanister", () => {
           memo: BigInt(1),
           controller: principal,
         });
-      expect(call).rejects.toThrow(UnrecognizedTypeError);
+      await expect(call).rejects.toThrow(UnrecognizedTypeError);
     });
   });
 

--- a/packages/nns/src/governance_test.canister.spec.ts
+++ b/packages/nns/src/governance_test.canister.spec.ts
@@ -38,7 +38,7 @@ describe("GovernanceTestCanister", () => {
       expect(service.update_neuron).toBeCalledTimes(1);
     });
 
-    it("should not update accountIdentifier", () => {
+    it("should not update accountIdentifier", async () => {
       const service = mock<ActorSubclass<GovernanceService>>();
       service.list_neurons.mockResolvedValue(mockListNeuronsResponse);
 
@@ -56,7 +56,7 @@ describe("GovernanceTestCanister", () => {
         accountIdentifier: newAccountIdentifier,
       };
 
-      expect(() => governance.updateNeuron(newNeuron)).rejects.toThrow(
+      await expect(() => governance.updateNeuron(newNeuron)).rejects.toThrow(
         "Neuron account identifier can't be changed",
       );
 

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -267,7 +267,7 @@ describe("Governance canister", () => {
       });
     });
 
-    it("should raise an error if call fails", () => {
+    it("should raise an error if call fails", async () => {
       const service = mock<ActorSubclass<SnsGovernanceService>>();
       service.list_proposals.mockRejectedValue(new Error("error"));
 
@@ -277,7 +277,7 @@ describe("Governance canister", () => {
       });
 
       const call = () => canister.listProposals({});
-      expect(call).rejects.toThrowError("error");
+      await expect(call).rejects.toThrowError("error");
     });
   });
 
@@ -322,7 +322,7 @@ describe("Governance canister", () => {
       });
     });
 
-    it("should raise error on governance error", () => {
+    it("should raise error on governance error", async () => {
       const service = mock<ActorSubclass<SnsGovernanceService>>();
       service.get_proposal.mockResolvedValue({
         result: [{ Error: { error_message: "error", error_type: 2 } }],
@@ -337,7 +337,7 @@ describe("Governance canister", () => {
           proposalId: proposalIdMock,
           certified: true,
         });
-      expect(call).rejects.toThrowError(SnsGovernanceError);
+      await expect(call).rejects.toThrowError(SnsGovernanceError);
     });
   });
 
@@ -359,7 +359,7 @@ describe("Governance canister", () => {
       expect(res).toEqual(neuronMock);
     });
 
-    it("should raise error on governance error", () => {
+    it("should raise error on governance error", async () => {
       const service = mock<ActorSubclass<SnsGovernanceService>>();
       service.get_neuron.mockResolvedValue({
         result: [{ Error: { error_message: "error", error_type: 2 } }],
@@ -374,7 +374,7 @@ describe("Governance canister", () => {
           neuronId: neuronIdMock,
           certified: true,
         });
-      expect(call).rejects.toThrowError(SnsGovernanceError);
+      await expect(call).rejects.toThrowError(SnsGovernanceError);
     });
   });
 
@@ -399,7 +399,7 @@ describe("Governance canister", () => {
       expect(service.manage_neuron).toBeCalled();
     });
 
-    it("should raise error", () => {
+    it("should raise error", async () => {
       const principal = Principal.fromText("aaaaa-aa");
       const permissions = [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE];
       const service = mock<ActorSubclass<SnsGovernanceService>>();
@@ -415,7 +415,7 @@ describe("Governance canister", () => {
           permissions,
           principal,
         });
-      expect(call).rejects.toThrowError(SnsGovernanceError);
+      await expect(call).rejects.toThrowError(SnsGovernanceError);
       expect(service.manage_neuron).toBeCalled();
     });
   });
@@ -441,7 +441,7 @@ describe("Governance canister", () => {
       expect(service.manage_neuron).toBeCalled();
     });
 
-    it("should raise error", () => {
+    it("should raise error", async () => {
       const principal = Principal.fromText("aaaaa-aa");
       const permissions = [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE];
       const service = mock<ActorSubclass<SnsGovernanceService>>();
@@ -457,7 +457,7 @@ describe("Governance canister", () => {
           permissions,
           principal,
         });
-      expect(call).rejects.toThrowError(SnsGovernanceError);
+      await expect(call).rejects.toThrowError(SnsGovernanceError);
       expect(service.manage_neuron).toBeCalled();
     });
   });
@@ -506,7 +506,7 @@ describe("Governance canister", () => {
       expect(service.manage_neuron).toBeCalledWith(request);
     });
 
-    it("should raise an error", () => {
+    it("should raise an error", async () => {
       const service = mock<ActorSubclass<SnsGovernanceService>>();
       service.manage_neuron.mockResolvedValue(mockErrorCommand);
 
@@ -516,7 +516,7 @@ describe("Governance canister", () => {
       });
       const call = () => canister.splitNeuron(params);
 
-      expect(call).rejects.toThrowError(SnsGovernanceError);
+      await expect(call).rejects.toThrowError(SnsGovernanceError);
       expect(service.manage_neuron).toBeCalled();
     });
   });
@@ -551,7 +551,7 @@ describe("Governance canister", () => {
       expect(service.manage_neuron).toBeCalled();
     });
 
-    it("should raise an error", () => {
+    it("should raise an error", async () => {
       const principal = Principal.fromText("aaaaa-aa");
       const permissions = [SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_VOTE];
       const request: ManageNeuron = {
@@ -575,7 +575,7 @@ describe("Governance canister", () => {
         certifiedServiceOverride: service,
       });
       const call = () => canister.manageNeuron(request);
-      expect(call).rejects.toThrowError(SnsGovernanceError);
+      await expect(call).rejects.toThrowError(SnsGovernanceError);
       expect(service.manage_neuron).toBeCalled();
     });
   });
@@ -659,7 +659,7 @@ describe("Governance canister", () => {
       expect(service.manage_neuron).toBeCalledWith(request);
     });
 
-    it("should raise an error", () => {
+    it("should raise an error", async () => {
       const service = mock<ActorSubclass<SnsGovernanceService>>();
       service.manage_neuron.mockResolvedValue(mockErrorCommand);
 
@@ -669,7 +669,7 @@ describe("Governance canister", () => {
       });
       const call = () => canister.disburse(params);
 
-      expect(call).rejects.toThrowError(SnsGovernanceError);
+      await expect(call).rejects.toThrowError(SnsGovernanceError);
       expect(service.manage_neuron).toBeCalled();
     });
   });

--- a/packages/sns/src/swap.canister.spec.ts
+++ b/packages/sns/src/swap.canister.spec.ts
@@ -78,7 +78,7 @@ describe("Swap canister", () => {
     expect(res).toEqual(saleTicketMock);
   });
 
-  it("should throw open sale ticket", () => {
+  it("should throw open sale ticket", async () => {
     const mockResponse: GetOpenTicketResponse = {
       result: [
         {
@@ -98,7 +98,7 @@ describe("Swap canister", () => {
     });
     const call = () => canister.getOpenTicket({});
 
-    expect(call).rejects.toThrow(
+    await expect(call).rejects.toThrow(
       new SnsSwapGetOpenTicketError(GetOpenTicketErrorType.TYPE_SALE_CLOSED),
     );
   });
@@ -129,7 +129,7 @@ describe("Swap canister", () => {
     expect(ticket).toEqual(saleTicketMock);
   });
 
-  it("should throw new sale ticket error", () => {
+  it("should throw new sale ticket error", async () => {
     const min_amount_icp_e8s_included = 123n;
     const max_amount_icp_e8s_included = 321n;
 
@@ -163,7 +163,7 @@ describe("Swap canister", () => {
         amount_icp_e8s: 3n,
       });
 
-    expect(call).rejects.toThrow(
+    await expect(call).rejects.toThrow(
       new SnsSwapNewTicketError({
         errorType: NewSaleTicketResponseErrorType.TYPE_TICKET_EXISTS,
         existingTicket: saleTicketMock,
@@ -264,7 +264,7 @@ describe("Swap canister", () => {
       expect(res).toEqual(mockResponse);
     });
 
-    it("throw UnsupportedMethodError if method not supported", () => {
+    it("throw UnsupportedMethodError if method not supported", async () => {
       const errorMessage = `Call failed:
       Canister: s55qq-oqaaa-aaaaa-aaakq-cai
       Method: get_auto_finalization_status (query)
@@ -282,12 +282,12 @@ describe("Swap canister", () => {
         certifiedServiceOverride: service,
       });
       const call = () => canister.getFinalizationStatus({});
-      expect(call).rejects.toThrow(
+      await expect(call).rejects.toThrow(
         new UnsupportedMethodError("getFinalizationStatus"),
       );
     });
 
-    it("throw forward error if not unsupported method error", () => {
+    it("throw forward error if not unsupported method error", async () => {
       const errorMessage = "Another error";
       const err = new Error(errorMessage);
 
@@ -299,7 +299,7 @@ describe("Swap canister", () => {
         certifiedServiceOverride: service,
       });
       const call = () => canister.getFinalizationStatus({});
-      expect(call).rejects.toThrow(err);
+      await expect(call).rejects.toThrow(err);
     });
   });
 


### PR DESCRIPTION
# Motivation

We will migrate to `vitest` instead of `jest` for the test suite. However, `vitest` flags expects statements that should await promises but are not awaited.

So, in this PR, we first make it so we await all `expect(...).rejects.toThrow()` statements.
