### PR TITLE
refactor: More specific assertion for error tests

### DIFF
--- a/packages/ckbtc/src/minter.canister.spec.ts
+++ b/packages/ckbtc/src/minter.canister.spec.ts
@@ -232,7 +232,7 @@ describe("ckBTC minter canister", () => {
       await expect(call).rejects.toThrowError(
         new MinterNoNewUtxosError({
           pending_utxos: [[pendingUtxo]],
-          required_confirmations: 12,
+          required_confirmations: 123,
         }),
       );
     });
@@ -262,7 +262,7 @@ describe("ckBTC minter canister", () => {
       await expect(call).rejects.toThrowError(
         new MinterNoNewUtxosError({
           pending_utxos: [],
-          required_confirmations: 12,
+          required_confirmations: 123,
         }),
       );
     });

--- a/packages/cketh/src/minter.canister.spec.ts
+++ b/packages/cketh/src/minter.canister.spec.ts
@@ -178,7 +178,9 @@ describe("ckETH minter canister", () => {
       const call = () => canister.withdrawEth(params);
 
       await expect(call).rejects.toThrowError(
-        new MinterAmountTooLowError({ details: error.Err.AmountTooLow }),
+        new MinterAmountTooLowError({
+          details: error.Err.AmountTooLow.min_withdrawal_amount,
+        }),
       );
     });
 
@@ -196,7 +198,7 @@ describe("ckETH minter canister", () => {
 
       await expect(call).rejects.toThrowError(
         new MinterRecipientAddressBlockedError({
-          details: error.Err.RecipientAddressBlocked,
+          details: error.Err.RecipientAddressBlocked.address,
         }),
       );
     });
@@ -213,7 +215,7 @@ describe("ckETH minter canister", () => {
 
       await expect(call).rejects.toThrowError(
         new MinterInsufficientFundsError({
-          details: error.Err.InsufficientFunds,
+          details: error.Err.InsufficientFunds.balance,
         }),
       );
     });
@@ -230,7 +232,7 @@ describe("ckETH minter canister", () => {
 
       await expect(call).rejects.toThrowError(
         new MinterInsufficientAllowanceError({
-          details: error.Err.InsufficientAllowance,
+          details: error.Err.InsufficientAllowance.allowance,
         }),
       );
     });
@@ -456,8 +458,7 @@ describe("ckETH minter canister", () => {
             new LedgerTemporaryUnavailableError({
               msg: error.Err.CkErc20LedgerError.error.TemporarilyUnavailable,
               details: {
-                cketh_block_index:
-                  error.Err.CkErc20LedgerError.cketh_block_index,
+                ckEthBlockIndex: error.Err.CkErc20LedgerError.cketh_block_index,
               },
             }),
           );

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -3,6 +3,7 @@ import { Principal } from "@dfinity/principal";
 import {
   arrayOfNumberToUint8Array,
   InvalidPercentageError,
+  toNullable,
 } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
 import type {
@@ -1282,7 +1283,7 @@ describe("Governance canister", () => {
         command: [
           {
             StakeMaturity: {
-              percentage_to_stake: [percentageToStake],
+              percentage_to_stake: toNullable(percentageToStake),
             },
           },
         ],


### PR DESCRIPTION
# Motivation

We want to migrate from `Jest` to `Vitest`. However, jest is a bit more lax when comparing error object: `Jest` loosely matches, while `Vitest` is more strict in comparing error objects.

To be more specific, we define the correct test values.