### PR TITLE
feat: Add method icrc1/icrc10_supported_standards to class IcrcLedgerCanister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - New utility `uint8ArraysEqual` to compare two Uint8Arrays for byte-level equality.
 - Replace usage of `Buffer` with `Uint8Array` in `checkAccountId` of `@dfinity/ledger-icp`.
-- Expose method `icrc1_supported_standards` in class `IcrcLedgerCanister`.
+- Expose method `icrc1_supported_standards` and `icrc10_supported_standards` in class `IcrcLedgerCanister`.
 
 ## Build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - New utility `uint8ArraysEqual` to compare two Uint8Arrays for byte-level equality.
 - Replace usage of `Buffer` with `Uint8Array` in `checkAccountId` of `@dfinity/ledger-icp`.
+- Expose method `icrc1_supported_standards` in class `IcrcLedgerCanister`.
 
 ## Build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - New utility `uint8ArraysEqual` to compare two Uint8Arrays for byte-level equality.
 - Replace usage of `Buffer` with `Uint8Array` in `checkAccountId` of `@dfinity/ledger-icp`.
-- Expose method `icrc1_supported_standards` and `icrc10_supported_standards` in the `IcrcLedgerCanister` class.
+- Expose the `icrc1_supported_standards` and `icrc10_supported_standards` methods in the `IcrcLedgerCanister` class.
 
 ## Build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - New utility `uint8ArraysEqual` to compare two Uint8Arrays for byte-level equality.
 - Replace usage of `Buffer` with `Uint8Array` in `checkAccountId` of `@dfinity/ledger-icp`.
-- Expose method `icrc1_supported_standards` and `icrc10_supported_standards` in class `IcrcLedgerCanister`.
+- Expose method `icrc1_supported_standards` and `icrc10_supported_standards` in the `IcrcLedgerCanister` class.
 
 ## Build
 

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -185,7 +185,7 @@ The balance of the given account.
 
 ### :factory: IcrcLedgerCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L42)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L43)
 
 #### Static Methods
 
@@ -197,7 +197,7 @@ The balance of the given account.
 | -------- | ---------------------------------------------------------------------- |
 | `create` | `(options: IcrcLedgerCanisterOptions<_SERVICE>) => IcrcLedgerCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L43)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L44)
 
 #### Methods
 
@@ -222,7 +222,7 @@ The token metadata (name, symbol, etc.).
 | ---------- | ------------------------------------------------------------- |
 | `metadata` | `(params: QueryParams) => Promise<IcrcTokenMetadataResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L57)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L58)
 
 ##### :gear: transactionFee
 
@@ -236,7 +236,7 @@ Returns:
 
 The ledger transaction fees in Tokens
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L65)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L66)
 
 ##### :gear: balance
 
@@ -254,7 +254,7 @@ Returns:
 
 The balance of the given account.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L74)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L75)
 
 ##### :gear: transfer
 
@@ -268,7 +268,7 @@ Parameters:
 
 - `params`: The parameters to transfer tokens.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L87)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L88)
 
 ##### :gear: totalTokensSupply
 
