### PR TITLE
chore: Remove duplicate tests for util `isNullish`

### DIFF
--- a/packages/utils/src/utils/nullish.utils.spec.ts
+++ b/packages/utils/src/utils/nullish.utils.spec.ts
@@ -28,17 +28,6 @@ describe("nullish-utils", () => {
     });
   });
 
-  describe("isNullish", () => {
-    it("should determine nullable", () => {
-      expect(isNullish(null)).toBeTruthy();
-      expect(isNullish(undefined)).toBeTruthy();
-      expect(isNullish(0)).toBeFalsy();
-      expect(isNullish(1)).toBeFalsy();
-      expect(isNullish("")).toBeFalsy();
-      expect(isNullish([])).toBeFalsy();
-    });
-  });
-
   describe("notEmptyString", () => {
     it("should determine not empty", () => {
       expect(notEmptyString(null)).toBeFalsy();


### PR DESCRIPTION
# Motivation

The tests for util `isNullish` were duplicated (they can be found on row 9 of the same file).