### PR TITLE
feat!: ledger-icp ICRC-21 LineDisplay replaced by FieldsDisplay

### DIFF
--- a/packages/ledger-icp/candid/index.certified.idl.js
+++ b/packages/ledger-icp/candid/index.certified.idl.js
@@ -97,7 +97,7 @@ export const idlFactory = ({ IDL }) => {
       ),
     'get_blocks' : IDL.Func([GetBlocksRequest], [GetBlocksResponse], []),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse], []),
-    'icrc1_balance_of' : IDL.Func([Account], [IDL.Nat64], []),
+    'icrc1_balance_of' : IDL.Func([Account], [IDL.Nat64], ['query']),
     'ledger_id' : IDL.Func([], [IDL.Principal], []),
     'status' : IDL.Func([], [Status], []),
   });

--- a/packages/ledger-icp/candid/index.did
+++ b/packages/ledger-icp/candid/index.did
@@ -1,25 +1,25 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/ledger_suite/icp/index/index.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/ledger_suite/icp/index/index.did' by import-candid
 type Account = record { owner : principal; subaccount : opt vec nat8 };
 type GetAccountIdentifierTransactionsArgs = record {
   max_results : nat64;
   start : opt nat64;
-  account_identifier : text;
+  account_identifier : text
 };
 type GetAccountTransactionsArgs = record {
-    account : Account;
-    // The txid of the last transaction seen by the client.
-    // If None then the results will start from the most recent
-    // txid. If set then the results will start from the next
-    // most recent txid after start (start won't be included).
-    start : opt nat;
-    // Maximum number of transactions to fetch.
-    max_results : nat;
+  account : Account;
+  // The txid of the last transaction seen by the client.
+  // If None then the results will start from the most recent
+  // txid. If set then the results will start from the next
+  // most recent txid after start (start won't be included).
+  start : opt nat;
+  // Maximum number of transactions to fetch.
+  max_results : nat
 };
 type GetAccountIdentifierTransactionsError = record { message : text };
 type GetAccountIdentifierTransactionsResponse = record {
   balance : nat64;
   transactions : vec TransactionWithId;
-  oldest_tx_id : opt nat64;
+  oldest_tx_id : opt nat64
 };
 type GetBlocksRequest = record { start : nat; length : nat };
 type GetBlocksResponse = record { blocks : vec vec nat8; chain_length : nat64 };
@@ -27,12 +27,12 @@ type HttpRequest = record {
   url : text;
   method : text;
   body : vec nat8;
-  headers : vec record { text; text };
+  headers : vec record { text; text }
 };
 type HttpResponse = record {
   body : vec nat8;
   headers : vec record { text; text };
-  status_code : nat16;
+  status_code : nat16
 };
 type InitArg = record { ledger_id : principal };
 type Operation = variant {
@@ -42,15 +42,21 @@ type Operation = variant {
     allowance : Tokens;
     expires_at : opt TimeStamp;
     spender : text;
-    expected_allowance : opt Tokens;
+    expected_allowance : opt Tokens
   };
   Burn : record { from : text; amount : Tokens; spender : opt text };
   Mint : record { to : text; amount : Tokens };
-  Transfer : record { to : text; fee : Tokens; from : text; amount : Tokens; spender : opt text };
+  Transfer : record {
+    to : text;
+    fee : Tokens;
+    from : text;
+    amount : Tokens;
+    spender : opt text
+  }
 };
 type GetAccountIdentifierTransactionsResult = variant {
   Ok : GetAccountIdentifierTransactionsResponse;
-  Err : GetAccountIdentifierTransactionsError;
+  Err : GetAccountIdentifierTransactionsError
 };
 type Status = record { num_blocks_synced : nat64 };
 type TimeStamp = record { timestamp_nanos : nat64 };
@@ -60,18 +66,18 @@ type Transaction = record {
   icrc1_memo : opt vec nat8;
   operation : Operation;
   created_at_time : opt TimeStamp;
-  timestamp : opt TimeStamp;
+  timestamp : opt TimeStamp
 };
 type TransactionWithId = record { id : nat64; transaction : Transaction };
 service : (InitArg) -> {
   get_account_identifier_balance : (text) -> (nat64) query;
   get_account_identifier_transactions : (
-      GetAccountIdentifierTransactionsArgs,
-    ) -> (GetAccountIdentifierTransactionsResult) query;
+    GetAccountIdentifierTransactionsArgs
+  ) -> (GetAccountIdentifierTransactionsResult) query;
   get_account_transactions : (GetAccountTransactionsArgs) -> (GetAccountIdentifierTransactionsResult) query;
   get_blocks : (GetBlocksRequest) -> (GetBlocksResponse) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
   ledger_id : () -> (principal) query;
   status : () -> (Status) query;
-  icrc1_balance_of : (Account) -> (nat64) query;
+  icrc1_balance_of : (Account) -> (nat64) query
 }

