### PR TITLE
fix: assert 32-bytes length when parsing ICP AccountIdentifier from Hex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Breaking Changes
 
 - Assert checksum when parsing ICP `AccountIdentifier` from hex. (\*).
+- Assert length equals 32 bytes when parsing ICP `AccountIdentifier` from hex. (\*).
 
 ## Features
 

--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -79,7 +79,7 @@ const data = await metadata();
 | --------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `fromPrincipal` | `({ principal, subAccount, }: { principal: Principal; subAccount?: SubAccount or undefined; }) => AccountIdentifier` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L30)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L36)
 
 #### Methods
 
@@ -94,7 +94,7 @@ const data = await metadata();
 | ------- | -------------- |
 | `toHex` | `() => string` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L56)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L62)
 
 ##### :gear: toUint8Array
 
@@ -102,7 +102,7 @@ const data = await metadata();
 | -------------- | ------------------ |
 | `toUint8Array` | `() => Uint8Array` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L60)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L66)
 
 ##### :gear: toNumbers
 
@@ -110,7 +110,7 @@ const data = await metadata();
 | ----------- | ---------------- |
 | `toNumbers` | `() => number[]` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L64)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L70)
 
 ##### :gear: toAccountIdentifierHash
 
@@ -118,11 +118,11 @@ const data = await metadata();
 | ------------------------- | ----------------------------- |
 | `toAccountIdentifierHash` | `() => { hash: Uint8Array; }` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L68)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L74)
 
 ### :factory: SubAccount
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L75)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L81)
 
 #### Static Methods
 
@@ -136,7 +136,7 @@ const data = await metadata();
 | ----------- | -------------------------------------------- |
 | `fromBytes` | `(bytes: Uint8Array) => SubAccount or Error` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L78)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L84)
 
 ##### :gear: fromPrincipal
 
@@ -144,7 +144,7 @@ const data = await metadata();
 | --------------- | -------------------------------------- |
 | `fromPrincipal` | `(principal: Principal) => SubAccount` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L86)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L92)
 
 ##### :gear: fromID
 
@@ -152,7 +152,7 @@ const data = await metadata();
 | -------- | ---------------------------- |
 | `fromID` | `(id: number) => SubAccount` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L99)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L105)
 
 #### Methods
 
@@ -164,7 +164,7 @@ const data = await metadata();
 | -------------- | ------------------ |
 | `toUint8Array` | `() => Uint8Array` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L123)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L129)
 
 ### :factory: LedgerCanister
 

--- a/packages/ledger-icp/src/account_identifier.spec.ts
+++ b/packages/ledger-icp/src/account_identifier.spec.ts
@@ -104,13 +104,19 @@ describe("AccountIdentifier", () => {
   it("should reject an invalid hex string", () => {
     expect(() => {
       AccountIdentifier.fromHex("foo bar");
-    }).toThrowError("Checksum mismatch. Expected 00000000, but got .");
+    }).toThrowError("Invalid AccountIdentifier: expected 32 bytes, got 0.");
   });
 
   it("should reject an empty hex string", () => {
     expect(() => {
       AccountIdentifier.fromHex("");
-    }).toThrowError("Checksum mismatch. Expected 00000000, but got .");
+    }).toThrowError("Invalid AccountIdentifier: expected 32 bytes, got 0.");
+  });
+
+  it("should reject an hex string too short", () => {
+    expect(() => {
+      AccountIdentifier.fromHex("deadbeef");
+    }).toThrowError("Invalid AccountIdentifier: expected 32 bytes, got 4.");
   });
 
   test("can be initialized from a principal", () => {

--- a/packages/ledger-icp/src/account_identifier.ts
+++ b/packages/ledger-icp/src/account_identifier.ts
@@ -13,6 +13,12 @@ export class AccountIdentifier {
   public static fromHex(hex: string): AccountIdentifier {
     const bytes = Uint8Array.from(Buffer.from(hex, "hex"));
 
+    if (bytes.length !== 32) {
+      throw new Error(
+        `Invalid AccountIdentifier: expected 32 bytes, got ${bytes.length}.`,
+      );
+    }
+
     const providedChecksum = uint8ArrayToHexString(bytes.slice(0, 4));
 
     const hash = bytes.slice(4);


### PR DESCRIPTION
# Motivation

An ICP account identifier is 32-bytes length. Currently, the function that parses the related class from hex does not checks if the inputs meets such criteria. Therefore, in addition to asserting checksum as provided in #948, I propose that we also enhance the function with a checks on the length.

# References

- https://internetcomputer.org/docs/references/ledger#_accounts
- https://mmapped.blog/posts/13-icp-ledger#account-id

# Changes

- If bytes length not 32 then error.
