### PR TITLE
chore: Remove unnecessary Jest globals imports

### DIFF
--- a/packages/ledger-icp/src/account_identifier.spec.ts
+++ b/packages/ledger-icp/src/account_identifier.spec.ts
@@ -1,5 +1,4 @@
 import { Principal } from "@dfinity/principal";
-import { describe, expect, it } from "@jest/globals";
 import { AccountIdentifier, SubAccount } from "./account_identifier";
 import { mockAccountIdentifier } from "./mocks/ledger.mock";
 

--- a/packages/utils/src/parser/token.spec.ts
+++ b/packages/utils/src/parser/token.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "@jest/globals";
 import { FromStringToTokenError } from "../enums/token.enums";
 import { ICPToken, TokenAmount, TokenAmountV2 } from "./token";
 

--- a/packages/utils/src/utils/agent.utils.spec.ts
+++ b/packages/utils/src/utils/agent.utils.spec.ts
@@ -1,5 +1,4 @@
 import { HttpAgent } from "@dfinity/agent";
-import { describe, expect } from "@jest/globals";
 import {
   mockAgentManagerConfig,
   mockHttpAgent,

--- a/packages/utils/src/utils/arrays.utils.spec.ts
+++ b/packages/utils/src/utils/arrays.utils.spec.ts
@@ -1,4 +1,3 @@
-import { expect } from "@jest/globals";
 import {
   arrayBufferToUint8Array,
   arrayOfNumberToUint8Array,

--- a/packages/utils/src/utils/date.utils.spec.ts
+++ b/packages/utils/src/utils/date.utils.spec.ts
@@ -1,4 +1,3 @@
-import { describe } from "@jest/globals";
 import {
   nowInBigIntNanoSeconds,
   secondsToDuration,


### PR DESCRIPTION
# Motivation

For consistency, we remove unnecessary global Jest imports.
