### PR TITLE
chore: remove unnecessary local-rules/use-option-type-wrapper eslint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,10 +11,6 @@ export default [
       // (which impacts the build pipeline) or setting up path aliases (which requires configuration).
       // Since neither is a current priority, the rule remains off.
       "import/no-relative-parent-imports": "off",
-      // Enforcing Option<Type> for nullish values would require every library to define or depend on such a wrapper.
-      // This rule is more appropriate in applications where null and undefined have distinct meanings.
-      // That is why, for now, it's disabled in this repo.
-      "local-rules/use-option-type-wrapper": "off",
     },
   },
   {


### PR DESCRIPTION
# Motivation

Follow-up of #999. We do not need to set the eslint rule `local-rules/use-option-type-wrapper` to `off` anymore because it has become an opt-in feature.

# Changes

- Remove unnecessary rule from eslint config.
