### PR TITLE
build: fix buffer bundle method for nns-dapp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ## Build
 
-- Add explicit peer dependency requirement on `buffer` to `@dfinity/nns`.
+- Add explicit dependency requirement on `buffer` to `@dfinity/nns`.
 
 ## Chore
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1927,8 +1927,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/bech32": {
       "version": "2.0.0",
@@ -2051,7 +2050,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -4118,8 +4116,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -7317,6 +7314,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
+        "buffer": "^6.0.3",
         "randombytes": "^2.1.0"
       },
       "devDependencies": {
@@ -7327,8 +7325,7 @@
         "@dfinity/candid": "^2.0.0",
         "@dfinity/ledger-icp": "^3",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.13.0",
-        "buffer": "^6.0.3"
+        "@dfinity/utils": "^2.13.0"
       }
     },
     "packages/nns-proto": {
@@ -7439,6 +7436,7 @@
       "requires": {
         "@noble/hashes": "^1.3.2",
         "@types/randombytes": "^2.0.0",
+        "buffer": "^6.0.3",
         "randombytes": "^2.1.0"
       }
     },
@@ -8477,8 +8475,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "peer": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bech32": {
       "version": "2.0.0",
@@ -8561,7 +8558,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "peer": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -9963,8 +9959,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "peer": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.3.2",

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.3.2",
+    "buffer": "^6.0.3",
     "randombytes": "^2.1.0"
   },
   "devDependencies": {
@@ -55,7 +56,6 @@
     "@dfinity/candid": "^2.0.0",
     "@dfinity/ledger-icp": "^3",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.13.0",
-    "buffer": "^6.0.3"
+    "@dfinity/utils": "^2.13.0"
   }
 }


### PR DESCRIPTION
# Motivation

Unfortunately, `buffer` must be bundled within `@dfinity/nns` and cannot be set as a peer dependency as proposed in #963, because the NNS dapp fails at runtime. `esbuild`, which we use to build `ic-js` and which is configured to treat peer dependencies as external resources, appears to require `buffer` to be included; otherwise, it fails when used in the NNS dapp.

Fundamentally, making `buffer` an explicit dependency of `@dfinity/nns` simply reflects how it already behaves—i.e., `buffer` was already included implicitly.

# Changes

- `npm rm buffer -w packages/nns && npm i buffer -w packages/nns`

# Screenshots

Using npm pack locally.

Before:

<img width="1536" alt="Capture d’écran 2025-07-01 à 14 17 02" src="https://github.com/user-attachments/assets/3f483887-b173-42a0-ae1d-e10955326d00" />

After:

<img width="1536" alt="Capture d’écran 2025-07-01 à 14 18 17" src="https://github.com/user-attachments/assets/e983ae37-ba32-4ac8-afde-ffac65103fd4" />

