### PR TITLE
chore: remove unnecessary cast

### DIFF
--- a/packages/nns/src/utils/neurons.utils.ts
+++ b/packages/nns/src/utils/neurons.utils.ts
@@ -116,7 +116,7 @@ export const memoToNeuronSubaccount = ({
     ]),
   );
 
-  return SubAccount.fromBytes(shaObj.digest()) as SubAccount;
+  return SubAccount.fromBytes(shaObj.digest());
 };
 
 export const memoToNeuronAccountIdentifier = ({


### PR DESCRIPTION
# Motivation

> ESLint: This assertion is unnecessary since it does not change the type of the expression. (@typescript-eslint/no-unnecessary-type-assertion)

# Changes

- Remove unnecessary cast
