### PR TITLE
chore: update Candid files

### DIFF
--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 9bdaa01adf (2025-06-25) 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit e915efe (2025-07-02 tags: release-2025-07-03_03-27-base) 'rs/nns/gtc/canister/gtc.did' by import-candid
 type AccountState = record {
   authenticated_principal_id : opt principal;
   successfully_transferred_neurons : vec TransferredNeuron;

--- a/packages/nns/candid/governance.certified.idl.js
+++ b/packages/nns/candid/governance.certified.idl.js
@@ -432,6 +432,7 @@ export const idlFactory = ({ IDL }) => {
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
+    'spawning_neurons_count' : IDL.Nat64,
     'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
       NeuronSubsetMetrics
     ),
@@ -1453,6 +1454,7 @@ export const init = ({ IDL }) => {
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
+    'spawning_neurons_count' : IDL.Nat64,
     'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
       NeuronSubsetMetrics
     ),

--- a/packages/nns/candid/governance.d.ts
+++ b/packages/nns/candid/governance.d.ts
@@ -278,6 +278,7 @@ export interface GovernanceCachedMetrics {
   total_voting_power_non_self_authenticating_controller: [] | [bigint];
   total_staked_maturity_e8s_equivalent: bigint;
   not_dissolving_neurons_e8s_buckets_ect: Array<[bigint, number]>;
+  spawning_neurons_count: bigint;
   declining_voting_power_neuron_subset_metrics: [] | [NeuronSubsetMetrics];
   total_staked_e8s_ect: bigint;
   not_dissolving_neurons_staked_maturity_e8s_equivalent_sum: bigint;

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 9bdaa01adf (2025-06-25) 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit e915efe (2025-07-02 tags: release-2025-07-03_03-27-base) 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -376,6 +376,7 @@ type GovernanceCachedMetrics = record {
   not_dissolving_neurons_e8s_buckets_seed : vec record { nat64; float64 };
   timestamp_seconds : nat64;
   seed_neuron_count : nat64;
+  spawning_neurons_count : nat64;
 
   non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
   public_neuron_subset_metrics : opt NeuronSubsetMetrics;

--- a/packages/nns/candid/governance.idl.js
+++ b/packages/nns/candid/governance.idl.js
@@ -432,6 +432,7 @@ export const idlFactory = ({ IDL }) => {
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
+    'spawning_neurons_count' : IDL.Nat64,
     'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
       NeuronSubsetMetrics
     ),
@@ -1469,6 +1470,7 @@ export const init = ({ IDL }) => {
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
+    'spawning_neurons_count' : IDL.Nat64,
     'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
       NeuronSubsetMetrics
     ),

--- a/packages/nns/candid/governance_test.certified.idl.js
+++ b/packages/nns/candid/governance_test.certified.idl.js
@@ -432,6 +432,7 @@ export const idlFactory = ({ IDL }) => {
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
+    'spawning_neurons_count' : IDL.Nat64,
     'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
       NeuronSubsetMetrics
     ),
@@ -1454,6 +1455,7 @@ export const init = ({ IDL }) => {
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
+    'spawning_neurons_count' : IDL.Nat64,
     'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
       NeuronSubsetMetrics
     ),

--- a/packages/nns/candid/governance_test.d.ts
+++ b/packages/nns/candid/governance_test.d.ts
@@ -278,6 +278,7 @@ export interface GovernanceCachedMetrics {
   total_voting_power_non_self_authenticating_controller: [] | [bigint];
   total_staked_maturity_e8s_equivalent: bigint;
   not_dissolving_neurons_e8s_buckets_ect: Array<[bigint, number]>;
+  spawning_neurons_count: bigint;
   declining_voting_power_neuron_subset_metrics: [] | [NeuronSubsetMetrics];
   total_staked_e8s_ect: bigint;
   not_dissolving_neurons_staked_maturity_e8s_equivalent_sum: bigint;

--- a/packages/nns/candid/governance_test.did
+++ b/packages/nns/candid/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 9bdaa01adf (2025-06-25) 'rs/nns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit e915efe (2025-07-02 tags: release-2025-07-03_03-27-base) 'rs/nns/governance/canister/governance_test.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -373,6 +373,7 @@ type GovernanceCachedMetrics = record {
   not_dissolving_neurons_e8s_buckets_seed : vec record { nat64; float64 };
   timestamp_seconds : nat64;
   seed_neuron_count : nat64;
+  spawning_neurons_count : nat64;
 
   non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
   public_neuron_subset_metrics : opt NeuronSubsetMetrics;

--- a/packages/nns/candid/governance_test.idl.js
+++ b/packages/nns/candid/governance_test.idl.js
@@ -432,6 +432,7 @@ export const idlFactory = ({ IDL }) => {
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
+    'spawning_neurons_count' : IDL.Nat64,
     'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
       NeuronSubsetMetrics
     ),
@@ -1470,6 +1471,7 @@ export const init = ({ IDL }) => {
     'not_dissolving_neurons_e8s_buckets_ect' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
+    'spawning_neurons_count' : IDL.Nat64,
     'declining_voting_power_neuron_subset_metrics' : IDL.Opt(
       NeuronSubsetMetrics
     ),

--- a/packages/nns/src/canisters/governance/response.converters.ts
+++ b/packages/nns/src/canisters/governance/response.converters.ts
@@ -1164,6 +1164,7 @@ export const toMetrics = (
   decliningVotingPowerNeuronSubsetMetrics: toNeuronSubsetMetrics(
     metrics.declining_voting_power_neuron_subset_metrics,
   ),
+  spawningNeuronsCount: metrics.spawning_neurons_count,
   totalStakedE8sEct: metrics.total_staked_e8s_ect,
   notDissolvingNeuronsStakedMaturityE8sEquivalentSum:
     metrics.not_dissolving_neurons_staked_maturity_e8s_equivalent_sum,

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -2444,6 +2444,7 @@ describe("GovernanceCanister", () => {
       total_staked_maturity_e8s_equivalent: BigInt(3),
       not_dissolving_neurons_e8s_buckets_ect: [],
       declining_voting_power_neuron_subset_metrics: [rawNeuronSubsetMetrics],
+      spawning_neurons_count: BigInt(55),
       total_staked_e8s_ect: BigInt(3),
       not_dissolving_neurons_staked_maturity_e8s_equivalent_sum: BigInt(3),
       dissolved_neurons_e8s: BigInt(3),
@@ -2468,6 +2469,7 @@ describe("GovernanceCanister", () => {
     const mockMetrics: GovernanceCachedMetrics = {
       communityFundTotalMaturityE8sEquivalent: 4n,
       communityFundTotalStakedE8s: 8n,
+      spawningNeuronsCount: 55n,
       decliningVotingPowerNeuronSubsetMetrics: {
         count: undefined,
         countBuckets: [[1n, 2n]],

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -793,6 +793,7 @@ export interface GovernanceCachedMetrics {
   totalVotingPowerNonSelfAuthenticatingController: Option<bigint>;
   totalStakedMaturityE8sEquivalent: bigint;
   notDissolvingNeuronsE8sBucketsEct: Array<[bigint, number]>;
+  spawningNeuronsCount: bigint;
   decliningVotingPowerNeuronSubsetMetrics: Option<NeuronSubsetMetrics>;
   totalStakedE8sEct: bigint;
   notDissolvingNeuronsStakedMaturityE8sEquivalentSum: bigint;


### PR DESCRIPTION
# Motivation

The canister APIs have been updated. This PR reverts the changes made in #984, which itself was a reversion of the changes in #980 and #982, due to a breaking change in the NNS canister.

# Changes

* Updated the candid interface files for the nns package.
* Updated the javascript bindings for the latest candid interfaces.
* Adds new type to mocks and types.

# Tests
  - [x] Please check the API updates for any breaking changes that affect our code.