@@ -278,7 +278,7 @@ Returns the total supply of tokens.
 | ------------------- | ------------------------------------------ |
 | `totalTokensSupply` | `(params: QueryParams) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L103)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L104)
 
 ##### :gear: transferFrom
 
@@ -294,7 +294,7 @@ Parameters:
 
 - `params`: The parameters to transfer tokens from to.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L115)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L116)
 
 ##### :gear: approve
 
@@ -310,7 +310,7 @@ Parameters:
 
 - `params`: The parameters to approve.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L137)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L138)
 
 ##### :gear: allowance
 
@@ -330,7 +330,7 @@ Returns:
 
 The token allowance. If there is no active approval, the ledger MUST return `{ allowance = 0; expires_at = null }`.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L159)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L160)
 
 ##### :gear: consentMessage
 
@@ -348,7 +348,7 @@ Returns:
 
 - A promise that resolves to the consent message response, which includes the consent message in the specified language and other related information.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L177)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L178)
 
 ##### :gear: getBlocks
 
@@ -366,7 +366,7 @@ Returns:
 
 The list of blocks.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L201)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L202)
 
 ##### :gear: getIndexPrincipal
 
@@ -380,21 +380,21 @@ Returns:
 
 The principal of the index canister.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L214)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L215)
 
 ##### :gear: getSupportedStandards
 
-Returns the list of standards this ledger supports.
+Returns the list of standards this ledger supports. Depending on the provided type, either icrc1_supported_standards (default option) or icrc10_supported_standards will be used. 
 
 | Method                  | Type                                                 |
 | ----------------------- | ---------------------------------------------------- |
-| `getSupportedStandards` | `(params: QueryParams) => Promise<StandardRecord[]>` |
+| `getSupportedStandards` | `(params: GetSupportedStandardsParams) => Promise<StandardRecord[]>` |
 
 Returns:
 
 The list of standards.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L233)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L239)
 
 ### :factory: IcrcIndexCanister
 

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -392,7 +392,7 @@ Returns the list of standards this ledger supports.
 
 Returns:
 
-The list of all supported standards.
+The list of standards.
 
 [:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L233)
 

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -386,8 +386,8 @@ The principal of the index canister.
 
 Returns the list of standards this ledger supports.
 
-| Method              | Type                                                 |
-| ------------------- |------------------------------------------------------|
+| Method                  | Type                                                 |
+| ----------------------- | ---------------------------------------------------- |
 | `getSupportedStandards` | `(params: QueryParams) => Promise<StandardRecord[]>` |
 
 Returns:

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -185,7 +185,7 @@ The balance of the given account.
 
 ### :factory: IcrcLedgerCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L43)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L42)
 
 #### Static Methods
 
@@ -197,7 +197,7 @@ The balance of the given account.
 | -------- | ---------------------------------------------------------------------- |
 | `create` | `(options: IcrcLedgerCanisterOptions<_SERVICE>) => IcrcLedgerCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L44)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L43)
 
 #### Methods
 
@@ -212,7 +212,8 @@ The balance of the given account.
 - [consentMessage](#gear-consentmessage)
 - [getBlocks](#gear-getblocks)
 - [getIndexPrincipal](#gear-getindexprincipal)
-- [getSupportedStandards](#gear-getsupportedstandards)
+- [icrc1SupportedStandards](#gear-icrc1SupportedStandards)
+- [icrc10SupportedStandards](#gear-icrc10SupportedStandards)
 
 ##### :gear: metadata
 
@@ -222,7 +223,7 @@ The token metadata (name, symbol, etc.).
 | ---------- | ------------------------------------------------------------- |
 | `metadata` | `(params: QueryParams) => Promise<IcrcTokenMetadataResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L58)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L57)
 
 ##### :gear: transactionFee
 
@@ -236,7 +237,7 @@ Returns:
 
 The ledger transaction fees in Tokens
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L66)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L65)
 
 ##### :gear: balance
 
@@ -254,7 +255,7 @@ Returns:
 
 The balance of the given account.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L75)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L74)
 
 ##### :gear: transfer
 
@@ -268,7 +269,7 @@ Parameters:
 
 - `params`: The parameters to transfer tokens.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L88)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L87)
 
 ##### :gear: totalTokensSupply
 
@@ -278,7 +279,7 @@ Returns the total supply of tokens.
 | ------------------- | ------------------------------------------ |
 | `totalTokensSupply` | `(params: QueryParams) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L104)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L103)
 
 ##### :gear: transferFrom
 
@@ -294,7 +295,7 @@ Parameters:
 
 - `params`: The parameters to transfer tokens from to.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L116)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L115)
 
 ##### :gear: approve
 
@@ -310,7 +311,7 @@ Parameters:
 
 - `params`: The parameters to approve.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L138)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L137)
 
 ##### :gear: allowance
 
