### PR TITLE
chore: disable vitest watch

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export const baseConfig: ViteUserConfig = {
   test: {
     environment: "node",
     globals: true,
+    watch: false,
   },
 };
 


### PR DESCRIPTION
# Motivation

We don't watch for test changes in any of our repo (I think), therefore I propose to turn this off for this repo as well.

>   PASS  Waiting for file changes...
>       press h to show help, press q to quit

# Changes

- `watch: false` in test config