### PR TITLE
feat: new utility uint8ArraysEqual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next
+
+## Features
+
+- New utility `uint8ArraysEqual` to compare two Uint8Arrays for byte-level equality.
+
 # v71
 
 ## Overview

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -51,6 +51,7 @@ npm i @dfinity/agent @dfinity/candid @dfinity/principal
 - [arrayOfNumberToUint8Array](#gear-arrayofnumbertouint8array)
 - [asciiStringToByteArray](#gear-asciistringtobytearray)
 - [hexStringToUint8Array](#gear-hexstringtouint8array)
+- [uint8ArraysEqual](#gear-uint8arraysequal)
 - [uint8ArrayToHexString](#gear-uint8arraytohexstring)
 - [candidNumberArrayToBigInt](#gear-candidnumberarraytobigint)
 - [encodeBase32](#gear-encodebase32)
@@ -334,13 +335,32 @@ Parameters:
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/arrays.utils.ts#L51)
 
+#### :gear: uint8ArraysEqual
+
+Compare two Uint8Arrays for byte-level equality.
+
+| Function           | Type                                                       |
+| ------------------ | ---------------------------------------------------------- |
+| `uint8ArraysEqual` | `({ a, b }: { a: Uint8Array; b: Uint8Array; }) => boolean` |
+
+Parameters:
+
+- `params.a`: - First Uint8Array to compare.
+- `params.b`: - Second Uint8Array to compare.
+
+Returns:
+
+True if both arrays have the same length and identical contents.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/arrays.utils.ts#L67)
+
 #### :gear: uint8ArrayToHexString
 
 | Function                | Type                                        |
 | ----------------------- | ------------------------------------------- |
 | `uint8ArrayToHexString` | `(bytes: Uint8Array or number[]) => string` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/arrays.utils.ts#L59)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/arrays.utils.ts#L70)
 
 #### :gear: candidNumberArrayToBigInt
 
@@ -348,7 +368,7 @@ Parameters:
 | --------------------------- | ----------------------------- |
 | `candidNumberArrayToBigInt` | `(array: number[]) => bigint` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/arrays.utils.ts#L69)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/arrays.utils.ts#L80)
 
 #### :gear: encodeBase32
 

--- a/packages/utils/src/utils/arrays.utils.spec.ts
+++ b/packages/utils/src/utils/arrays.utils.spec.ts
@@ -6,6 +6,7 @@ import {
   candidNumberArrayToBigInt,
   hexStringToUint8Array,
   numberToUint8Array,
+  uint8ArraysEqual,
   uint8ArrayToArrayOfNumber,
   uint8ArrayToBigInt,
   uint8ArrayToHexString,
@@ -99,5 +100,35 @@ describe("arrays-utils", () => {
         55083,
       ]),
     ).toBe(345763845793847239482739482739482739482739482374928374234928374n);
+  });
+
+  describe("uint8ArraysEqual", () => {
+    it("should return true for identical arrays", () => {
+      const a = new Uint8Array([1, 2, 3]);
+      const b = new Uint8Array([1, 2, 3]);
+
+      expect(uint8ArraysEqual({ a, b })).toBeTruthy();
+    });
+
+    it("should return false for arrays with different lengths", () => {
+      const a = new Uint8Array([1, 2, 3]);
+      const b = new Uint8Array([1, 2, 3, 4]);
+
+      expect(uint8ArraysEqual({ a, b })).toBeFalsy();
+    });
+
+    it("should return false for arrays with same length but different content", () => {
+      const a = new Uint8Array([1, 2, 3]);
+      const b = new Uint8Array([1, 2, 4]);
+
+      expect(uint8ArraysEqual({ a, b })).toBeFalsy();
+    });
+
+    it("should return true for two empty arrays", () => {
+      const a = new Uint8Array([]);
+      const b = new Uint8Array([]);
+
+      expect(uint8ArraysEqual({ a, b })).toBeTruthy();
+    });
   });
 });

--- a/packages/utils/src/utils/arrays.utils.ts
+++ b/packages/utils/src/utils/arrays.utils.ts
@@ -56,6 +56,17 @@ export const hexStringToUint8Array = (hexString: string): Uint8Array => {
   return Uint8Array.from(matches.map((byte) => parseInt(byte, 16)));
 };
 
+/**
+ * Compare two Uint8Arrays for byte-level equality.
+ *
+ * @param {Object} params
+ * @param {Uint8Array} params.a - First Uint8Array to compare.
+ * @param {Uint8Array} params.b - Second Uint8Array to compare.
+ * @returns {boolean} True if both arrays have the same length and identical contents.
+ */
+export const uint8ArraysEqual = ({ a, b }: { a: Uint8Array; b: Uint8Array }) =>
+  a.length === b.length && a.every((byte, i) => byte === b[i]);
+
 export const uint8ArrayToHexString = (bytes: Uint8Array | number[]) => {
   if (!(bytes instanceof Uint8Array)) {
     bytes = Uint8Array.from(bytes);


### PR DESCRIPTION
# Motivation

To deprecate the use of `Buffer` in the account ID assertion of `ledger-icp` we will need a comparison of Uint8arrays. I find it handy to have it in utils as we already have few arrays related utilities.

# Changes

- New util function `uint8ArraysEqual`.