@@ -330,7 +331,7 @@ Returns:
 
 The token allowance. If there is no active approval, the ledger MUST return `{ allowance = 0; expires_at = null }`.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L160)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L159)
 
 ##### :gear: consentMessage
 
@@ -348,7 +349,7 @@ Returns:
 
 - A promise that resolves to the consent message response, which includes the consent message in the specified language and other related information.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L178)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L177)
 
 ##### :gear: getBlocks
 
@@ -366,7 +367,7 @@ Returns:
 
 The list of blocks.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L202)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L201)
 
 ##### :gear: getIndexPrincipal
 
@@ -380,28 +381,43 @@ Returns:
 
 The principal of the index canister.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L215)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L214)
 
-##### :gear: getSupportedStandards
+##### :gear: icrc1SupportedStandards
 
-Returns the list of standards this ledger supports.
-Depending on the provided type, either icrc1_supported_standards or icrc10_supported_standards will be used.
-If no type provided, icrc1_supported_standards will be used by default.
+Returns the list of standards this ledger supports by using icrc1_supported_standards.
 
-| Method                  | Type                                                                                   |
-| ----------------------- | -------------------------------------------------------------------------------------- |
-| `getSupportedStandards` | `({ type, ...queryParams }: GetSupportedStandardsParams) => Promise<StandardRecord[]>` |
+| Method                  | Type                                                 |
+| ----------------------- |------------------------------------------------------|
+| `icrc1SupportedStandards` | `(params: QueryParams) => Promise<StandardRecord[]>` |
 
 Parameters:
 
 - `params`: The parameters to get the standards.
-- `params.type`: An optional param to decide which ledger method to use.
 
 Returns:
 
 The list of standards.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L239)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L233)
+
+##### :gear: icrc10SupportedStandards
+
+Returns the list of standards this ledger supports by using icrc10_supported_standards.
+
+| Method                     | Type                                                 |
+|----------------------------|------------------------------------------------------|
+| `icrc10SupportedStandards` | `(params: QueryParams) => Promise<{ url: string; name: string }[]>` |
+
+Parameters:
+
+- `params`: The parameters to get the standards.
+
+Returns:
+
+The list of standards.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L243)
 
 ### :factory: IcrcIndexCanister
 

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -384,11 +384,18 @@ The principal of the index canister.
 
 ##### :gear: getSupportedStandards
 
-Returns the list of standards this ledger supports. Depending on the provided type, either icrc1_supported_standards (default option) or icrc10_supported_standards will be used. 
+Returns the list of standards this ledger supports.
+Depending on the provided type, either icrc1_supported_standards or icrc10_supported_standards will be used.
+If no type provided, icrc1_supported_standards will be used by default.
 
