### PR TITLE
Fix account id from hex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Expose method `listSubaccounts` in class `IcrcIndexNgCanister`.
 - Extend the `transform` function to support `provisional_create_canister_with_cycles` when used with PocketIC.
 
+## Fix
+
+- Check the check sum in `AccountIdentifier.fromHex` in ledger-icp.
+
 # v69
 
 ## Overview

--- a/packages/ledger-icp/src/account_identifier.spec.ts
+++ b/packages/ledger-icp/src/account_identifier.spec.ts
@@ -93,6 +93,20 @@ describe("AccountIdentifier", () => {
     ).toBe("d3e13d4777e22367532053190b6c6ccf57444a61337e996242b1abfb52cf92c8");
   });
 
+  test("rejects a hex string with an invalid check-sum", () => {
+    expect(() => {
+      AccountIdentifier.fromHex(
+        "bad13d4777e22367532053190b6c6ccf57444a61337e996242b1abfb52cf92c8",
+      );
+    }).toThrow();
+  });
+
+  test("rejects an invalid hex string", () => {
+    expect(() => {
+      AccountIdentifier.fromHex("foo bar");
+    }).toThrow();
+  });
+
   test("can be initialized from a principal", () => {
     expect(
       AccountIdentifier.fromPrincipal({

--- a/packages/ledger-icp/src/account_identifier.ts
+++ b/packages/ledger-icp/src/account_identifier.ts
@@ -11,7 +11,15 @@ export class AccountIdentifier {
   private constructor(private readonly bytes: Uint8Array) {}
 
   public static fromHex(hex: string): AccountIdentifier {
-    return new AccountIdentifier(Uint8Array.from(Buffer.from(hex, "hex")));
+    const buffer = Uint8Array.from(Buffer.from(hex, "hex"));
+    const hash = buffer.slice(4);
+    const expectedChecksum = uint8ArrayToHexString(buffer.slice(0, 4));
+    const actualChecksum = uint8ArrayToHexString(bigEndianCrc32(hash));
+
+    if (expectedChecksum != actualChecksum) {
+      throw Error(`invalid account identifier: the check sum does not match`);
+    }
+    return new AccountIdentifier(buffer);
   }
 
   public static fromPrincipal({

--- a/packages/ledger-icp/src/mocks/ledger.mock.ts
+++ b/packages/ledger-icp/src/mocks/ledger.mock.ts
@@ -2,7 +2,7 @@ import { Principal } from "@dfinity/principal";
 import { AccountIdentifier } from "../account_identifier";
 
 export const mockAccountIdentifier = AccountIdentifier.fromHex(
-  "3e8bbceef8b9338e56a1b561a127326e6614894ab9b0739df4cc3664d40a5958",
+  "d3e13d4777e22367532053190b6c6ccf57444a61337e996242b1abfb52cf92c8",
 );
 
 export const mockPrincipalText =


### PR DESCRIPTION
`AccountIdentifier.fromHex` checks the check sum and throws if it doesn't match the contents.

This is potentially a breaking change because the applications that previously would accept
invalid account identifiers are going to fail now. One could argue that such applications were
already broken.

Issue: #944

- [x] Add entry to changelog (if necessary).