--- a/packages/ledger-icp/candid/ledger.certified.idl.js
+++ b/packages/ledger-icp/candid/ledger.certified.idl.js
@@ -101,13 +101,7 @@ export const idlFactory = ({ IDL }) => {
   const icrc21_consent_message_spec = IDL.Record({
     'metadata' : icrc21_consent_message_metadata,
     'device_spec' : IDL.Opt(
-      IDL.Variant({
-        'GenericDisplay' : IDL.Null,
-        'LineDisplay' : IDL.Record({
-          'characters_per_line' : IDL.Nat16,
-          'lines_per_page' : IDL.Nat16,
-        }),
-      })
+      IDL.Variant({ 'GenericDisplay' : IDL.Null, 'FieldsDisplay' : IDL.Null })
     ),
   });
   const icrc21_consent_message_request = IDL.Record({
@@ -115,10 +109,22 @@ export const idlFactory = ({ IDL }) => {
     'method' : IDL.Text,
     'user_preferences' : icrc21_consent_message_spec,
   });
-  const icrc21_consent_message = IDL.Variant({
-    'LineDisplayMessage' : IDL.Record({
-      'pages' : IDL.Vec(IDL.Record({ 'lines' : IDL.Vec(IDL.Text) })),
+  const Icrc21Value = IDL.Variant({
+    'Text' : IDL.Record({ 'content' : IDL.Text }),
+    'TokenAmount' : IDL.Record({
+      'decimals' : IDL.Nat8,
+      'amount' : IDL.Nat64,
+      'symbol' : IDL.Text,
     }),
+    'TimestampSeconds' : IDL.Record({ 'amount' : IDL.Nat64 }),
+    'DurationSeconds' : IDL.Record({ 'amount' : IDL.Nat64 }),
+  });
+  const FieldsDisplay = IDL.Record({
+    'fields' : IDL.Vec(IDL.Tuple(IDL.Text, Icrc21Value)),
+    'intent' : IDL.Text,
+  });
+  const icrc21_consent_message = IDL.Variant({
+    'FieldsDisplayMessage' : FieldsDisplay,
     'GenericDisplayMessage' : IDL.Text,
   });
   const icrc21_consent_info = IDL.Record({
@@ -293,6 +299,11 @@ export const idlFactory = ({ IDL }) => {
     'first_block_index' : IDL.Nat64,
     'archived_blocks' : IDL.Vec(ArchivedEncodedBlocksRange),
   });
+  const RemoveApprovalArgs = IDL.Record({
+    'fee' : IDL.Opt(Icrc1Tokens),
+    'from_subaccount' : IDL.Opt(SubAccount),
+    'spender' : AccountIdentifier,
+  });
   const SendArgs = IDL.Record({
     'to' : TextAccountIdentifier,
     'fee' : Tokens,
@@ -364,7 +375,7 @@ export const idlFactory = ({ IDL }) => {
         [TransferFromResult],
         [],
       ),
-    'is_ledger_ready' : IDL.Func([], [IDL.Bool], []),
+    'is_ledger_ready' : IDL.Func([], [IDL.Bool], ['query']),
     'name' : IDL.Func([], [IDL.Record({ 'name' : IDL.Text })], []),
     'query_blocks' : IDL.Func([GetBlocksArgs], [QueryBlocksResponse], []),
     'query_encoded_blocks' : IDL.Func(
@@ -372,6 +383,7 @@ export const idlFactory = ({ IDL }) => {
         [QueryEncodedBlocksResponse],
         [],
       ),
+    'remove_approval' : IDL.Func([RemoveApprovalArgs], [ApproveResult], []),
     'send_dfx' : IDL.Func([SendArgs], [BlockIndex], []),
     'symbol' : IDL.Func([], [IDL.Record({ 'symbol' : IDL.Text })], []),
     'tip_of_chain' : IDL.Func([], [TipOfChainRes], []),

--- a/packages/ledger-icp/candid/ledger.d.ts
+++ b/packages/ledger-icp/candid/ledger.d.ts
@@ -92,6 +92,10 @@ export interface Duration {
 export interface FeatureFlags {
   icrc2: boolean;
 }
+export interface FieldsDisplay {
+  fields: Array<[string, Icrc21Value]>;
+  intent: string;
+}
 export interface GetAllowancesArgs {
   prev_spender_id: [] | [TextAccountIdentifier];
   from_account_id: TextAccountIdentifier;
@@ -118,6 +122,17 @@ export type Icrc1TransferError =
 export type Icrc1TransferResult =
   | { Ok: Icrc1BlockIndex }
   | { Err: Icrc1TransferError };
+export type Icrc21Value =
+  | { Text: { content: string } }
+  | {
+      TokenAmount: {
+        decimals: number;
+        amount: bigint;
+        symbol: string;
+      };
+    }
+  | { TimestampSeconds: { amount: bigint } }
+  | { DurationSeconds: { amount: bigint } };
 export interface InitArgs {
   send_whitelist: Array<Principal>;
   token_symbol: [] | [string];
@@ -189,6 +204,11 @@ export interface QueryEncodedBlocksResponse {
   chain_length: bigint;
   first_block_index: bigint;
   archived_blocks: Array<ArchivedEncodedBlocksRange>;
+}
+export interface RemoveApprovalArgs {
+  fee: [] | [Icrc1Tokens];
+  from_subaccount: [] | [SubAccount];
+  spender: AccountIdentifier;
 }
 export interface SendArgs {
   to: TextAccountIdentifier;
@@ -284,7 +304,7 @@ export interface icrc21_consent_info {
 }
 export type icrc21_consent_message =
   | {
-      LineDisplayMessage: { pages: Array<{ lines: Array<string> }> };
+      FieldsDisplayMessage: FieldsDisplay;
     }
   | { GenericDisplayMessage: string };
 export interface icrc21_consent_message_metadata {
@@ -301,17 +321,7 @@ export type icrc21_consent_message_response =
   | { Err: icrc21_error };
 export interface icrc21_consent_message_spec {
   metadata: icrc21_consent_message_metadata;
-  device_spec:
-    | []
-    | [
-        | { GenericDisplay: null }
-        | {
-            LineDisplay: {
-              characters_per_line: number;
-              lines_per_page: number;
-            };
-          },
-      ];
+  device_spec: [] | [{ GenericDisplay: null } | { FieldsDisplay: null }];
 }
 export type icrc21_error =
   | {
@@ -361,6 +371,7 @@ export interface _SERVICE {
     [GetBlocksArgs],
     QueryEncodedBlocksResponse
   >;
+  remove_approval: ActorMethod<[RemoveApprovalArgs], ApproveResult>;
   send_dfx: ActorMethod<[SendArgs], BlockIndex>;
   symbol: ActorMethod<[], { symbol: string }>;
   tip_of_chain: ActorMethod<[], TipOfChainRes>;

--- a/packages/ledger-icp/candid/ledger.did
+++ b/packages/ledger-icp/candid/ledger.did
@@ -1,14 +1,14 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/ledger_suite/icp/ledger.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/ledger_suite/icp/ledger.did' by import-candid
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.
 type Tokens = record {
-     e8s : nat64;
+  e8s : nat64
 };
 
 // Number of nanoseconds from the UNIX epoch in UTC timezone.
 type TimeStamp = record {
-    timestamp_nanos: nat64;
+  timestamp_nanos : nat64
 };
 
 // AccountIdentifier is a 32-byte array.
@@ -24,10 +24,10 @@ type SubAccount = blob;
 type BlockIndex = nat64;
 
 type Transaction = record {
-    memo : Memo;
-    icrc1_memo: opt blob;
-    operation : opt Operation;
-    created_at_time : TimeStamp;
+  memo : Memo;
+  icrc1_memo : opt blob;
+  operation : opt Operation;
+  created_at_time : TimeStamp
 };
 
 // An arbitrary number associated with a transaction.
@@ -36,148 +36,146 @@ type Memo = nat64;
 
 // Arguments for the `transfer` call.
 type TransferArgs = record {
-    // Transaction memo.
-    // See comments for the `Memo` type.
-    memo: Memo;
-    // The amount that the caller wants to transfer to the destination address.
-    amount: Tokens;
-    // The amount that the caller pays for the transaction.
-    // Must be 10000 e8s.
-    fee: Tokens;
-    // The subaccount from which the caller wants to transfer funds.
-    // If null, the ledger uses the default (all zeros) subaccount to compute the source address.
-    // See comments for the `SubAccount` type.
-    from_subaccount: opt SubAccount;
-    // The destination account.
-    // If the transfer is successful, the balance of this address increases by `amount`.
-    to: AccountIdentifier;
-    // The point in time when the caller created this request.
-    // If null, the ledger uses current IC time as the timestamp.
-    created_at_time: opt TimeStamp;
+  // Transaction memo.
+  // See comments for the `Memo` type.
+  memo : Memo;
+  // The amount that the caller wants to transfer to the destination address.
+  amount : Tokens;
+  // The amount that the caller pays for the transaction.
+  // Must be 10000 e8s.
+  fee : Tokens;
+  // The subaccount from which the caller wants to transfer funds.
+  // If null, the ledger uses the default (all zeros) subaccount to compute the source address.
+  // See comments for the `SubAccount` type.
+  from_subaccount : opt SubAccount;
+  // The destination account.
+  // If the transfer is successful, the balance of this address increases by `amount`.
+  to : AccountIdentifier;
+  // The point in time when the caller created this request.
+  // If null, the ledger uses current IC time as the timestamp.
+  created_at_time : opt TimeStamp
 };
 
 type TransferError = variant {
-    // The fee that the caller specified in the transfer request was not the one that ledger expects.
-    // The caller can change the transfer fee to the `expected_fee` and retry the request.
-    BadFee : record { expected_fee : Tokens; };
-    // The account specified by the caller doesn't have enough funds.
-    InsufficientFunds : record { balance: Tokens; };
-    // The request is too old.
-    // The ledger only accepts requests created within 24 hours window.
-    // This is a non-recoverable error.
-    TxTooOld : record { allowed_window_nanos: nat64 };
-    // The caller specified `created_at_time` that is too far in future.
-    // The caller can retry the request later.
-    TxCreatedInFuture : null;
-    // The ledger has already executed the request.
-    // `duplicate_of` field is equal to the index of the block containing the original transaction.
-    TxDuplicate : record { duplicate_of: BlockIndex; }
+  // The fee that the caller specified in the transfer request was not the one that ledger expects.
+  // The caller can change the transfer fee to the `expected_fee` and retry the request.
+  BadFee : record { expected_fee : Tokens };
+  // The account specified by the caller doesn't have enough funds.
+  InsufficientFunds : record { balance : Tokens };
+  // The request is too old.
+  // The ledger only accepts requests created within 24 hours window.
+  // This is a non-recoverable error.
+  TxTooOld : record { allowed_window_nanos : nat64 };
+  // The caller specified `created_at_time` that is too far in future.
+  // The caller can retry the request later.
+  TxCreatedInFuture : null;
+  // The ledger has already executed the request.
+  // `duplicate_of` field is equal to the index of the block containing the original transaction.
+  TxDuplicate : record { duplicate_of : BlockIndex }
 };
 
 type TransferResult = variant {
-    Ok : BlockIndex;
-    Err : TransferError;
+  Ok : BlockIndex;
+  Err : TransferError
 };
 
 // Arguments for the `account_balance` call.
 type AccountBalanceArgs = record {
-    account: AccountIdentifier;
+  account : AccountIdentifier
 };
 
 type TransferFeeArg = record {};
 
 type TransferFee = record {
-    // The fee to pay to perform a transfer
-    transfer_fee: Tokens;
+  // The fee to pay to perform a transfer
+  transfer_fee : Tokens
 };
 
 type GetBlocksArgs = record {
-    // The index of the first block to fetch.
-    start : BlockIndex;
-    // Max number of blocks to fetch.
-    length : nat64;
+  // The index of the first block to fetch.
+  start : BlockIndex;
+  // Max number of blocks to fetch.
+  length : nat64
 };
 
 type Operation = variant {
-    Mint : record {
-        to : AccountIdentifier;
-        amount : Tokens;
-    };
-    Burn : record {
-        from : AccountIdentifier;
-        spender : opt AccountIdentifier;
-        amount : Tokens;
-    };
-    Transfer : record {
-        from : AccountIdentifier;
-        to : AccountIdentifier;
-        amount : Tokens;
-        fee : Tokens;
-        spender : opt vec nat8;
-    };
-    Approve : record {
-        from : AccountIdentifier;
-        spender : AccountIdentifier;
-        // This field is deprecated and should not be used.
-        allowance_e8s : int;
-        allowance: Tokens;
-        fee : Tokens;
-        expires_at : opt TimeStamp;
-        expected_allowance : opt Tokens;
-    };
+  Mint : record {
+    to : AccountIdentifier;
+    amount : Tokens
+  };
+  Burn : record {
+    from : AccountIdentifier;
+    spender : opt AccountIdentifier;
+    amount : Tokens
+  };
+  Transfer : record {
+    from : AccountIdentifier;
+    to : AccountIdentifier;
+    amount : Tokens;
+    fee : Tokens;
+    spender : opt vec nat8
+  };
+  Approve : record {
+    from : AccountIdentifier;
+    spender : AccountIdentifier;
+    // This field is deprecated and should not be used.
+    allowance_e8s : int;
+    allowance : Tokens;
+    fee : Tokens;
+    expires_at : opt TimeStamp;
+    expected_allowance : opt Tokens
+  }
 };
 
- 
-
 type Block = record {
-    parent_hash : opt blob;
-    transaction : Transaction;
-    timestamp : TimeStamp;
+  parent_hash : opt blob;
+  transaction : Transaction;
+  timestamp : TimeStamp
 };
 
 // A prefix of the block range specified in the [GetBlocksArgs] request.
 type BlockRange = record {
-    // A prefix of the requested block range.
-    // The index of the first block is equal to [GetBlocksArgs.from].
-    //
-    // Note that the number of blocks might be less than the requested
-    // [GetBlocksArgs.len] for various reasons, for example:
-    //
-    // 1. The query might have hit the replica with an outdated state
-    //    that doesn't have the full block range yet.
-    // 2. The requested range is too large to fit into a single reply.
-    //
-    // NOTE: the list of blocks can be empty if:
-    // 1. [GetBlocksArgs.len] was zero.
-    // 2. [GetBlocksArgs.from] was larger than the last block known to the canister.
-    blocks : vec Block;
+  // A prefix of the requested block range.
+  // The index of the first block is equal to [GetBlocksArgs.from].
+  //
+  // Note that the number of blocks might be less than the requested
+  // [GetBlocksArgs.len] for various reasons, for example:
+  //
+  // 1. The query might have hit the replica with an outdated state
+  //    that doesn't have the full block range yet.
+  // 2. The requested range is too large to fit into a single reply.
+  //
+  // NOTE: the list of blocks can be empty if:
+  // 1. [GetBlocksArgs.len] was zero.
+  // 2. [GetBlocksArgs.from] was larger than the last block known to the canister.
+  blocks : vec Block
 };
 
 // An error indicating that the arguments passed to [QueryArchiveFn] were invalid.
 type QueryArchiveError = variant {
-    // [GetBlocksArgs.from] argument was smaller than the first block
-    // served by the canister that received the request.
-    BadFirstBlockIndex : record {
-        requested_index : BlockIndex;
-        first_valid_index : BlockIndex;
-    };
+  // [GetBlocksArgs.from] argument was smaller than the first block
+  // served by the canister that received the request.
+  BadFirstBlockIndex : record {
+    requested_index : BlockIndex;
+    first_valid_index : BlockIndex
+  };
 
-    // Reserved for future use.
-    Other : record {
-        error_code : nat64;
-        error_message : text;
-    };
+  // Reserved for future use.
+  Other : record {
+    error_code : nat64;
+    error_message : text
+  }
 };
 
 type QueryArchiveResult = variant {
-    // Successfully fetched zero or more blocks.
-    Ok : BlockRange;
-    // The [GetBlocksArgs] request was invalid.
-    Err : QueryArchiveError;
+  // Successfully fetched zero or more blocks.
+  Ok : BlockRange;
+  // The [GetBlocksArgs] request was invalid.
+  Err : QueryArchiveError
 };
 
 // A function that is used for fetching archived ledger blocks.
-type QueryArchiveFn = func (GetBlocksArgs) -> (QueryArchiveResult) query;
+type QueryArchiveFn = func(GetBlocksArgs) -> (QueryArchiveResult) query;
 
 // The result of a "query_blocks" call.
 //
@@ -185,89 +183,89 @@ type QueryArchiveFn = func (GetBlocksArgs) -> (QueryArchiveResult) query;
 // not have all the blocks that the caller requested: One or more "archive" canisters might
 // store some of the requested blocks.
 //
-// Note: as of Q4 2021 when this interface is authored, the IC doesn't support making nested 
+// Note: as of Q4 2021 when this interface is authored, the IC doesn't support making nested
 // query calls within a query call.
 type QueryBlocksResponse = record {
-    // The total number of blocks in the chain.
-    // If the chain length is positive, the index of the last block is `chain_len - 1`.
-    chain_length : nat64;
+  // The total number of blocks in the chain.
+  // If the chain length is positive, the index of the last block is `chain_len - 1`.
+  chain_length : nat64;
 
-    // System certificate for the hash of the latest block in the chain.
-    // Only present if `query_blocks` is called in a non-replicated query context.
-    certificate : opt blob;
+  // System certificate for the hash of the latest block in the chain.
+  // Only present if `query_blocks` is called in a non-replicated query context.
+  certificate : opt blob;
 
-    // List of blocks that were available in the ledger when it processed the call.
-    //
-    // The blocks form a contiguous range, with the first block having index
-    // [first_block_index] (see below), and the last block having index
-    // [first_block_index] + len(blocks) - 1.
-    //
-    // The block range can be an arbitrary sub-range of the originally requested range.
-    blocks : vec Block;
+  // List of blocks that were available in the ledger when it processed the call.
+  //
+  // The blocks form a contiguous range, with the first block having index
+  // [first_block_index] (see below), and the last block having index
+  // [first_block_index] + len(blocks) - 1.
+  //
+  // The block range can be an arbitrary sub-range of the originally requested range.
+  blocks : vec Block;
 
-    // The index of the first block in "blocks".
-    // If the blocks vector is empty, the exact value of this field is not specified.
-    first_block_index : BlockIndex;
+  // The index of the first block in "blocks".
+  // If the blocks vector is empty, the exact value of this field is not specified.
+  first_block_index : BlockIndex;
 
-    // Encoding of instructions for fetching archived blocks whose indices fall into the
-    // requested range.
-    //
-    // For each entry `e` in [archived_blocks], `[e.from, e.from + len)` is a sub-range
-    // of the originally requested block range.
-    archived_blocks : vec ArchivedBlocksRange;
+  // Encoding of instructions for fetching archived blocks whose indices fall into the
+  // requested range.
+  //
+  // For each entry `e` in [archived_blocks], `[e.from, e.from + len)` is a sub-range
+  // of the originally requested block range.
+  archived_blocks : vec ArchivedBlocksRange
 };
 
 type ArchivedBlocksRange = record {
-    // The index of the first archived block that can be fetched using the callback.
-    start : BlockIndex;
+  // The index of the first archived block that can be fetched using the callback.
+  start : BlockIndex;
 
-    // The number of blocks that can be fetch using the callback.
-    length : nat64;
+  // The number of blocks that can be fetch using the callback.
+  length : nat64;
 
-    // The function that should be called to fetch the archived blocks.
-    // The range of the blocks accessible using this function is given by [from]
-    // and [len] fields above.
-    callback : QueryArchiveFn;
+  // The function that should be called to fetch the archived blocks.
+  // The range of the blocks accessible using this function is given by [from]
+  // and [len] fields above.
+  callback : QueryArchiveFn
 };
 
 type ArchivedEncodedBlocksRange = record {
-    callback : func (GetBlocksArgs) -> (
-        variant { Ok : vec blob; Err : QueryArchiveError },
-        ) query;
-    start : nat64;
-    length : nat64;
+  callback : func(GetBlocksArgs) -> (
+    variant { Ok : vec blob; Err : QueryArchiveError }
+  ) query;
+  start : nat64;
+  length : nat64
 };
 
 type QueryEncodedBlocksResponse = record {
-    certificate : opt blob;
-    blocks : vec blob;
-    chain_length : nat64;
-    first_block_index : nat64;
-    archived_blocks : vec ArchivedEncodedBlocksRange;
+  certificate : opt blob;
+  blocks : vec blob;
+  chain_length : nat64;
+  first_block_index : nat64;
+  archived_blocks : vec ArchivedEncodedBlocksRange
 };
 
 type Archive = record {
-    canister_id: principal;
+  canister_id : principal
 };
 
 type Archives = record {
-    archives: vec Archive;
+  archives : vec Archive
 };
 
 type Duration = record {
-    secs: nat64;
-    nanos: nat32;
+  secs : nat64;
+  nanos : nat32
 };
 
 type ArchiveOptions = record {
-    trigger_threshold : nat64;
-    num_blocks_to_archive : nat64;
-    node_max_memory_size_bytes : opt nat64;
-    max_message_size_bytes : opt nat64;
-    controller_id : principal;
-    more_controller_ids: opt vec principal;
-    cycles_for_archive_creation : opt nat64;
-    max_transactions_per_response : opt nat64;
+  trigger_threshold : nat64;
+  num_blocks_to_archive : nat64;
+  node_max_memory_size_bytes : opt nat64;
+  max_message_size_bytes : opt nat64;
+  controller_id : principal;
+  more_controller_ids : opt vec principal;
+  cycles_for_archive_creation : opt nat64;
+  max_transactions_per_response : opt nat64
 };
 
 // Account identifier encoded as a 64-byte ASCII hex string.
@@ -275,34 +273,34 @@ type TextAccountIdentifier = text;
 
 // Arguments for the `send_dfx` call.
 type SendArgs = record {
-    memo: Memo;
-    amount: Tokens;
-    fee: Tokens;
-    from_subaccount: opt SubAccount;
-    to: TextAccountIdentifier;
-    created_at_time: opt TimeStamp;
+  memo : Memo;
+  amount : Tokens;
+  fee : Tokens;
+  from_subaccount : opt SubAccount;
+  to : TextAccountIdentifier;
+  created_at_time : opt TimeStamp
 };
 
 type AccountBalanceArgsDfx = record {
-    account: TextAccountIdentifier;
+  account : TextAccountIdentifier
 };
 
 type FeatureFlags = record {
-    icrc2 : bool;
+  icrc2 : bool
 };
 
 type InitArgs = record {
-    minting_account: TextAccountIdentifier;
-    icrc1_minting_account: opt Account;
-    initial_values: vec record {TextAccountIdentifier; Tokens};
-    max_message_size_bytes: opt nat64;
-    transaction_window: opt Duration;
-    archive_options: opt ArchiveOptions;
-    send_whitelist: vec principal;
-    transfer_fee: opt Tokens;
-    token_symbol: opt text;
-    token_name: opt text;
-    feature_flags : opt FeatureFlags;
+  minting_account : TextAccountIdentifier;
+  icrc1_minting_account : opt Account;
+  initial_values : vec record { TextAccountIdentifier; Tokens };
+  max_message_size_bytes : opt nat64;
+  transaction_window : opt Duration;
+  archive_options : opt ArchiveOptions;
+  send_whitelist : vec principal;
+  transfer_fee : opt Tokens;
+  token_symbol : opt text;
+  token_name : opt text;
+  feature_flags : opt FeatureFlags
 };
 
 type Icrc1BlockIndex = nat;
@@ -311,173 +309,188 @@ type Icrc1Timestamp = nat64;
 type Icrc1Tokens = nat;
 
 type Account = record {
-    owner : principal;
-    subaccount : opt SubAccount;
+  owner : principal;
+  subaccount : opt SubAccount
 };
 
 type TransferArg = record {
-    from_subaccount : opt SubAccount;
-    to : Account;
-    amount : Icrc1Tokens;
-    fee : opt Icrc1Tokens;
-    memo : opt blob;
-    created_at_time: opt Icrc1Timestamp;
+  from_subaccount : opt SubAccount;
+  to : Account;
+  amount : Icrc1Tokens;
+  fee : opt Icrc1Tokens;
+  memo : opt blob;
+  created_at_time : opt Icrc1Timestamp
 };
 
 type Icrc1TransferError = variant {
-    BadFee : record { expected_fee : Icrc1Tokens };
-    BadBurn : record { min_burn_amount : Icrc1Tokens };
-    InsufficientFunds : record { balance : Icrc1Tokens };
-    TooOld;
-    CreatedInFuture : record { ledger_time : nat64 };
-    TemporarilyUnavailable;
-    Duplicate : record { duplicate_of : Icrc1BlockIndex };
-    GenericError : record { error_code : nat; message : text };
+  BadFee : record { expected_fee : Icrc1Tokens };
+  BadBurn : record { min_burn_amount : Icrc1Tokens };
+  InsufficientFunds : record { balance : Icrc1Tokens };
+  TooOld;
+  CreatedInFuture : record { ledger_time : nat64 };
+  TemporarilyUnavailable;
+  Duplicate : record { duplicate_of : Icrc1BlockIndex };
+  GenericError : record { error_code : nat; message : text }
 };
 
 type Icrc1TransferResult = variant {
-    Ok : Icrc1BlockIndex;
-    Err : Icrc1TransferError;
+  Ok : Icrc1BlockIndex;
+  Err : Icrc1TransferError
 };
 
 // The value returned from the [icrc1_metadata] endpoint.
 type Value = variant {
-    Nat : nat;
-    Int : int;
-    Text : text;
-    Blob : blob;
+  Nat : nat;
+  Int : int;
+  Text : text;
+  Blob : blob
 };
 
 type UpgradeArgs = record {
   icrc1_minting_account : opt Account;
-  feature_flags : opt FeatureFlags;
+  feature_flags : opt FeatureFlags
 };
 
 type LedgerCanisterPayload = variant {
-    Init: InitArgs;
-    Upgrade: opt UpgradeArgs;
+  Init : InitArgs;
+  Upgrade : opt UpgradeArgs
 };
 
 type ApproveArgs = record {
-    from_subaccount : opt SubAccount;
-    spender : Account;
-    amount : Icrc1Tokens;
-    expected_allowance : opt Icrc1Tokens;
-    expires_at : opt Icrc1Timestamp;
-    fee : opt Icrc1Tokens;
-    memo : opt blob;
-    created_at_time: opt Icrc1Timestamp;
+  from_subaccount : opt SubAccount;
+  spender : Account;
+  amount : Icrc1Tokens;
+  expected_allowance : opt Icrc1Tokens;
+  expires_at : opt Icrc1Timestamp;
+  fee : opt Icrc1Tokens;
+  memo : opt blob;
+  created_at_time : opt Icrc1Timestamp
 };
 
 type ApproveError = variant {
-    BadFee : record { expected_fee : Icrc1Tokens };
-    InsufficientFunds : record { balance : Icrc1Tokens };
-    AllowanceChanged : record { current_allowance : Icrc1Tokens };
-    Expired : record { ledger_time : nat64 };
-    TooOld;
-    CreatedInFuture : record { ledger_time : nat64 };
-    Duplicate : record { duplicate_of : Icrc1BlockIndex };
-    TemporarilyUnavailable;
-    GenericError : record { error_code : nat; message : text };
+  BadFee : record { expected_fee : Icrc1Tokens };
+  InsufficientFunds : record { balance : Icrc1Tokens };
+  AllowanceChanged : record { current_allowance : Icrc1Tokens };
+  Expired : record { ledger_time : nat64 };
+  TooOld;
+  CreatedInFuture : record { ledger_time : nat64 };
+  Duplicate : record { duplicate_of : Icrc1BlockIndex };
+  TemporarilyUnavailable;
+  GenericError : record { error_code : nat; message : text }
 };
 
 type ApproveResult = variant {
-    Ok : Icrc1BlockIndex;
-    Err : ApproveError;
+  Ok : Icrc1BlockIndex;
+  Err : ApproveError
 };
 
 type AllowanceArgs = record {
-    account : Account;
-    spender : Account;
+  account : Account;
+  spender : Account
 };
 
 type Allowance = record {
-    allowance : Icrc1Tokens;
-    expires_at : opt Icrc1Timestamp;
+  allowance : Icrc1Tokens;
+  expires_at : opt Icrc1Timestamp
 };
 
 type TransferFromArgs = record {
-    spender_subaccount : opt SubAccount;
-    from : Account;
-    to : Account;
-    amount : Icrc1Tokens;
-    fee : opt Icrc1Tokens;
-    memo : opt blob;
-    created_at_time: opt Icrc1Timestamp;
+  spender_subaccount : opt SubAccount;
+  from : Account;
+  to : Account;
+  amount : Icrc1Tokens;
+  fee : opt Icrc1Tokens;
+  memo : opt blob;
+  created_at_time : opt Icrc1Timestamp
 };
 
 type TransferFromResult = variant {
-    Ok : Icrc1BlockIndex;
-    Err : TransferFromError;
+  Ok : Icrc1BlockIndex;
+  Err : TransferFromError
 };
 
 type TransferFromError = variant {
-    BadFee : record { expected_fee : Icrc1Tokens };
-    BadBurn : record { min_burn_amount : Icrc1Tokens };
-    InsufficientFunds : record { balance : Icrc1Tokens };
-    InsufficientAllowance : record { allowance : Icrc1Tokens };
-    TooOld;
-    CreatedInFuture : record { ledger_time : Icrc1Timestamp };
-    Duplicate : record { duplicate_of : Icrc1BlockIndex };
-    TemporarilyUnavailable;
-    GenericError : record { error_code : nat; message : text };
+  BadFee : record { expected_fee : Icrc1Tokens };
+  BadBurn : record { min_burn_amount : Icrc1Tokens };
+  InsufficientFunds : record { balance : Icrc1Tokens };
+  InsufficientAllowance : record { allowance : Icrc1Tokens };
+  TooOld;
+  CreatedInFuture : record { ledger_time : Icrc1Timestamp };
+  Duplicate : record { duplicate_of : Icrc1BlockIndex };
+  TemporarilyUnavailable;
+  GenericError : record { error_code : nat; message : text }
 };
 
 type icrc21_consent_message_metadata = record {
-    language: text;
-    utc_offset_minutes: opt int16;
+  language : text;
+  utc_offset_minutes : opt int16
 };
 
 type icrc21_consent_message_spec = record {
-    metadata: icrc21_consent_message_metadata;
-    device_spec: opt variant {
-        GenericDisplay;
-        LineDisplay: record {
-            characters_per_line: nat16;
-            lines_per_page: nat16;
-        };
-    };
+  metadata : icrc21_consent_message_metadata;
+  device_spec : opt variant {
+    GenericDisplay;
+    FieldsDisplay
+  }
 };
 
 type icrc21_consent_message_request = record {
-    method: text;
-    arg: blob;
-    user_preferences: icrc21_consent_message_spec;
+  method : text;
+  arg : blob;
+  user_preferences : icrc21_consent_message_spec
+};
+
+type Icrc21Value = variant {
+  TokenAmount : record {
+    decimals : nat8;
+    amount : nat64;
+    symbol : text
+  };
+  TimestampSeconds : record {
+    amount : nat64
+  };
+  DurationSeconds : record {
+    amount : nat64
+  };
+  Text : record {
+    content : text
+  }
+};
+
+type FieldsDisplay = record {
+  intent : text;
+  fields : vec record { text; Icrc21Value }
 };
 
 type icrc21_consent_message = variant {
-    GenericDisplayMessage: text;
-    LineDisplayMessage: record {
-        pages: vec record {
-            lines: vec text;
-        };
-    };
+  GenericDisplayMessage : text;
+  FieldsDisplayMessage : FieldsDisplay
 };
 
 type icrc21_consent_info = record {
-    consent_message: icrc21_consent_message;
-    metadata: icrc21_consent_message_metadata;
+  consent_message : icrc21_consent_message;
+  metadata : icrc21_consent_message_metadata
 };
 
 type icrc21_error_info = record {
-    description: text;
+  description : text
 };
 
 type icrc21_error = variant {
-    UnsupportedCanisterCall: icrc21_error_info;
-    ConsentMessageUnavailable: icrc21_error_info;
-    InsufficientPayment: icrc21_error_info;
+  UnsupportedCanisterCall : icrc21_error_info;
+  ConsentMessageUnavailable : icrc21_error_info;
+  InsufficientPayment : icrc21_error_info;
 
-    // Any error not covered by the above variants.
-    GenericError: record {
-       error_code: nat;
-       description: text;
-   };
+  // Any error not covered by the above variants.
+  GenericError : record {
+    error_code : nat;
+    description : text
+  }
 };
 
 type icrc21_consent_message_response = variant {
-    Ok: icrc21_consent_info;
-    Err: icrc21_error;
+  Ok : icrc21_consent_info;
+  Err : icrc21_error
 };
 
 // The arguments for the `get_allowances` endpoint.
@@ -485,82 +498,90 @@ type icrc21_consent_message_response = variant {
 // the endpoint returns allowances that are lexicographically greater than
 // (`from_account_id`, `prev_spender_id`) - start with spender after `prev_spender_id`.
 type GetAllowancesArgs = record {
-    from_account_id: TextAccountIdentifier;
-    prev_spender_id: opt TextAccountIdentifier;
-    take: opt nat64;
+  from_account_id : TextAccountIdentifier;
+  prev_spender_id : opt TextAccountIdentifier;
+  take : opt nat64
 };
 
 // The allowances returned by the `get_allowances` endpoint.
 type Allowances = vec record {
-    from_account_id: TextAccountIdentifier;
-    to_spender_id: TextAccountIdentifier;
-    allowance: Tokens;
-    expires_at: opt nat64;
+  from_account_id : TextAccountIdentifier;
+  to_spender_id : TextAccountIdentifier;
+  allowance : Tokens;
+  expires_at : opt nat64
 };
 
 type TipOfChainRes = record {
-    certification: opt blob;
-    tip_index: BlockIndex;
+  certification : opt blob;
+  tip_index : BlockIndex
 };
 
-service: (LedgerCanisterPayload) -> {
-    // Transfers tokens from a subaccount of the caller to the destination address.
-    // The source address is computed from the principal of the caller and the specified subaccount.
-    // When successful, returns the index of the block containing the transaction.
-    transfer : (TransferArgs) -> (TransferResult);
+type RemoveApprovalArgs = record {
+  from_subaccount : opt SubAccount;
+  spender : AccountIdentifier;
+  fee : opt Icrc1Tokens
+};
 
-    // Returns the amount of Tokens on the specified account.
-    account_balance : (AccountBalanceArgs) -> (Tokens) query;
+service : (LedgerCanisterPayload) -> {
+  // Transfers tokens from a subaccount of the caller to the destination address.
+  // The source address is computed from the principal of the caller and the specified subaccount.
+  // When successful, returns the index of the block containing the transaction.
+  transfer : (TransferArgs) -> (TransferResult);
 
-    // Returns the account identifier for the given Principal and subaccount.
-    account_identifier : (Account) -> (AccountIdentifier) query;
+  // Returns the amount of Tokens on the specified account.
+  account_balance : (AccountBalanceArgs) -> (Tokens) query;
 
-    // Returns the current transfer_fee.
-    transfer_fee : (TransferFeeArg) -> (TransferFee) query;
+  // Returns the account identifier for the given Principal and subaccount.
+  account_identifier : (Account) -> (AccountIdentifier) query;
 
-    // Queries blocks in the specified range.
-    query_blocks : (GetBlocksArgs) -> (QueryBlocksResponse) query;
+  // Returns the current transfer_fee.
+  transfer_fee : (TransferFeeArg) -> (TransferFee) query;
 
-    // Queries encoded blocks in the specified range
-    query_encoded_blocks : (GetBlocksArgs) -> (QueryEncodedBlocksResponse) query;
-    
-    // Returns token symbol.
-    symbol : () -> (record { symbol: text }) query;
+  // Queries blocks in the specified range.
+  query_blocks : (GetBlocksArgs) -> (QueryBlocksResponse) query;
 
-    // Returns token name.
-    name : () -> (record { name: text }) query;
+  // Queries encoded blocks in the specified range
+  query_encoded_blocks : (GetBlocksArgs) -> (QueryEncodedBlocksResponse) query;
 
-    // Returns token decimals.
-    decimals : () -> (record { decimals: nat32 }) query;
+  // Returns token symbol.
+  symbol : () -> (record { symbol : text }) query;
 
-    // Returns the existing archive canisters information.
-    archives : () -> (Archives) query;
+  // Returns token name.
+  name : () -> (record { name : text }) query;
 
-    send_dfx : (SendArgs) -> (BlockIndex);
-    account_balance_dfx : (AccountBalanceArgsDfx) -> (Tokens) query;
+  // Returns token decimals.
+  decimals : () -> (record { decimals : nat32 }) query;
 
-    // The following methods implement the ICRC-1 Token Standard.
-    // https://github.com/dfinity/ICRC-1/tree/main/standards/ICRC-1
-    icrc1_name : () -> (text) query;
-    icrc1_symbol : () -> (text) query;
-    icrc1_decimals : () -> (nat8) query;
-    icrc1_metadata : () -> (vec record { text; Value }) query;
-    icrc1_total_supply : () -> (Icrc1Tokens) query;
-    icrc1_fee : () -> (Icrc1Tokens) query;
-    icrc1_minting_account : () -> (opt Account) query;
-    icrc1_balance_of : (Account) -> (Icrc1Tokens) query;
-    icrc1_transfer : (TransferArg) -> (Icrc1TransferResult);
-    icrc1_supported_standards : () -> (vec record { name : text; url : text }) query;
-    icrc2_approve : (ApproveArgs) -> (ApproveResult);
-    icrc2_allowance : (AllowanceArgs) -> (Allowance) query;
-    icrc2_transfer_from : (TransferFromArgs) -> (TransferFromResult);
+  // Returns the existing archive canisters information.
+  archives : () -> (Archives) query;
 
-    icrc21_canister_call_consent_message: (icrc21_consent_message_request) -> (icrc21_consent_message_response);
-    icrc10_supported_standards : () -> (vec record { name : text; url : text }) query;
+  send_dfx : (SendArgs) -> (BlockIndex);
+  account_balance_dfx : (AccountBalanceArgsDfx) -> (Tokens) query;
 
-    get_allowances : (GetAllowancesArgs) -> (Allowances) query;
+  // The following methods implement the ICRC-1 Token Standard.
+  // https://github.com/dfinity/ICRC-1/tree/main/standards/ICRC-1
+  icrc1_name : () -> (text) query;
+  icrc1_symbol : () -> (text) query;
+  icrc1_decimals : () -> (nat8) query;
+  icrc1_metadata : () -> (vec record { text; Value }) query;
+  icrc1_total_supply : () -> (Icrc1Tokens) query;
+  icrc1_fee : () -> (Icrc1Tokens) query;
+  icrc1_minting_account : () -> (opt Account) query;
+  icrc1_balance_of : (Account) -> (Icrc1Tokens) query;
+  icrc1_transfer : (TransferArg) -> (Icrc1TransferResult);
+  icrc1_supported_standards : () -> (vec record { name : text; url : text }) query;
+  icrc2_approve : (ApproveArgs) -> (ApproveResult);
+  icrc2_allowance : (AllowanceArgs) -> (Allowance) query;
+  icrc2_transfer_from : (TransferFromArgs) -> (TransferFromResult);
 
-    tip_of_chain : () -> (TipOfChainRes) query;
+  remove_approval : (RemoveApprovalArgs) -> (ApproveResult);
 
-    is_ledger_ready: () -> (bool) query;
+  icrc21_canister_call_consent_message : (icrc21_consent_message_request) -> (icrc21_consent_message_response);
+  icrc10_supported_standards : () -> (vec record { name : text; url : text }) query;
+
+  get_allowances : (GetAllowancesArgs) -> (Allowances) query;
+
+  tip_of_chain : () -> (TipOfChainRes) query;
+
+  is_ledger_ready : () -> (bool) query
 }

--- a/packages/ledger-icp/candid/ledger.idl.js
+++ b/packages/ledger-icp/candid/ledger.idl.js
@@ -101,13 +101,7 @@ export const idlFactory = ({ IDL }) => {
   const icrc21_consent_message_spec = IDL.Record({
     'metadata' : icrc21_consent_message_metadata,
     'device_spec' : IDL.Opt(
-      IDL.Variant({
-        'GenericDisplay' : IDL.Null,
-        'LineDisplay' : IDL.Record({
-          'characters_per_line' : IDL.Nat16,
-          'lines_per_page' : IDL.Nat16,
-        }),
-      })
+      IDL.Variant({ 'GenericDisplay' : IDL.Null, 'FieldsDisplay' : IDL.Null })
     ),
   });
   const icrc21_consent_message_request = IDL.Record({
@@ -115,10 +109,22 @@ export const idlFactory = ({ IDL }) => {
     'method' : IDL.Text,
     'user_preferences' : icrc21_consent_message_spec,
   });
-  const icrc21_consent_message = IDL.Variant({
-    'LineDisplayMessage' : IDL.Record({
-      'pages' : IDL.Vec(IDL.Record({ 'lines' : IDL.Vec(IDL.Text) })),
+  const Icrc21Value = IDL.Variant({
+    'Text' : IDL.Record({ 'content' : IDL.Text }),
+    'TokenAmount' : IDL.Record({
+      'decimals' : IDL.Nat8,
+      'amount' : IDL.Nat64,
+      'symbol' : IDL.Text,
     }),
+    'TimestampSeconds' : IDL.Record({ 'amount' : IDL.Nat64 }),
+    'DurationSeconds' : IDL.Record({ 'amount' : IDL.Nat64 }),
+  });
+  const FieldsDisplay = IDL.Record({
+    'fields' : IDL.Vec(IDL.Tuple(IDL.Text, Icrc21Value)),
+    'intent' : IDL.Text,
+  });
+  const icrc21_consent_message = IDL.Variant({
+    'FieldsDisplayMessage' : FieldsDisplay,
     'GenericDisplayMessage' : IDL.Text,
   });
   const icrc21_consent_info = IDL.Record({
@@ -297,6 +303,11 @@ export const idlFactory = ({ IDL }) => {
     'first_block_index' : IDL.Nat64,
     'archived_blocks' : IDL.Vec(ArchivedEncodedBlocksRange),
   });
+  const RemoveApprovalArgs = IDL.Record({
+    'fee' : IDL.Opt(Icrc1Tokens),
+    'from_subaccount' : IDL.Opt(SubAccount),
+    'spender' : AccountIdentifier,
+  });
   const SendArgs = IDL.Record({
     'to' : TextAccountIdentifier,
     'fee' : Tokens,
@@ -392,6 +403,7 @@ export const idlFactory = ({ IDL }) => {
         [QueryEncodedBlocksResponse],
         ['query'],
       ),
+    'remove_approval' : IDL.Func([RemoveApprovalArgs], [ApproveResult], []),
     'send_dfx' : IDL.Func([SendArgs], [BlockIndex], []),
     'symbol' : IDL.Func([], [IDL.Record({ 'symbol' : IDL.Text })], ['query']),
     'tip_of_chain' : IDL.Func([], [TipOfChainRes], ['query']),

--- a/packages/ledger-icp/src/canisters/ledger/ledger.request.converts.spec.ts
+++ b/packages/ledger-icp/src/canisters/ledger/ledger.request.converts.spec.ts
@@ -117,18 +117,13 @@ describe("ledger.request.converts", () => {
     );
   });
 
-  it("toIcrc21ConsentMessageRawRequest should return a valid ICRC-21 line display consent message request", () => {
-    const lineDisplay = {
-      charactersPerLine: 2,
-      linesPerPage: 10,
-    };
-
+  it("toIcrc21ConsentMessageRawRequest should return a valid ICRC-21 fields display consent message request", () => {
     const consentMessageRequest = {
       ...mockConsentMessageRequest,
       userPreferences: {
         ...mockConsentMessageRequest.userPreferences,
         deriveSpec: {
-          LineDisplay: lineDisplay,
+          FieldsDisplay: null,
         },
       },
     };
@@ -137,10 +132,7 @@ describe("ledger.request.converts", () => {
 
     expect(result.user_preferences.device_spec).toEqual(
       toNullable({
-        LineDisplay: {
-          characters_per_line: lineDisplay.charactersPerLine,
-          lines_per_page: lineDisplay.linesPerPage,
-        },
+        FieldsDisplay: null,
       }),
     );
   });

--- a/packages/ledger-icp/src/canisters/ledger/ledger.request.converts.ts
+++ b/packages/ledger-icp/src/canisters/ledger/ledger.request.converts.ts
@@ -101,10 +101,7 @@ export const toIcrc21ConsentMessageRawRequest = ({
           "GenericDisplay" in deriveSpec
             ? { GenericDisplay: null }
             : {
-                LineDisplay: {
-                  characters_per_line: deriveSpec.LineDisplay.charactersPerLine,
-                  lines_per_page: deriveSpec.LineDisplay.linesPerPage,
-                },
+                FieldsDisplay: null,
               },
         ),
   },

--- a/packages/ledger-icp/src/ledger.canister.spec.ts
+++ b/packages/ledger-icp/src/ledger.canister.spec.ts
@@ -1089,10 +1089,15 @@ describe("LedgerCanister", () => {
     const consentMessageLineDisplayResponse: icrc21_consent_message_response = {
       Ok: {
         consent_message: {
-          LineDisplayMessage: {
-            pages: [
-              { lines: ["Transfer 1 ICP", "to account abcd"] },
-              { lines: ["Fee: 0.0001 ICP"] },
+          FieldsDisplayMessage: {
+            intent: "Send ICP",
+            fields: [
+              [
+                "Fees",
+                {
+                  TokenAmount: { decimals: 10, amount: 10_000n, symbol: "ICP" },
+                },
+              ],
             ],
           },
         },
@@ -1154,10 +1159,7 @@ describe("LedgerCanister", () => {
             language: "en-US",
           },
           deriveSpec: {
-            LineDisplay: {
-              charactersPerLine: 20,
-              linesPerPage: 4,
-            },
+            FieldsDisplay: null,
           },
         },
       };
@@ -1178,10 +1180,7 @@ describe("LedgerCanister", () => {
             },
             device_spec: [
               {
-                LineDisplay: {
-                  characters_per_line: 20,
-                  lines_per_page: 4,
-                },
+                FieldsDisplay: null,
               },
             ],
           },

--- a/packages/ledger-icp/src/types/ledger_converters.ts
+++ b/packages/ledger-icp/src/types/ledger_converters.ts
@@ -69,17 +69,12 @@ export interface Icrc21ConsentMessageMetadata {
  * Device specification for displaying the consent message.
  *
  * @param {null} [GenericDisplay] -  A generic display able to handle large documents and do line wrapping and pagination / scrolling.  Text must be Markdown formatted, no external resources (e.g. images) are allowed.
- * @param {Object} [LineDisplay] - Simple display able to handle lines of text with a maximum number of characters per line.
- * @param {number} LineDisplay.charactersPerLine - Maximum number of characters that can be displayed per line.
- * @param {number} LineDisplay.linesPerPage - Maximum number of lines that can be displayed at once on a single page.
+ * @param {Object} [FieldsDisplay] - A simple display able to handle multiple fields with a title and content.
  */
 export type Icrc21ConsentMessageDeviceSpec =
   | { GenericDisplay: null }
   | {
-      LineDisplay: {
-        charactersPerLine: number;
-        linesPerPage: number;
-      };
+      FieldsDisplay: null;
     };
 
 /**


### PR DESCRIPTION
# Motivation

The latest ICRC-21 introduces a breaking changes https://github.com/dfinity/wg-identity-authentication/pull/229 which remove `LineDisplay` and introduce  `FieldsDisplay`.
The change has now been implemented in the ledger suite as provided by PR #1027.

# Changes

- Copy did and js for the ledger-icp from #1027
- Remove `LineDisplay` and add `FIeldsDisplay`

