### PR TITLE
build: bump tsdoc-markdown to render references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "prettier-plugin-organize-imports": "^4.1.0",
         "size-limit": "^11.2.0",
         "ts-protoc-gen": "^0.15.0",
-        "tsdoc-markdown": "^1.3.0",
+        "tsdoc-markdown": "^1.4.0",
         "typescript": "^5.8.3",
         "vitest": "^3.2.4",
         "vitest-mock-extended": "^3.1.0"
@@ -6131,9 +6131,9 @@
       }
     },
     "node_modules/tsdoc-markdown": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.3.0.tgz",
-      "integrity": "sha512-PAj5EkcRj7rZKqZDH802hDoRGjSm+N+N5GeIFVXOuCKpkJF8f1GRphrGO6lpwTCUauL4OgE0FBB9vNugRdZTAg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.4.0.tgz",
+      "integrity": "sha512-Y0CMWjj3kAzi3qeNPzVKoTCFwoVW86uxo27rWJaB4709hEriBMeVN6Lf300PF4KnJsHZT53nBNc+2ChCA9PGDw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -10717,9 +10717,9 @@
       }
     },
     "tsdoc-markdown": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.3.0.tgz",
-      "integrity": "sha512-PAj5EkcRj7rZKqZDH802hDoRGjSm+N+N5GeIFVXOuCKpkJF8f1GRphrGO6lpwTCUauL4OgE0FBB9vNugRdZTAg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.4.0.tgz",
+      "integrity": "sha512-Y0CMWjj3kAzi3qeNPzVKoTCFwoVW86uxo27rWJaB4709hEriBMeVN6Lf300PF4KnJsHZT53nBNc+2ChCA9PGDw==",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "prettier-plugin-organize-imports": "^4.1.0",
         "size-limit": "^11.2.0",
         "ts-protoc-gen": "^0.15.0",
-        "tsdoc-markdown": "^1.4.0",
+        "tsdoc-markdown": "^1.4.1",
         "typescript": "^5.8.3",
         "vitest": "^3.2.4",
         "vitest-mock-extended": "^3.1.0"
@@ -6131,9 +6131,9 @@
       }
     },
     "node_modules/tsdoc-markdown": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.4.0.tgz",
-      "integrity": "sha512-Y0CMWjj3kAzi3qeNPzVKoTCFwoVW86uxo27rWJaB4709hEriBMeVN6Lf300PF4KnJsHZT53nBNc+2ChCA9PGDw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.4.1.tgz",
+      "integrity": "sha512-N+yt68b/L22zVr1T4yyRjG0OihgfExkDlNTPJyhFa7yh/27h4y8qNzKqSzloLjelQn9R5laDeTY6iwMpURHnLw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -10717,9 +10717,9 @@
       }
     },
     "tsdoc-markdown": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.4.0.tgz",
-      "integrity": "sha512-Y0CMWjj3kAzi3qeNPzVKoTCFwoVW86uxo27rWJaB4709hEriBMeVN6Lf300PF4KnJsHZT53nBNc+2ChCA9PGDw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.4.1.tgz",
+      "integrity": "sha512-N+yt68b/L22zVr1T4yyRjG0OihgfExkDlNTPJyhFa7yh/27h4y8qNzKqSzloLjelQn9R5laDeTY6iwMpURHnLw==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prettier-plugin-organize-imports": "^4.1.0",
     "size-limit": "^11.2.0",
     "ts-protoc-gen": "^0.15.0",
-    "tsdoc-markdown": "^1.4.0",
+    "tsdoc-markdown": "^1.4.1",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4",
     "vitest-mock-extended": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prettier-plugin-organize-imports": "^4.1.0",
     "size-limit": "^11.2.0",
     "ts-protoc-gen": "^0.15.0",
-    "tsdoc-markdown": "^1.3.0",
+    "tsdoc-markdown": "^1.4.0",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4",
     "vitest-mock-extended": "^3.1.0"

--- a/packages/cketh/README.md
+++ b/packages/cketh/README.md
@@ -201,6 +201,10 @@ Parameters:
 
 Class representing the CkETH Orchestrator Canister, which manages the Ledger and Index canisters of ckERC20 tokens.
 
+References:
+
+- [Source Code](https://github.com/dfinity/ic/tree/master/rs/ethereum/ledger-suite-orchestrator)
+
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/cketh/src/orchestrator.canister.ts#L15)
 
 #### Static Methods

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1012,12 +1012,12 @@ Useful when identities have changed or if you want to reset all active connectio
 
 #### :gear: FromStringToTokenError
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/enums/token.enums.ts#L1)
-
 | Property                      | Type | Description |
 | ----------------------------- | ---- | ----------- |
 | `FractionalMoreThan8Decimals` | ``   |             |
 | `InvalidFormat`               | ``   |             |
 | `FractionalTooManyDecimals`   | ``   |             |
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/enums/token.enums.ts#L1)
 
 <!-- TSDOC_END -->

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1012,6 +1012,8 @@ Useful when identities have changed or if you want to reset all active connectio
 
 #### :gear: FromStringToTokenError
 
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/enums/token.enums.ts#L1)
+
 | Property                      | Type | Description |
 | ----------------------------- | ---- | ----------- |
 | `FractionalMoreThan8Decimals` | ``   |             |


### PR DESCRIPTION
# Motivation

When I improved the documentation of `AccountIdentifier` earlier this morning (in #1014), I noticed the `@see` and `@link` references weren't rendered in the READMEs. So I improved `tsdoc-markdown` (see [release notes](https://github.com/peterpeterparker/tsdoc-markdown/releases/tag/v1.4.0) and small [patch](https://github.com/peterpeterparker/tsdoc-markdown/releases/tag/v1.4.1)) to support such options.

# Changes

- Bump library to latest version.
