### PR TITLE
feat(governance): expose total voting power in proposals list

### DIFF
--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -1286,6 +1286,9 @@ export const toProposalInfo = (
   topic: proposalInfo.topic,
   status: proposalInfo.status,
   rewardStatus: proposalInfo.reward_status,
+  totalPotentialVotingPower: fromNullable(
+    proposalInfo.total_potential_voting_power,
+  ),
 });
 
 export const toArrayOfNeuronInfo = ({

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -474,6 +474,7 @@ export interface ProposalInfo {
   topic: Topic;
   status: ProposalStatus;
   rewardStatus: ProposalRewardStatus;
+  totalPotentialVotingPower: Option<bigint>;
 }
 
 export interface RegisterVote {


### PR DESCRIPTION
# Motivation

The nns-dapp will display information about the total voting power of the IC.

# Changes

- Expose `total_potential_voting_power` in the listProposals canister method.

# Tests

- Update unit tests.

# Todos

- [ ] Add entry to changelog (if necessary).
