### PR TITLE
feat: remove base58-js custom type declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Build
 
 - Bump `@noble/hashes` to v1.8.0 in ckBTC, NNS, and SNS JS libraries.
-- Bump `base58-js` to v3.0.3 in ckBTC JS library.
+- Bump `base58-js` to v3.0.3 in ckBTC JS library and remove custom type declarations.
 
 # v71
 

--- a/packages/ckbtc/src/base58.d.ts
+++ b/packages/ckbtc/src/base58.d.ts
@@ -1,3 +1,0 @@
-declare module "base58-js" {
-  const base58_to_binary: (address: string) => Uint8Array;
-}


### PR DESCRIPTION
# Motivation

`base58-js` (bumped in PR #998) is now shipped with its related TypeScript definitions (see v3 [release notes](https://github.com/pur3miish/base58-js/releases/tag/v3.0.0)). Therefore, we do not need custom types anymore.

# Changes

- Remove custom TS types for base58-js library