-| Method                  | Type                                                 |
-| ----------------------- | ---------------------------------------------------- |
-| `getSupportedStandards` | `(params: GetSupportedStandardsParams) => Promise<StandardRecord[]>` |
+| Method                  | Type                                                                                   |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| `getSupportedStandards` | `({ type, ...queryParams }: GetSupportedStandardsParams) => Promise<StandardRecord[]>` |
+
+Parameters:
+
+- `params`: The parameters to get the standards.
+- `params.type`: An optional param to decide which ledger method to use.
 
 Returns:
 

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -212,8 +212,8 @@ The balance of the given account.
 - [consentMessage](#gear-consentmessage)
 - [getBlocks](#gear-getblocks)
 - [getIndexPrincipal](#gear-getindexprincipal)
-- [icrc1SupportedStandards](#gear-icrc1SupportedStandards)
-- [icrc10SupportedStandards](#gear-icrc10SupportedStandards)
+- [icrc1SupportedStandards](#gear-icrc1supportedstandards)
+- [icrc10SupportedStandards](#gear-icrc10supportedstandards)
 
 ##### :gear: metadata
 
@@ -387,13 +387,9 @@ The principal of the index canister.
 
 Returns the list of standards this ledger supports by using icrc1_supported_standards.
 
-| Method                  | Type                                                 |
-| ----------------------- |------------------------------------------------------|
+| Method                    | Type                                                 |
+| ------------------------- | ---------------------------------------------------- |
 | `icrc1SupportedStandards` | `(params: QueryParams) => Promise<StandardRecord[]>` |
-
-Parameters:
-
-- `params`: The parameters to get the standards.
 
 Returns:
 
@@ -405,13 +401,9 @@ The list of standards.
 
 Returns the list of standards this ledger supports by using icrc10_supported_standards.
 
-| Method                     | Type                                                 |
-|----------------------------|------------------------------------------------------|
-| `icrc10SupportedStandards` | `(params: QueryParams) => Promise<{ url: string; name: string }[]>` |
-
-Parameters:
-
-- `params`: The parameters to get the standards.
+| Method                     | Type                                                                 |
+| -------------------------- | -------------------------------------------------------------------- |
+| `icrc10SupportedStandards` | `(params: QueryParams) => Promise<{ url: string; name: string; }[]>` |
 
 Returns:
 

--- a/packages/ledger-icrc/README.md
+++ b/packages/ledger-icrc/README.md
@@ -185,7 +185,7 @@ The balance of the given account.
 
 ### :factory: IcrcLedgerCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L41)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L42)
 
 #### Static Methods
 
@@ -197,7 +197,7 @@ The balance of the given account.
 | -------- | ---------------------------------------------------------------------- |
 | `create` | `(options: IcrcLedgerCanisterOptions<_SERVICE>) => IcrcLedgerCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L42)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L43)
 
 #### Methods
 
@@ -212,6 +212,7 @@ The balance of the given account.
 - [consentMessage](#gear-consentmessage)
 - [getBlocks](#gear-getblocks)
 - [getIndexPrincipal](#gear-getindexprincipal)
+- [getSupportedStandards](#gear-getsupportedstandards)
 
 ##### :gear: metadata
 
@@ -221,7 +222,7 @@ The token metadata (name, symbol, etc.).
 | ---------- | ------------------------------------------------------------- |
 | `metadata` | `(params: QueryParams) => Promise<IcrcTokenMetadataResponse>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L56)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L57)
 
 ##### :gear: transactionFee
 
@@ -235,7 +236,7 @@ Returns:
 
 The ledger transaction fees in Tokens
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L64)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L65)
 
 ##### :gear: balance
 
@@ -253,7 +254,7 @@ Returns:
 
 The balance of the given account.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L73)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L74)
 
 ##### :gear: transfer
 
@@ -267,7 +268,7 @@ Parameters:
 
 - `params`: The parameters to transfer tokens.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L86)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L87)
 
 ##### :gear: totalTokensSupply
 
