### PR TITLE
build: bump base58-js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next
+
+## Build
+
+- Bump `base58-js` to v3.0.3 in ckBTC JS library.
+
 # v71
 
 ## Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Build
 
 - Bump `@noble/hashes` to v1.8.0 in ckBTC, NNS, and SNS JS libraries.
+- Bump `base58-js` to v3.0.3 in ckBTC JS library.
 
 # v71
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1908,14 +1908,6 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/base58-js": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-1.0.5.tgz",
-      "integrity": "sha512-LkkAPP8Zu+c0SVNRTRVDyMfKVORThX+rCViget00xdgLRrKkClCTz1T7cIrpr69ShwV5XJuuoZvMvJ43yURwkA==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/base64-arraybuffer": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
@@ -7247,7 +7239,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
-        "base58-js": "^1.0.5",
+        "base58-js": "^3.0.3",
         "bech32": "^2.0.0"
       },
       "peerDependencies": {
@@ -7255,6 +7247,16 @@
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
         "@dfinity/utils": "^2.13.0"
+      }
+    },
+    "packages/ckbtc/node_modules/base58-js": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-3.0.3.tgz",
+      "integrity": "sha512-3hf42BysHnUqmZO7mK6e5X/hs1AvyEJIhdVLbG/Mxn/fhFnhGxOO37mWbMHg1RT4TxqcPKXgqj9/bp1YG0GBXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "packages/cketh": {
@@ -7400,8 +7402,15 @@
       "version": "file:packages/ckbtc",
       "requires": {
         "@noble/hashes": "^1.3.2",
-        "base58-js": "^1.0.5",
+        "base58-js": "^3.0.3",
         "bech32": "^2.0.0"
+      },
+      "dependencies": {
+        "base58-js": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-3.0.3.tgz",
+          "integrity": "sha512-3hf42BysHnUqmZO7mK6e5X/hs1AvyEJIhdVLbG/Mxn/fhFnhGxOO37mWbMHg1RT4TxqcPKXgqj9/bp1YG0GBXA=="
+        }
       }
     },
     "@dfinity/cketh": {
@@ -8468,11 +8477,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "peer": true
-    },
-    "base58-js": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-1.0.5.tgz",
-      "integrity": "sha512-LkkAPP8Zu+c0SVNRTRVDyMfKVORThX+rCViget00xdgLRrKkClCTz1T7cIrpr69ShwV5XJuuoZvMvJ43yURwkA=="
     },
     "base64-arraybuffer": {
       "version": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1909,14 +1909,6 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/base58-js": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-1.0.5.tgz",
-      "integrity": "sha512-LkkAPP8Zu+c0SVNRTRVDyMfKVORThX+rCViget00xdgLRrKkClCTz1T7cIrpr69ShwV5XJuuoZvMvJ43yURwkA==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/base64-arraybuffer": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
@@ -7248,7 +7240,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
-        "base58-js": "^1.0.5",
+        "base58-js": "^3.0.3",
         "bech32": "^2.0.0"
       },
       "peerDependencies": {
@@ -7268,6 +7260,16 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/ckbtc/node_modules/base58-js": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-3.0.3.tgz",
+      "integrity": "sha512-3hf42BysHnUqmZO7mK6e5X/hs1AvyEJIhdVLbG/Mxn/fhFnhGxOO37mWbMHg1RT4TxqcPKXgqj9/bp1YG0GBXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "packages/cketh": {
@@ -7437,7 +7439,7 @@
       "version": "file:packages/ckbtc",
       "requires": {
         "@noble/hashes": "^1.8.0",
-        "base58-js": "^1.0.5",
+        "base58-js": "^3.0.3",
         "bech32": "^2.0.0"
       },
       "dependencies": {
@@ -7445,6 +7447,11 @@
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
           "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="
+        },
+        "base58-js": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-3.0.3.tgz",
+          "integrity": "sha512-3hf42BysHnUqmZO7mK6e5X/hs1AvyEJIhdVLbG/Mxn/fhFnhGxOO37mWbMHg1RT4TxqcPKXgqj9/bp1YG0GBXA=="
         }
       }
     },
@@ -8527,11 +8534,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "peer": true
-    },
-    "base58-js": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-1.0.5.tgz",
-      "integrity": "sha512-LkkAPP8Zu+c0SVNRTRVDyMfKVORThX+rCViget00xdgLRrKkClCTz1T7cIrpr69ShwV5XJuuoZvMvJ43yURwkA=="
     },
     "base64-arraybuffer": {
       "version": "0.2.0",

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",
-    "base58-js": "^1.0.5",
+    "base58-js": "^3.0.3",
     "bech32": "^2.0.0"
   }
 }

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.3.2",
-    "base58-js": "^1.0.5",
+    "base58-js": "^3.0.3",
     "bech32": "^2.0.0"
   }
 }


### PR DESCRIPTION
# Motivation

Stay up-to-date with the latest improvements in the dependencies of the libraries.

# Notes

In a follow-up PR we will be able to deprecate the custom type definition because [base58-js](https://github.com/pur3miish/base58-js) since its version 2 ships the types.

# Changes

- Bump base58-js to 3.0.3
