### PR TITLE
docs: ICP account identifier and subaccount

### DIFF
--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -65,6 +65,12 @@ It’s a unique value derived from a principal (the identity controlling the acc
 and a subaccount. This design allows a single principal to control multiple accounts
 by using different subaccounts.
 
+References:
+
+- [https://internetcomputer.org/docs/references/ledger#\_accounts](https://internetcomputer.org/docs/references/ledger#_accounts)
+- [https://internetcomputer.org/docs/defi/token-ledgers/setup/icp_ledger_setup](https://internetcomputer.org/docs/defi/token-ledgers/setup/icp_ledger_setup)
+- [https://internetcomputer.org/docs/references/ledger#\_operations_transactions_blocks_transaction_ledger](https://internetcomputer.org/docs/references/ledger#_operations_transactions_blocks_transaction_ledger)
+
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L22)
 
 #### Static Methods
@@ -182,6 +188,10 @@ Returns:
 
 A subaccount in the ICP ledger is a 32-byte identifier that allows a principal (user or canister)
 to control multiple independent accounts under the same principal.
+
+References:
+
+- [https://internetcomputer.org/docs/references/ledger#\_accounts](https://internetcomputer.org/docs/references/ledger#_accounts)
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L139)
 

--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -58,7 +58,14 @@ const data = await metadata();
 
 ### :factory: AccountIdentifier
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L10)
+A 32-byte account identifier used to send and receive ICP tokens.
+
+The ICP Ledger uses the concept of an `AccountIdentifier` to represent accounts.
+It’s a unique value derived from a principal (the identity controlling the account)
+and a subaccount. This design allows a single principal to control multiple accounts
+by using different subaccounts.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L22)
 
 #### Static Methods
 
@@ -67,19 +74,45 @@ const data = await metadata();
 
 ##### :gear: fromHex
 
+Creates an `AccountIdentifier` object from a hexadecimal string (e.g. d3e13d4777e22367532053190b6c6ccf57444a61337e996242b1abfb52cf92c8).
+Validates the checksum in the process.
+
 | Method    | Type                                 |
 | --------- | ------------------------------------ |
 | `fromHex` | `(hex: string) => AccountIdentifier` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L13)
+Parameters:
+
+- `hex`: - The 64-character hexadecimal representation of the account identifier.
+
+Returns:
+
+An instance of `AccountIdentifier`.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L33)
 
 ##### :gear: fromPrincipal
+
+Creates an `AccountIdentifier` object from a principal and optional subaccount.
+
+When no subaccount is provided, a 32-byte array of zeros is used by default.
+You can use any arbitrary 32 bytes as a subaccount identifier to derive a distinct account identifier
+for the same principal.
 
 | Method          | Type                                                                                                                 |
 | --------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `fromPrincipal` | `({ principal, subAccount, }: { principal: Principal; subAccount?: SubAccount or undefined; }) => AccountIdentifier` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L36)
+Parameters:
+
+- `options.principal`: - The principal to derive the account from.
+- `options.subAccount`: - The optional subaccount (defaults to 0).
+
+Returns:
+
+An instance of `AccountIdentifier`.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L67)
 
 #### Methods
 
@@ -90,39 +123,67 @@ const data = await metadata();
 
 ##### :gear: toHex
 
+Returns the ICP Ledger Account Identifier as a 64-character hexadecimal string.
+This is the format typically used to display the account identifier in a human-readable way.
+
 | Method  | Type           |
 | ------- | -------------- |
 | `toHex` | `() => string` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L62)
+Returns:
+
+Hex representation (64-character string).
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L99)
 
 ##### :gear: toUint8Array
