### PR TITLE
feat: update candid files (except ic-mgmt)

### DIFF
--- a/packages/ckbtc/candid/minter.did
+++ b/packages/ckbtc/candid/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
 // Represents an account on the ckBTC ledger.
 type Account = record { owner : principal; subaccount : opt blob };
 
@@ -350,12 +350,35 @@ type ReimbursementReason = variant {
     };
 };
 
+type ReplacedReason = variant {
+  to_retry;
+  to_cancel : record {
+    reason : WithdrawalReimbursementReason;
+  };
+};
+
+type WithdrawalReimbursementReason = variant {
+    invalid_transaction : InvalidTransactionError;
+};
+
+type InvalidTransactionError = variant {
+  too_many_inputs : record {
+        num_inputs : nat64;
+        max_num_inputs : nat64;
+  };
+};
+
 type SuspendedReason = variant {
     // The minter ignored this UTXO because UTXO's value is too small to pay
     // the check fees.
     ValueTooSmall;
     // The Bitcoin checker considered this UTXO to be tainted.
     Quarantined;
+};
+
+type WithdrawalFee = record {
+    minter_fee : nat64;
+    bitcoin_fee : nat64;
 };
 
 type Event = record {
@@ -388,13 +411,17 @@ type EventType = variant {
         change_output : opt record { vout : nat32; value : nat64 };
         submitted_at : nat64;
         fee: opt nat64;
+        withdrawal_fee : opt WithdrawalFee;
     };
     replaced_transaction : record {
         new_txid : blob;
         old_txid : blob;
         change_output : record { vout : nat32; value : nat64 };
         submitted_at : nat64;
-        fee: nat64;
+        fee : nat64;
+        withdrawal_fee : opt WithdrawalFee;
+        reason : opt ReplacedReason;
+        new_utxos : opt vec Utxo;
     };
     confirmed_transaction : record { txid : blob };
     checked_utxo : record {
@@ -428,6 +455,19 @@ type EventType = variant {
         reason : ReimbursementReason;
     };
     reimbursed_failed_deposit : record { burn_block_index : nat64; mint_block_index : nat64 };
+    schedule_withdrawal_reimbursement : record {
+        account : Account;
+        burn_block_index : nat64;
+        amount : nat64;
+        reason : WithdrawalReimbursementReason;
+    };
+    quarantined_withdrawal_reimbursement : record {
+        burn_block_index : nat64;
+    };
+    reimbursed_withdrawal : record {
+        burn_block_index : nat64;
+        mint_block_index : nat64;
+    };
 };
 
 type MinterArg = variant {

--- a/packages/cketh/candid/minter.did
+++ b/packages/cketh/candid/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
 type EthereumNetwork = variant {
     // The public Ethereum mainnet.
     Mainnet;

--- a/packages/cketh/candid/orchestrator.did
+++ b/packages/cketh/candid/orchestrator.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did' by import-candid
 type OrchestratorArg = variant {
     UpgradeArg : UpgradeArg;
     InitArg : InitArg;

--- a/packages/cmc/candid/cmc.did
+++ b/packages/cmc/candid/cmc.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/nns/cmc/cmc.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/nns/cmc/cmc.did' by import-candid
 type Cycles = nat;
 type BlockIndex = nat64;
 type log_visibility = variant {

--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/nns/gtc/canister/gtc.did' by import-candid
 type AccountState = record {
   authenticated_principal_id : opt principal;
   successfully_transferred_neurons : vec TransferredNeuron;

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/nns/governance/canister/governance.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };

--- a/packages/nns/candid/governance_test.did
+++ b/packages/nns/candid/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/nns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/nns/governance/canister/governance_test.did' by import-candid
 type AccountIdentifier = record {
   hash : blob;
 };

--- a/packages/nns/candid/sns_wasm.did
+++ b/packages/nns/candid/sns_wasm.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/packages/sns/candid/sns_governance.certified.idl.js
+++ b/packages/sns/candid/sns_governance.certified.idl.js
@@ -277,13 +277,23 @@ export const idlFactory = ({ IDL }) => {
     'operation_name' : IDL.Opt(IDL.Text),
     'operation_arg' : IDL.Opt(ExtensionOperationArg),
   });
-  const SetTopicsForCustomProposals = IDL.Record({
-    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
-  });
   const ChunkedCanisterWasm = IDL.Record({
     'wasm_module_hash' : IDL.Vec(IDL.Nat8),
     'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
     'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const Wasm = IDL.Variant({
+    'Chunked' : ChunkedCanisterWasm,
+    'Bytes' : IDL.Vec(IDL.Nat8),
+  });
+  const ExtensionUpgradeArg = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
+  const UpgradeExtension = IDL.Record({
+    'extension_canister_id' : IDL.Opt(IDL.Principal),
+    'wasm' : IDL.Opt(Wasm),
+    'canister_upgrade_arg' : IDL.Opt(ExtensionUpgradeArg),
+  });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
   });
   const ExtensionInit = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
   const RegisterExtension = IDL.Record({
@@ -342,6 +352,7 @@ export const idlFactory = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'ExecuteExtensionOperation' : ExecuteExtensionOperation,
+    'UpgradeExtension' : UpgradeExtension,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'RegisterExtension' : RegisterExtension,
@@ -711,7 +722,23 @@ export const idlFactory = ({ IDL }) => {
     'include_topic_filtering' : IDL.Opt(IDL.Bool),
   });
   const ListTopicsRequest = IDL.Record({});
+  const ExtensionOperationType = IDL.Variant({
+    'TreasuryManagerWithdraw' : IDL.Null,
+    'TreasuryManagerDeposit' : IDL.Null,
+  });
+  const ExtensionType = IDL.Variant({ 'TreasuryManager' : IDL.Null });
+  const ExtensionOperationSpec = IDL.Record({
+    'topic' : IDL.Opt(Topic),
+    'operation_type' : IDL.Opt(ExtensionOperationType),
+    'description' : IDL.Opt(IDL.Text),
+    'extension_type' : IDL.Opt(ExtensionType),
+  });
+  const RegisteredExtensionOperationSpec = IDL.Record({
+    'spec' : IDL.Opt(ExtensionOperationSpec),
+    'canister_id' : IDL.Opt(IDL.Principal),
+  });
   const TopicInfo = IDL.Record({
+    'extension_operations' : IDL.Opt(IDL.Vec(RegisteredExtensionOperationSpec)),
     'native_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
     'topic' : IDL.Opt(Topic),
     'is_critical' : IDL.Opt(IDL.Bool),
@@ -1125,13 +1152,23 @@ export const init = ({ IDL }) => {
     'operation_name' : IDL.Opt(IDL.Text),
     'operation_arg' : IDL.Opt(ExtensionOperationArg),
   });
-  const SetTopicsForCustomProposals = IDL.Record({
-    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
-  });
   const ChunkedCanisterWasm = IDL.Record({
     'wasm_module_hash' : IDL.Vec(IDL.Nat8),
     'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
     'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const Wasm = IDL.Variant({
+    'Chunked' : ChunkedCanisterWasm,
+    'Bytes' : IDL.Vec(IDL.Nat8),
+  });
+  const ExtensionUpgradeArg = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
+  const UpgradeExtension = IDL.Record({
+    'extension_canister_id' : IDL.Opt(IDL.Principal),
+    'wasm' : IDL.Opt(Wasm),
+    'canister_upgrade_arg' : IDL.Opt(ExtensionUpgradeArg),
+  });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
   });
   const ExtensionInit = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
   const RegisterExtension = IDL.Record({
@@ -1190,6 +1227,7 @@ export const init = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'ExecuteExtensionOperation' : ExecuteExtensionOperation,
+    'UpgradeExtension' : UpgradeExtension,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'RegisterExtension' : RegisterExtension,

--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -13,6 +13,7 @@ export type Action =
   | { AddGenericNervousSystemFunction: NervousSystemFunction }
   | { ManageDappCanisterSettings: ManageDappCanisterSettings }
   | { ExecuteExtensionOperation: ExecuteExtensionOperation }
+  | { UpgradeExtension: UpgradeExtension }
   | { RemoveGenericNervousSystemFunction: bigint }
   | { SetTopicsForCustomProposals: SetTopicsForCustomProposals }
   | { RegisterExtension: RegisterExtension }
@@ -202,6 +203,19 @@ export interface ExtensionInit {
   value: [] | [PreciseValue];
 }
 export interface ExtensionOperationArg {
+  value: [] | [PreciseValue];
+}
+export interface ExtensionOperationSpec {
+  topic: [] | [Topic];
+  operation_type: [] | [ExtensionOperationType];
+  description: [] | [string];
+  extension_type: [] | [ExtensionType];
+}
+export type ExtensionOperationType =
+  | { TreasuryManagerWithdraw: null }
+  | { TreasuryManagerDeposit: null };
+export type ExtensionType = { TreasuryManager: null };
+export interface ExtensionUpgradeArg {
   value: [] | [PreciseValue];
 }
 export interface FinalizeDisburseMaturity {
@@ -611,6 +625,10 @@ export interface RegisterVote {
   vote: number;
   proposal: [] | [ProposalId];
 }
+export interface RegisteredExtensionOperationSpec {
+  spec: [] | [ExtensionOperationSpec];
+  canister_id: [] | [Principal];
+}
 export interface RemoveNeuronPermissions {
   permissions_to_remove: [] | [NeuronPermissionList];
   principal_id: [] | [Principal];
@@ -700,6 +718,7 @@ export type Topic =
   | { Governance: null }
   | { SnsFrameworkManagement: null };
 export interface TopicInfo {
+  extension_operations: [] | [Array<RegisteredExtensionOperationSpec>];
   native_functions: [] | [Array<NervousSystemFunction>];
   topic: [] | [Topic];
   is_critical: [] | [boolean];
@@ -725,6 +744,11 @@ export interface TreasuryMetrics {
   ledger_canister_id: [] | [Principal];
   treasury: number;
   timestamp_seconds: [] | [bigint];
+}
+export interface UpgradeExtension {
+  extension_canister_id: [] | [Principal];
+  wasm: [] | [Wasm];
+  canister_upgrade_arg: [] | [ExtensionUpgradeArg];
 }
 export interface UpgradeInProgress {
   mark_failed_at_seconds: bigint;
@@ -818,6 +842,9 @@ export interface VotingRewardsParameters {
 export interface WaitForQuietState {
   current_deadline_timestamp_seconds: bigint;
 }
+export type Wasm =
+  | { Chunked: ChunkedCanisterWasm }
+  | { Bytes: Uint8Array | number[] };
 export interface _SERVICE {
   claim_swap_neurons: ActorMethod<
     [ClaimSwapNeuronsRequest],

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/sns/governance/canister/governance.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -14,6 +14,7 @@ type Action = variant {
   AdvanceSnsTargetVersion : AdvanceSnsTargetVersion;
   RegisterDappCanisters : RegisterDappCanisters;
   RegisterExtension : RegisterExtension;
+  UpgradeExtension : UpgradeExtension;
   ExecuteExtensionOperation : ExecuteExtensionOperation;
   TransferSnsTreasuryFunds : TransferSnsTreasuryFunds;
   UpgradeSnsControlledCanister : UpgradeSnsControlledCanister;
@@ -752,12 +753,48 @@ type ExtensionOperationArg = record {
   value : opt PreciseValue;
 };
 
+type ExtensionUpgradeArg = record {
+  value : opt PreciseValue;
+};
+
+type Wasm = variant {
+  Bytes : blob;
+  Chunked : ChunkedCanisterWasm;
+};
+
+type UpgradeExtension = record {
+  extension_canister_id : opt principal;
+  canister_upgrade_arg : opt ExtensionUpgradeArg;
+  wasm : opt Wasm;
+};
+
 type ExecuteExtensionOperation = record {
   extension_canister_id : opt principal;
 
   operation_name : opt text;
 
   operation_arg : opt ExtensionOperationArg;
+};
+
+type ExtensionOperationSpec = record {
+  operation_type : opt ExtensionOperationType;
+  description : opt text;
+  extension_type : opt ExtensionType;
+  topic : opt Topic;
+};
+
+type ExtensionOperationType = variant {
+  TreasuryManagerDeposit;
+  TreasuryManagerWithdraw;
+};
+
+type ExtensionType = variant {
+  TreasuryManager;
+};
+
+type RegisteredExtensionOperationSpec = record {
+  canister_id : opt principal;
+  spec : opt ExtensionOperationSpec;
 };
 
 type RegisterVote = record {
@@ -993,6 +1030,7 @@ type TopicInfo = record {
   description : opt text;
   native_functions : opt vec NervousSystemFunction;
   custom_functions : opt vec NervousSystemFunction;
+  extension_operations : opt vec RegisteredExtensionOperationSpec;
   is_critical : opt bool;
 };
 

--- a/packages/sns/candid/sns_governance.idl.js
+++ b/packages/sns/candid/sns_governance.idl.js
@@ -277,13 +277,23 @@ export const idlFactory = ({ IDL }) => {
     'operation_name' : IDL.Opt(IDL.Text),
     'operation_arg' : IDL.Opt(ExtensionOperationArg),
   });
-  const SetTopicsForCustomProposals = IDL.Record({
-    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
-  });
   const ChunkedCanisterWasm = IDL.Record({
     'wasm_module_hash' : IDL.Vec(IDL.Nat8),
     'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
     'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const Wasm = IDL.Variant({
+    'Chunked' : ChunkedCanisterWasm,
+    'Bytes' : IDL.Vec(IDL.Nat8),
+  });
+  const ExtensionUpgradeArg = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
+  const UpgradeExtension = IDL.Record({
+    'extension_canister_id' : IDL.Opt(IDL.Principal),
+    'wasm' : IDL.Opt(Wasm),
+    'canister_upgrade_arg' : IDL.Opt(ExtensionUpgradeArg),
+  });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
   });
   const ExtensionInit = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
   const RegisterExtension = IDL.Record({
@@ -342,6 +352,7 @@ export const idlFactory = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'ExecuteExtensionOperation' : ExecuteExtensionOperation,
+    'UpgradeExtension' : UpgradeExtension,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'RegisterExtension' : RegisterExtension,
@@ -711,7 +722,23 @@ export const idlFactory = ({ IDL }) => {
     'include_topic_filtering' : IDL.Opt(IDL.Bool),
   });
   const ListTopicsRequest = IDL.Record({});
+  const ExtensionOperationType = IDL.Variant({
+    'TreasuryManagerWithdraw' : IDL.Null,
+    'TreasuryManagerDeposit' : IDL.Null,
+  });
+  const ExtensionType = IDL.Variant({ 'TreasuryManager' : IDL.Null });
+  const ExtensionOperationSpec = IDL.Record({
+    'topic' : IDL.Opt(Topic),
+    'operation_type' : IDL.Opt(ExtensionOperationType),
+    'description' : IDL.Opt(IDL.Text),
+    'extension_type' : IDL.Opt(ExtensionType),
+  });
+  const RegisteredExtensionOperationSpec = IDL.Record({
+    'spec' : IDL.Opt(ExtensionOperationSpec),
+    'canister_id' : IDL.Opt(IDL.Principal),
+  });
   const TopicInfo = IDL.Record({
+    'extension_operations' : IDL.Opt(IDL.Vec(RegisteredExtensionOperationSpec)),
     'native_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
     'topic' : IDL.Opt(Topic),
     'is_critical' : IDL.Opt(IDL.Bool),
@@ -1141,13 +1168,23 @@ export const init = ({ IDL }) => {
     'operation_name' : IDL.Opt(IDL.Text),
     'operation_arg' : IDL.Opt(ExtensionOperationArg),
   });
-  const SetTopicsForCustomProposals = IDL.Record({
-    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
-  });
   const ChunkedCanisterWasm = IDL.Record({
     'wasm_module_hash' : IDL.Vec(IDL.Nat8),
     'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
     'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const Wasm = IDL.Variant({
+    'Chunked' : ChunkedCanisterWasm,
+    'Bytes' : IDL.Vec(IDL.Nat8),
+  });
+  const ExtensionUpgradeArg = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
+  const UpgradeExtension = IDL.Record({
+    'extension_canister_id' : IDL.Opt(IDL.Principal),
+    'wasm' : IDL.Opt(Wasm),
+    'canister_upgrade_arg' : IDL.Opt(ExtensionUpgradeArg),
+  });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
   });
   const ExtensionInit = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
   const RegisterExtension = IDL.Record({
@@ -1206,6 +1243,7 @@ export const init = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'ExecuteExtensionOperation' : ExecuteExtensionOperation,
+    'UpgradeExtension' : UpgradeExtension,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'RegisterExtension' : RegisterExtension,

--- a/packages/sns/candid/sns_governance_test.certified.idl.js
+++ b/packages/sns/candid/sns_governance_test.certified.idl.js
@@ -277,13 +277,23 @@ export const idlFactory = ({ IDL }) => {
     'operation_name' : IDL.Opt(IDL.Text),
     'operation_arg' : IDL.Opt(ExtensionOperationArg),
   });
-  const SetTopicsForCustomProposals = IDL.Record({
-    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
-  });
   const ChunkedCanisterWasm = IDL.Record({
     'wasm_module_hash' : IDL.Vec(IDL.Nat8),
     'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
     'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const Wasm = IDL.Variant({
+    'Chunked' : ChunkedCanisterWasm,
+    'Bytes' : IDL.Vec(IDL.Nat8),
+  });
+  const ExtensionUpgradeArg = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
+  const UpgradeExtension = IDL.Record({
+    'extension_canister_id' : IDL.Opt(IDL.Principal),
+    'wasm' : IDL.Opt(Wasm),
+    'canister_upgrade_arg' : IDL.Opt(ExtensionUpgradeArg),
+  });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
   });
   const ExtensionInit = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
   const RegisterExtension = IDL.Record({
@@ -342,6 +352,7 @@ export const idlFactory = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'ExecuteExtensionOperation' : ExecuteExtensionOperation,
+    'UpgradeExtension' : UpgradeExtension,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'RegisterExtension' : RegisterExtension,
@@ -722,7 +733,23 @@ export const idlFactory = ({ IDL }) => {
     'include_topic_filtering' : IDL.Opt(IDL.Bool),
   });
   const ListTopicsRequest = IDL.Record({});
+  const ExtensionOperationType = IDL.Variant({
+    'TreasuryManagerWithdraw' : IDL.Null,
+    'TreasuryManagerDeposit' : IDL.Null,
+  });
+  const ExtensionType = IDL.Variant({ 'TreasuryManager' : IDL.Null });
+  const ExtensionOperationSpec = IDL.Record({
+    'topic' : IDL.Opt(Topic),
+    'operation_type' : IDL.Opt(ExtensionOperationType),
+    'description' : IDL.Opt(IDL.Text),
+    'extension_type' : IDL.Opt(ExtensionType),
+  });
+  const RegisteredExtensionOperationSpec = IDL.Record({
+    'spec' : IDL.Opt(ExtensionOperationSpec),
+    'canister_id' : IDL.Opt(IDL.Principal),
+  });
   const TopicInfo = IDL.Record({
+    'extension_operations' : IDL.Opt(IDL.Vec(RegisteredExtensionOperationSpec)),
     'native_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
     'topic' : IDL.Opt(Topic),
     'is_critical' : IDL.Opt(IDL.Bool),
@@ -1153,13 +1180,23 @@ export const init = ({ IDL }) => {
     'operation_name' : IDL.Opt(IDL.Text),
     'operation_arg' : IDL.Opt(ExtensionOperationArg),
   });
-  const SetTopicsForCustomProposals = IDL.Record({
-    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
-  });
   const ChunkedCanisterWasm = IDL.Record({
     'wasm_module_hash' : IDL.Vec(IDL.Nat8),
     'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
     'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const Wasm = IDL.Variant({
+    'Chunked' : ChunkedCanisterWasm,
+    'Bytes' : IDL.Vec(IDL.Nat8),
+  });
+  const ExtensionUpgradeArg = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
+  const UpgradeExtension = IDL.Record({
+    'extension_canister_id' : IDL.Opt(IDL.Principal),
+    'wasm' : IDL.Opt(Wasm),
+    'canister_upgrade_arg' : IDL.Opt(ExtensionUpgradeArg),
+  });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
   });
   const ExtensionInit = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
   const RegisterExtension = IDL.Record({
@@ -1218,6 +1255,7 @@ export const init = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'ExecuteExtensionOperation' : ExecuteExtensionOperation,
+    'UpgradeExtension' : UpgradeExtension,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'RegisterExtension' : RegisterExtension,

--- a/packages/sns/candid/sns_governance_test.d.ts
+++ b/packages/sns/candid/sns_governance_test.d.ts
@@ -13,6 +13,7 @@ export type Action =
   | { AddGenericNervousSystemFunction: NervousSystemFunction }
   | { ManageDappCanisterSettings: ManageDappCanisterSettings }
   | { ExecuteExtensionOperation: ExecuteExtensionOperation }
+  | { UpgradeExtension: UpgradeExtension }
   | { RemoveGenericNervousSystemFunction: bigint }
   | { SetTopicsForCustomProposals: SetTopicsForCustomProposals }
   | { RegisterExtension: RegisterExtension }
@@ -213,6 +214,19 @@ export interface ExtensionInit {
   value: [] | [PreciseValue];
 }
 export interface ExtensionOperationArg {
+  value: [] | [PreciseValue];
+}
+export interface ExtensionOperationSpec {
+  topic: [] | [Topic];
+  operation_type: [] | [ExtensionOperationType];
+  description: [] | [string];
+  extension_type: [] | [ExtensionType];
+}
+export type ExtensionOperationType =
+  | { TreasuryManagerWithdraw: null }
+  | { TreasuryManagerDeposit: null };
+export type ExtensionType = { TreasuryManager: null };
+export interface ExtensionUpgradeArg {
   value: [] | [PreciseValue];
 }
 export interface FinalizeDisburseMaturity {
@@ -626,6 +640,10 @@ export interface RegisterVote {
   vote: number;
   proposal: [] | [ProposalId];
 }
+export interface RegisteredExtensionOperationSpec {
+  spec: [] | [ExtensionOperationSpec];
+  canister_id: [] | [Principal];
+}
 export interface RemoveNeuronPermissions {
   permissions_to_remove: [] | [NeuronPermissionList];
   principal_id: [] | [Principal];
@@ -715,6 +733,7 @@ export type Topic =
   | { Governance: null }
   | { SnsFrameworkManagement: null };
 export interface TopicInfo {
+  extension_operations: [] | [Array<RegisteredExtensionOperationSpec>];
   native_functions: [] | [Array<NervousSystemFunction>];
   topic: [] | [Topic];
   is_critical: [] | [boolean];
@@ -740,6 +759,11 @@ export interface TreasuryMetrics {
   ledger_canister_id: [] | [Principal];
   treasury: number;
   timestamp_seconds: [] | [bigint];
+}
+export interface UpgradeExtension {
+  extension_canister_id: [] | [Principal];
+  wasm: [] | [Wasm];
+  canister_upgrade_arg: [] | [ExtensionUpgradeArg];
 }
 export interface UpgradeInProgress {
   mark_failed_at_seconds: bigint;
@@ -833,6 +857,9 @@ export interface VotingRewardsParameters {
 export interface WaitForQuietState {
   current_deadline_timestamp_seconds: bigint;
 }
+export type Wasm =
+  | { Chunked: ChunkedCanisterWasm }
+  | { Bytes: Uint8Array | number[] };
 export interface _SERVICE {
   add_maturity: ActorMethod<[AddMaturityRequest], AddMaturityResponse>;
   advance_target_version: ActorMethod<

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/sns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/sns/governance/canister/governance_test.did' by import-candid
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -14,6 +14,7 @@ type Action = variant {
   AdvanceSnsTargetVersion : AdvanceSnsTargetVersion;
   RegisterDappCanisters : RegisterDappCanisters;
   RegisterExtension : RegisterExtension;
+  UpgradeExtension : UpgradeExtension;
   ExecuteExtensionOperation : ExecuteExtensionOperation;
   TransferSnsTreasuryFunds : TransferSnsTreasuryFunds;
   UpgradeSnsControlledCanister : UpgradeSnsControlledCanister;
@@ -766,12 +767,48 @@ type ExtensionOperationArg = record {
   value : opt PreciseValue;
 };
 
+type ExtensionUpgradeArg = record {
+  value : opt PreciseValue;
+};
+
+type Wasm = variant {
+  Bytes : blob;
+  Chunked : ChunkedCanisterWasm;
+};
+
+type UpgradeExtension = record {
+  extension_canister_id : opt principal;
+  canister_upgrade_arg : opt ExtensionUpgradeArg;
+  wasm : opt Wasm;
+};
+
 type ExecuteExtensionOperation = record {
   extension_canister_id : opt principal;
 
   operation_name : opt text;
 
   operation_arg : opt ExtensionOperationArg;
+};
+
+type ExtensionOperationSpec = record {
+  operation_type : opt ExtensionOperationType;
+  description : opt text;
+  extension_type : opt ExtensionType;
+  topic : opt Topic;
+};
+
+type ExtensionOperationType = variant {
+  TreasuryManagerDeposit;
+  TreasuryManagerWithdraw;
+};
+
+type ExtensionType = variant {
+  TreasuryManager;
+};
+
+type RegisteredExtensionOperationSpec = record {
+  canister_id : opt principal;
+  spec : opt ExtensionOperationSpec;
 };
 
 type RegisterVote = record {
@@ -1011,6 +1048,7 @@ type TopicInfo = record {
   description : opt text;
   native_functions : opt vec NervousSystemFunction;
   custom_functions : opt vec NervousSystemFunction;
+  extension_operations : opt vec RegisteredExtensionOperationSpec;
   is_critical : opt bool;
 };
 

--- a/packages/sns/candid/sns_governance_test.idl.js
+++ b/packages/sns/candid/sns_governance_test.idl.js
@@ -277,13 +277,23 @@ export const idlFactory = ({ IDL }) => {
     'operation_name' : IDL.Opt(IDL.Text),
     'operation_arg' : IDL.Opt(ExtensionOperationArg),
   });
-  const SetTopicsForCustomProposals = IDL.Record({
-    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
-  });
   const ChunkedCanisterWasm = IDL.Record({
     'wasm_module_hash' : IDL.Vec(IDL.Nat8),
     'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
     'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const Wasm = IDL.Variant({
+    'Chunked' : ChunkedCanisterWasm,
+    'Bytes' : IDL.Vec(IDL.Nat8),
+  });
+  const ExtensionUpgradeArg = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
+  const UpgradeExtension = IDL.Record({
+    'extension_canister_id' : IDL.Opt(IDL.Principal),
+    'wasm' : IDL.Opt(Wasm),
+    'canister_upgrade_arg' : IDL.Opt(ExtensionUpgradeArg),
+  });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
   });
   const ExtensionInit = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
   const RegisterExtension = IDL.Record({
@@ -342,6 +352,7 @@ export const idlFactory = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'ExecuteExtensionOperation' : ExecuteExtensionOperation,
+    'UpgradeExtension' : UpgradeExtension,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'RegisterExtension' : RegisterExtension,
@@ -722,7 +733,23 @@ export const idlFactory = ({ IDL }) => {
     'include_topic_filtering' : IDL.Opt(IDL.Bool),
   });
   const ListTopicsRequest = IDL.Record({});
+  const ExtensionOperationType = IDL.Variant({
+    'TreasuryManagerWithdraw' : IDL.Null,
+    'TreasuryManagerDeposit' : IDL.Null,
+  });
+  const ExtensionType = IDL.Variant({ 'TreasuryManager' : IDL.Null });
+  const ExtensionOperationSpec = IDL.Record({
+    'topic' : IDL.Opt(Topic),
+    'operation_type' : IDL.Opt(ExtensionOperationType),
+    'description' : IDL.Opt(IDL.Text),
+    'extension_type' : IDL.Opt(ExtensionType),
+  });
+  const RegisteredExtensionOperationSpec = IDL.Record({
+    'spec' : IDL.Opt(ExtensionOperationSpec),
+    'canister_id' : IDL.Opt(IDL.Principal),
+  });
   const TopicInfo = IDL.Record({
+    'extension_operations' : IDL.Opt(IDL.Vec(RegisteredExtensionOperationSpec)),
     'native_functions' : IDL.Opt(IDL.Vec(NervousSystemFunction)),
     'topic' : IDL.Opt(Topic),
     'is_critical' : IDL.Opt(IDL.Bool),
@@ -1169,13 +1196,23 @@ export const init = ({ IDL }) => {
     'operation_name' : IDL.Opt(IDL.Text),
     'operation_arg' : IDL.Opt(ExtensionOperationArg),
   });
-  const SetTopicsForCustomProposals = IDL.Record({
-    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
-  });
   const ChunkedCanisterWasm = IDL.Record({
     'wasm_module_hash' : IDL.Vec(IDL.Nat8),
     'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
     'store_canister_id' : IDL.Opt(IDL.Principal),
+  });
+  const Wasm = IDL.Variant({
+    'Chunked' : ChunkedCanisterWasm,
+    'Bytes' : IDL.Vec(IDL.Nat8),
+  });
+  const ExtensionUpgradeArg = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
+  const UpgradeExtension = IDL.Record({
+    'extension_canister_id' : IDL.Opt(IDL.Principal),
+    'wasm' : IDL.Opt(Wasm),
+    'canister_upgrade_arg' : IDL.Opt(ExtensionUpgradeArg),
+  });
+  const SetTopicsForCustomProposals = IDL.Record({
+    'custom_function_id_to_topic' : IDL.Vec(IDL.Tuple(IDL.Nat64, Topic)),
   });
   const ExtensionInit = IDL.Record({ 'value' : IDL.Opt(PreciseValue) });
   const RegisterExtension = IDL.Record({
@@ -1234,6 +1271,7 @@ export const init = ({ IDL }) => {
     'AddGenericNervousSystemFunction' : NervousSystemFunction,
     'ManageDappCanisterSettings' : ManageDappCanisterSettings,
     'ExecuteExtensionOperation' : ExecuteExtensionOperation,
+    'UpgradeExtension' : UpgradeExtension,
     'RemoveGenericNervousSystemFunction' : IDL.Nat64,
     'SetTopicsForCustomProposals' : SetTopicsForCustomProposals,
     'RegisterExtension' : RegisterExtension,

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/sns/root/canister/root.did' by import-candid
 type CanisterCallError = record {
   code : opt int32;
   description : text;

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 047925d (2025-08-06 tags: release-2025-08-07_03-33-base) 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 9173238 (2025-08-18 tags: release-2025-08-28_03-17-snapshot-feature) 'rs/sns/swap/canister/swap.did' by import-candid
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;


### PR DESCRIPTION
# Motivation

Cherry pick all Candid files update provided by the weekly bot in PR #1027 except those for `@dfinity/ic-management` because it contains the keyword `any` which seems inaccurate. Started an thread about it internally.

# Changes

- Update candid files to latest definitions.
