### PR TITLE
feat: replace usage of Buffer with Uint8Array in checkAccountId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - New utility `uint8ArraysEqual` to compare two Uint8Arrays for byte-level equality.
+- Replace usage of `Buffer` with `Uint8Array` in `checkAccountId` of `@dfinity/ledger-icp`.
 
 ## Build
 

--- a/packages/ledger-icp/src/utils/accounts.utils.spec.ts
+++ b/packages/ledger-icp/src/utils/accounts.utils.spec.ts
@@ -3,18 +3,30 @@ import { checkAccountId, isIcpAccountIdentifier } from "./accounts.utils";
 
 describe("accounts-utils", () => {
   describe("checkAccountId", () => {
+    const validAccountId =
+      "cd70bfa0f092c38a0ff8643d4617219761eb61d199b15418c0b1114d59e30f8e";
+
     it("should not throw if valid account id", () => {
-      expect(() =>
-        checkAccountId(
-          "cd70bfa0f092c38a0ff8643d4617219761eb61d199b15418c0b1114d59e30f8e",
-        ),
-      ).not.toThrow();
+      expect(() => checkAccountId(validAccountId)).not.toThrow();
+    });
+
+    it("should throw if invalid checksum", () => {
+      const incorrectChecksum = `a${validAccountId.slice(1)}`;
+      const usage = () => checkAccountId(incorrectChecksum);
+
+      expect(usage).toThrow(InvalidAccountIDError);
+      expect(usage).toThrow(
+        `Account identifier ${incorrectChecksum} has an invalid checksum. Are you sure the account identifier is correct?`,
+      );
     });
 
     it("should throw if not valid account id", () => {
-      const call1 = () => checkAccountId("not-valid");
+      const usage = () => checkAccountId("not-valid");
 
-      expect(call1).toThrow(InvalidAccountIDError);
+      expect(usage).toThrow(InvalidAccountIDError);
+      expect(usage).toThrow(
+        "Invalid account identifier not-valid. The account identifier must be 64 chars in length.",
+      );
     });
   });
 

--- a/packages/ledger-icp/src/utils/accounts.utils.ts
+++ b/packages/ledger-icp/src/utils/accounts.utils.ts
@@ -3,8 +3,8 @@ import {
   hexStringToUint8Array,
   isNullish,
   uint8ArrayToHexString,
+  uint8ArraysEqual,
 } from "@dfinity/utils";
-import { uint8ArraysEqual } from "@dfinity/utils/src";
 import { InvalidAccountIDError } from "../errors/ledger.errors";
 
 /**

--- a/packages/ledger-icp/src/utils/accounts.utils.ts
+++ b/packages/ledger-icp/src/utils/accounts.utils.ts
@@ -1,4 +1,10 @@
-import { bigEndianCrc32, isNullish } from "@dfinity/utils";
+import {
+  bigEndianCrc32,
+  hexStringToUint8Array,
+  isNullish,
+  uint8ArrayToHexString,
+} from "@dfinity/utils";
+import { uint8ArraysEqual } from "@dfinity/utils/src";
 import { InvalidAccountIDError } from "../errors/ledger.errors";
 
 /**
@@ -14,14 +20,12 @@ export const checkAccountId = (accountId: string): void => {
     );
   }
 
-  const toAccountBytes = Buffer.from(accountId, "hex");
+  const toAccountBytes = hexStringToUint8Array(accountId);
   const foundChecksum = toAccountBytes.slice(0, 4);
-  const expectedCheckum = Buffer.from(bigEndianCrc32(toAccountBytes.slice(4)));
-  if (!expectedCheckum.equals(foundChecksum)) {
+  const expectedCheckum = bigEndianCrc32(toAccountBytes.slice(4));
+  if (!uint8ArraysEqual({ a: expectedCheckum, b: foundChecksum })) {
     throw new InvalidAccountIDError(
-      `Account identifier ${accountId} has an invalid checksum. Are you sure the account identifier is correct?\n\nExpected checksum: ${expectedCheckum.toString(
-        "hex",
-      )}\nFound checksum: ${foundChecksum.toString("hex")}`,
+      `Account identifier ${accountId} has an invalid checksum. Are you sure the account identifier is correct?\n\nExpected checksum: ${uint8ArrayToHexString(expectedCheckum)}\nFound checksum: ${uint8ArrayToHexString(foundChecksum)}`,
     );
   }
 };


### PR DESCRIPTION
# Motivation

On one hand, we generally want to move away from using `Buffer`, on the other, when bumping TypeScript in #1004, the compiler reports issues related to its usage.  

This PR replaces `Buffer` with `Uint8Array` in the `checkAccountId` function of `@dfinity/ledger-icp` to address both concerns.

# Changes

- Use existing utils and new comparison utils (introduced in #1005) to replace buffer with Uint8Array.
- Improve tests to validate checksum.