+
+Returns the raw 32-byte `Uint8Array` of the account identifier.
 
 | Method         | Type                                |
 | -------------- | ----------------------------------- |
 | `toUint8Array` | `() => Uint8Array<ArrayBufferLike>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L66)
+Returns:
+
+The raw bytes of the account identifier.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L108)
 
 ##### :gear: toNumbers
+
+Returns the account identifier as an array of numbers.
 
 | Method      | Type             |
 | ----------- | ---------------- |
 | `toNumbers` | `() => number[]` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L70)
+Returns:
+
+An array of byte values.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L117)
 
 ##### :gear: toAccountIdentifierHash
+
+Returns the raw bytes wrapped in an object under the `hash` key.
 
 | Method                    | Type                                           |
 | ------------------------- | ---------------------------------------------- |
 | `toAccountIdentifierHash` | `() => { hash: Uint8Array<ArrayBufferLike>; }` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L74)
+Returns:
+
+`{ hash: Uint8Array }` where `hash` is the raw 32-byte `Uint8Array`.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L126)
 
 ### :factory: SubAccount
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L81)
+A subaccount in the ICP ledger is a 32-byte identifier that allows a principal (user or canister)
+to control multiple independent accounts under the same principal.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L139)
 
 #### Static Methods
 
@@ -132,27 +193,62 @@ const data = await metadata();
 
 ##### :gear: fromBytes
 
+Creates a `SubAccount` from a 32‑byte array.
+
 | Method      | Type                                                 |
 | ----------- | ---------------------------------------------------- |
 | `fromBytes` | `(bytes: Uint8Array<ArrayBufferLike>) => SubAccount` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L84)
+Parameters:
+
+- `bytes`: - A `Uint8Array` of exactly 32 bytes.
+
+Returns:
+
+A `SubAccount` instance.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L149)
 
 ##### :gear: fromPrincipal
+
+Generates a `SubAccount` from a principal.
+
+The principal is embedded into the beginning of a 32‑byte array.
 
 | Method          | Type                                   |
 | --------------- | -------------------------------------- |
 | `fromPrincipal` | `(principal: Principal) => SubAccount` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L92)
+Parameters:
+
+- `principal`: - A principal to encode into the subaccount.
+
+Returns:
+
+A `SubAccount` instance.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L165)
 
 ##### :gear: fromID
+
+Generates a `SubAccount` from a non‑negative number.
+
+The number is encoded into the last 8 bytes of the 32‑byte array.
+This is a common pattern when using numbered subaccounts like 0, 1, 2...
 
 | Method   | Type                         |
 | -------- | ---------------------------- |
 | `fromID` | `(id: number) => SubAccount` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L105)
+Parameters:
+
+- `id`: - A non-negative integer.
+
+Returns:
+
+A `SubAccount` instance.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L188)
 
 #### Methods
 
@@ -160,11 +256,17 @@ const data = await metadata();
 
 ##### :gear: toUint8Array
 
+Returns the raw 32-byte `Uint8Array` representing this subaccount.
+
 | Method         | Type                                |
 | -------------- | ----------------------------------- |
 | `toUint8Array` | `() => Uint8Array<ArrayBufferLike>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L129)
+Returns:
+
+A 32-byte array.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L217)
 
 ### :factory: LedgerCanister
 

--- a/packages/ledger-icp/src/account_identifier.ts
+++ b/packages/ledger-icp/src/account_identifier.ts
@@ -7,9 +7,29 @@ import {
 } from "@dfinity/utils";
 import { sha224 } from "@noble/hashes/sha2";
 
