### PR TITLE
Revert "chore: workflow_dispatch for publish (#1022)"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ name: Publish Release
 on:
   release:
     types: [released]
-  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
# Motivation

We can revert #1022 as the patch for zod-schemas has been released in #996.
