### PR TITLE
fix: mocks after candid upgrade

### DIFF
--- a/packages/sns/src/mocks/sns.mock.ts
+++ b/packages/sns/src/mocks/sns.mock.ts
@@ -30,6 +30,7 @@ export const snsMock: ListSnsCanistersResponse = {
   index: [indexCanisterIdMock],
   dapps: [],
   archives: [],
+  extensions: [],
 };
 
 export const saleTicketMock: Ticket = {


### PR DESCRIPTION
# Motivation

For some reasons, the Candid weekly PR could be merged as no issues at all were reported but, after merging few other PRs, the tests started having an issue:

> packages/sns/src/mocks/sns.mock.ts:25:14 - error TS2741: Property 'extensions' is missing in type '{ root: [Principal]; ledger: [Principal]; governance: [Principal]; swap: [Principal]; index: [Principal]; dapps: never[]; archives: never[]; }' but required in type 'ListSnsCanistersResponse'.
> 
> 25 export const snsMock: ListSnsCanistersResponse = {
>                 ~~~~~~~
> 
>   packages/sns/candid/sns_root.d.ts:99:3
>     99   extensions: [] | [Extensions];
>          ~~~~~~~~~~
>     'extensions' is declared here.
> 
> 
> Found 1 error in packages/sns/src/mocks/sns.mock.ts:25

# Changes

- Update mock to comply with Candid types.
