### PR TITLE
Upgrade IC for Sns Metric types

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     {
       "name": "@dfinity/sns",
       "path": "./packages/sns/dist/index.js",
-      "limit": "19 kB",
+      "limit": "20 kB",
       "gzip": true,
       "ignore": [
         "@dfinity/agent",

--- a/packages/sns/candid/sns_governance.certified.idl.js
+++ b/packages/sns/candid/sns_governance.certified.idl.js
@@ -46,7 +46,26 @@ export const idlFactory = ({ IDL }) => {
     'description' : IDL.Opt(IDL.Text),
     'function_type' : IDL.Opt(FunctionType),
   });
+  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
+  const Account = IDL.Record({
+    'owner' : IDL.Opt(IDL.Principal),
+    'subaccount' : IDL.Opt(Subaccount),
+  });
+  const TreasuryMetrics = IDL.Record({
+    'name' : IDL.Opt(IDL.Text),
+    'original_amount_e8s' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account' : IDL.Opt(Account),
+    'ledger_canister_id' : IDL.Opt(IDL.Principal),
+    'treasury' : IDL.Int32,
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const VotingPowerMetrics = IDL.Record({
+    'governance_total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const GovernanceCachedMetrics = IDL.Record({
+    'treasury_metrics' : IDL.Vec(TreasuryMetrics),
     'not_dissolving_neurons_e8s_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
@@ -59,6 +78,7 @@ export const idlFactory = ({ IDL }) => {
     'dissolved_neurons_count' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
     'total_supply_governance_tokens' : IDL.Nat64,
+    'voting_power_metrics' : IDL.Opt(VotingPowerMetrics),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'dissolved_neurons_e8s' : IDL.Nat64,
     'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
@@ -185,11 +205,6 @@ export const idlFactory = ({ IDL }) => {
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
-  });
-  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
-  const Account = IDL.Record({
-    'owner' : IDL.Opt(IDL.Principal),
-    'subaccount' : IDL.Opt(Subaccount),
   });
   const Decimal = IDL.Record({ 'human_readable' : IDL.Opt(IDL.Text) });
   const Tokens = IDL.Record({ 'e8s' : IDL.Opt(IDL.Nat64) });
@@ -574,9 +589,12 @@ export const idlFactory = ({ IDL }) => {
     'time_window_seconds' : IDL.Opt(IDL.Nat64),
   });
   const Metrics = IDL.Record({
+    'treasury_metrics' : IDL.Opt(IDL.Vec(TreasuryMetrics)),
+    'voting_power_metrics' : IDL.Opt(VotingPowerMetrics),
     'last_ledger_block_timestamp' : IDL.Opt(IDL.Nat64),
     'num_recently_executed_proposals' : IDL.Opt(IDL.Nat64),
     'num_recently_submitted_proposals' : IDL.Opt(IDL.Nat64),
+    'genesis_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
   const GetMetricsResult = IDL.Variant({
     'Ok' : Metrics,
@@ -764,6 +782,11 @@ export const idlFactory = ({ IDL }) => {
       ),
     'get_metadata' : IDL.Func([IDL.Record({})], [GetMetadataResponse], []),
     'get_metrics' : IDL.Func([GetMetricsRequest], [GetMetricsResponse], []),
+    'get_metrics_replicated' : IDL.Func(
+        [GetMetricsRequest],
+        [GetMetricsResponse],
+        [],
+      ),
     'get_mode' : IDL.Func([IDL.Record({})], [GetModeResponse], []),
     'get_nervous_system_parameters' : IDL.Func(
         [IDL.Null],
@@ -853,7 +876,26 @@ export const init = ({ IDL }) => {
     'description' : IDL.Opt(IDL.Text),
     'function_type' : IDL.Opt(FunctionType),
   });
+  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
+  const Account = IDL.Record({
+    'owner' : IDL.Opt(IDL.Principal),
+    'subaccount' : IDL.Opt(Subaccount),
+  });
+  const TreasuryMetrics = IDL.Record({
+    'name' : IDL.Opt(IDL.Text),
+    'original_amount_e8s' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account' : IDL.Opt(Account),
+    'ledger_canister_id' : IDL.Opt(IDL.Principal),
+    'treasury' : IDL.Int32,
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const VotingPowerMetrics = IDL.Record({
+    'governance_total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const GovernanceCachedMetrics = IDL.Record({
+    'treasury_metrics' : IDL.Vec(TreasuryMetrics),
     'not_dissolving_neurons_e8s_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
@@ -866,6 +908,7 @@ export const init = ({ IDL }) => {
     'dissolved_neurons_count' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
     'total_supply_governance_tokens' : IDL.Nat64,
+    'voting_power_metrics' : IDL.Opt(VotingPowerMetrics),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'dissolved_neurons_e8s' : IDL.Nat64,
     'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
@@ -992,11 +1035,6 @@ export const init = ({ IDL }) => {
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
-  });
-  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
-  const Account = IDL.Record({
-    'owner' : IDL.Opt(IDL.Principal),
-    'subaccount' : IDL.Opt(Subaccount),
   });
   const Decimal = IDL.Record({ 'human_readable' : IDL.Opt(IDL.Text) });
   const Tokens = IDL.Record({ 'e8s' : IDL.Opt(IDL.Nat64) });

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -310,6 +310,7 @@ export interface Governance {
   genesis_timestamp_seconds: bigint;
 }
 export interface GovernanceCachedMetrics {
+  treasury_metrics: Array<TreasuryMetrics>;
   not_dissolving_neurons_e8s_buckets: Array<[bigint, number]>;
   garbage_collectable_neurons_count: bigint;
   neurons_with_invalid_stake_count: bigint;
@@ -318,6 +319,7 @@ export interface GovernanceCachedMetrics {
   dissolved_neurons_count: bigint;
   total_staked_e8s: bigint;
   total_supply_governance_tokens: bigint;
+  voting_power_metrics: [] | [VotingPowerMetrics];
   not_dissolving_neurons_count: bigint;
   dissolved_neurons_e8s: bigint;
   neurons_with_less_than_6_months_dissolve_delay_e8s: bigint;
@@ -408,9 +410,12 @@ export interface MergeMaturityResponse {
   new_stake_e8s: bigint;
 }
 export interface Metrics {
+  treasury_metrics: [] | [Array<TreasuryMetrics>];
+  voting_power_metrics: [] | [VotingPowerMetrics];
   last_ledger_block_timestamp: [] | [bigint];
   num_recently_executed_proposals: [] | [bigint];
   num_recently_submitted_proposals: [] | [bigint];
+  genesis_timestamp_seconds: [] | [bigint];
 }
 export interface MintSnsTokens {
   to_principal: [] | [Principal];
@@ -692,6 +697,15 @@ export interface TransferSnsTreasuryFunds {
   memo: [] | [bigint];
   amount_e8s: bigint;
 }
+export interface TreasuryMetrics {
+  name: [] | [string];
+  original_amount_e8s: [] | [bigint];
+  amount_e8s: [] | [bigint];
+  account: [] | [Account];
+  ledger_canister_id: [] | [Principal];
+  treasury: number;
+  timestamp_seconds: [] | [bigint];
+}
 export interface UpgradeInProgress {
   mark_failed_at_seconds: bigint;
   checking_upgrade_lock: bigint;
@@ -771,6 +785,10 @@ export interface Version {
 export interface Versions {
   versions: Array<Version>;
 }
+export interface VotingPowerMetrics {
+  governance_total_potential_voting_power: [] | [bigint];
+  timestamp_seconds: [] | [bigint];
+}
 export interface VotingRewardsParameters {
   final_reward_rate_basis_points: [] | [bigint];
   initial_reward_rate_basis_points: [] | [bigint];
@@ -791,6 +809,7 @@ export interface _SERVICE {
   get_maturity_modulation: ActorMethod<[{}], GetMaturityModulationResponse>;
   get_metadata: ActorMethod<[{}], GetMetadataResponse>;
   get_metrics: ActorMethod<[GetMetricsRequest], GetMetricsResponse>;
+  get_metrics_replicated: ActorMethod<[GetMetricsRequest], GetMetricsResponse>;
   get_mode: ActorMethod<[{}], GetModeResponse>;
   get_nervous_system_parameters: ActorMethod<[null], NervousSystemParameters>;
   get_neuron: ActorMethod<[GetNeuron], GetNeuronResponse>;

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit e915efe (2025-07-02 tags: release-2025-07-03_03-27-base) 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 5f36668c9b (2025-07-11) 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -254,10 +254,43 @@ type GetMetricsRequest = record {
   time_window_seconds : opt nat64;
 };
 
+type TreasuryMetrics = record {
+  // Same as, e.g., `TransferSnsTreasuryFunds.from_treasury`.
+  treasury : int32;
+
+  // A human-readable identified for this treasury, e.g., "ICP".
+  name : opt text;
+  
+  // The source of truth for the treasury balance is this ledger canister / account.
+  ledger_canister_id : opt principal;
+  account : opt Account;
+
+  // The regularly updated amount of tokens in this treasury.
+  amount_e8s : opt nat64;
+  // The amount of tokens in this treasury at the end of swap finalization.
+  original_amount_e8s : opt nat64;
+
+  // When the metrics were last updated.
+  timestamp_seconds : opt nat64;
+};
+
+type VotingPowerMetrics = record {
+  governance_total_potential_voting_power : opt nat64; 
+
+  // When the metrics were last updated.
+  timestamp_seconds : opt nat64;
+};
+
 type Metrics = record {
   num_recently_submitted_proposals : opt nat64;
   num_recently_executed_proposals: opt nat64;
+
   last_ledger_block_timestamp : opt nat64;
+
+  // The metrics below are cached (albeit this is an implementation detail).
+  treasury_metrics : opt vec TreasuryMetrics;
+  voting_power_metrics : opt VotingPowerMetrics;
+  genesis_timestamp_seconds : opt nat64;
 };
 
 type GetMetricsResult = variant {
@@ -360,6 +393,8 @@ type GovernanceCachedMetrics = record {
   dissolving_neurons_count : nat64;
   dissolving_neurons_e8s_buckets : vec record { nat64; float64 };
   timestamp_seconds : nat64;
+  treasury_metrics : vec TreasuryMetrics;
+  voting_power_metrics : opt VotingPowerMetrics;
 };
 
 type GovernanceError = record {
@@ -950,6 +985,7 @@ service : (Governance) -> {
   get_maturity_modulation : (record {}) -> (GetMaturityModulationResponse);
   get_metadata : (record {}) -> (GetMetadataResponse) query;
   get_metrics : (GetMetricsRequest) -> (GetMetricsResponse) composite_query;
+  get_metrics_replicated : (GetMetricsRequest) -> (GetMetricsResponse);
   get_mode : (record {}) -> (GetModeResponse) query;
   get_nervous_system_parameters : (null) -> (NervousSystemParameters) query;
   get_neuron : (GetNeuron) -> (GetNeuronResponse) query;

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -46,7 +46,26 @@ export const idlFactory = ({ IDL }) => {
     'description' : IDL.Opt(IDL.Text),
     'function_type' : IDL.Opt(FunctionType),
   });
+  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
+  const Account = IDL.Record({
+    'owner' : IDL.Opt(IDL.Principal),
+    'subaccount' : IDL.Opt(Subaccount),
+  });
+  const TreasuryMetrics = IDL.Record({
+    'name' : IDL.Opt(IDL.Text),
+    'original_amount_e8s' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account' : IDL.Opt(Account),
+    'ledger_canister_id' : IDL.Opt(IDL.Principal),
+    'treasury' : IDL.Int32,
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const VotingPowerMetrics = IDL.Record({
+    'governance_total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const GovernanceCachedMetrics = IDL.Record({
+    'treasury_metrics' : IDL.Vec(TreasuryMetrics),
     'not_dissolving_neurons_e8s_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
@@ -59,6 +78,7 @@ export const idlFactory = ({ IDL }) => {
     'dissolved_neurons_count' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
     'total_supply_governance_tokens' : IDL.Nat64,
+    'voting_power_metrics' : IDL.Opt(VotingPowerMetrics),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'dissolved_neurons_e8s' : IDL.Nat64,
     'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
@@ -185,11 +205,6 @@ export const idlFactory = ({ IDL }) => {
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
-  });
-  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
-  const Account = IDL.Record({
-    'owner' : IDL.Opt(IDL.Principal),
-    'subaccount' : IDL.Opt(Subaccount),
   });
   const Decimal = IDL.Record({ 'human_readable' : IDL.Opt(IDL.Text) });
   const Tokens = IDL.Record({ 'e8s' : IDL.Opt(IDL.Nat64) });
@@ -574,9 +589,12 @@ export const idlFactory = ({ IDL }) => {
     'time_window_seconds' : IDL.Opt(IDL.Nat64),
   });
   const Metrics = IDL.Record({
+    'treasury_metrics' : IDL.Opt(IDL.Vec(TreasuryMetrics)),
+    'voting_power_metrics' : IDL.Opt(VotingPowerMetrics),
     'last_ledger_block_timestamp' : IDL.Opt(IDL.Nat64),
     'num_recently_executed_proposals' : IDL.Opt(IDL.Nat64),
     'num_recently_submitted_proposals' : IDL.Opt(IDL.Nat64),
+    'genesis_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
   const GetMetricsResult = IDL.Variant({
     'Ok' : Metrics,
@@ -772,6 +790,11 @@ export const idlFactory = ({ IDL }) => {
         [GetMetricsResponse],
         ['composite_query'],
       ),
+    'get_metrics_replicated' : IDL.Func(
+        [GetMetricsRequest],
+        [GetMetricsResponse],
+        [],
+      ),
     'get_mode' : IDL.Func([IDL.Record({})], [GetModeResponse], ['query']),
     'get_nervous_system_parameters' : IDL.Func(
         [IDL.Null],
@@ -869,7 +892,26 @@ export const init = ({ IDL }) => {
     'description' : IDL.Opt(IDL.Text),
     'function_type' : IDL.Opt(FunctionType),
   });
+  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
+  const Account = IDL.Record({
+    'owner' : IDL.Opt(IDL.Principal),
+    'subaccount' : IDL.Opt(Subaccount),
+  });
+  const TreasuryMetrics = IDL.Record({
+    'name' : IDL.Opt(IDL.Text),
+    'original_amount_e8s' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account' : IDL.Opt(Account),
+    'ledger_canister_id' : IDL.Opt(IDL.Principal),
+    'treasury' : IDL.Int32,
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const VotingPowerMetrics = IDL.Record({
+    'governance_total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const GovernanceCachedMetrics = IDL.Record({
+    'treasury_metrics' : IDL.Vec(TreasuryMetrics),
     'not_dissolving_neurons_e8s_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
@@ -882,6 +924,7 @@ export const init = ({ IDL }) => {
     'dissolved_neurons_count' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
     'total_supply_governance_tokens' : IDL.Nat64,
+    'voting_power_metrics' : IDL.Opt(VotingPowerMetrics),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'dissolved_neurons_e8s' : IDL.Nat64,
     'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
@@ -1008,11 +1051,6 @@ export const init = ({ IDL }) => {
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
-  });
-  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
-  const Account = IDL.Record({
-    'owner' : IDL.Opt(IDL.Principal),
-    'subaccount' : IDL.Opt(Subaccount),
   });
   const Decimal = IDL.Record({ 'human_readable' : IDL.Opt(IDL.Text) });
   const Tokens = IDL.Record({ 'e8s' : IDL.Opt(IDL.Nat64) });

--- a/packages/sns/candid/sns_governance_test.certified.idl.js
+++ b/packages/sns/candid/sns_governance_test.certified.idl.js
@@ -46,7 +46,26 @@ export const idlFactory = ({ IDL }) => {
     'description' : IDL.Opt(IDL.Text),
     'function_type' : IDL.Opt(FunctionType),
   });
+  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
+  const Account = IDL.Record({
+    'owner' : IDL.Opt(IDL.Principal),
+    'subaccount' : IDL.Opt(Subaccount),
+  });
+  const TreasuryMetrics = IDL.Record({
+    'name' : IDL.Opt(IDL.Text),
+    'original_amount_e8s' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account' : IDL.Opt(Account),
+    'ledger_canister_id' : IDL.Opt(IDL.Principal),
+    'treasury' : IDL.Int32,
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const VotingPowerMetrics = IDL.Record({
+    'governance_total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const GovernanceCachedMetrics = IDL.Record({
+    'treasury_metrics' : IDL.Vec(TreasuryMetrics),
     'not_dissolving_neurons_e8s_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
@@ -59,6 +78,7 @@ export const idlFactory = ({ IDL }) => {
     'dissolved_neurons_count' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
     'total_supply_governance_tokens' : IDL.Nat64,
+    'voting_power_metrics' : IDL.Opt(VotingPowerMetrics),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'dissolved_neurons_e8s' : IDL.Nat64,
     'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
@@ -185,11 +205,6 @@ export const idlFactory = ({ IDL }) => {
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
-  });
-  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
-  const Account = IDL.Record({
-    'owner' : IDL.Opt(IDL.Principal),
-    'subaccount' : IDL.Opt(Subaccount),
   });
   const Decimal = IDL.Record({ 'human_readable' : IDL.Opt(IDL.Text) });
   const Tokens = IDL.Record({ 'e8s' : IDL.Opt(IDL.Nat64) });
@@ -585,9 +600,12 @@ export const idlFactory = ({ IDL }) => {
     'time_window_seconds' : IDL.Opt(IDL.Nat64),
   });
   const Metrics = IDL.Record({
+    'treasury_metrics' : IDL.Opt(IDL.Vec(TreasuryMetrics)),
+    'voting_power_metrics' : IDL.Opt(VotingPowerMetrics),
     'last_ledger_block_timestamp' : IDL.Opt(IDL.Nat64),
     'num_recently_executed_proposals' : IDL.Opt(IDL.Nat64),
     'num_recently_submitted_proposals' : IDL.Opt(IDL.Nat64),
+    'genesis_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
   const GetMetricsResult = IDL.Variant({
     'Ok' : Metrics,
@@ -785,6 +803,11 @@ export const idlFactory = ({ IDL }) => {
       ),
     'get_metadata' : IDL.Func([IDL.Record({})], [GetMetadataResponse], []),
     'get_metrics' : IDL.Func([GetMetricsRequest], [GetMetricsResponse], []),
+    'get_metrics_replicated' : IDL.Func(
+        [GetMetricsRequest],
+        [GetMetricsResponse],
+        [],
+      ),
     'get_mode' : IDL.Func([IDL.Record({})], [GetModeResponse], []),
     'get_nervous_system_parameters' : IDL.Func(
         [IDL.Null],
@@ -881,7 +904,26 @@ export const init = ({ IDL }) => {
     'description' : IDL.Opt(IDL.Text),
     'function_type' : IDL.Opt(FunctionType),
   });
+  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
+  const Account = IDL.Record({
+    'owner' : IDL.Opt(IDL.Principal),
+    'subaccount' : IDL.Opt(Subaccount),
+  });
+  const TreasuryMetrics = IDL.Record({
+    'name' : IDL.Opt(IDL.Text),
+    'original_amount_e8s' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account' : IDL.Opt(Account),
+    'ledger_canister_id' : IDL.Opt(IDL.Principal),
+    'treasury' : IDL.Int32,
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const VotingPowerMetrics = IDL.Record({
+    'governance_total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const GovernanceCachedMetrics = IDL.Record({
+    'treasury_metrics' : IDL.Vec(TreasuryMetrics),
     'not_dissolving_neurons_e8s_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
@@ -894,6 +936,7 @@ export const init = ({ IDL }) => {
     'dissolved_neurons_count' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
     'total_supply_governance_tokens' : IDL.Nat64,
+    'voting_power_metrics' : IDL.Opt(VotingPowerMetrics),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'dissolved_neurons_e8s' : IDL.Nat64,
     'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
@@ -1020,11 +1063,6 @@ export const init = ({ IDL }) => {
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
-  });
-  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
-  const Account = IDL.Record({
-    'owner' : IDL.Opt(IDL.Principal),
-    'subaccount' : IDL.Opt(Subaccount),
   });
   const Decimal = IDL.Record({ 'human_readable' : IDL.Opt(IDL.Text) });
   const Tokens = IDL.Record({ 'e8s' : IDL.Opt(IDL.Nat64) });

--- a/packages/sns/candid/sns_governance_test.d.ts
+++ b/packages/sns/candid/sns_governance_test.d.ts
@@ -321,6 +321,7 @@ export interface Governance {
   genesis_timestamp_seconds: bigint;
 }
 export interface GovernanceCachedMetrics {
+  treasury_metrics: Array<TreasuryMetrics>;
   not_dissolving_neurons_e8s_buckets: Array<[bigint, number]>;
   garbage_collectable_neurons_count: bigint;
   neurons_with_invalid_stake_count: bigint;
@@ -329,6 +330,7 @@ export interface GovernanceCachedMetrics {
   dissolved_neurons_count: bigint;
   total_staked_e8s: bigint;
   total_supply_governance_tokens: bigint;
+  voting_power_metrics: [] | [VotingPowerMetrics];
   not_dissolving_neurons_count: bigint;
   dissolved_neurons_e8s: bigint;
   neurons_with_less_than_6_months_dissolve_delay_e8s: bigint;
@@ -419,9 +421,12 @@ export interface MergeMaturityResponse {
   new_stake_e8s: bigint;
 }
 export interface Metrics {
+  treasury_metrics: [] | [Array<TreasuryMetrics>];
+  voting_power_metrics: [] | [VotingPowerMetrics];
   last_ledger_block_timestamp: [] | [bigint];
   num_recently_executed_proposals: [] | [bigint];
   num_recently_submitted_proposals: [] | [bigint];
+  genesis_timestamp_seconds: [] | [bigint];
 }
 export interface MintSnsTokens {
   to_principal: [] | [Principal];
@@ -707,6 +712,15 @@ export interface TransferSnsTreasuryFunds {
   memo: [] | [bigint];
   amount_e8s: bigint;
 }
+export interface TreasuryMetrics {
+  name: [] | [string];
+  original_amount_e8s: [] | [bigint];
+  amount_e8s: [] | [bigint];
+  account: [] | [Account];
+  ledger_canister_id: [] | [Principal];
+  treasury: number;
+  timestamp_seconds: [] | [bigint];
+}
 export interface UpgradeInProgress {
   mark_failed_at_seconds: bigint;
   checking_upgrade_lock: bigint;
@@ -786,6 +800,10 @@ export interface Version {
 export interface Versions {
   versions: Array<Version>;
 }
+export interface VotingPowerMetrics {
+  governance_total_potential_voting_power: [] | [bigint];
+  timestamp_seconds: [] | [bigint];
+}
 export interface VotingRewardsParameters {
   final_reward_rate_basis_points: [] | [bigint];
   initial_reward_rate_basis_points: [] | [bigint];
@@ -811,6 +829,7 @@ export interface _SERVICE {
   get_maturity_modulation: ActorMethod<[{}], GetMaturityModulationResponse>;
   get_metadata: ActorMethod<[{}], GetMetadataResponse>;
   get_metrics: ActorMethod<[GetMetricsRequest], GetMetricsResponse>;
+  get_metrics_replicated: ActorMethod<[GetMetricsRequest], GetMetricsResponse>;
   get_mode: ActorMethod<[{}], GetModeResponse>;
   get_nervous_system_parameters: ActorMethod<[null], NervousSystemParameters>;
   get_neuron: ActorMethod<[GetNeuron], GetNeuronResponse>;

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit e915efe (2025-07-02 tags: release-2025-07-03_03-27-base) 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 5f36668c9b (2025-07-11) 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -263,10 +263,43 @@ type GetMetricsRequest = record {
   time_window_seconds : opt nat64;
 };
 
+type TreasuryMetrics = record {
+  // Same as, e.g., `TransferSnsTreasuryFunds.from_treasury`.
+  treasury : int32;
+
+  // A human-readable identified for this treasury, e.g., "ICP".
+  name : opt text;
+  
+  // The source of truth for the treasury balance is this ledger canister / account.
+  ledger_canister_id : opt principal;
+  account : opt Account;
+
+  // The regularly updated amount of tokens in this treasury.
+  amount_e8s : opt nat64;
+  // The amount of tokens in this treasury at the end of swap finalization.
+  original_amount_e8s : opt nat64;
+
+  // When the metrics were last updated.
+  timestamp_seconds : opt nat64;
+};
+
+type VotingPowerMetrics = record {
+  governance_total_potential_voting_power : opt nat64;
+
+  // When the metrics were last updated.
+  timestamp_seconds : opt nat64;
+};
+
 type Metrics = record {
   num_recently_submitted_proposals : opt nat64;
   num_recently_executed_proposals: opt nat64;
+  
   last_ledger_block_timestamp : opt nat64;
+
+  // The metrics below are cached (albeit this is an implementation detail).
+  treasury_metrics : opt vec TreasuryMetrics;
+  voting_power_metrics : opt VotingPowerMetrics;
+  genesis_timestamp_seconds : opt nat64;
 };
 
 type GetMetricsResult = variant {
@@ -369,6 +402,8 @@ type GovernanceCachedMetrics = record {
   dissolving_neurons_count : nat64;
   dissolving_neurons_e8s_buckets : vec record { nat64; float64 };
   timestamp_seconds : nat64;
+  treasury_metrics : vec TreasuryMetrics;
+  voting_power_metrics : opt VotingPowerMetrics;
 };
 
 type GovernanceError = record {
@@ -969,6 +1004,7 @@ service : (Governance) -> {
   get_maturity_modulation : (record {}) -> (GetMaturityModulationResponse);
   get_metadata : (record {}) -> (GetMetadataResponse) query;
   get_metrics : (GetMetricsRequest) -> (GetMetricsResponse) composite_query;
+  get_metrics_replicated : (GetMetricsRequest) -> (GetMetricsResponse);
   get_mode : (record {}) -> (GetModeResponse) query;
   get_nervous_system_parameters : (null) -> (NervousSystemParameters) query;
   get_neuron : (GetNeuron) -> (GetNeuronResponse) query;

--- a/packages/sns/candid/sns_governance_test.idl.js
+++ b/packages/sns/candid/sns_governance_test.idl.js
@@ -46,7 +46,26 @@ export const idlFactory = ({ IDL }) => {
     'description' : IDL.Opt(IDL.Text),
     'function_type' : IDL.Opt(FunctionType),
   });
+  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
+  const Account = IDL.Record({
+    'owner' : IDL.Opt(IDL.Principal),
+    'subaccount' : IDL.Opt(Subaccount),
+  });
+  const TreasuryMetrics = IDL.Record({
+    'name' : IDL.Opt(IDL.Text),
+    'original_amount_e8s' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account' : IDL.Opt(Account),
+    'ledger_canister_id' : IDL.Opt(IDL.Principal),
+    'treasury' : IDL.Int32,
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const VotingPowerMetrics = IDL.Record({
+    'governance_total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const GovernanceCachedMetrics = IDL.Record({
+    'treasury_metrics' : IDL.Vec(TreasuryMetrics),
     'not_dissolving_neurons_e8s_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
@@ -59,6 +78,7 @@ export const idlFactory = ({ IDL }) => {
     'dissolved_neurons_count' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
     'total_supply_governance_tokens' : IDL.Nat64,
+    'voting_power_metrics' : IDL.Opt(VotingPowerMetrics),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'dissolved_neurons_e8s' : IDL.Nat64,
     'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
@@ -185,11 +205,6 @@ export const idlFactory = ({ IDL }) => {
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
-  });
-  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
-  const Account = IDL.Record({
-    'owner' : IDL.Opt(IDL.Principal),
-    'subaccount' : IDL.Opt(Subaccount),
   });
   const Decimal = IDL.Record({ 'human_readable' : IDL.Opt(IDL.Text) });
   const Tokens = IDL.Record({ 'e8s' : IDL.Opt(IDL.Nat64) });
@@ -585,9 +600,12 @@ export const idlFactory = ({ IDL }) => {
     'time_window_seconds' : IDL.Opt(IDL.Nat64),
   });
   const Metrics = IDL.Record({
+    'treasury_metrics' : IDL.Opt(IDL.Vec(TreasuryMetrics)),
+    'voting_power_metrics' : IDL.Opt(VotingPowerMetrics),
     'last_ledger_block_timestamp' : IDL.Opt(IDL.Nat64),
     'num_recently_executed_proposals' : IDL.Opt(IDL.Nat64),
     'num_recently_submitted_proposals' : IDL.Opt(IDL.Nat64),
+    'genesis_timestamp_seconds' : IDL.Opt(IDL.Nat64),
   });
   const GetMetricsResult = IDL.Variant({
     'Ok' : Metrics,
@@ -793,6 +811,11 @@ export const idlFactory = ({ IDL }) => {
         [GetMetricsResponse],
         ['composite_query'],
       ),
+    'get_metrics_replicated' : IDL.Func(
+        [GetMetricsRequest],
+        [GetMetricsResponse],
+        [],
+      ),
     'get_mode' : IDL.Func([IDL.Record({})], [GetModeResponse], ['query']),
     'get_nervous_system_parameters' : IDL.Func(
         [IDL.Null],
@@ -897,7 +920,26 @@ export const init = ({ IDL }) => {
     'description' : IDL.Opt(IDL.Text),
     'function_type' : IDL.Opt(FunctionType),
   });
+  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
+  const Account = IDL.Record({
+    'owner' : IDL.Opt(IDL.Principal),
+    'subaccount' : IDL.Opt(Subaccount),
+  });
+  const TreasuryMetrics = IDL.Record({
+    'name' : IDL.Opt(IDL.Text),
+    'original_amount_e8s' : IDL.Opt(IDL.Nat64),
+    'amount_e8s' : IDL.Opt(IDL.Nat64),
+    'account' : IDL.Opt(Account),
+    'ledger_canister_id' : IDL.Opt(IDL.Principal),
+    'treasury' : IDL.Int32,
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const VotingPowerMetrics = IDL.Record({
+    'governance_total_potential_voting_power' : IDL.Opt(IDL.Nat64),
+    'timestamp_seconds' : IDL.Opt(IDL.Nat64),
+  });
   const GovernanceCachedMetrics = IDL.Record({
+    'treasury_metrics' : IDL.Vec(TreasuryMetrics),
     'not_dissolving_neurons_e8s_buckets' : IDL.Vec(
       IDL.Tuple(IDL.Nat64, IDL.Float64)
     ),
@@ -910,6 +952,7 @@ export const init = ({ IDL }) => {
     'dissolved_neurons_count' : IDL.Nat64,
     'total_staked_e8s' : IDL.Nat64,
     'total_supply_governance_tokens' : IDL.Nat64,
+    'voting_power_metrics' : IDL.Opt(VotingPowerMetrics),
     'not_dissolving_neurons_count' : IDL.Nat64,
     'dissolved_neurons_e8s' : IDL.Nat64,
     'neurons_with_less_than_6_months_dissolve_delay_e8s' : IDL.Nat64,
@@ -1036,11 +1079,6 @@ export const init = ({ IDL }) => {
   const GovernanceError = IDL.Record({
     'error_message' : IDL.Text,
     'error_type' : IDL.Int32,
-  });
-  const Subaccount = IDL.Record({ 'subaccount' : IDL.Vec(IDL.Nat8) });
-  const Account = IDL.Record({
-    'owner' : IDL.Opt(IDL.Principal),
-    'subaccount' : IDL.Opt(Subaccount),
   });
   const Decimal = IDL.Record({ 'human_readable' : IDL.Opt(IDL.Text) });
   const Tokens = IDL.Record({ 'e8s' : IDL.Opt(IDL.Nat64) });

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit e915efe (2025-07-02 tags: release-2025-07-03_03-27-base) 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit 5f36668c9b (2025-07-11) 'rs/sns/root/canister/root.did' by import-candid
 type CanisterCallError = record {
   code : opt int32;
   description : text;

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit e915efe (2025-07-02 tags: release-2025-07-03_03-27-base) 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 5f36668c9b (2025-07-11) 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;


### PR DESCRIPTION
# Motivation

To use SNS metrics from the aggregator consistently, they need to be encoded to match the Candid format. This PR upgrades the SNS types to make them available in the NNS dapp.

# Changes

- scripts/import-candid (latest master — 5f36668c9b1685ab41f146a7ff15d05f9ba2e245)
- scripts/compile-idl-js.
- increase sns/size-limit

# Tests

- Should pass, since there is no changes in old logic/types.

# Todos

- [ ] Add entry to changelog (if necessary).
