### PR TITLE
feat!: ledger-icrc ICRC-21 LineDisplay replaced by FieldsDisplay

### DIFF
--- a/packages/ledger-icrc/candid/icrc_index-ng.certified.idl.js
+++ b/packages/ledger-icrc/candid/icrc_index-ng.certified.idl.js
@@ -122,7 +122,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(SubAccount)],
         [],
       ),
-    'status' : IDL.Func([], [Status], []),
+    'status' : IDL.Func([], [Status], ['query']),
   });
 };
 export const init = ({ IDL }) => {

--- a/packages/ledger-icrc/candid/icrc_index-ng.did
+++ b/packages/ledger-icrc/candid/icrc_index-ng.did
@@ -1,40 +1,40 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/ledger_suite/icrc1/index-ng/index-ng.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/ledger_suite/icrc1/index-ng/index-ng.did' by import-candid
 type Tokens = nat;
 
 type InitArg = record {
-    ledger_id: principal;
-    // The interval in seconds in which to retrieve blocks from the ledger. A lower value makes the index more
-    // responsive in showing new blocks, but increases the consumption of cycles of both the index and ledger canisters.
-    // A higher values means that it takes longer for new blocks to show up in the index.
-    retrieve_blocks_from_ledger_interval_seconds : opt nat64;
+  ledger_id : principal;
+  // The interval in seconds in which to retrieve blocks from the ledger. A lower value makes the index more
+  // responsive in showing new blocks, but increases the consumption of cycles of both the index and ledger canisters.
+  // A higher values means that it takes longer for new blocks to show up in the index.
+  retrieve_blocks_from_ledger_interval_seconds : opt nat64
 };
 
 type UpgradeArg = record {
-    ledger_id: opt principal;
-    // The interval in seconds in which to retrieve blocks from the ledger. A lower value makes the index more
-    // responsive in showing new blocks, but increases the consumption of cycles of both the index and ledger canisters.
-    // A higher values means that it takes longer for new blocks to show up in the index.
-    retrieve_blocks_from_ledger_interval_seconds : opt nat64;
+  ledger_id : opt principal;
+  // The interval in seconds in which to retrieve blocks from the ledger. A lower value makes the index more
+  // responsive in showing new blocks, but increases the consumption of cycles of both the index and ledger canisters.
+  // A higher values means that it takes longer for new blocks to show up in the index.
+  retrieve_blocks_from_ledger_interval_seconds : opt nat64
 };
 
 type IndexArg = variant {
-    Init: InitArg;
-    Upgrade: UpgradeArg;
+  Init : InitArg;
+  Upgrade : UpgradeArg
 };
 
 type GetBlocksRequest = record {
-    start : nat;
-    length : nat;
+  start : nat;
+  length : nat
 };
 
 type Value = variant {
-    Blob : blob;
-    Text : text;
-    Nat : nat;
-    Nat64: nat64;
-    Int : int;
-    Array : vec Value;
-    Map : Map;
+  Blob : blob;
+  Text : text;
+  Nat : nat;
+  Nat64 : nat64;
+  Int : int;
+  Array : vec Value;
+  Map : Map
 };
 
 type Map = vec record { text; Value };
@@ -42,8 +42,8 @@ type Map = vec record { text; Value };
 type Block = Value;
 
 type GetBlocksResponse = record {
-    chain_length: nat64;
-    blocks: vec Block;
+  chain_length : nat64;
+  blocks : vec Block
 };
 
 type BlockIndex = nat;
@@ -58,7 +58,7 @@ type Transaction = record {
   mint : opt Mint;
   approve : opt Approve;
   timestamp : nat64;
-  transfer : opt Transfer;
+  transfer : opt Transfer
 };
 
 type Approve = record {
@@ -69,7 +69,7 @@ type Approve = record {
   amount : Tokens;
   expected_allowance : opt Tokens;
   expires_at : opt nat64;
-  spender : Account;
+  spender : Account
 };
 
 type Burn = record {
@@ -77,14 +77,14 @@ type Burn = record {
   memo : opt vec nat8;
   created_at_time : opt nat64;
   amount : Tokens;
-  spender : opt Account;
+  spender : opt Account
 };
 
 type Mint = record {
   to : Account;
   memo : opt vec nat8;
   created_at_time : opt nat64;
-  amount : Tokens;
+  amount : Tokens
 };
 
 type Transfer = record {
@@ -94,60 +94,60 @@ type Transfer = record {
   memo : opt vec nat8;
   created_at_time : opt nat64;
   amount : Tokens;
-  spender : opt Account;
+  spender : opt Account
 };
 
 type GetAccountTransactionsArgs = record {
-    account : Account;
-    // The txid of the last transaction seen by the client.
-    // If None then the results will start from the most recent
-    // txid. If set then the results will start from the next
-    // most recent txid after start (start won't be included).
-    start : opt BlockIndex;
-    // Maximum number of transactions to fetch.
-    max_results : nat;
+  account : Account;
+  // The txid of the last transaction seen by the client.
+  // If None then the results will start from the most recent
+  // txid. If set then the results will start from the next
+  // most recent txid after start (start won't be included).
+  start : opt BlockIndex;
+  // Maximum number of transactions to fetch.
+  max_results : nat
 };
 
 type TransactionWithId = record {
   id : BlockIndex;
-  transaction : Transaction;
+  transaction : Transaction
 };
 
 type GetTransactions = record {
   balance : Tokens;
   transactions : vec TransactionWithId;
   // The txid of the oldest transaction the account has
-  oldest_tx_id : opt BlockIndex;
+  oldest_tx_id : opt BlockIndex
 };
 
 type GetTransactionsErr = record {
-  message : text;
+  message : text
 };
 
 type GetTransactionsResult = variant {
   Ok : GetTransactions;
-  Err : GetTransactionsErr;
+  Err : GetTransactionsErr
 };
 
 type ListSubaccountsArgs = record {
-    owner: principal;
-    start: opt SubAccount;
+  owner : principal;
+  start : opt SubAccount
 };
 
 type Status = record {
-    num_blocks_synced : BlockIndex;
+  num_blocks_synced : BlockIndex
 };
 
 type FeeCollectorRanges = record {
-    ranges : vec  record { Account; vec record { BlockIndex; BlockIndex } };
+  ranges : vec record { Account; vec record { BlockIndex; BlockIndex } }
 }
 
-service : (index_arg: opt IndexArg) -> {
-    get_account_transactions : (GetAccountTransactionsArgs) -> (GetTransactionsResult) query;
-    get_blocks : (GetBlocksRequest) -> (GetBlocksResponse) query;
-    get_fee_collectors_ranges : () -> (FeeCollectorRanges) query;
-    icrc1_balance_of : (Account) -> (Tokens) query;
-    ledger_id : () -> (principal) query;
-    list_subaccounts : (ListSubaccountsArgs) -> (vec SubAccount) query;
-    status : () -> (Status) query;
+service : (index_arg : opt IndexArg) -> {
+  get_account_transactions : (GetAccountTransactionsArgs) -> (GetTransactionsResult) query;
+  get_blocks : (GetBlocksRequest) -> (GetBlocksResponse) query;
+  get_fee_collectors_ranges : () -> (FeeCollectorRanges) query;
+  icrc1_balance_of : (Account) -> (Tokens) query;
+  ledger_id : () -> (principal) query;
+  list_subaccounts : (ListSubaccountsArgs) -> (vec SubAccount) query;
+  status : () -> (Status) query
 }

--- a/packages/ledger-icrc/candid/icrc_ledger.certified.idl.js
+++ b/packages/ledger-icrc/candid/icrc_ledger.certified.idl.js
@@ -242,13 +242,7 @@ export const idlFactory = ({ IDL }) => {
   const icrc21_consent_message_spec = IDL.Record({
     'metadata' : icrc21_consent_message_metadata,
     'device_spec' : IDL.Opt(
-      IDL.Variant({
-        'GenericDisplay' : IDL.Null,
-        'LineDisplay' : IDL.Record({
-          'characters_per_line' : IDL.Nat16,
-          'lines_per_page' : IDL.Nat16,
-        }),
-      })
+      IDL.Variant({ 'GenericDisplay' : IDL.Null, 'FieldsDisplay' : IDL.Null })
     ),
   });
   const icrc21_consent_message_request = IDL.Record({
@@ -256,10 +250,22 @@ export const idlFactory = ({ IDL }) => {
     'method' : IDL.Text,
     'user_preferences' : icrc21_consent_message_spec,
   });
-  const icrc21_consent_message = IDL.Variant({
-    'LineDisplayMessage' : IDL.Record({
-      'pages' : IDL.Vec(IDL.Record({ 'lines' : IDL.Vec(IDL.Text) })),
+  const Icrc21Value = IDL.Variant({
+    'Text' : IDL.Record({ 'content' : IDL.Text }),
+    'TokenAmount' : IDL.Record({
+      'decimals' : IDL.Nat8,
+      'amount' : IDL.Nat64,
+      'symbol' : IDL.Text,
     }),
+    'TimestampSeconds' : IDL.Record({ 'amount' : IDL.Nat64 }),
+    'DurationSeconds' : IDL.Record({ 'amount' : IDL.Nat64 }),
+  });
+  const FieldsDisplay = IDL.Record({
+    'fields' : IDL.Vec(IDL.Tuple(IDL.Text, Icrc21Value)),
+    'intent' : IDL.Text,
+  });
+  const icrc21_consent_message = IDL.Variant({
+    'FieldsDisplayMessage' : FieldsDisplay,
     'GenericDisplayMessage' : IDL.Text,
   });
   const icrc21_consent_info = IDL.Record({
@@ -371,7 +377,7 @@ export const idlFactory = ({ IDL }) => {
           'callback' : IDL.Func(
               [IDL.Vec(GetBlocksArgs)],
               [GetBlocksResult],
-              [],
+              ['query'],
             ),
         })
       ),
@@ -443,7 +449,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(IDL.Record({ 'url' : IDL.Text, 'block_type' : IDL.Text }))],
         [],
       ),
-    'is_ledger_ready' : IDL.Func([], [IDL.Bool], []),
+    'is_ledger_ready' : IDL.Func([], [IDL.Bool], ['query']),
   });
 };
 export const init = ({ IDL }) => {

--- a/packages/ledger-icrc/candid/icrc_ledger.d.ts
+++ b/packages/ledger-icrc/candid/icrc_ledger.d.ts
@@ -89,6 +89,10 @@ export type Duration = bigint;
 export interface FeatureFlags {
   icrc2: boolean;
 }
+export interface FieldsDisplay {
+  fields: Array<[string, Icrc21Value]>;
+  intent: string;
+}
 export interface GetAllowancesArgs {
   take: [] | [bigint];
   prev_spender: [] | [Account];
@@ -174,6 +178,17 @@ export type ICRC3Value =
   | { Blob: Uint8Array | number[] }
   | { Text: string }
   | { Array: Array<ICRC3Value> };
+export type Icrc21Value =
+  | { Text: { content: string } }
+  | {
+      TokenAmount: {
+        decimals: number;
+        amount: bigint;
+        symbol: string;
+      };
+    }
+  | { TimestampSeconds: { amount: bigint } }
+  | { DurationSeconds: { amount: bigint } };
 export interface InitArgs {
   decimals: [] | [number];
   token_symbol: string;
@@ -315,7 +330,7 @@ export interface icrc21_consent_info {
 }
 export type icrc21_consent_message =
   | {
-      LineDisplayMessage: { pages: Array<{ lines: Array<string> }> };
+      FieldsDisplayMessage: FieldsDisplay;
     }
   | { GenericDisplayMessage: string };
 export interface icrc21_consent_message_metadata {
@@ -332,17 +347,7 @@ export type icrc21_consent_message_response =
   | { Err: icrc21_error };
 export interface icrc21_consent_message_spec {
   metadata: icrc21_consent_message_metadata;
-  device_spec:
-    | []
-    | [
-        | { GenericDisplay: null }
-        | {
-            LineDisplay: {
-              characters_per_line: number;
-              lines_per_page: number;
-            };
-          },
-      ];
+  device_spec: [] | [{ GenericDisplay: null } | { FieldsDisplay: null }];
 }
 export type icrc21_error =
   | {

--- a/packages/ledger-icrc/candid/icrc_ledger.did
+++ b/packages/ledger-icrc/candid/icrc_ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/ledger_suite/icrc1/ledger/ledger.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/ledger_suite/icrc1/ledger/ledger.did' by import-candid
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.
@@ -17,7 +17,7 @@ type Approve = record {
   amount : nat;
   expected_allowance : opt nat;
   expires_at : opt Timestamp;
-  spender : Account;
+  spender : Account
 };
 type ApproveArgs = record {
   fee : opt nat;
@@ -27,7 +27,7 @@ type ApproveArgs = record {
   amount : nat;
   expected_allowance : opt nat;
   expires_at : opt Timestamp;
-  spender : Account;
+  spender : Account
 };
 type ApproveError = variant {
   GenericError : record { message : text; error_code : nat };
@@ -38,7 +38,7 @@ type ApproveError = variant {
   CreatedInFuture : record { ledger_time : Timestamp };
   TooOld;
   Expired : record { ledger_time : Timestamp };
-  InsufficientFunds : record { balance : nat };
+  InsufficientFunds : record { balance : nat }
 };
 type ApproveResult = variant { Ok : BlockIndex; Err : ApproveError };
 
@@ -46,179 +46,179 @@ type HttpRequest = record {
   url : text;
   method : text;
   body : blob;
-  headers : vec record { text; text };
+  headers : vec record { text; text }
 };
 type HttpResponse = record {
   body : blob;
   headers : vec record { text; text };
-  status_code : nat16;
+  status_code : nat16
 };
 
 type Account = record {
-    owner : principal;
-    subaccount : opt Subaccount;
+  owner : principal;
+  subaccount : opt Subaccount
 };
 
 type TransferArg = record {
-    from_subaccount : opt Subaccount;
-    to : Account;
-    amount : Tokens;
-    fee : opt Tokens;
-    memo : opt blob;
-    created_at_time: opt Timestamp;
+  from_subaccount : opt Subaccount;
+  to : Account;
+  amount : Tokens;
+  fee : opt Tokens;
+  memo : opt blob;
+  created_at_time : opt Timestamp
 };
 
 type TransferError = variant {
-    BadFee : record { expected_fee : Tokens };
-    BadBurn : record { min_burn_amount : Tokens };
-    InsufficientFunds : record { balance : Tokens };
-    TooOld;
-    CreatedInFuture : record { ledger_time : Timestamp };
-    TemporarilyUnavailable;
-    Duplicate : record { duplicate_of : BlockIndex };
-    GenericError : record { error_code : nat; message : text };
+  BadFee : record { expected_fee : Tokens };
+  BadBurn : record { min_burn_amount : Tokens };
+  InsufficientFunds : record { balance : Tokens };
+  TooOld;
+  CreatedInFuture : record { ledger_time : Timestamp };
+  TemporarilyUnavailable;
+  Duplicate : record { duplicate_of : BlockIndex };
+  GenericError : record { error_code : nat; message : text }
 };
 
 type TransferResult = variant {
-    Ok : BlockIndex;
-    Err : TransferError;
+  Ok : BlockIndex;
+  Err : TransferError
 };
 
 // The value returned from the [icrc1_metadata] endpoint.
 type MetadataValue = variant {
-    Nat : nat;
-    Int : int;
-    Text : text;
-    Blob : blob;
+  Nat : nat;
+  Int : int;
+  Text : text;
+  Blob : blob
 };
 
 type FeatureFlags = record {
-    icrc2 : bool;
+  icrc2 : bool
 };
 
 // The initialization parameters of the Ledger
 type InitArgs = record {
-    minting_account : Account;
-    fee_collector_account : opt Account;
-    transfer_fee : nat;
-    decimals : opt nat8;
-    max_memo_length : opt nat16;
-    token_symbol : text;
-    token_name : text;
-    metadata : vec record { text; MetadataValue };
-    initial_balances : vec record { Account; nat };
-    feature_flags : opt FeatureFlags;
-    archive_options : record {
-        num_blocks_to_archive : nat64;
-        max_transactions_per_response : opt nat64;
-        trigger_threshold : nat64;
-        max_message_size_bytes : opt nat64;
-        cycles_for_archive_creation : opt nat64;
-        node_max_memory_size_bytes : opt nat64;
-        controller_id : principal;
-        more_controller_ids : opt vec principal;
-    };
-    index_principal : opt principal;
-};
-
-type ChangeFeeCollector = variant {
-    Unset; SetTo: Account;
-};
-
-type ChangeArchiveOptions = record {
-    num_blocks_to_archive : opt nat64;
+  minting_account : Account;
+  fee_collector_account : opt Account;
+  transfer_fee : nat;
+  decimals : opt nat8;
+  max_memo_length : opt nat16;
+  token_symbol : text;
+  token_name : text;
+  metadata : vec record { text; MetadataValue };
+  initial_balances : vec record { Account; nat };
+  feature_flags : opt FeatureFlags;
+  archive_options : record {
+    num_blocks_to_archive : nat64;
     max_transactions_per_response : opt nat64;
-    trigger_threshold : opt nat64;
+    trigger_threshold : nat64;
     max_message_size_bytes : opt nat64;
     cycles_for_archive_creation : opt nat64;
     node_max_memory_size_bytes : opt nat64;
-    controller_id : opt principal;
-    more_controller_ids : opt vec principal;
+    controller_id : principal;
+    more_controller_ids : opt vec principal
+  };
+  index_principal : opt principal
+};
+
+type ChangeFeeCollector = variant {
+  Unset;
+  SetTo : Account
+};
+
+type ChangeArchiveOptions = record {
+  num_blocks_to_archive : opt nat64;
+  max_transactions_per_response : opt nat64;
+  trigger_threshold : opt nat64;
+  max_message_size_bytes : opt nat64;
+  cycles_for_archive_creation : opt nat64;
+  node_max_memory_size_bytes : opt nat64;
+  controller_id : opt principal;
+  more_controller_ids : opt vec principal
 };
 
 type UpgradeArgs = record {
-    metadata : opt vec record { text; MetadataValue };
-    token_symbol : opt text;
-    token_name : opt text;
-    transfer_fee : opt nat;
-    change_fee_collector : opt ChangeFeeCollector;
-    max_memo_length : opt nat16;
-    feature_flags : opt FeatureFlags;
-    change_archive_options : opt ChangeArchiveOptions;
-    index_principal : opt principal;
+  metadata : opt vec record { text; MetadataValue };
+  token_symbol : opt text;
+  token_name : opt text;
+  transfer_fee : opt nat;
+  change_fee_collector : opt ChangeFeeCollector;
+  max_memo_length : opt nat16;
+  feature_flags : opt FeatureFlags;
+  change_archive_options : opt ChangeArchiveOptions;
+  index_principal : opt principal
 };
 
 type LedgerArg = variant {
-    Init: InitArgs;
-    Upgrade: opt UpgradeArgs;
+  Init : InitArgs;
+  Upgrade : opt UpgradeArgs
 };
 
 type GetTransactionsRequest = record {
-    // The index of the first tx to fetch.
-    start : TxIndex;
-    // The number of transactions to fetch.
-    length : nat;
+  // The index of the first tx to fetch.
+  start : TxIndex;
+  // The number of transactions to fetch.
+  length : nat
 };
 
 type GetTransactionsResponse = record {
-    // The total number of transactions in the log.
-    log_length : nat;
+  // The total number of transactions in the log.
+  log_length : nat;
 
-    // List of transaction that were available in the ledger when it processed the call.
-    //
-    // The transactions form a contiguous range, with the first transaction having index
-    // [first_index] (see below), and the last transaction having index
-    // [first_index] + len(transactions) - 1.
-    //
-    // The transaction range can be an arbitrary sub-range of the originally requested range.
-    transactions : vec Transaction;
+  // List of transaction that were available in the ledger when it processed the call.
+  //
+  // The transactions form a contiguous range, with the first transaction having index
+  // [first_index] (see below), and the last transaction having index
+  // [first_index] + len(transactions) - 1.
+  //
+  // The transaction range can be an arbitrary sub-range of the originally requested range.
+  transactions : vec Transaction;
 
-    // The index of the first transaction in [transactions].
-    // If the transaction vector is empty, the exact value of this field is not specified.
-    first_index : TxIndex;
+  // The index of the first transaction in [transactions].
+  // If the transaction vector is empty, the exact value of this field is not specified.
+  first_index : TxIndex;
 
-    // Encoding of instructions for fetching archived transactions whose indices fall into the
-    // requested range.
-    //
-    // For each entry `e` in [archived_transactions], `[e.from, e.from + len)` is a sub-range
-    // of the originally requested transaction range.
-    archived_transactions : vec record {
-        // The index of the first archived transaction you can fetch using the [callback].
-        start : TxIndex;
+  // Encoding of instructions for fetching archived transactions whose indices fall into the
+  // requested range.
+  //
+  // For each entry `e` in [archived_transactions], `[e.from, e.from + len)` is a sub-range
+  // of the originally requested transaction range.
+  archived_transactions : vec record {
+    // The index of the first archived transaction you can fetch using the [callback].
+    start : TxIndex;
 
-        // The number of transactions you can fetch using the callback.
-        length : nat;
+    // The number of transactions you can fetch using the callback.
+    length : nat;
 
-        // The function you should call to fetch the archived transactions.
-        // The range of the transaction accessible using this function is given by [from]
-        // and [len] fields above.
-        callback : QueryArchiveFn;
-    };
+    // The function you should call to fetch the archived transactions.
+    // The range of the transaction accessible using this function is given by [from]
+    // and [len] fields above.
+    callback : QueryArchiveFn
+  }
 };
-
 
 // A prefix of the transaction range specified in the [GetTransactionsRequest] request.
 type TransactionRange = record {
-    // A prefix of the requested transaction range.
-    // The index of the first transaction is equal to [GetTransactionsRequest.from].
-    //
-    // Note that the number of transactions might be less than the requested
-    // [GetTransactionsRequest.length] for various reasons, for example:
-    //
-    // 1. The query might have hit the replica with an outdated state
-    //    that doesn't have the whole range yet.
-    // 2. The requested range is too large to fit into a single reply.
-    //
-    // NOTE: the list of transactions can be empty if:
-    //
-    // 1. [GetTransactionsRequest.length] was zero.
-    // 2. [GetTransactionsRequest.from] was larger than the last transaction known to
-    //    the canister.
-    transactions : vec Transaction;
+  // A prefix of the requested transaction range.
+  // The index of the first transaction is equal to [GetTransactionsRequest.from].
+  //
+  // Note that the number of transactions might be less than the requested
+  // [GetTransactionsRequest.length] for various reasons, for example:
+  //
+  // 1. The query might have hit the replica with an outdated state
+  //    that doesn't have the whole range yet.
+  // 2. The requested range is too large to fit into a single reply.
+  //
+  // NOTE: the list of transactions can be empty if:
+  //
+  // 1. [GetTransactionsRequest.length] was zero.
+  // 2. [GetTransactionsRequest.from] was larger than the last transaction known to
+  //    the canister.
+  transactions : vec Transaction
 };
 
 // A function for fetching archived transaction.
-type QueryArchiveFn = func (GetTransactionsRequest) -> (TransactionRange) query;
+type QueryArchiveFn = func(GetTransactionsRequest) -> (TransactionRange) query;
 
 type Transaction = record {
   burn : opt Burn;
@@ -226,7 +226,7 @@ type Transaction = record {
   mint : opt Mint;
   approve : opt Approve;
   timestamp : Timestamp;
-  transfer : opt Transfer;
+  transfer : opt Transfer
 };
 
 type Burn = record {
@@ -234,14 +234,14 @@ type Burn = record {
   memo : opt blob;
   created_at_time : opt Timestamp;
   amount : nat;
-  spender : opt Account;
+  spender : opt Account
 };
 
 type Mint = record {
   to : Account;
   memo : opt blob;
   created_at_time : opt Timestamp;
-  amount : nat;
+  amount : nat
 };
 
 type Transfer = record {
@@ -251,17 +251,17 @@ type Transfer = record {
   memo : opt blob;
   created_at_time : opt Timestamp;
   amount : nat;
-  spender : opt Account;
+  spender : opt Account
 };
 
 type Value = variant {
-    Blob : blob;
-    Text : text;
-    Nat : nat;
-    Nat64: nat64;
-    Int : int;
-    Array : vec Value;
-    Map : Map;
+  Blob : blob;
+  Text : text;
+  Nat : nat;
+  Nat64 : nat64;
+  Int : int;
+  Array : vec Value;
+  Map : Map
 };
 
 type Map = vec record { text; Value };
@@ -269,151 +269,151 @@ type Map = vec record { text; Value };
 type Block = Value;
 
 type GetBlocksArgs = record {
-    // The index of the first block to fetch.
-    start : BlockIndex;
-    // Max number of blocks to fetch.
-    length : nat;
+  // The index of the first block to fetch.
+  start : BlockIndex;
+  // Max number of blocks to fetch.
+  length : nat
 };
 
 // A prefix of the block range specified in the [GetBlocksArgs] request.
 type BlockRange = record {
-    // A prefix of the requested block range.
-    // The index of the first block is equal to [GetBlocksArgs.start].
-    //
-    // Note that the number of blocks might be less than the requested
-    // [GetBlocksArgs.length] for various reasons, for example:
-    //
-    // 1. The query might have hit the replica with an outdated state
-    //    that doesn't have the whole range yet.
-    // 2. The requested range is too large to fit into a single reply.
-    //
-    // NOTE: the list of blocks can be empty if:
-    //
-    // 1. [GetBlocksArgs.length] was zero.
-    // 2. [GetBlocksArgs.start] was larger than the last block known to
-    //    the canister.
-    blocks : vec Block;
+  // A prefix of the requested block range.
+  // The index of the first block is equal to [GetBlocksArgs.start].
+  //
+  // Note that the number of blocks might be less than the requested
+  // [GetBlocksArgs.length] for various reasons, for example:
+  //
+  // 1. The query might have hit the replica with an outdated state
+  //    that doesn't have the whole range yet.
+  // 2. The requested range is too large to fit into a single reply.
+  //
+  // NOTE: the list of blocks can be empty if:
+  //
+  // 1. [GetBlocksArgs.length] was zero.
+  // 2. [GetBlocksArgs.start] was larger than the last block known to
+  //    the canister.
+  blocks : vec Block
 };
 
 // A function for fetching archived blocks.
-type QueryBlockArchiveFn = func (GetBlocksArgs) -> (BlockRange) query;
+type QueryBlockArchiveFn = func(GetBlocksArgs) -> (BlockRange) query;
 
 // The result of a "get_blocks" call.
 type GetBlocksResponse = record {
-    // The index of the first block in "blocks".
-    // If the blocks vector is empty, the exact value of this field is not specified.
-    first_index : BlockIndex;
+  // The index of the first block in "blocks".
+  // If the blocks vector is empty, the exact value of this field is not specified.
+  first_index : BlockIndex;
 
-    // The total number of blocks in the chain.
-    // If the chain length is positive, the index of the last block is `chain_len - 1`.
-    chain_length : nat64;
+  // The total number of blocks in the chain.
+  // If the chain length is positive, the index of the last block is `chain_len - 1`.
+  chain_length : nat64;
 
-    // System certificate for the hash of the latest block in the chain.
-    // Only present if `get_blocks` is called in a non-replicated query context.
-    certificate : opt blob;
+  // System certificate for the hash of the latest block in the chain.
+  // Only present if `get_blocks` is called in a non-replicated query context.
+  certificate : opt blob;
 
-    // List of blocks that were available in the ledger when it processed the call.
-    //
-    // The blocks form a contiguous range, with the first block having index
-    // [first_block_index] (see below), and the last block having index
-    // [first_block_index] + len(blocks) - 1.
-    //
-    // The block range can be an arbitrary sub-range of the originally requested range.
-    blocks : vec Block;
+  // List of blocks that were available in the ledger when it processed the call.
+  //
+  // The blocks form a contiguous range, with the first block having index
+  // [first_block_index] (see below), and the last block having index
+  // [first_block_index] + len(blocks) - 1.
+  //
+  // The block range can be an arbitrary sub-range of the originally requested range.
+  blocks : vec Block;
 
-    // Encoding of instructions for fetching archived blocks.
-    archived_blocks : vec record {
-        // The index of the first archived block.
-        start : BlockIndex;
+  // Encoding of instructions for fetching archived blocks.
+  archived_blocks : vec record {
+    // The index of the first archived block.
+    start : BlockIndex;
 
-        // The number of blocks that can be fetched.
-        length : nat;
+    // The number of blocks that can be fetched.
+    length : nat;
 
-        // Callback to fetch the archived blocks.
-        callback : QueryBlockArchiveFn;
-    };
+    // Callback to fetch the archived blocks.
+    callback : QueryBlockArchiveFn
+  }
 };
 
 // Certificate for the block at `block_index`.
 type DataCertificate = record {
-    certificate : opt blob;
-    hash_tree : blob;
+  certificate : opt blob;
+  hash_tree : blob
 };
 
 type StandardRecord = record { url : text; name : text };
 
 type TransferFromArgs = record {
-    spender_subaccount : opt Subaccount;
-    from : Account;
-    to : Account;
-    amount : Tokens;
-    fee : opt Tokens;
-    memo : opt blob;
-    created_at_time: opt Timestamp;
+  spender_subaccount : opt Subaccount;
+  from : Account;
+  to : Account;
+  amount : Tokens;
+  fee : opt Tokens;
+  memo : opt blob;
+  created_at_time : opt Timestamp
 };
 
 type TransferFromResult = variant {
-    Ok : BlockIndex;
-    Err : TransferFromError;
+  Ok : BlockIndex;
+  Err : TransferFromError
 };
 
 type TransferFromError = variant {
-    BadFee : record { expected_fee : Tokens };
-    BadBurn : record { min_burn_amount : Tokens };
-    InsufficientFunds : record { balance : Tokens };
-    InsufficientAllowance : record { allowance : Tokens };
-    TooOld;
-    CreatedInFuture : record { ledger_time : Timestamp };
-    Duplicate : record { duplicate_of : BlockIndex };
-    TemporarilyUnavailable;
-    GenericError : record { error_code : nat; message : text };
+  BadFee : record { expected_fee : Tokens };
+  BadBurn : record { min_burn_amount : Tokens };
+  InsufficientFunds : record { balance : Tokens };
+  InsufficientAllowance : record { allowance : Tokens };
+  TooOld;
+  CreatedInFuture : record { ledger_time : Timestamp };
+  Duplicate : record { duplicate_of : BlockIndex };
+  TemporarilyUnavailable;
+  GenericError : record { error_code : nat; message : text }
 };
 
 type ArchiveInfo = record {
-    canister_id: principal;
-    block_range_start: BlockIndex;
-    block_range_end: BlockIndex;
+  canister_id : principal;
+  block_range_start : BlockIndex;
+  block_range_end : BlockIndex
 };
 
 type ICRC3Value = variant {
-    Blob : blob;
-    Text : text;
-    Nat : nat;
-    Int : int;
-    Array : vec ICRC3Value;
-    Map : vec record { text; ICRC3Value };
+  Blob : blob;
+  Text : text;
+  Nat : nat;
+  Int : int;
+  Array : vec ICRC3Value;
+  Map : vec record { text; ICRC3Value }
 };
 
 type GetArchivesArgs = record {
-    // The last archive seen by the client.
-    // The Ledger will return archives coming
-    // after this one if set, otherwise it
-    // will return the first archives.
-    from : opt principal;
+  // The last archive seen by the client.
+  // The Ledger will return archives coming
+  // after this one if set, otherwise it
+  // will return the first archives.
+  from : opt principal
 };
 
 type GetArchivesResult = vec record {
-    // The id of the archive
-    canister_id : principal;
+  // The id of the archive
+  canister_id : principal;
 
-    // The first block in the archive
-    start : nat;
+  // The first block in the archive
+  start : nat;
 
-    // The last block in the archive
-    end : nat;
+  // The last block in the archive
+  end : nat
 };
 
 type GetBlocksResult = record {
-    // Total number of blocks in the
-    // block log
-    log_length : nat;
+  // Total number of blocks in the
+  // block log
+  log_length : nat;
 
-    blocks : vec record { id : nat; block: ICRC3Value };
+  blocks : vec record { id : nat; block : ICRC3Value };
 
-    archived_blocks : vec record {
-        args : vec GetBlocksArgs;
-        callback : func (vec GetBlocksArgs) -> (GetBlocksResult) query;
-    };
+  archived_blocks : vec record {
+    args : vec GetBlocksArgs;
+    callback : func(vec GetBlocksArgs) -> (GetBlocksResult) query
+  }
 };
 
 type ICRC3DataCertificate = record {
@@ -421,141 +421,156 @@ type ICRC3DataCertificate = record {
   certificate : blob;
 
   // CBOR encoded hash_tree
-  hash_tree : blob;
+  hash_tree : blob
 };
 
 type icrc21_consent_message_metadata = record {
-    language: text;
-    utc_offset_minutes: opt int16;
+  language : text;
+  utc_offset_minutes : opt int16
 };
 
 type icrc21_consent_message_spec = record {
-    metadata: icrc21_consent_message_metadata;
-    device_spec: opt variant {
-        GenericDisplay;
-        LineDisplay: record {
-            characters_per_line: nat16;
-            lines_per_page: nat16;
-        };
-    };
+  metadata : icrc21_consent_message_metadata;
+  device_spec : opt variant {
+    GenericDisplay;
+    FieldsDisplay
+  }
 };
 
 type icrc21_consent_message_request = record {
-    method: text;
-    arg: blob;
-    user_preferences: icrc21_consent_message_spec;
+  method : text;
+  arg : blob;
+  user_preferences : icrc21_consent_message_spec
+};
+
+type Icrc21Value = variant {
+  TokenAmount : record {
+    decimals : nat8;
+    amount : nat64;
+    symbol : text
+  };
+  TimestampSeconds : record {
+    amount : nat64
+  };
+  DurationSeconds : record {
+    amount : nat64
+  };
+  Text : record {
+    content : text
+  }
+};
+
+type FieldsDisplay = record {
+  intent : text;
+  fields : vec record { text; Icrc21Value }
 };
 
 type icrc21_consent_message = variant {
-    GenericDisplayMessage: text;
-    LineDisplayMessage: record {
-        pages: vec record {
-            lines: vec text;
-        };
-    };
+  GenericDisplayMessage : text;
+  FieldsDisplayMessage : FieldsDisplay
 };
 
 type icrc21_consent_info = record {
-    consent_message: icrc21_consent_message;
-    metadata: icrc21_consent_message_metadata;
+  consent_message : icrc21_consent_message;
+  metadata : icrc21_consent_message_metadata
 };
 
 type icrc21_error_info = record {
-    description: text;
+  description : text
 };
 
 type icrc21_error = variant {
-    UnsupportedCanisterCall: icrc21_error_info;
-    ConsentMessageUnavailable: icrc21_error_info;
-    InsufficientPayment: icrc21_error_info;
+  UnsupportedCanisterCall : icrc21_error_info;
+  ConsentMessageUnavailable : icrc21_error_info;
+  InsufficientPayment : icrc21_error_info;
 
-    // Any error not covered by the above variants.
-    GenericError: record {
-       error_code: nat;
-       description: text;
-   };
+  // Any error not covered by the above variants.
+  GenericError : record {
+    error_code : nat;
+    description : text
+  }
 };
 
 type icrc21_consent_message_response = variant {
-    Ok: icrc21_consent_info;
-    Err: icrc21_error;
+  Ok : icrc21_consent_info;
+  Err : icrc21_error
 };
 
 type GetAllowancesArgs = record {
-    from_account: opt Account;
-    prev_spender: opt Account;
-    take: opt nat;
+  from_account : opt Account;
+  prev_spender : opt Account;
+  take : opt nat
 };
 
 type Allowance103 = record {
-    from_account: Account;
-    to_spender: Account;
-    allowance: nat;
-    expires_at: opt nat64;
+  from_account : Account;
+  to_spender : Account;
+  allowance : nat;
+  expires_at : opt nat64
 };
 
 type GetAllowancesError = variant {
-    AccessDenied: record {
-        reason: text;
-    };
-    GenericError: record {
-       error_code: nat;
-       message: text;
-   };
+  AccessDenied : record {
+    reason : text
+  };
+  GenericError : record {
+    error_code : nat;
+    message : text
+  }
 };
 
 type icrc103_get_allowances_response = variant {
-    Ok: vec Allowance103;
-    Err: GetAllowancesError;
+  Ok : vec Allowance103;
+  Err : GetAllowancesError
 };
 
 type GetIndexPrincipalResult = variant {
-    Ok : principal;
-    Err : GetIndexPrincipalError;
+  Ok : principal;
+  Err : GetIndexPrincipalError
 };
 
 type GetIndexPrincipalError = variant {
-    IndexPrincipalNotSet;
+  IndexPrincipalNotSet;
 
-    // Any error not covered by the above variants.
-    GenericError: record {
-       error_code: nat;
-       description: text;
-   };
+  // Any error not covered by the above variants.
+  GenericError : record {
+    error_code : nat;
+    description : text
+  }
 };
 
 service : (ledger_arg : LedgerArg) -> {
-    archives : () -> (vec ArchiveInfo) query;
-    get_transactions : (GetTransactionsRequest) -> (GetTransactionsResponse) query;
-    get_blocks : (GetBlocksArgs) -> (GetBlocksResponse) query;
-    get_data_certificate : () -> (DataCertificate) query;
+  archives : () -> (vec ArchiveInfo) query;
+  get_transactions : (GetTransactionsRequest) -> (GetTransactionsResponse) query;
+  get_blocks : (GetBlocksArgs) -> (GetBlocksResponse) query;
+  get_data_certificate : () -> (DataCertificate) query;
 
-    icrc1_name : () -> (text) query;
-    icrc1_symbol : () -> (text) query;
-    icrc1_decimals : () -> (nat8) query;
-    icrc1_metadata : () -> (vec record { text; MetadataValue }) query;
-    icrc1_total_supply : () -> (Tokens) query;
-    icrc1_fee : () -> (Tokens) query;
-    icrc1_minting_account : () -> (opt Account) query;
-    icrc1_balance_of : (Account) -> (Tokens) query;
-    icrc1_transfer : (TransferArg) -> (TransferResult);
-    icrc1_supported_standards : () -> (vec StandardRecord) query;
+  icrc1_name : () -> (text) query;
+  icrc1_symbol : () -> (text) query;
+  icrc1_decimals : () -> (nat8) query;
+  icrc1_metadata : () -> (vec record { text; MetadataValue }) query;
+  icrc1_total_supply : () -> (Tokens) query;
+  icrc1_fee : () -> (Tokens) query;
+  icrc1_minting_account : () -> (opt Account) query;
+  icrc1_balance_of : (Account) -> (Tokens) query;
+  icrc1_transfer : (TransferArg) -> (TransferResult);
+  icrc1_supported_standards : () -> (vec StandardRecord) query;
 
-    icrc2_approve : (ApproveArgs) -> (ApproveResult);
-    icrc2_allowance : (AllowanceArgs) -> (Allowance) query;
-    icrc2_transfer_from : (TransferFromArgs) -> (TransferFromResult);
+  icrc2_approve : (ApproveArgs) -> (ApproveResult);
+  icrc2_allowance : (AllowanceArgs) -> (Allowance) query;
+  icrc2_transfer_from : (TransferFromArgs) -> (TransferFromResult);
 
-    icrc3_get_archives : (GetArchivesArgs) -> (GetArchivesResult) query;
-    icrc3_get_tip_certificate : () -> (opt ICRC3DataCertificate) query;
-    icrc3_get_blocks : (vec GetBlocksArgs) -> (GetBlocksResult) query;
-    icrc3_supported_block_types : () -> (vec record { block_type : text; url : text }) query;
+  icrc3_get_archives : (GetArchivesArgs) -> (GetArchivesResult) query;
+  icrc3_get_tip_certificate : () -> (opt ICRC3DataCertificate) query;
+  icrc3_get_blocks : (vec GetBlocksArgs) -> (GetBlocksResult) query;
+  icrc3_supported_block_types : () -> (vec record { block_type : text; url : text }) query;
 
-    icrc21_canister_call_consent_message: (icrc21_consent_message_request) -> (icrc21_consent_message_response);
-    icrc10_supported_standards : () -> (vec record { name : text; url : text }) query;
+  icrc21_canister_call_consent_message : (icrc21_consent_message_request) -> (icrc21_consent_message_response);
+  icrc10_supported_standards : () -> (vec record { name : text; url : text }) query;
 
-    icrc103_get_allowances : (GetAllowancesArgs) -> (icrc103_get_allowances_response) query;
+  icrc103_get_allowances : (GetAllowancesArgs) -> (icrc103_get_allowances_response) query;
 
-    icrc106_get_index_principal: () -> (GetIndexPrincipalResult) query;
+  icrc106_get_index_principal : () -> (GetIndexPrincipalResult) query;
 
-    is_ledger_ready: () -> (bool) query;
+  is_ledger_ready : () -> (bool) query
 }

--- a/packages/ledger-icrc/candid/icrc_ledger.idl.js
+++ b/packages/ledger-icrc/candid/icrc_ledger.idl.js
@@ -246,13 +246,7 @@ export const idlFactory = ({ IDL }) => {
   const icrc21_consent_message_spec = IDL.Record({
     'metadata' : icrc21_consent_message_metadata,
     'device_spec' : IDL.Opt(
-      IDL.Variant({
-        'GenericDisplay' : IDL.Null,
-        'LineDisplay' : IDL.Record({
-          'characters_per_line' : IDL.Nat16,
-          'lines_per_page' : IDL.Nat16,
-        }),
-      })
+      IDL.Variant({ 'GenericDisplay' : IDL.Null, 'FieldsDisplay' : IDL.Null })
     ),
   });
   const icrc21_consent_message_request = IDL.Record({
@@ -260,10 +254,22 @@ export const idlFactory = ({ IDL }) => {
     'method' : IDL.Text,
     'user_preferences' : icrc21_consent_message_spec,
   });
-  const icrc21_consent_message = IDL.Variant({
-    'LineDisplayMessage' : IDL.Record({
-      'pages' : IDL.Vec(IDL.Record({ 'lines' : IDL.Vec(IDL.Text) })),
+  const Icrc21Value = IDL.Variant({
+    'Text' : IDL.Record({ 'content' : IDL.Text }),
+    'TokenAmount' : IDL.Record({
+      'decimals' : IDL.Nat8,
+      'amount' : IDL.Nat64,
+      'symbol' : IDL.Text,
     }),
+    'TimestampSeconds' : IDL.Record({ 'amount' : IDL.Nat64 }),
+    'DurationSeconds' : IDL.Record({ 'amount' : IDL.Nat64 }),
+  });
+  const FieldsDisplay = IDL.Record({
+    'fields' : IDL.Vec(IDL.Tuple(IDL.Text, Icrc21Value)),
+    'intent' : IDL.Text,
+  });
+  const icrc21_consent_message = IDL.Variant({
+    'FieldsDisplayMessage' : FieldsDisplay,
     'GenericDisplayMessage' : IDL.Text,
   });
   const icrc21_consent_info = IDL.Record({

--- a/packages/ledger-icrc/src/converters/ledger.converters.spec.ts
+++ b/packages/ledger-icrc/src/converters/ledger.converters.spec.ts
@@ -106,10 +106,7 @@ describe("ledger.converters", () => {
             utcOffsetMinutes: 120,
           },
           deriveSpec: {
-            LineDisplay: {
-              charactersPerLine: 40,
-              linesPerPage: 10,
-            },
+            FieldsDisplay: null,
           },
         },
       };
@@ -127,10 +124,7 @@ describe("ledger.converters", () => {
             ),
           },
           device_spec: toNullable({
-            LineDisplay: {
-              characters_per_line: 40,
-              lines_per_page: 10,
-            },
+            FieldsDisplay: null,
           }),
         },
       });

--- a/packages/ledger-icrc/src/converters/ledger.converters.ts
+++ b/packages/ledger-icrc/src/converters/ledger.converters.ts
@@ -82,10 +82,7 @@ export const toIcrc21ConsentMessageArgs = ({
           "GenericDisplay" in deriveSpec
             ? { GenericDisplay: null }
             : {
-                LineDisplay: {
-                  characters_per_line: deriveSpec.LineDisplay.charactersPerLine,
-                  lines_per_page: deriveSpec.LineDisplay.linesPerPage,
-                },
+                FieldsDisplay: null,
               },
         ),
   },

--- a/packages/ledger-icrc/src/types/ledger.params.ts
+++ b/packages/ledger-icrc/src/types/ledger.params.ts
@@ -94,17 +94,12 @@ export interface Icrc21ConsentMessageMetadata {
  * Device specification for displaying the consent message.
  *
  * @param {null} [GenericDisplay] -  A generic display able to handle large documents and do line wrapping and pagination / scrolling.  Text must be Markdown formatted, no external resources (e.g. images) are allowed.
- * @param {Object} [LineDisplay] - Simple display able to handle lines of text with a maximum number of characters per line.
- * @param {number} LineDisplay.charactersPerLine - Maximum number of characters that can be displayed per line.
- * @param {number} LineDisplay.linesPerPage - Maximum number of lines that can be displayed at once on a single page.
+ * @param {Object} [FieldsDisplay] - A simple display able to handle multiple fields with a title and content.
  */
 export type Icrc21ConsentMessageDeviceSpec =
   | { GenericDisplay: null }
   | {
-      LineDisplay: {
-        charactersPerLine: number;
-        linesPerPage: number;
-      };
+      FieldsDisplay: null;
     };
 
 /**


### PR DESCRIPTION
# Motivation

The latest ICRC-21 introduces a breaking changes https://github.com/dfinity/wg-identity-authentication/pull/229 which remove `LineDisplay` and introduce  `FieldsDisplay`.
The change has now been implemented in the ledger suite as provided by PR #1027.

# Changes

- Copy did and js for the ledger-icp from #1027
- Remove `LineDisplay` and add `FIeldsDisplay`

