### PR TITLE
feat: remove usage of Buffer from nns-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1982,25 +1982,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
@@ -2030,30 +2011,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/bytes-iec": {
@@ -3778,25 +3735,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -6668,8 +6606,7 @@
       "version": "9.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/hashes": "^1.8.0",
-        "buffer": "^6.0.3"
+        "@noble/hashes": "^1.8.0"
       },
       "peerDependencies": {
         "@dfinity/agent": "^3",
@@ -6794,8 +6731,7 @@
     "@dfinity/nns": {
       "version": "file:packages/nns",
       "requires": {
-        "@noble/hashes": "^1.8.0",
-        "buffer": "^6.0.3"
+        "@noble/hashes": "^1.8.0"
       }
     },
     "@dfinity/nns-proto": {
@@ -7851,11 +7787,6 @@
       "dev": true,
       "peer": true
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
     "bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
@@ -7880,15 +7811,6 @@
       "peer": true,
       "requires": {
         "fill-range": "^7.1.1"
-      }
-    },
-    "buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "bytes-iec": {
@@ -9055,11 +8977,6 @@
       "requires": {
         "function-bind": "^1.1.2"
       }
-    },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -122,8 +122,7 @@
         "@dfinity/candid",
         "@dfinity/principal",
         "@dfinity/utils",
-        "@dfinity/ledger-icp",
-        "buffer"
+        "@dfinity/ledger-icp"
       ]
     },
     {

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -19,8 +19,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@noble/hashes": "^1.8.0",
-    "buffer": "^6.0.3"
+    "@noble/hashes": "^1.8.0"
   },
   "repository": {
     "type": "git",

--- a/packages/nns/src/utils/account_identifier.utils.ts
+++ b/packages/nns/src/utils/account_identifier.utils.ts
@@ -4,19 +4,17 @@ import {
   arrayOfNumberToUint8Array,
   asciiStringToByteArray,
   bigEndianCrc32,
+  hexStringToUint8Array,
   uint8ArrayToHexString,
 } from "@dfinity/utils";
 import { sha224 } from "@noble/hashes/sha2";
-import { Buffer } from "buffer";
 
 // The following functions were originally made available in @dfinity/ledger-icp for domain alignment reasons.
-// However, they rely on Buffer — which requires a polyfill and significantly increases bundle size in web environments.
 // Since they are only used by @dfinity/nns and potentially the NNS dapp, they have been moved to this package instead.
 
 export const accountIdentifierToBytes = (
   accountIdentifier: AccountIdentifierHex,
-): Uint8Array =>
-  Uint8Array.from(Buffer.from(accountIdentifier, "hex")).subarray(4);
+): Uint8Array => hexStringToUint8Array(accountIdentifier).subarray(4);
 
 export const accountIdentifierFromBytes = (
   accountIdentifier: Uint8Array,


### PR DESCRIPTION
# Motivation

Get finally rid of Buffer in the browser. Best day ever for bundle size!

# Changes

- Remove `buffer` dependency from `@dfinity/nns`
- Replace single usage by a utility of `@dfinity/utils`