### PR TITLE
Update Candid Files

### DIFF
--- a/packages/ckbtc/candid/minter.did
+++ b/packages/ckbtc/candid/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
 // Represents an account on the ckBTC ledger.
 type Account = record { owner : principal; subaccount : opt blob };
 

--- a/packages/cketh/candid/minter.did
+++ b/packages/cketh/candid/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
 type EthereumNetwork = variant {
     // The public Ethereum mainnet.
     Mainnet;

--- a/packages/cketh/candid/orchestrator.did
+++ b/packages/cketh/candid/orchestrator.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did' by import-candid
 type OrchestratorArg = variant {
     UpgradeArg : UpgradeArg;
     InitArg : InitArg;

--- a/packages/cmc/candid/cmc.did
+++ b/packages/cmc/candid/cmc.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/nns/cmc/cmc.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/nns/cmc/cmc.did' by import-candid
 type Cycles = nat;
 type BlockIndex = nat64;
 type log_visibility = variant {

--- a/packages/ledger-icp/candid/index.did
+++ b/packages/ledger-icp/candid/index.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/ledger_suite/icp/index/index.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/ledger_suite/icp/index/index.did' by import-candid
 type Account = record { owner : principal; subaccount : opt vec nat8 };
 type GetAccountIdentifierTransactionsArgs = record {
   max_results : nat64;

--- a/packages/ledger-icp/candid/ledger.did
+++ b/packages/ledger-icp/candid/ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/ledger_suite/icp/ledger.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/ledger_suite/icp/ledger.did' by import-candid
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.

--- a/packages/ledger-icp/src/ledger.canister.spec.ts
+++ b/packages/ledger-icp/src/ledger.canister.spec.ts
@@ -593,7 +593,7 @@ describe("LedgerCanister", () => {
         });
       });
 
-      it("handles duplicate transaction", () => {
+      it("handles duplicate transaction", async () => {
         const service = mock<ActorSubclass<LedgerService>>();
         service.icrc1_transfer.mockResolvedValue({
           Err: {
@@ -613,10 +613,10 @@ describe("LedgerCanister", () => {
             fee: BigInt(10_000),
           });
 
-        expect(call).rejects.toThrowError(TxDuplicateError);
+        await expect(call).rejects.toThrowError(TxDuplicateError);
       });
 
-      it("handles insufficient balance", () => {
+      it("handles insufficient balance", async () => {
         const service = mock<ActorSubclass<LedgerService>>();
         service.icrc1_transfer.mockResolvedValue({
           Err: {
@@ -636,10 +636,10 @@ describe("LedgerCanister", () => {
             fee: BigInt(10_000),
           });
 
-        expect(call).rejects.toThrowError(InsufficientFundsError);
+        await expect(call).rejects.toThrowError(InsufficientFundsError);
       });
 
-      it("handles old tx", () => {
+      it("handles old tx", async () => {
         const service = mock<ActorSubclass<LedgerService>>();
         service.icrc1_transfer.mockResolvedValue({
           Err: {
@@ -657,10 +657,10 @@ describe("LedgerCanister", () => {
             fee: BigInt(10_000),
           });
 
-        expect(call).rejects.toThrowError(TxTooOldError);
+        await expect(call).rejects.toThrowError(TxTooOldError);
       });
 
-      it("handles bad fee", () => {
+      it("handles bad fee", async () => {
         const service = mock<ActorSubclass<LedgerService>>();
         service.icrc1_transfer.mockResolvedValue({
           Err: {
@@ -680,10 +680,10 @@ describe("LedgerCanister", () => {
             fee: BigInt(10_000),
           });
 
-        expect(call).rejects.toThrowError(BadFeeError);
+        await expect(call).rejects.toThrowError(BadFeeError);
       });
 
-      it("handles transaction created in the future", () => {
+      it("handles transaction created in the future", async () => {
         const service = mock<ActorSubclass<LedgerService>>();
         service.icrc1_transfer.mockResolvedValue({
           Err: {
@@ -701,7 +701,7 @@ describe("LedgerCanister", () => {
             fee: BigInt(10_000),
           });
 
-        expect(call).rejects.toThrowError(TxCreatedInFutureError);
+        await expect(call).rejects.toThrowError(TxCreatedInFutureError);
       });
     });
   });
@@ -896,7 +896,7 @@ describe("LedgerCanister", () => {
       });
     });
 
-    it("should raise GenericError", () => {
+    it("should raise GenericError", async () => {
       const service = mock<ActorSubclass<LedgerService>>();
       service.icrc2_approve.mockResolvedValue({
         Err: {
@@ -911,10 +911,10 @@ describe("LedgerCanister", () => {
 
       const call = async () => await ledger.icrc2Approve(approveRequest);
 
-      expect(call).rejects.toThrowError(GenericError);
+      await expect(call).rejects.toThrowError(GenericError);
     });
 
-    it("should raise TemporarilyUnavailableError", () => {
+    it("should raise TemporarilyUnavailableError", async () => {
       const service = mock<ActorSubclass<LedgerService>>();
       service.icrc2_approve.mockResolvedValue({
         Err: {
@@ -929,10 +929,10 @@ describe("LedgerCanister", () => {
 
       const call = async () => await ledger.icrc2Approve(approveRequest);
 
-      expect(call).rejects.toThrowError(TemporarilyUnavailableError);
+      await expect(call).rejects.toThrowError(TemporarilyUnavailableError);
     });
 
-    it("should raise DuplicateError", () => {
+    it("should raise DuplicateError", async () => {
       const service = mock<ActorSubclass<LedgerService>>();
       service.icrc2_approve.mockResolvedValue({
         Err: {
@@ -947,10 +947,10 @@ describe("LedgerCanister", () => {
 
       const call = async () => await ledger.icrc2Approve(approveRequest);
 
-      expect(call).rejects.toThrowError(DuplicateError);
+      await expect(call).rejects.toThrowError(DuplicateError);
     });
 
-    it("should raise BadFeeError", () => {
+    it("should raise BadFeeError", async () => {
       const service = mock<ActorSubclass<LedgerService>>();
       service.icrc2_approve.mockResolvedValue({
         Err: {
@@ -965,10 +965,10 @@ describe("LedgerCanister", () => {
 
       const call = async () => await ledger.icrc2Approve(approveRequest);
 
-      expect(call).rejects.toThrowError(BadFeeError);
+      await expect(call).rejects.toThrowError(BadFeeError);
     });
 
-    it("should raise AllowanceChangedError", () => {
+    it("should raise AllowanceChangedError", async () => {
       const service = mock<ActorSubclass<LedgerService>>();
       service.icrc2_approve.mockResolvedValue({
         Err: {
@@ -983,10 +983,10 @@ describe("LedgerCanister", () => {
 
       const call = async () => await ledger.icrc2Approve(approveRequest);
 
-      expect(call).rejects.toThrowError(AllowanceChangedError);
+      await expect(call).rejects.toThrowError(AllowanceChangedError);
     });
 
-    it("should raise CreatedInFutureError", () => {
+    it("should raise CreatedInFutureError", async () => {
       const service = mock<ActorSubclass<LedgerService>>();
       service.icrc2_approve.mockResolvedValue({
         Err: {
@@ -1001,10 +1001,10 @@ describe("LedgerCanister", () => {
 
       const call = async () => await ledger.icrc2Approve(approveRequest);
 
-      expect(call).rejects.toThrowError(CreatedInFutureError);
+      await expect(call).rejects.toThrowError(CreatedInFutureError);
     });
 
-    it("should raise TooOldError", () => {
+    it("should raise TooOldError", async () => {
       const service = mock<ActorSubclass<LedgerService>>();
       service.icrc2_approve.mockResolvedValue({
         Err: {
@@ -1019,10 +1019,10 @@ describe("LedgerCanister", () => {
 
       const call = async () => await ledger.icrc2Approve(approveRequest);
 
-      expect(call).rejects.toThrowError(TooOldError);
+      await expect(call).rejects.toThrowError(TooOldError);
     });
 
-    it("should raise ExpiredError", () => {
+    it("should raise ExpiredError", async () => {
       const service = mock<ActorSubclass<LedgerService>>();
       service.icrc2_approve.mockResolvedValue({
         Err: {
@@ -1037,10 +1037,10 @@ describe("LedgerCanister", () => {
 
       const call = async () => await ledger.icrc2Approve(approveRequest);
 
-      expect(call).rejects.toThrowError(ExpiredError);
+      await expect(call).rejects.toThrowError(ExpiredError);
     });
 
-    it("should raise InsufficientFundsError", () => {
+    it("should raise InsufficientFundsError", async () => {
       const service = mock<ActorSubclass<LedgerService>>();
       service.icrc2_approve.mockResolvedValue({
         Err: {
@@ -1055,7 +1055,7 @@ describe("LedgerCanister", () => {
 
       const call = async () => await ledger.icrc2Approve(approveRequest);
 
-      expect(call).rejects.toThrowError(InsufficientFundsError);
+      await expect(call).rejects.toThrowError(InsufficientFundsError);
     });
   });
 

--- a/packages/ledger-icrc/candid/icrc_index-ng.did
+++ b/packages/ledger-icrc/candid/icrc_index-ng.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/ledger_suite/icrc1/index-ng/index-ng.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/ledger_suite/icrc1/index-ng/index-ng.did' by import-candid
 type Tokens = nat;
 
 type InitArg = record {

--- a/packages/ledger-icrc/candid/icrc_ledger.did
+++ b/packages/ledger-icrc/candid/icrc_ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/ledger_suite/icrc1/ledger/ledger.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/ledger_suite/icrc1/ledger/ledger.did' by import-candid
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.

--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/nns/gtc/canister/gtc.did' by import-candid
 type AccountState = record {
   authenticated_principal_id : opt principal;
   successfully_transferred_neurons : vec TransferredNeuron;

--- a/packages/nns/candid/governance.certified.idl.js
+++ b/packages/nns/candid/governance.certified.idl.js
@@ -605,6 +605,12 @@ export const idlFactory = ({ IDL }) => {
     'vote' : IDL.Int32,
     'proposal_id' : IDL.Opt(ProposalId),
   });
+  const MaturityDisbursement = IDL.Record({
+    'timestamp_of_disbursement_seconds' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const DissolveState = IDL.Variant({
     'DissolveDelaySeconds' : IDL.Nat64,
     'WhenDissolvedTimestampSeconds' : IDL.Nat64,
@@ -628,6 +634,9 @@ export const idlFactory = ({ IDL }) => {
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'maturity_disbursements_in_progress' : IDL.Opt(
+      IDL.Vec(MaturityDisbursement)
+    ),
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,
@@ -1603,6 +1612,12 @@ export const init = ({ IDL }) => {
     'vote' : IDL.Int32,
     'proposal_id' : IDL.Opt(ProposalId),
   });
+  const MaturityDisbursement = IDL.Record({
+    'timestamp_of_disbursement_seconds' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const DissolveState = IDL.Variant({
     'DissolveDelaySeconds' : IDL.Nat64,
     'WhenDissolvedTimestampSeconds' : IDL.Nat64,
@@ -1626,6 +1641,9 @@ export const init = ({ IDL }) => {
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'maturity_disbursements_in_progress' : IDL.Opt(
+      IDL.Vec(MaturityDisbursement)
+    ),
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -434,6 +434,12 @@ export interface ManageNeuronRequest {
 export interface ManageNeuronResponse {
   command: [] | [Command_1];
 }
+export interface MaturityDisbursement {
+  timestamp_of_disbursement_seconds: [] | [bigint];
+  amount_e8s: [] | [bigint];
+  account_to_disburse_to: [] | [Account];
+  finalize_disbursement_timestamp_seconds: [] | [bigint];
+}
 export interface Merge {
   source_neuron_id: [] | [NeuronId];
 }
@@ -493,6 +499,7 @@ export interface Neuron {
   hot_keys: Array<Principal>;
   account: Uint8Array | number[];
   joined_community_fund_timestamp_seconds: [] | [bigint];
+  maturity_disbursements_in_progress: [] | [Array<MaturityDisbursement>];
   dissolve_state: [] | [DissolveState];
   followees: Array<[number, Followees]>;
   neuron_fees_e8s: bigint;

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -533,6 +533,12 @@ export interface NeuronInFlightCommand {
   command: [] | [Command_2];
   timestamp: bigint;
 }
+export interface MaturityDisbursement {
+  timestamp_of_disbursement_seconds: [] | [bigint];
+  amount_e8s: [] | [bigint];
+  account_to_disburse_to: [] | [Account];
+  finalize_disbursement_timestamp_seconds: [] | [bigint];
+}
 export interface NeuronInfo {
   dissolve_delay_seconds: bigint;
   recent_ballots: Array<BallotInfo>;

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -733,6 +733,10 @@ type Neuron = record {
   //
   // Per NNS policy, this is opt. Nevertheless, it will never be null.
   potential_voting_power : opt nat64;
+
+  // The maturity disbursements in progress, i.e. the disbursements that are initiated but not
+  // finalized. The finalization happens 7 days after the disbursement is initiated.
+  maturity_disbursements_in_progress : opt vec MaturityDisbursement;
 };
 
 type NeuronBasketConstructionParameters = record {
@@ -1267,6 +1271,13 @@ type WaitForQuietState = record {
 type XdrConversionRate = record {
   xdr_permyriad_per_icp : opt nat64;
   timestamp_seconds : opt nat64;
+};
+
+type MaturityDisbursement = record {
+  amount_e8s : opt nat64;
+  timestamp_of_disbursement_seconds : opt nat64;
+  finalize_disbursement_timestamp_seconds : opt nat64;
+  account_to_disburse_to : opt Account;
 };
 
 service : (Governance) -> {

--- a/packages/nns/candid/governance.idl.js
+++ b/packages/nns/candid/governance.idl.js
@@ -605,6 +605,12 @@ export const idlFactory = ({ IDL }) => {
     'vote' : IDL.Int32,
     'proposal_id' : IDL.Opt(ProposalId),
   });
+  const MaturityDisbursement = IDL.Record({
+    'timestamp_of_disbursement_seconds' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const DissolveState = IDL.Variant({
     'DissolveDelaySeconds' : IDL.Nat64,
     'WhenDissolvedTimestampSeconds' : IDL.Nat64,
@@ -628,6 +634,9 @@ export const idlFactory = ({ IDL }) => {
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'maturity_disbursements_in_progress' : IDL.Opt(
+      IDL.Vec(MaturityDisbursement)
+    ),
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,
@@ -1619,6 +1628,12 @@ export const init = ({ IDL }) => {
     'vote' : IDL.Int32,
     'proposal_id' : IDL.Opt(ProposalId),
   });
+  const MaturityDisbursement = IDL.Record({
+    'timestamp_of_disbursement_seconds' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const DissolveState = IDL.Variant({
     'DissolveDelaySeconds' : IDL.Nat64,
     'WhenDissolvedTimestampSeconds' : IDL.Nat64,
@@ -1642,6 +1657,9 @@ export const init = ({ IDL }) => {
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'maturity_disbursements_in_progress' : IDL.Opt(
+      IDL.Vec(MaturityDisbursement)
+    ),
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,

--- a/packages/nns/candid/governance_test.certified.idl.js
+++ b/packages/nns/candid/governance_test.certified.idl.js
@@ -605,6 +605,12 @@ export const idlFactory = ({ IDL }) => {
     'vote' : IDL.Int32,
     'proposal_id' : IDL.Opt(ProposalId),
   });
+  const MaturityDisbursement = IDL.Record({
+    'timestamp_of_disbursement_seconds' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const DissolveState = IDL.Variant({
     'DissolveDelaySeconds' : IDL.Nat64,
     'WhenDissolvedTimestampSeconds' : IDL.Nat64,
@@ -628,6 +634,9 @@ export const idlFactory = ({ IDL }) => {
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'maturity_disbursements_in_progress' : IDL.Opt(
+      IDL.Vec(MaturityDisbursement)
+    ),
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,
@@ -1604,6 +1613,12 @@ export const init = ({ IDL }) => {
     'vote' : IDL.Int32,
     'proposal_id' : IDL.Opt(ProposalId),
   });
+  const MaturityDisbursement = IDL.Record({
+    'timestamp_of_disbursement_seconds' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const DissolveState = IDL.Variant({
     'DissolveDelaySeconds' : IDL.Nat64,
     'WhenDissolvedTimestampSeconds' : IDL.Nat64,
@@ -1627,6 +1642,9 @@ export const init = ({ IDL }) => {
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'maturity_disbursements_in_progress' : IDL.Opt(
+      IDL.Vec(MaturityDisbursement)
+    ),
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,

--- a/packages/nns/candid/governance_test.d.ts
+++ b/packages/nns/candid/governance_test.d.ts
@@ -434,6 +434,12 @@ export interface ManageNeuronRequest {
 export interface ManageNeuronResponse {
   command: [] | [Command_1];
 }
+export interface MaturityDisbursement {
+  timestamp_of_disbursement_seconds: [] | [bigint];
+  amount_e8s: [] | [bigint];
+  account_to_disburse_to: [] | [Account];
+  finalize_disbursement_timestamp_seconds: [] | [bigint];
+}
 export interface Merge {
   source_neuron_id: [] | [NeuronId];
 }
@@ -493,6 +499,7 @@ export interface Neuron {
   hot_keys: Array<Principal>;
   account: Uint8Array | number[];
   joined_community_fund_timestamp_seconds: [] | [bigint];
+  maturity_disbursements_in_progress: [] | [Array<MaturityDisbursement>];
   dissolve_state: [] | [DissolveState];
   followees: Array<[number, Followees]>;
   neuron_fees_e8s: bigint;

--- a/packages/nns/candid/governance_test.did
+++ b/packages/nns/candid/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/nns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/nns/governance/canister/governance_test.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -642,6 +642,7 @@ type Neuron = record {
   voting_power_refreshed_timestamp_seconds : opt nat64;
   deciding_voting_power : opt nat64;
   potential_voting_power : opt nat64;
+  maturity_disbursements_in_progress : opt vec MaturityDisbursement;
 };
 
 type NeuronBasketConstructionParameters = record {
@@ -1154,6 +1155,13 @@ type WaitForQuietState = record {
 type XdrConversionRate = record {
   xdr_permyriad_per_icp : opt nat64;
   timestamp_seconds : opt nat64;
+};
+
+type MaturityDisbursement = record {
+  amount_e8s : opt nat64;
+  timestamp_of_disbursement_seconds : opt nat64;
+  finalize_disbursement_timestamp_seconds : opt nat64;
+  account_to_disburse_to : opt Account;
 };
 
 service : (Governance) -> {

--- a/packages/nns/candid/governance_test.idl.js
+++ b/packages/nns/candid/governance_test.idl.js
@@ -605,6 +605,12 @@ export const idlFactory = ({ IDL }) => {
     'vote' : IDL.Int32,
     'proposal_id' : IDL.Opt(ProposalId),
   });
+  const MaturityDisbursement = IDL.Record({
+    'timestamp_of_disbursement_seconds' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const DissolveState = IDL.Variant({
     'DissolveDelaySeconds' : IDL.Nat64,
     'WhenDissolvedTimestampSeconds' : IDL.Nat64,
@@ -628,6 +634,9 @@ export const idlFactory = ({ IDL }) => {
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'maturity_disbursements_in_progress' : IDL.Opt(
+      IDL.Vec(MaturityDisbursement)
+    ),
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,
@@ -1620,6 +1629,12 @@ export const init = ({ IDL }) => {
     'vote' : IDL.Int32,
     'proposal_id' : IDL.Opt(ProposalId),
   });
+  const MaturityDisbursement = IDL.Record({
+    'timestamp_of_disbursement_seconds' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account_to_disburse_to' : IDL.Opt(Account),
+    'finalize_disbursement_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const DissolveState = IDL.Variant({
     'DissolveDelaySeconds' : IDL.Nat64,
     'WhenDissolvedTimestampSeconds' : IDL.Nat64,
@@ -1643,6 +1658,9 @@ export const init = ({ IDL }) => {
     'hot_keys' : IDL.Vec(IDL.Principal),
     'account' : IDL.Vec(IDL.Nat8),
     'joined_community_fund_timestamp_seconds' : IDL.Opt(IDL.Nat64),
+    'maturity_disbursements_in_progress' : IDL.Opt(
+      IDL.Vec(MaturityDisbursement)
+    ),
     'dissolve_state' : IDL.Opt(DissolveState),
     'followees' : IDL.Vec(IDL.Tuple(IDL.Int32, Followees)),
     'neuron_fees_e8s' : IDL.Nat64,

--- a/packages/nns/candid/sns_wasm.did
+++ b/packages/nns/candid/sns_wasm.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/packages/nns/src/canisters/governance/response.converters.spec.ts
+++ b/packages/nns/src/canisters/governance/response.converters.spec.ts
@@ -366,24 +366,6 @@ describe("response.converters", () => {
         maturityDisbursementsInProgress: [
           testMaturityDisbursementWithSubaccount,
           testMaturityDisbursementWithoutSubaccount,
-          //   {
-          //     timestampOfDisbursementSeconds: 10n,
-          //     amountE8s: 11n,
-          //     accountToDisburseTo: {
-          //       owner: testPrincipal,
-          //       subaccount: [1, 2, 3],
-          //     },
-          //     finalizeDisbursementTimestampSeconds: 12n,
-          //   },
-          //   {
-          //     timestampOfDisbursementSeconds: 20n,
-          //     amountE8s: 21n,
-          //     accountToDisburseTo: {
-          //       owner: testPrincipal,
-          //       subaccount: undefined,
-          //     },
-          //     finalizeDisbursementTimestampSeconds: 22n,
-          //   },
         ],
       });
     });

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -372,25 +372,22 @@ const toBallot = ({
   };
 };
 
-const toAccount = (account: RawAccount): Account => {
-  const subaccount = fromNullable(account.subaccount);
+const toAccount = ({ subaccount, owner }: RawAccount): Account => {
+  const unwrappedSubaccount = fromNullable(subaccount);
   return {
-    owner: fromNullable(account.owner),
-    subaccount: nonNullish(subaccount)
-      ? uint8ArrayToArrayOfNumber(Uint8Array.from(subaccount))
+    owner: fromNullable(owner),
+    subaccount: nonNullish(unwrappedSubaccount)
+      ? uint8ArrayToArrayOfNumber(Uint8Array.from(unwrappedSubaccount))
       : undefined,
   };
 };
 
-const toRawAccount = (account: Account): RawAccount => {
-  const subaccount = account.subaccount;
-  return {
-    owner: toNullable(account.owner),
-    subaccount: nonNullish(subaccount)
-      ? toNullable(Uint8Array.from(subaccount))
-      : [],
-  };
-};
+const toRawAccount = ({ owner, subaccount }: Account): RawAccount => ({
+  owner: toNullable(owner),
+  subaccount: nonNullish(subaccount)
+    ? toNullable(Uint8Array.from(subaccount))
+    : [],
+});
 
 const toProposal = ({
   title,

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -40,6 +40,7 @@ import type {
   LedgerParameters as RawLedgerParameters,
   ListNeuronsResponse as RawListNeuronsResponse,
   ListProposalInfoResponse as RawListProposalInfoResponse,
+  MaturityDisbursement as RawMaturityDisbursement,
   NetworkEconomics as RawNetworkEconomics,
   Neuron as RawNeuron,
   NeuronBasketConstructionParameters as RawNeuronBasketConstructionParameters,
@@ -98,6 +99,7 @@ import type {
   KnownNeuron,
   LedgerParameters,
   ListProposalsResponse,
+  MaturityDisbursement,
   NetworkEconomics,
   Neuron,
   NeuronBasketConstructionParameters,
@@ -194,6 +196,10 @@ export const toNeuron = ({
     .joined_community_fund_timestamp_seconds.length
     ? neuron.joined_community_fund_timestamp_seconds[0]
     : undefined,
+  maturityDisbursementsInProgress:
+    neuron.maturity_disbursements_in_progress[0]?.map(
+      toMaturityDisbursementInProgress,
+    ),
   dissolveState: neuron.dissolve_state.length
     ? toDissolveState(neuron.dissolve_state[0])
     : undefined,
@@ -243,6 +249,11 @@ export const toRawNeuron = ({
   joined_community_fund_timestamp_seconds: toNullable(
     neuron.joinedCommunityFundTimestampSeconds,
   ),
+  maturity_disbursements_in_progress: toNullable(
+    neuron.maturityDisbursementsInProgress?.map(
+      toRawMaturityDisbursementInProgress,
+    ),
+  ),
   dissolve_state: nonNullish(neuron.dissolveState)
     ? [neuron.dissolveState]
     : [],
@@ -280,6 +291,41 @@ const toDissolveState = (dissolveState: RawDissolveState): DissolveState => {
     WhenDissolvedTimestampSeconds: dissolveState.WhenDissolvedTimestampSeconds,
   };
 };
+
+const toMaturityDisbursementInProgress = (
+  maturityDisbursement: RawMaturityDisbursement,
+): MaturityDisbursement => {
+  const accountToDisburseTo = fromNullable(
+    maturityDisbursement.account_to_disburse_to,
+  );
+  return {
+    timestampOfDisbursementSeconds: fromNullable(
+      maturityDisbursement.timestamp_of_disbursement_seconds,
+    ),
+    amountE8s: fromNullable(maturityDisbursement.amount_e8s),
+    accountToDisburseTo: nonNullish(accountToDisburseTo)
+      ? toAccount(accountToDisburseTo)
+      : undefined,
+    finalizeDisbursementTimestampSeconds: fromNullable(
+      maturityDisbursement.finalize_disbursement_timestamp_seconds,
+    ),
+  };
+};
+
+const toRawMaturityDisbursementInProgress = (
+  maturityDisbursement: MaturityDisbursement,
+): RawMaturityDisbursement => ({
+  timestamp_of_disbursement_seconds: toNullable(
+    maturityDisbursement.timestampOfDisbursementSeconds,
+  ),
+  amount_e8s: toNullable(maturityDisbursement.amountE8s),
+  account_to_disburse_to: nonNullish(maturityDisbursement.accountToDisburseTo)
+    ? toNullable(toRawAccount(maturityDisbursement.accountToDisburseTo))
+    : [],
+  finalize_disbursement_timestamp_seconds: toNullable(
+    maturityDisbursement.finalizeDisbursementTimestampSeconds,
+  ),
+});
 
 const toFollowees = ({
   topic,
@@ -326,12 +372,25 @@ const toBallot = ({
   };
 };
 
-const toAccount = (account: RawAccount): Account => ({
-  owner: fromNullable(account.owner),
-  subaccount: uint8ArrayToArrayOfNumber(
-    Uint8Array.from(account.subaccount[0] ?? []),
-  ),
-});
+const toAccount = (account: RawAccount): Account => {
+  const subaccount = fromNullable(account.subaccount);
+  return {
+    owner: fromNullable(account.owner),
+    subaccount: nonNullish(subaccount)
+      ? uint8ArrayToArrayOfNumber(Uint8Array.from(subaccount))
+      : undefined,
+  };
+};
+
+const toRawAccount = (account: Account): RawAccount => {
+  const subaccount = account.subaccount;
+  return {
+    owner: toNullable(account.owner),
+    subaccount: nonNullish(subaccount)
+      ? toNullable(Uint8Array.from(subaccount))
+      : [],
+  };
+};
 
 const toProposal = ({
   title,

--- a/packages/nns/src/mocks/governance.mock.ts
+++ b/packages/nns/src/mocks/governance.mock.ts
@@ -40,6 +40,7 @@ export const mockNeuron: Neuron = {
   hot_keys: [],
   account: new Uint8Array([1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 5, 6]),
   joined_community_fund_timestamp_seconds: [],
+  maturity_disbursements_in_progress: [],
   dissolve_state: [],
   followees: [],
   neuron_fees_e8s: one,

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -170,6 +170,13 @@ export interface DisburseMaturity {
   percentageToDisburse: number;
 }
 
+export interface MaturityDisbursement {
+  timestampOfDisbursementSeconds: Option<bigint>;
+  amountE8s: Option<bigint>;
+  accountToDisburseTo: Option<Account>;
+  finalizeDisbursementTimestampSeconds: Option<bigint>;
+}
+
 export interface IncreaseDissolveDelay {
   additionalDissolveDelaySeconds: number;
 }
@@ -388,6 +395,7 @@ export interface Neuron {
   hotKeys: Array<PrincipalString>;
   accountIdentifier: AccountIdentifierHex;
   joinedCommunityFundTimestampSeconds: Option<bigint>;
+  maturityDisbursementsInProgress: Option<Array<MaturityDisbursement>>;
   dissolveState: Option<DissolveState>;
   followees: Array<Followees>;
   visibility: Option<NeuronVisibility>;

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/sns/root/canister/root.did' by import-candid
 type CanisterCallError = record {
   code : opt int32;
   description : text;

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit f195ba7 (2025-04-30 tags: release-2025-05-01_03-23-base) 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 2f52f298de (2025-05-07 tags: release-2025-05-08_03-21-base) 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;


### PR DESCRIPTION
# Motivation

The canister APIs have been updated. A new neuron field (maturity_disbursements_in_progress) was introduced, which broke the automatic upgrade ([Bot PR](https://github.com/dfinity/ic-js/pull/933)).

# Changes

- scripts/import-candid.
- scripts/compile-idl-js.
- Add new neuron field maturity_disbursements_in_progress field.
- Update from/to neuron converters to include new data.

# Tests

- Added tests to verify that the new field is converted correctly.

# Todos

- [ ] Add entry to changelog (if necessary).