@@ -277,7 +278,7 @@ Returns the total supply of tokens.
 | ------------------- | ------------------------------------------ |
 | `totalTokensSupply` | `(params: QueryParams) => Promise<bigint>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L102)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L103)
 
 ##### :gear: transferFrom
 
@@ -293,7 +294,7 @@ Parameters:
 
 - `params`: The parameters to transfer tokens from to.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L114)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L115)
 
 ##### :gear: approve
 
@@ -309,7 +310,7 @@ Parameters:
 
 - `params`: The parameters to approve.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L136)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L137)
 
 ##### :gear: allowance
 
@@ -329,7 +330,7 @@ Returns:
 
 The token allowance. If there is no active approval, the ledger MUST return `{ allowance = 0; expires_at = null }`.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L158)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L159)
 
 ##### :gear: consentMessage
 
@@ -347,7 +348,7 @@ Returns:
 
 - A promise that resolves to the consent message response, which includes the consent message in the specified language and other related information.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L176)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L177)
 
 ##### :gear: getBlocks
 
@@ -365,7 +366,7 @@ Returns:
 
 The list of blocks.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L200)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L201)
 
 ##### :gear: getIndexPrincipal
 
@@ -379,7 +380,21 @@ Returns:
 
 The principal of the index canister.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L213)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L214)
+
+##### :gear: getSupportedStandards
+
+Returns the list of standards this ledger supports.
+
+| Method              | Type                                                 |
+| ------------------- |------------------------------------------------------|
+| `getSupportedStandards` | `(params: QueryParams) => Promise<StandardRecord[]>` |
+
+Returns:
+
+The list of all supported standards.
+
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icrc/src/ledger.canister.ts#L233)
 
 ### :factory: IcrcIndexCanister
 

--- a/packages/ledger-icrc/src/index.ts
+++ b/packages/ledger-icrc/src/index.ts
@@ -1,6 +1,7 @@
 export type {
   ApproveError as IcrcApproveError,
   BlockIndex as IcrcBlockIndex,
+  StandardRecord as IcrcStandardRecord,
   Subaccount as IcrcSubaccount,
   Tokens as IcrcTokens,
   TransferArg as IcrcTransferArg,

--- a/packages/ledger-icrc/src/ledger.canister.spec.ts
+++ b/packages/ledger-icrc/src/ledger.canister.spec.ts
@@ -807,4 +807,23 @@ describe("Ledger canister", () => {
       );
     });
   });
+
+  describe("getSupportedStandards", () => {
+    it("should return the list of standards", async () => {
+      const service = mock<ActorSubclass<IcrcLedgerService>>();
+      const standards = [
+        { name: "ICRC-1", url: "https://github.com/dfinity/ICRC-1" },
+      ];
+      service.icrc1_supported_standards.mockResolvedValue(standards);
+
+      const canister = IcrcLedgerCanister.create({
+        canisterId: ledgerCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+
+      const res = await canister.getSupportedStandards({});
+
+      expect(res).toEqual(standards);
+    });
+  });
 });

--- a/packages/ledger-icrc/src/ledger.canister.spec.ts
+++ b/packages/ledger-icrc/src/ledger.canister.spec.ts
@@ -831,7 +831,10 @@ describe("Ledger canister", () => {
     it("should return the list of standards", async () => {
       const service = mock<ActorSubclass<IcrcLedgerService>>();
       const standards = [
-        { name: "ICRC-10", url: "https://github.com/dfinity/ICRC-10" },
+        {
+          name: "ICRC-10",
+          url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-10",
+        },
       ];
       service.icrc10_supported_standards.mockResolvedValue(standards);
 

--- a/packages/ledger-icrc/src/ledger.canister.spec.ts
+++ b/packages/ledger-icrc/src/ledger.canister.spec.ts
@@ -809,11 +809,16 @@ describe("Ledger canister", () => {
   });
 
   describe("getSupportedStandards", () => {
-    it("should return the list of standards", async () => {
-      const service = mock<ActorSubclass<IcrcLedgerService>>();
-      const standards = [
-        { name: "ICRC-1", url: "https://github.com/dfinity/ICRC-1" },
-      ];
+    const service = mock<ActorSubclass<IcrcLedgerService>>();
+    const standards = [
+      { name: "ICRC-1", url: "https://github.com/dfinity/ICRC-1" },
+    ];
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("should use icrc1_supported_standards to return the list of standards by default", async () => {
       service.icrc1_supported_standards.mockResolvedValue(standards);
 
       const canister = IcrcLedgerCanister.create({
@@ -823,6 +828,35 @@ describe("Ledger canister", () => {
 
       const res = await canister.getSupportedStandards({});
 
+      expect(service.icrc1_supported_standards).toHaveBeenCalledOnce();
+      expect(res).toEqual(standards);
+    });
+
+    it("should use icrc1_supported_standards to return the list of standards", async () => {
+      service.icrc1_supported_standards.mockResolvedValue(standards);
+
+      const canister = IcrcLedgerCanister.create({
+        canisterId: ledgerCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+
+      const res = await canister.getSupportedStandards({ type: "icrc1" });
+
+      expect(service.icrc1_supported_standards).toHaveBeenCalledOnce();
+      expect(res).toEqual(standards);
+    });
+
+    it("should use icrc10_supported_standards to return the list of standards", async () => {
+      service.icrc10_supported_standards.mockResolvedValue(standards);
+
+      const canister = IcrcLedgerCanister.create({
+        canisterId: ledgerCanisterIdMock,
+        certifiedServiceOverride: service,
+      });
+
+      const res = await canister.getSupportedStandards({ type: "icrc10" });
+
+      expect(service.icrc10_supported_standards).toHaveBeenCalledOnce();
       expect(res).toEqual(standards);
     });
   });

--- a/packages/ledger-icrc/src/ledger.canister.spec.ts
+++ b/packages/ledger-icrc/src/ledger.canister.spec.ts
@@ -808,17 +808,12 @@ describe("Ledger canister", () => {
     });
   });
 
-  describe("getSupportedStandards", () => {
-    const service = mock<ActorSubclass<IcrcLedgerService>>();
-    const standards = [
-      { name: "ICRC-1", url: "https://github.com/dfinity/ICRC-1" },
-    ];
-
-    beforeEach(() => {
-      vi.clearAllMocks();
-    });
-
-    it("should use icrc1_supported_standards to return the list of standards by default", async () => {
+  describe("icrc1SupportedStandards", () => {
+    it("should return the list of standards", async () => {
+      const service = mock<ActorSubclass<IcrcLedgerService>>();
+      const standards = [
+        { name: "ICRC-1", url: "https://github.com/dfinity/ICRC-1" },
+      ];
       service.icrc1_supported_standards.mockResolvedValue(standards);
 
       const canister = IcrcLedgerCanister.create({
@@ -826,27 +821,18 @@ describe("Ledger canister", () => {
         certifiedServiceOverride: service,
       });
 
-      const res = await canister.getSupportedStandards({});
+      const res = await canister.icrc1SupportedStandards({});
 
-      expect(service.icrc1_supported_standards).toHaveBeenCalledOnce();
       expect(res).toEqual(standards);
     });
+  });
 
-    it("should use icrc1_supported_standards to return the list of standards", async () => {
-      service.icrc1_supported_standards.mockResolvedValue(standards);
-
-      const canister = IcrcLedgerCanister.create({
-        canisterId: ledgerCanisterIdMock,
-        certifiedServiceOverride: service,
-      });
-
-      const res = await canister.getSupportedStandards({ type: "icrc1" });
-
-      expect(service.icrc1_supported_standards).toHaveBeenCalledOnce();
-      expect(res).toEqual(standards);
-    });
-
-    it("should use icrc10_supported_standards to return the list of standards", async () => {
+  describe("icrc10SupportedStandards", () => {
+    it("should return the list of standards", async () => {
+      const service = mock<ActorSubclass<IcrcLedgerService>>();
+      const standards = [
+        { name: "ICRC-10", url: "https://github.com/dfinity/ICRC-10" },
+      ];
       service.icrc10_supported_standards.mockResolvedValue(standards);
 
       const canister = IcrcLedgerCanister.create({
@@ -854,9 +840,8 @@ describe("Ledger canister", () => {
         certifiedServiceOverride: service,
       });
 
-      const res = await canister.getSupportedStandards({ type: "icrc10" });
+      const res = await canister.icrc10SupportedStandards({});
 
-      expect(service.icrc10_supported_standards).toHaveBeenCalledOnce();
       expect(res).toEqual(standards);
     });
   });

--- a/packages/ledger-icrc/src/ledger.canister.ts
+++ b/packages/ledger-icrc/src/ledger.canister.ts
@@ -28,7 +28,7 @@ import {
   mapIcrc21ConsentMessageError,
 } from "./errors/ledger.errors";
 import type { IcrcLedgerCanisterOptions } from "./types/canister.options";
-import {
+import type {
   AllowanceParams,
   ApproveParams,
   BalanceParams,

--- a/packages/ledger-icrc/src/ledger.canister.ts
+++ b/packages/ledger-icrc/src/ledger.canister.ts
@@ -28,11 +28,12 @@ import {
   mapIcrc21ConsentMessageError,
 } from "./errors/ledger.errors";
 import type { IcrcLedgerCanisterOptions } from "./types/canister.options";
-import type {
+import {
   AllowanceParams,
   ApproveParams,
   BalanceParams,
   GetBlocksParams,
+  GetSupportedStandardsParams,
   Icrc21ConsentMessageParams,
   TransferFromParams,
   TransferParams,
@@ -225,11 +226,27 @@ export class IcrcLedgerCanister extends Canister<IcrcLedgerService> {
 
   /**
    * Returns the list of standards this ledger supports.
+   * Depending on the provided type, either icrc1_supported_standards or icrc10_supported_standards will be used.
+   * If no type provided, icrc1_supported_standards will be used by default.
    *
    * @link: https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#icrc1_supported_standards
+   * @link: https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-10/ICRC-10.md#icrc10_supported_standards
    *
+   * @param {GetSupportedStandardsParams} params The parameters to get the standards.
+   * @param {GetSupportedStandardsParams} params.type An optional param to decide which ledger method to use.
    * @returns {Promise<StandardRecord[]>} The list of standards.
    */
-  getSupportedStandards = (params: QueryParams): Promise<StandardRecord[]> =>
-    this.caller(params).icrc1_supported_standards();
+  getSupportedStandards = ({
+    type = "icrc1",
+    ...queryParams
+  }: GetSupportedStandardsParams): Promise<StandardRecord[]> => {
+    switch (type) {
+      case "icrc10":
+        return this.caller(queryParams).icrc10_supported_standards();
+
+      case "icrc1":
+      default:
+        return this.caller(queryParams).icrc1_supported_standards();
+    }
+  };
 }

--- a/packages/ledger-icrc/src/ledger.canister.ts
+++ b/packages/ledger-icrc/src/ledger.canister.ts
@@ -33,7 +33,6 @@ import type {
   ApproveParams,
   BalanceParams,
   GetBlocksParams,
-  GetSupportedStandardsParams,
   Icrc21ConsentMessageParams,
   TransferFromParams,
   TransferParams,
@@ -225,28 +224,24 @@ export class IcrcLedgerCanister extends Canister<IcrcLedgerService> {
   };
 
   /**
-   * Returns the list of standards this ledger supports.
-   * Depending on the provided type, either icrc1_supported_standards or icrc10_supported_standards will be used.
-   * If no type provided, icrc1_supported_standards will be used by default.
+   * Returns the list of standards this ledger supports by using icrc1_supported_standards.
    *
    * @link: https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#icrc1_supported_standards
-   * @link: https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-10/ICRC-10.md#icrc10_supported_standards
    *
-   * @param {GetSupportedStandardsParams} params The parameters to get the standards.
-   * @param {GetSupportedStandardsParams} params.type An optional param to decide which ledger method to use.
    * @returns {Promise<StandardRecord[]>} The list of standards.
    */
-  getSupportedStandards = ({
-    type = "icrc1",
-    ...queryParams
-  }: GetSupportedStandardsParams): Promise<StandardRecord[]> => {
-    switch (type) {
-      case "icrc10":
-        return this.caller(queryParams).icrc10_supported_standards();
+  icrc1SupportedStandards = (params: QueryParams): Promise<StandardRecord[]> =>
+    this.caller(params).icrc1_supported_standards();
 
-      case "icrc1":
-      default:
-        return this.caller(queryParams).icrc1_supported_standards();
-    }
-  };
+  /**
+   * Returns the list of standards this ledger supports by using icrc10_supported_standards.
+   *
+   * @link: https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-10/ICRC-10.md#icrc10_supported_standards
+   *
+   * @returns {Promise<{ url: string; name: string }[]>} The list of standards.
+   */
+  icrc10SupportedStandards = (
+    params: QueryParams,
+  ): Promise<{ url: string; name: string }[]> =>
+    this.caller(params).icrc10_supported_standards();
 }

--- a/packages/ledger-icrc/src/ledger.canister.ts
+++ b/packages/ledger-icrc/src/ledger.canister.ts
@@ -228,7 +228,7 @@ export class IcrcLedgerCanister extends Canister<IcrcLedgerService> {
    *
    * @link: https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#icrc1_supported_standards
    *
-   * @returns {Promise<StandardRecord>} The list of standards.
+   * @returns {Promise<StandardRecord[]>} The list of standards.
    */
   getSupportedStandards = (params: QueryParams): Promise<StandardRecord[]> =>
     this.caller(params).icrc1_supported_standards();

--- a/packages/ledger-icrc/src/ledger.canister.ts
+++ b/packages/ledger-icrc/src/ledger.canister.ts
@@ -9,9 +9,10 @@ import type {
   Allowance,
   BlockIndex,
   GetBlocksResult,
-  _SERVICE as IcrcLedgerService,
-  Tokens,
   icrc21_consent_info,
+  _SERVICE as IcrcLedgerService,
+  StandardRecord,
+  Tokens,
 } from "../candid/icrc_ledger";
 import { idlFactory as certifiedIdlFactory } from "../candid/icrc_ledger.certified.idl";
 import { idlFactory } from "../candid/icrc_ledger.idl";
@@ -221,4 +222,14 @@ export class IcrcLedgerCanister extends Canister<IcrcLedgerService> {
 
     return response.Ok;
   };
+
+  /**
+   * Returns the list of standards this ledger supports.
+   *
+   * @link: https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#icrc1_supported_standards
+   *
+   * @returns {Promise<StandardRecord>} The list of standards.
+   */
+  getSupportedStandards = (params: QueryParams): Promise<StandardRecord[]> =>
+    this.caller(params).icrc1_supported_standards();
 }

--- a/packages/ledger-icrc/src/types/ledger.params.ts
+++ b/packages/ledger-icrc/src/types/ledger.params.ts
@@ -138,10 +138,3 @@ export type Icrc21ConsentMessageParams = Omit<
 export type GetBlocksParams = QueryParams & {
   args: GetBlocksArgs[];
 };
-
-/**
- * Parameters to get supported by ledger standards.
- */
-export type GetSupportedStandardsParams = QueryParams & {
-  type?: "icrc1" | "icrc10";
-};

--- a/packages/ledger-icrc/src/types/ledger.params.ts
+++ b/packages/ledger-icrc/src/types/ledger.params.ts
@@ -138,3 +138,10 @@ export type Icrc21ConsentMessageParams = Omit<
 export type GetBlocksParams = QueryParams & {
   args: GetBlocksArgs[];
 };
+
+/**
+ * Parameters to get supported by ledger standards.
+ */
+export type GetSupportedStandardsParams = QueryParams & {
+  type?: "icrc1" | "icrc10";
+};


### PR DESCRIPTION
# Motivation

The idea is too expose the `icrc1_supported_standards` and `icrc10_supported_standards` methods (https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#icrc1_supported_standards) in the IcrcLedgerCanister class.

# Changes

Added method `getSupportedStandards` in IcrcLedgerCanister.

# Tests

Added test for the new method.

# Todos

- [x] Add entry to changelog (if necessary).
