### PR TITLE
build: add explicit lib requirement on buffer to nns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## Build
 
-- Add explicit peer dependency requirement on `buffer` to `@dfinity/nns`. 
+- Add explicit peer dependency requirement on `buffer` to `@dfinity/nns`.
 
 # v70
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Updated `@dfinity/nns` to add support to a new type of action `RegisterExtension`.
 - Updated `@dfinity/nns` to add support for setting following for multiple topics (`setFollowing`).
 
+## Build
+
+- Add explicit peer dependency requirement on `buffer` to `@dfinity/nns`. 
+
 # v70
 
 ## Overview

--- a/package-lock.json
+++ b/package-lock.json
@@ -3064,6 +3064,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
@@ -9637,7 +9638,8 @@
         "@dfinity/candid": "^2.0.0",
         "@dfinity/ledger-icp": "^3",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.13.0"
+        "@dfinity/utils": "^2.13.0",
+        "buffer": "^6.0.3"
       }
     },
     "packages/nns-proto": {

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -55,6 +55,7 @@
     "@dfinity/candid": "^2.0.0",
     "@dfinity/ledger-icp": "^3",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.13.0"
+    "@dfinity/utils": "^2.13.0",
+    "buffer": "^6.0.3"
   }
 }


### PR DESCRIPTION
# Motivation

`@dfinity/nns` has unfortunately a requirement on the `buffer` library, which is really a pity. This is notably used to convert  identifier from and to bytes back and forth. I guess it's historical code of the governance and/or the hardware wallet.

Anyway, on the other end, agent-js removes its dependency to `buffer` in its version v3. Depency which is currently inherited to build the library.

That is why - because I think that improving nns would require a bit of time - I propose to "just" set `buffer` as an explicit dependency of `nns-js`.

# Changes

- ` npm i buffer --save-peer -w packages/nns`
