### PR TITLE
test: remove `.only` modifier for tests of util `smallerVersion`

### DIFF
--- a/packages/utils/src/utils/version.utils.spec.ts
+++ b/packages/utils/src/utils/version.utils.spec.ts
@@ -33,6 +33,7 @@ describe("smallerVersion", () => {
       }),
     ).toBe(true);
   });
+
   it("returns false if current version is bigger than min version", () => {
     expect(
       smallerVersion({
@@ -65,6 +66,7 @@ describe("smallerVersion", () => {
       }),
     ).toBe(false);
   });
+
   it("returns false if current version is same as min version", () => {
     expect(
       smallerVersion({
@@ -98,7 +100,7 @@ describe("smallerVersion", () => {
     ).toBe(false);
   });
 
-  it.only("works with tagged versions", () => {
+  it("works with tagged versions", () => {
     expect(
       smallerVersion({
         minVersion: "1.0.0-alpha",


### PR DESCRIPTION
# Motivation

Since we are going to migrate to Vitest, we receive an error while testing:

```css
→ [Vitest] Unexpected .only modifier. Remove it or pass --allowOnly argument to bypass this error
```

meaning that Vitest blocks `.only` unless we explicitly allow it.

This is a safety feature to prevent accidentally committing focused tests (`it.only`, `describe.only`) which would skip the rest of your suite.

However, the test suite specific for util `smallerVersion` works correctly, so we remove the modifier.