### PR TITLE
chore: update team name to governance-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dfinity/gix @dfinity/nns-team
+* @dfinity/gix @dfinity/governance-team


### PR DESCRIPTION
# Motivation

The name of the [nns-team](https://github.com/orgs/dfinity/teams/nns-team) has changed to [governance-team](https://github.com/orgs/dfinity/teams/governance-team). More information can be found [here](https://dfinity.slack.com/archives/CGJND92DA/p1747828796597669?thread_ts=1747671441.856149&cid=CGJND92DA) and [here](https://dfinity.slack.com/archives/CGJND92DA/p1747740057505439).

# Changes

- Update references from the old team name to the new one.

# Tests

Not necessary.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.