### PR TITLE
chore: Expose response types for Ledger Canister class

### DIFF
--- a/packages/ledger-icrc/src/index.ts
+++ b/packages/ledger-icrc/src/index.ts
@@ -1,6 +1,8 @@
 export type {
+  Allowance as IcrcAllowance,
   ApproveError as IcrcApproveError,
   BlockIndex as IcrcBlockIndex,
+  GetBlocksResult as IcrcGetBlocksResult,
   StandardRecord as IcrcStandardRecord,
   Subaccount as IcrcSubaccount,
   Tokens as IcrcTokens,


### PR DESCRIPTION
# Motivation

Some params and repsonse types for the Ledger canister were not exposed.
