### PR TITLE
build: support for releasing beta tags

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -2,6 +2,15 @@ name: Next Publication
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'npm tag to publish under'
+        required: true
+        default: 'next'
+        type: choice
+        options:
+          - next
+          - beta
 
 jobs:
   publish:
@@ -17,50 +26,50 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
 
-      - name: Build next version
-        run: ./scripts/build-next
+      - name: Build version for tag
+        run: ./scripts/build-next --tag=${{ inputs.tag }}
 
       - name: Publish utils
-        run: npm publish --provenance --tag next --workspace=packages/utils
+        run: npm publish --provenance --tag ${{ inputs.tag }} --workspace=packages/utils
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish Ledger ICRC
-        run: npm publish --provenance --tag next --workspace=packages/ledger-icrc
+        run: npm publish --provenance --tag ${{ inputs.tag }} --workspace=packages/ledger-icrc
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish Ledger ICP
-        run: npm publish --provenance --tag next --workspace=packages/ledger-icp
+        run: npm publish --provenance --tag ${{ inputs.tag }} --workspace=packages/ledger-icp
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish NNS-proto
-        run: npm publish --provenance --tag next --workspace=packages/nns-proto
+        run: npm publish --provenance --tag ${{ inputs.tag }} --workspace=packages/nns-proto
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish NNS
-        run: npm publish --provenance --tag next --workspace=packages/nns
+        run: npm publish --provenance --tag ${{ inputs.tag }} --workspace=packages/nns
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish SNS
-        run: npm publish --provenance --tag next --workspace=packages/sns
+        run: npm publish --provenance --tag ${{ inputs.tag }} --workspace=packages/sns
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish CMC
-        run: npm publish --provenance --tag next --workspace=packages/cmc
+        run: npm publish --provenance --tag ${{ inputs.tag }} --workspace=packages/cmc
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish ckBTC
-        run: npm publish --provenance --tag next --workspace=packages/ckbtc
+        run: npm publish --provenance --tag ${{ inputs.tag }} --workspace=packages/ckbtc
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish ckETH
-        run: npm publish --provenance --tag next --workspace=packages/cketh
+        run: npm publish --provenance --tag ${{ inputs.tag }} --workspace=packages/cketh
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish ic-management
-        run: npm publish --provenance --tag next --workspace=packages/ic-management
+        run: npm publish --provenance --tag ${{ inputs.tag }} --workspace=packages/ic-management
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish Zod schemas
-        run: npm publish --provenance --tag next --workspace=packages/zod-schemas
+        run: npm publish --provenance --tag ${{ inputs.tag }} --workspace=packages/zod-schemas
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/scripts/build-next
+++ b/scripts/build-next
@@ -8,15 +8,15 @@ TAG=
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --tag=*)
-      TAG="${1#*=}"
-      shift
-      ;;
-    *)
-      echo "Unknown argument: $1"
-      echo "Usage: ./scripts/build-next [--tag=TAG_NAME]"
-      exit 1
-      ;;
+  --tag=*)
+    TAG="${1#*=}"
+    shift
+    ;;
+  *)
+    echo "Unknown argument: $1"
+    echo "Usage: ./scripts/build-next [--tag=TAG_NAME]"
+    exit 1
+    ;;
   esac
 done
 

--- a/scripts/build-next
+++ b/scripts/build-next
@@ -3,18 +3,35 @@ set -eux
 
 npm ci
 
+: Optional tag argument
+TAG=
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag=*)
+      TAG="${1#*=}"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      echo "Usage: ./scripts/build-next [--tag=TAG_NAME]"
+      exit 1
+      ;;
+  esac
+done
+
 : Update the package.json version before build and publish
-node ./scripts/update-version.mjs utils
-node ./scripts/update-version.mjs zod-schemas
-node ./scripts/update-version.mjs nns-proto
-node ./scripts/update-version.mjs ledger-icp
-node ./scripts/update-version.mjs ledger-icrc
-node ./scripts/update-version.mjs nns
-node ./scripts/update-version.mjs sns
-node ./scripts/update-version.mjs cmc
-node ./scripts/update-version.mjs ckbtc
-node ./scripts/update-version.mjs cketh
-node ./scripts/update-version.mjs ic-management
+node ./scripts/update-version.mjs utils $TAG
+node ./scripts/update-version.mjs zod-schemas $TAG
+node ./scripts/update-version.mjs nns-proto $TAG
+node ./scripts/update-version.mjs ledger-icp $TAG
+node ./scripts/update-version.mjs ledger-icrc $TAG
+node ./scripts/update-version.mjs nns $TAG
+node ./scripts/update-version.mjs sns $TAG
+node ./scripts/update-version.mjs cmc $TAG
+node ./scripts/update-version.mjs ckbtc $TAG
+node ./scripts/update-version.mjs cketh $TAG
+node ./scripts/update-version.mjs ic-management $TAG
 
 : Now we can build
 npm run build --workspaces

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -2,11 +2,12 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import fetch from "node-fetch";
 import { join } from "path";
 
-// The suffix we use to publish to npm wip version of the libs
-const SUFFIX = "next";
+// The project - name of the library in the workspace - and suffix we use to publish to npm as wip version
+const [project, tag] = process.argv.slice(2);
+const suffix = tag !== undefined && tag !== "" ? tag : "next";
 
 const nextVersion = async ({ project, currentVersion }) => {
-  const version = `${currentVersion}-${SUFFIX}-${new Date()
+  const version = `${currentVersion}-${suffix}-${new Date()
     .toISOString()
     .slice(0, 10)}`;
 
@@ -25,12 +26,12 @@ const nextVersion = async ({ project, currentVersion }) => {
 };
 
 const updateVersion = async () => {
-  if (process.argv.length !== 3) {
-    console.log("Invalid arguments: node update-version.mjs nns|sns|etc.");
-    return;
+  if (project === undefined || process.argv.length > 4) {
+    console.log(
+      "Invalid arguments: node update-version.mjs nns|sns|etc. [tag]",
+    );
+    process.exit(1);
   }
-
-  const project = process.argv[2];
 
   const packagePath = join(process.cwd(), "packages", project, "package.json");
 


### PR DESCRIPTION
# Motivation

Agent-js v3 has been released in beta (see [forum](https://forum.dfinity.org/t/agent-js-beta-release-v3-0-0-beta-0/50854)).  IMO, it's a really promising release as it (finally) reduces its size.

However, like other developers using our libraries, we can't easily use this `@beta` version without forcing its installation, which isn't very clean.  

That's why I propose we expand support for releasing versions with a similar tag as well - i.e. being able to release `beta` tag in addition to our existing `next` tags. This way we can stick to next for our lifecycle and beta for experiments.

In addition, this can also be useful when upgrading direct dependencies — as I'm planning to do for the Zod schemas.

# Changes

- Expand GitHub Actions to support and publish a tag from input
- Pass down the tag to the versioning script
