### PR TITLE
Optional disbursements in progress

### DIFF
--- a/packages/nns/src/canisters/governance/response.converters.spec.ts
+++ b/packages/nns/src/canisters/governance/response.converters.spec.ts
@@ -310,6 +310,20 @@ describe("response.converters", () => {
         toNeuron({
           neuron: {
             ...defaultCandidNeuron,
+            // Test against the outdated nns governance canister.
+            maturity_disbursements_in_progress: undefined as unknown as [],
+          },
+          canisterId,
+        }),
+      ).toEqual({
+        ...defaultNeuron,
+        maturityDisbursementsInProgress: undefined,
+      });
+
+      expect(
+        toNeuron({
+          neuron: {
+            ...defaultCandidNeuron,
             maturity_disbursements_in_progress: [[]],
           },
           canisterId,

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -197,7 +197,7 @@ export const toNeuron = ({
     ? neuron.joined_community_fund_timestamp_seconds[0]
     : undefined,
   maturityDisbursementsInProgress:
-    neuron.maturity_disbursements_in_progress[0]?.map(
+    neuron.maturity_disbursements_in_progress?.[0]?.map(
       toMaturityDisbursementInProgress,
     ),
   dissolveState: neuron.dissolve_state.length

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -196,10 +196,9 @@ export const toNeuron = ({
     .joined_community_fund_timestamp_seconds.length
     ? neuron.joined_community_fund_timestamp_seconds[0]
     : undefined,
-  maturityDisbursementsInProgress:
-    neuron.maturity_disbursements_in_progress?.[0]?.map(
-      toMaturityDisbursementInProgress,
-    ),
+  maturityDisbursementsInProgress: fromNullable(
+    neuron.maturity_disbursements_in_progress,
+  )?.map(toMaturityDisbursementInProgress),
   dissolveState: neuron.dissolve_state.length
     ? toDissolveState(neuron.dissolve_state[0])
     : undefined,


### PR DESCRIPTION
# Motivation

The maturity_disbursements_in_progress field is new, and not all test environments support it yet.
To ensure ic-js works consistently across all environments, this PR makes the field optional.

# Changes
 
- Check for `maturity_disbursements_in_progress` existence before reading it.

# Tests

- Updated.
- Verified locally that the nns-dapp doesn't break against the outdated NNS dapp canister (ic-js returns undefined).

![Screenshot 2025-05-26 at 14 24 17](https://github.com/user-attachments/assets/6c067dd7-81f4-44f8-a9f7-398f6c61b171)

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.