### PR TITLE
chore: prepare release version 73 for AgentJS v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# v73
+
+## Overview
+
+| Library                  | Version | Status        |
+| ------------------------ |---------| ------------- |
+| `@dfinity/ckbtc`         | v4.0.0  | Enhanced 🔧️  |
+| `@dfinity/cketh`         | v4.0.0  | Enhanced 🔧️ |
+| `@dfinity/cmc`           | v6.0.0  | Enhanced 🔧️ |
+| `@dfinity/ic-management` | v7.0.0  | Enhanced 🔧️ |
+| `@dfinity/ledger-icp`    | v5.0.0  | Enhanced 🔧️  |
+| `@dfinity/ledger-icrc`   | v3.0.0  | Enhanced 🔧️  |
+| `@dfinity/nns`           | v10.0.0 | Enhanced 🔧️  |
+| `@dfinity/nns-proto`     | v2.0.2  | Unchanged️    |
+| `@dfinity/sns`           | v4.0.0  | Enhanced 🔧️  |
+| `@dfinity/utils`         | v3.0.0  | Enhanced 🔧️  |
+| `@dfinity/zod-schemas`   | v2.1.0  | Enhanced 🔧️️    |
+
+## Build
+
+- Migrate to AgentJS v3. For upgrade guidelines, check out its [release notes](https://js.icp.build/core/release-notes/v300/).
+- Accept any version of `@dfinity/principal` for `zod-schemas`.
+
+> [!NOTE]  
+> The libraries are published using major versioning to highlight the update to this important peer dependency.  
+> However, there are no other changes in this release, so no functional changes should be expected.
+
 # v72
 
 ## Overview

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "72",
+  "version": "73",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/ic-js",
-      "version": "72",
+      "version": "73",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/utils",
@@ -6584,7 +6584,7 @@
     },
     "packages/ckbtc": {
       "name": "@dfinity/ckbtc",
-      "version": "3.2.0",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
@@ -6595,7 +6595,7 @@
         "@dfinity/agent": "^3",
         "@dfinity/candid": "^3",
         "@dfinity/principal": "^3",
-        "@dfinity/utils": "^2.14.0"
+        "@dfinity/utils": "^3"
       }
     },
     "packages/ckbtc/node_modules/base58-js": {
@@ -6610,62 +6610,62 @@
     },
     "packages/cketh": {
       "name": "@dfinity/cketh",
-      "version": "3.4.12",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^3",
         "@dfinity/candid": "^3",
         "@dfinity/principal": "^3",
-        "@dfinity/utils": "^2.14.0"
+        "@dfinity/utils": "^3"
       }
     },
     "packages/cmc": {
       "name": "@dfinity/cmc",
-      "version": "5.0.8",
+      "version": "6.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^3",
         "@dfinity/candid": "^3",
         "@dfinity/principal": "^3",
-        "@dfinity/utils": "^2.14.0"
+        "@dfinity/utils": "^3"
       }
     },
     "packages/ic-management": {
       "name": "@dfinity/ic-management",
-      "version": "6.2.2",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^3",
         "@dfinity/candid": "^3",
         "@dfinity/principal": "^3",
-        "@dfinity/utils": "^2.14.0"
+        "@dfinity/utils": "^3"
       }
     },
     "packages/ledger-icp": {
       "name": "@dfinity/ledger-icp",
-      "version": "4.1.0",
+      "version": "5.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^3",
         "@dfinity/candid": "^3",
         "@dfinity/principal": "^3",
-        "@dfinity/utils": "^2.14.0"
+        "@dfinity/utils": "^3"
       }
     },
     "packages/ledger-icrc": {
       "name": "@dfinity/ledger-icrc",
-      "version": "2.10.0",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^3",
         "@dfinity/candid": "^3",
         "@dfinity/principal": "^3",
-        "@dfinity/utils": "^2.14.0"
+        "@dfinity/utils": "^3"
       }
     },
     "packages/nns": {
       "name": "@dfinity/nns",
-      "version": "9.1.0",
+      "version": "10.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
@@ -6674,9 +6674,9 @@
       "peerDependencies": {
         "@dfinity/agent": "^3",
         "@dfinity/candid": "^3",
-        "@dfinity/ledger-icp": "^4",
+        "@dfinity/ledger-icp": "^5",
         "@dfinity/principal": "^3",
-        "@dfinity/utils": "^2.14.0"
+        "@dfinity/utils": "^3"
       }
     },
     "packages/nns-proto": {
@@ -6692,7 +6692,7 @@
     },
     "packages/sns": {
       "name": "@dfinity/sns",
-      "version": "3.8.0",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0"
@@ -6700,14 +6700,14 @@
       "peerDependencies": {
         "@dfinity/agent": "^3",
         "@dfinity/candid": "^3",
-        "@dfinity/ledger-icrc": "^2.10",
+        "@dfinity/ledger-icrc": "^3",
         "@dfinity/principal": "^3",
-        "@dfinity/utils": "^2.14.0"
+        "@dfinity/utils": "^3"
       }
     },
     "packages/utils": {
       "name": "@dfinity/utils",
-      "version": "2.14.0",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^3",
@@ -6717,7 +6717,7 @@
     },
     "packages/zod-schemas": {
       "name": "@dfinity/zod-schemas",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/principal": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "72",
+  "version": "73",
   "description": "A collection of library for interfacing with the Internet Computer.",
   "license": "Apache-2.0",
   "workspaces": [

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ckbtc",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "A library for interfacing with ckBTC.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -41,7 +41,7 @@
     "@dfinity/agent": "^3",
     "@dfinity/candid": "^3",
     "@dfinity/principal": "^3",
-    "@dfinity/utils": "^2.14.0"
+    "@dfinity/utils": "^3"
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",

--- a/packages/cketh/package.json
+++ b/packages/cketh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/cketh",
-  "version": "3.4.12",
+  "version": "4.0.0",
   "description": "A library for interfacing with ckETH.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -41,6 +41,6 @@
     "@dfinity/agent": "^3",
     "@dfinity/candid": "^3",
     "@dfinity/principal": "^3",
-    "@dfinity/utils": "^2.14.0"
+    "@dfinity/utils": "^3"
   }
 }