+/**
+ * A 32-byte account identifier used to send and receive ICP tokens.
+ *
+ * The ICP Ledger uses the concept of an `AccountIdentifier` to represent accounts.
+ * It’s a unique value derived from a principal (the identity controlling the account)
+ * and a subaccount. This design allows a single principal to control multiple accounts
+ * by using different subaccounts.
+ *
+ * @see https://internetcomputer.org/docs/references/ledger#_accounts
+ * @see https://internetcomputer.org/docs/defi/token-ledgers/setup/icp_ledger_setup
+ * @see https://internetcomputer.org/docs/references/ledger#_operations_transactions_blocks_transaction_ledger
+ */
 export class AccountIdentifier {
   private constructor(private readonly bytes: Uint8Array) {}
 
+  /**
+   * Creates an `AccountIdentifier` object from a hexadecimal string (e.g. d3e13d4777e22367532053190b6c6ccf57444a61337e996242b1abfb52cf92c8).
+   * Validates the checksum in the process.
+   *
+   * @param hex - The 64-character hexadecimal representation of the account identifier.
+   * @throws If the length is not 32 bytes or if the checksum is invalid.
+   * @returns An instance of `AccountIdentifier`.
+   */
   public static fromHex(hex: string): AccountIdentifier {
     const bytes = Uint8Array.from(Buffer.from(hex, "hex"));
 
@@ -33,6 +53,17 @@ export class AccountIdentifier {
     return new AccountIdentifier(bytes);
   }
 
+  /**
+   * Creates an `AccountIdentifier` object from a principal and optional subaccount.
+   *
+   * When no subaccount is provided, a 32-byte array of zeros is used by default.
+   * You can use any arbitrary 32 bytes as a subaccount identifier to derive a distinct account identifier
+   * for the same principal.
+   *
+   * @param options.principal - The principal to derive the account from.
+   * @param options.subAccount - The optional subaccount (defaults to 0).
+   * @returns An instance of `AccountIdentifier`.
+   */
   public static fromPrincipal({
     principal,
     subAccount = SubAccount.fromID(0),
@@ -59,18 +90,39 @@ export class AccountIdentifier {
     return new AccountIdentifier(bytes);
   }
 
+  /**
+   * Returns the ICP Ledger Account Identifier as a 64-character hexadecimal string.
+   * This is the format typically used to display the account identifier in a human-readable way.
+   *
+   * @returns Hex representation (64-character string).
+   */
   public toHex(): string {
     return uint8ArrayToHexString(this.bytes);
   }
 
+  /**
+   * Returns the raw 32-byte `Uint8Array` of the account identifier.
+   *
+   * @returns The raw bytes of the account identifier.
+   */
   public toUint8Array(): Uint8Array {
     return this.bytes;
   }
 
+  /**
+   * Returns the account identifier as an array of numbers.
+   *
+   * @returns An array of byte values.
+   */
   public toNumbers(): number[] {
     return Array.from(this.bytes);
   }
 
+  /**
+   * Returns the raw bytes wrapped in an object under the `hash` key.
+   *
+   * @returns `{ hash: Uint8Array }` where `hash` is the raw 32-byte `Uint8Array`.
+   */
   public toAccountIdentifierHash(): { hash: Uint8Array } {
     return {
       hash: this.toUint8Array(),
@@ -78,9 +130,22 @@ export class AccountIdentifier {
   }
 }
 
+/**
+ * A subaccount in the ICP ledger is a 32-byte identifier that allows a principal (user or canister)
+ * to control multiple independent accounts under the same principal.
+ *
+ * @see https://internetcomputer.org/docs/references/ledger#_accounts
+ */
 export class SubAccount {
   private constructor(private readonly bytes: Uint8Array) {}
 
+  /**
+   * Creates a `SubAccount` from a 32‑byte array.
+   *
+   * @param bytes - A `Uint8Array` of exactly 32 bytes.
+   * @throws If the byte array length is not 32.
+   * @returns A `SubAccount` instance.
+   */
   public static fromBytes(bytes: Uint8Array): SubAccount {
     if (bytes.length !== 32) {
       throw new Error("Subaccount length must be 32-bytes");
@@ -89,6 +154,14 @@ export class SubAccount {
     return new SubAccount(bytes);
   }
 
+  /**
+   * Generates a `SubAccount` from a principal.
+   *
+   * The principal is embedded into the beginning of a 32‑byte array.
+   *
+   * @param principal - A principal to encode into the subaccount.
+   * @returns A `SubAccount` instance.
+   */
   public static fromPrincipal(principal: Principal): SubAccount {
     const bytes = new Uint8Array(32).fill(0);
 
@@ -102,6 +175,16 @@ export class SubAccount {
     return new SubAccount(bytes);
   }
 
+  /**
+   * Generates a `SubAccount` from a non‑negative number.
+   *
+   * The number is encoded into the last 8 bytes of the 32‑byte array.
+   * This is a common pattern when using numbered subaccounts like 0, 1, 2...
+   *
+   * @param id - A non-negative integer.
+   * @throws If the number is negative or exceeds `Number.MAX_SAFE_INTEGER`.
+   * @returns A `SubAccount` instance.
+   */
   public static fromID(id: number): SubAccount {
     if (id < 0) {
       throw new Error("Number cannot be negative");
@@ -126,6 +209,11 @@ export class SubAccount {
     return new SubAccount(uint8Arary);
   }
 
+  /**
+   * Returns the raw 32-byte `Uint8Array` representing this subaccount.
+   *
+   * @returns A 32-byte array.
+   */
   public toUint8Array(): Uint8Array {
     return this.bytes;
   }


### PR DESCRIPTION
# Motivation

@marc0olo had some questions yesterday evening about the ICP `AccountIdentifier` and `SubAccount`, which lead me to notice the lack of JSDoc comments. While this doesn't answer everything, I’ve added some comments that should help clarify things a little bit hopefully.

# Changes

- Provide JSDocs for ICP `AccountIdentifier` and `SubAccount`

