### PR TITLE
build: update agent-js (in lock file only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.2.0.tgz",
-      "integrity": "sha512-GIobACWPxhjdnFMKR7GS4nMqlq1rMYEImYvSWfNAtPbAAwNqfNk7Sgr6/2qLt4XWxiRhbShk65w+hLJGor0xlw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.2.4.tgz",
+      "integrity": "sha512-2TpFyaInmdRemQ8QlP4yZusO+6Dqe98SBvSSGOWcCL2zQ7u/dgKA1jXwXb7tdHHMXvdC1bXFjeyBGqpqTG6avA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -49,19 +49,19 @@
         "@noble/curves": "^1.9.2"
       },
       "peerDependencies": {
-        "@dfinity/candid": "3.2.0",
-        "@dfinity/principal": "3.2.0",
+        "@dfinity/candid": "3.2.4",
+        "@dfinity/principal": "3.2.4",
         "@noble/hashes": "^1.8.0"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.2.0.tgz",
-      "integrity": "sha512-HbyXp1QGHU/xa2lBSL9GjoHFAGbPiFrgJwabK0/VZzrcjQPKjv7G/krMKCIMm4pfaGl3ChWan9FyV9Ax/an3/g==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.2.4.tgz",
+      "integrity": "sha512-VpzY4mFHmm/F4iuqW3AMehKEsTeFbM5CDkRqp0IHS2gqxBm0XDkreJhIyv5S4P93NxGx1QzPCN1wzO5wPuH8OA==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "3.2.0"
+        "@dfinity/principal": "3.2.4"
       }
     },
     "node_modules/@dfinity/cbor": {
@@ -133,9 +133,9 @@
       "link": true
     },
     "node_modules/@dfinity/principal": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.2.0.tgz",
-      "integrity": "sha512-2VY3dLKLCxiZdJmgj+5LPZxb5DeJ0EJABUXGeYitAx6EikRpNYnpZUOXpb6TjPOUT67AednA7aLAP6xnXNV3nA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.2.4.tgz",
+      "integrity": "sha512-7qTjDb9k/J/55k0/ZnD8s2+L+IgfG6K1lC7iywhQQL/4Qe0UIljUTasDk85kooY2QeNvWSl7MsLWp69LPBiYjw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -845,9 +845,9 @@
       "license": "MIT"
     },
     "node_modules/@noble/curves": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.6.tgz",
-      "integrity": "sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6727,9 +6727,9 @@
   },
   "dependencies": {
     "@dfinity/agent": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.2.0.tgz",
-      "integrity": "sha512-GIobACWPxhjdnFMKR7GS4nMqlq1rMYEImYvSWfNAtPbAAwNqfNk7Sgr6/2qLt4XWxiRhbShk65w+hLJGor0xlw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.2.4.tgz",
+      "integrity": "sha512-2TpFyaInmdRemQ8QlP4yZusO+6Dqe98SBvSSGOWcCL2zQ7u/dgKA1jXwXb7tdHHMXvdC1bXFjeyBGqpqTG6avA==",
       "peer": true,
       "requires": {
         "@dfinity/cbor": "^0.2.2",
@@ -6737,9 +6737,9 @@
       }
     },
     "@dfinity/candid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.2.0.tgz",
-      "integrity": "sha512-HbyXp1QGHU/xa2lBSL9GjoHFAGbPiFrgJwabK0/VZzrcjQPKjv7G/krMKCIMm4pfaGl3ChWan9FyV9Ax/an3/g==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.2.4.tgz",
+      "integrity": "sha512-VpzY4mFHmm/F4iuqW3AMehKEsTeFbM5CDkRqp0IHS2gqxBm0XDkreJhIyv5S4P93NxGx1QzPCN1wzO5wPuH8OA==",
       "peer": true,
       "requires": {}
     },
@@ -6806,9 +6806,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.2.0.tgz",
-      "integrity": "sha512-2VY3dLKLCxiZdJmgj+5LPZxb5DeJ0EJABUXGeYitAx6EikRpNYnpZUOXpb6TjPOUT67AednA7aLAP6xnXNV3nA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.2.4.tgz",
+      "integrity": "sha512-7qTjDb9k/J/55k0/ZnD8s2+L+IgfG6K1lC7iywhQQL/4Qe0UIljUTasDk85kooY2QeNvWSl7MsLWp69LPBiYjw==",
       "peer": true,
       "requires": {
         "@noble/hashes": "^1.8.0"
@@ -7164,9 +7164,9 @@
       "dev": true
     },
     "@noble/curves": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.6.tgz",
-      "integrity": "sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "peer": true,
       "requires": {
         "@noble/hashes": "1.8.0"


### PR DESCRIPTION
# Motivation

There was a bug in AgentJS that impacted the `@dfinity/ic-management` library resolved in https://github.com/dfinity/icp-js-core/releases/tag/v4.0.2.

While the libraries reference any version of AgentJS v3, for the state of the art, I thought we can bump the Agent for the repo.

# Changes

- Bump latest AgentJS in `package-lock`