--- a/packages/cmc/package.json
+++ b/packages/cmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/cmc",
-  "version": "5.0.8",
+  "version": "6.0.0",
   "description": "A library for interfacing with the cycle minting canister.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -39,6 +39,6 @@
     "@dfinity/agent": "^3",
     "@dfinity/candid": "^3",
     "@dfinity/principal": "^3",
-    "@dfinity/utils": "^2.14.0"
+    "@dfinity/utils": "^3"
   }
 }

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-management",
-  "version": "6.2.2",
+  "version": "7.0.0",
   "description": "A library for interfacing with the IC management canister.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -37,6 +37,6 @@
     "@dfinity/agent": "^3",
     "@dfinity/candid": "^3",
     "@dfinity/principal": "^3",
-    "@dfinity/utils": "^2.14.0"
+    "@dfinity/utils": "^3"
   }
 }

--- a/packages/ledger-icp/package.json
+++ b/packages/ledger-icp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ledger-icp",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "A library for interfacing with the ICP ledger on the Internet Computer.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -41,6 +41,6 @@
     "@dfinity/agent": "^3",
     "@dfinity/candid": "^3",
     "@dfinity/principal": "^3",
-    "@dfinity/utils": "^2.14.0"
+    "@dfinity/utils": "^3"
   }
 }

--- a/packages/ledger-icrc/package.json
+++ b/packages/ledger-icrc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ledger-icrc",
-  "version": "2.10.0",
+  "version": "3.0.0",
   "description": "A library for interfacing with ICRC ledgers on the Internet Computer.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -40,6 +40,6 @@
     "@dfinity/agent": "^3",
     "@dfinity/candid": "^3",
     "@dfinity/principal": "^3",
-    "@dfinity/utils": "^2.14.0"
+    "@dfinity/utils": "^3"
   }
 }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "9.1.0",
+  "version": "10.0.0",
   "description": "A library for interfacing with the Internet Computer's Network Nervous System.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -50,8 +50,8 @@
   "peerDependencies": {
     "@dfinity/agent": "^3",
     "@dfinity/candid": "^3",
-    "@dfinity/ledger-icp": "^4",
+    "@dfinity/ledger-icp": "^5",
     "@dfinity/principal": "^3",
-    "@dfinity/utils": "^2.14.0"
+    "@dfinity/utils": "^3"
   }
 }

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/sns",
-  "version": "3.8.0",
+  "version": "4.0.0",
   "description": "A library for interfacing with a Service Nervous System (SNS) project.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -38,9 +38,9 @@
   "peerDependencies": {
     "@dfinity/agent": "^3",
     "@dfinity/candid": "^3",
-    "@dfinity/ledger-icrc": "^2.10",
+    "@dfinity/ledger-icrc": "^3",
     "@dfinity/principal": "^3",
-    "@dfinity/utils": "^2.14.0"
+    "@dfinity/utils": "^3"
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/utils",
-  "version": "2.14.0",
+  "version": "3.0.0",
   "description": "A collection of utilities and constants for NNS/SNS projects.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/zod-schemas/package.json
+++ b/packages/zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/zod-schemas",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A collection of reusable Zod schemas and validators for common data patterns in ICP applications",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",


### PR DESCRIPTION
# Motivation

We are not going to release today but, I think it's probably useful to already use the major version of the library to integrate those for final testing in NNS dapp and OISY.

# Changes

- Bump version and update CHANGELOG to prepare upcomfing release