### PR TITLE
chore: Await all rejects promises in tests for `cketh` package

### DIFF
--- a/packages/cketh/src/minter.canister.spec.ts
+++ b/packages/cketh/src/minter.canister.spec.ts
@@ -826,7 +826,7 @@ describe("ckETH minter canister", () => {
       expect(res).toEqual(result);
     });
 
-    it("should bubble errors", async  () => {
+    it("should bubble errors", async () => {
       const service = mock<ActorSubclass<CkETHMinterService>>();
       service.retrieve_eth_status.mockRejectedValue(new Error());
 

--- a/packages/cketh/src/minter.canister.spec.ts
+++ b/packages/cketh/src/minter.canister.spec.ts
@@ -826,7 +826,7 @@ describe("ckETH minter canister", () => {
       expect(res).toEqual(result);
     });
 
-    it("should bubble errors", () => {
+    it("should bubble errors", async  () => {
       const service = mock<ActorSubclass<CkETHMinterService>>();
       service.retrieve_eth_status.mockRejectedValue(new Error());
 
@@ -834,7 +834,7 @@ describe("ckETH minter canister", () => {
 
       const call = () => canister.retrieveEthStatus(123n);
 
-      expect(call).rejects.toThrowError();
+      await expect(call).rejects.toThrowError();
     });
   });
 


### PR DESCRIPTION
# Motivation

We will migrate to `vitest` instead of `jest` for the test suite. However, `vitest` flags expects statements that should await promises but are not awaited.

So, in this PR, we first make it so we await all `expect(...).rejects.toThrow()` statements for package `cketh`.
