### PR TITLE
feat: move few account identifier functions from ledger-icp to nns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next version
 
+## Breaking Changes
+
+- Move `accountIdentifierToBytes`, `accountIdentifierFromBytes` and `principalToAccountIdentifier` from `@dfinity/ledger-icp` to `@dfinity/nns`.
+
 ## Features
 
 - Updated `@dfinity/nns` to add support to a new type of action `RegisterExtension`.

--- a/packages/ledger-icp/src/index.ts
+++ b/packages/ledger-icp/src/index.ts
@@ -25,5 +25,4 @@ export type {
   Icrc2ApproveRequest,
   TransferRequest,
 } from "./types/ledger_converters";
-export * from "./utils/account_identifier.utils";
 export * from "./utils/accounts.utils";

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -1,7 +1,6 @@
-import {
-  accountIdentifierToBytes,
-  type AccountIdentifier as AccountIdentifierClass,
-  type AccountIdentifierHex,
+import type {
+  AccountIdentifier as AccountIdentifierClass,
+  AccountIdentifierHex,
 } from "@dfinity/ledger-icp";
 import { Principal } from "@dfinity/principal";
 import {
@@ -94,6 +93,7 @@ import type {
   VotingPowerEconomics,
   VotingRewardParameters,
 } from "../../types/governance_converters";
+import { accountIdentifierToBytes } from "../../utils/account_identifier.utils";
 
 const fromProposalId = (proposalId: ProposalId): RawNeuronId => ({
   id: proposalId,

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -1,8 +1,4 @@
-import {
-  accountIdentifierFromBytes,
-  principalToAccountIdentifier,
-  type AccountIdentifierHex,
-} from "@dfinity/ledger-icp";
+import type { AccountIdentifierHex } from "@dfinity/ledger-icp";
 import { Principal } from "@dfinity/principal";
 import {
   fromDefinedNullable,
@@ -122,6 +118,10 @@ import type {
   VotingPowerEconomics,
   VotingRewardParameters,
 } from "../../types/governance_converters";
+import {
+  accountIdentifierFromBytes,
+  principalToAccountIdentifier,
+} from "../../utils/account_identifier.utils";
 import { fromAccountIdentifier } from "./request.converters";
 
 export const toNeuronInfo = ({

--- a/packages/nns/src/governance_test.canister.ts
+++ b/packages/nns/src/governance_test.canister.ts
@@ -1,5 +1,4 @@
 import type { ActorSubclass } from "@dfinity/agent";
-import { principalToAccountIdentifier } from "@dfinity/ledger-icp";
 import type { Principal } from "@dfinity/principal";
 import {
   assertNonNullish,
@@ -13,6 +12,7 @@ import { fromListNeurons } from "./canisters/governance/request.converters";
 import { toRawNeuron } from "./canisters/governance/response.converters";
 import { MAINNET_GOVERNANCE_CANISTER_ID } from "./constants/canister_ids";
 import type { Neuron } from "./types/governance_converters";
+import { principalToAccountIdentifier } from "./utils/account_identifier.utils";
 
 export class GovernanceTestCanister {
   private constructor(

--- a/packages/nns/src/index.ts
+++ b/packages/nns/src/index.ts
@@ -10,4 +10,5 @@ export * from "./types/common";
 export * from "./types/governance.options";
 export * from "./types/governance_converters";
 export type { SnsWasmCanisterOptions } from "./types/sns_wasm.options";
+export * from "./utils/account_identifier.utils";
 export * from "./utils/neurons.utils";

--- a/packages/nns/src/utils/account_identifier.utils.ts
+++ b/packages/nns/src/utils/account_identifier.utils.ts
@@ -1,3 +1,4 @@
+import type { AccountIdentifierHex } from "@dfinity/ledger-icp";
 import type { Principal } from "@dfinity/principal";
 import {
   arrayOfNumberToUint8Array,
@@ -7,7 +8,10 @@ import {
 } from "@dfinity/utils";
 import { sha224 } from "@noble/hashes/sha256";
 import { Buffer } from "buffer";
-import type { AccountIdentifierHex } from "../types/common";
+
+// The following functions were originally made available in @dfinity/ledger-icp for domain alignment reasons.
+// However, they rely on Buffer — which requires a polyfill and significantly increases bundle size in web environments.
+// Since they are only used by @dfinity/nns and potentially the NNS dapp, they have been moved to this package instead.
 
 export const accountIdentifierToBytes = (
   accountIdentifier: AccountIdentifierHex,


### PR DESCRIPTION
# Motivation

Agent-js v3 will drop the requirement for `buffer`.

Historically, both the NNS governance (protobuf?) and the NNS dapp (hardware wallet) relied on buffer for a few identifier-to-bytes conversions. This dependency was inherited via the agent-js.

Since buffer will be removed, projects will now need to add it explicitly if needed. This is kind of acceptable for nns-js (#963), but a bit unfortunate for ledger-icp.

After reviewing the code, I noticed that only a few legacy methods in ledger-icp actually require buffer. Looking through the DFINITY org, it seems that only the NNS dapp still depends on them. While these methods arguably don’t belong in nns-js (they handle "account identifier"-related logic), moving them there would be a win: it would prevent other dapps using ledger-icp from being forced to polyfill buffer.

Additionally, this would scope the buffer dependency to a single library, making it easier in the future for anyone motivated to remove it entirely.

# Notes

Results of dropping buffer in ledger-icp:

<img width="360" alt="Capture d’écran 2025-06-26 à 13 04 39" src="https://github.com/user-attachments/assets/198c8f4b-3995-4440-946b-de02e79f0a11" />

# Changes

- Move `account_identifier.utils` from `@dfinity/ledger-icp` to `@dfinity/nns`.
