### PR TITLE
build: accept any principal lib version in zod-schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6893,7 +6893,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/principal": "^2.0.0",
+        "@dfinity/principal": "*",
         "zod": "^4"
       }
     }

--- a/packages/zod-schemas/package.json
+++ b/packages/zod-schemas/package.json
@@ -47,7 +47,7 @@
     "service-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/principal": "^2.0.0",
+    "@dfinity/principal": "*",
     "zod": "^4"
   }
 }


### PR DESCRIPTION
# Motivation

There is currently no particular reason to pin `@dfinity/principal` version in zod-schemas because as far as I know `Principal.fromText` always existed. Therefore and also to ease migration, I propose to accept any version of the peer dependency.

# Changes

- Mark peer dependency as `*`