### PR TITLE
feat: throw error instead of returning one on invalid ICP subaccount length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Next version
 
+## Breaking Changes
+
+- Modify the ICP `SubAccount.fromBytes` to throw an error instead of returning one when the input length is invalid. (\*\*)
+
+(\*\*) Returning an error was likely a historical artifact. For consistency, we decided to align this behavior with other similar functions.
+
 ## Features
 
 - Expose method `listSubaccounts` in class `IcrcIndexNgCanister`.

--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -132,9 +132,9 @@ const data = await metadata();
 
 ##### :gear: fromBytes
 
-| Method      | Type                                         |
-| ----------- | -------------------------------------------- |
-| `fromBytes` | `(bytes: Uint8Array) => SubAccount or Error` |
+| Method      | Type                                |
+| ----------- | ----------------------------------- |
+| `fromBytes` | `(bytes: Uint8Array) => SubAccount` |
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L65)
 

--- a/packages/ledger-icp/src/account_identifier.spec.ts
+++ b/packages/ledger-icp/src/account_identifier.spec.ts
@@ -4,9 +4,15 @@ import { AccountIdentifier, SubAccount } from "./account_identifier";
 
 describe("SubAccount", () => {
   it("only accepts 32-byte blobs", () => {
-    expect(SubAccount.fromBytes(new Uint8Array([1, 2]))).toBeInstanceOf(Error);
-    expect(SubAccount.fromBytes(new Uint8Array(31))).toBeInstanceOf(Error);
-    expect(SubAccount.fromBytes(new Uint8Array(33))).toBeInstanceOf(Error);
+    expect(() => SubAccount.fromBytes(new Uint8Array([1, 2]))).toThrowError(
+      "Subaccount length must be 32-bytes",
+    );
+    expect(() => SubAccount.fromBytes(new Uint8Array(31))).toThrowError(
+      "Subaccount length must be 32-bytes",
+    );
+    expect(() => SubAccount.fromBytes(new Uint8Array(33))).toThrowError(
+      "Subaccount length must be 32-bytes",
+    );
     expect(SubAccount.fromBytes(new Uint8Array(32))).toBeInstanceOf(SubAccount);
   });
 

--- a/packages/ledger-icp/src/account_identifier.ts
+++ b/packages/ledger-icp/src/account_identifier.ts
@@ -62,9 +62,9 @@ export class AccountIdentifier {
 export class SubAccount {
   private constructor(private readonly bytes: Uint8Array) {}
 
-  public static fromBytes(bytes: Uint8Array): SubAccount | Error {
-    if (bytes.length != 32) {
-      return Error("Subaccount length must be 32-bytes");
+  public static fromBytes(bytes: Uint8Array): SubAccount {
+    if (bytes.length !== 32) {
+      throw new Error("Subaccount length must be 32-bytes");
     }
 
     return new SubAccount(bytes);


### PR DESCRIPTION
# Motivation

An inconsistency in the ICP `SubAccount` class was reported. Its formatter is returning an `Error` instead of throwing one unlike all other functions of the same module and generally speaking in our codebase.

# Notes

This is a breaking changes and requires change in NNS dapp.

# Changes

- Throw error instead of returning one.