### PR TITLE
feat: spawning_neurons_count nns metrics

### DIFF
--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -1161,6 +1161,7 @@ export const toMetrics = (
     metrics.total_staked_maturity_e8s_equivalent,
   notDissolvingNeuronsE8sBucketsEct:
     metrics.not_dissolving_neurons_e8s_buckets_ect,
+  spawningNeuronsCount: metrics.spawning_neurons_count,
   decliningVotingPowerNeuronSubsetMetrics: toNeuronSubsetMetrics(
     metrics.declining_voting_power_neuron_subset_metrics,
   ),

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -2432,6 +2432,7 @@ describe("GovernanceCanister", () => {
       total_voting_power_non_self_authenticating_controller: [],
       total_staked_maturity_e8s_equivalent: BigInt(3),
       not_dissolving_neurons_e8s_buckets_ect: [],
+      spawning_neurons_count: BigInt(55),
       declining_voting_power_neuron_subset_metrics: [rawNeuronSubsetMetrics],
       total_staked_e8s_ect: BigInt(3),
       not_dissolving_neurons_staked_maturity_e8s_equivalent_sum: BigInt(3),
@@ -2457,6 +2458,7 @@ describe("GovernanceCanister", () => {
     const mockMetrics: GovernanceCachedMetrics = {
       communityFundTotalMaturityE8sEquivalent: 4n,
       communityFundTotalStakedE8s: 8n,
+      spawningNeuronsCount: 55n,
       decliningVotingPowerNeuronSubsetMetrics: {
         count: undefined,
         countBuckets: [[1n, 2n]],

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -792,6 +792,7 @@ export interface GovernanceCachedMetrics {
   totalVotingPowerNonSelfAuthenticatingController: Option<bigint>;
   totalStakedMaturityE8sEquivalent: bigint;
   notDissolvingNeuronsE8sBucketsEct: Array<[bigint, number]>;
+  spawningNeuronsCount: bigint;
   decliningVotingPowerNeuronSubsetMetrics: Option<NeuronSubsetMetrics>;
   totalStakedE8sEct: bigint;
   notDissolvingNeuronsStakedMaturityE8sEquivalentSum: bigint;


### PR DESCRIPTION
# Motivation

I merged the weekly Candid PR #980 and noticed a new field related to the recent NNS `get_metrics` PR #977. This mapping includes the additional field `spawning_neurons_count`.

# Notes

For some reasons tests passed in CI in #980 but, actually, when I run the test on `main` now they don't as this field is missing. i.e. we need this PR.

> packages/nns/src/governance.canister.spec.ts:2410:11 - error TS2741: Property 'spawning_neurons_count' is missing in type '{ total_maturity_e8s_equivalent: bigint; not_dissolving_neurons_e8s_buckets: [bigint, number][]; dissolving_neurons_staked_maturity_e8s_equivalent_sum: bigint; garbage_collectable_neurons_count: bigint; ... 36 more ...; seed_neuron_count: bigint; }' but required in type 'GovernanceCachedMetrics'.
>
>2410     const rawMetrics: RawGovernanceCachedMetrics = {
>               ~~~~~~~~~~
>
>  packages/nns/candid/governance.d.ts:281:3
>    281   spawning_neurons_count: bigint;
>          ~~~~~~~~~~~~~~~~~~~~~~
>    'spawning_neurons_count' is declared here.

# Changes

- Map field for response and test
