### PR TITLE
build: patch zod-schemas 1.x with agent-js v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@
 
 - Move `accountIdentifierToBytes`, `accountIdentifierFromBytes` and `principalToAccountIdentifier` from `@dfinity/ledger-icp` to `@dfinity/nns`.
 - Rename `getLastestRewardEvent` to `getLatestRewardEvent` in `@dfinity/nns`.
-- Migrate `@dfinity/zod-schemas` to Zod library v4.
 
 ## Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -840,28 +840,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "peerDependencies": {
-        "zod": "^3.24.1"
-      }
-    },
     "node_modules/@noble/curves": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
@@ -3351,17 +3329,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/espree": {
@@ -7232,13 +7199,24 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
-      "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+      "version": "3.25.63",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.63.tgz",
+      "integrity": "sha512-3ttCkqhtpncYXfP0f6dsyabbYV/nEUW+Xlu89jiXbTBifUfjaSqXOG6JnQPLtqt87n7KAmnMqcjay6c0Wq0Vbw==",
       "license": "MIT",
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "packages/ckbtc": {
@@ -7370,7 +7348,7 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/principal": "^2.0.0",
-        "zod": "^4"
+        "zod": "^3.25"
       }
     }
   },
@@ -7813,23 +7791,6 @@
         "raw-body": "^3.0.0",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.24.1"
-      },
-      "dependencies": {
-        "zod": {
-          "version": "3.25.76",
-          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-          "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-          "dev": true,
-          "peer": true
-        },
-        "zod-to-json-schema": {
-          "version": "3.24.6",
-          "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-          "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-          "dev": true,
-          "peer": true,
-          "requires": {}
-        }
       }
     },
     "@noble/curves": {
@@ -9174,13 +9135,6 @@
           "requires": {
             "p-limit": "^3.0.2"
           }
-        },
-        "zod": {
-          "version": "3.25.76",
-          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-          "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-          "dev": true,
-          "peer": true
         }
       }
     },
@@ -11912,10 +11866,18 @@
       "peer": true
     },
     "zod": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
-      "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+      "version": "3.25.63",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.63.tgz",
+      "integrity": "sha512-3ttCkqhtpncYXfP0f6dsyabbYV/nEUW+Xlu89jiXbTBifUfjaSqXOG6JnQPLtqt87n7KAmnMqcjay6c0Wq0Vbw==",
       "peer": true
+    },
+    "zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "dev": true,
+      "peer": true,
+      "requires": {}
     }
   }
 }

--- a/packages/zod-schemas/package.json
+++ b/packages/zod-schemas/package.json
@@ -48,6 +48,6 @@
   ],
   "peerDependencies": {
     "@dfinity/principal": "^2.0.0",
-    "zod": "^4"
+    "zod": "^3.25"
   }
 }

--- a/packages/zod-schemas/src/principal.ts
+++ b/packages/zod-schemas/src/principal.ts
@@ -1,5 +1,5 @@
 import { Principal } from "@dfinity/principal";
-import * as z from "zod";
+import * as z from "zod/v4";
 
 /**
  * Zod schema to validate a string as a valid textual representation of a Principal.

--- a/packages/zod-schemas/src/url.ts
+++ b/packages/zod-schemas/src/url.ts
@@ -1,4 +1,4 @@
-import * as z from "zod";
+import * as z from "zod/v4";
 
 /**
  * A URL protocol as template literal type.


### PR DESCRIPTION
# Motivation

`@dfinity/zod-schemas` depends on `@dfinity/principal`.  At the moment, both v1 and v2 of zod-schemas exist because we cannot fully migrate to Zod v4 yet — the ecosystem isn't ready.  We keep it around, though, as it's occasionally useful to check if we can move forward until we can migrate.

Long story short, we need a way to bump `@dfinity/principal` in zod-schemas for `agent-js` v3, hence this branch.

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
