### PR TITLE
chore: Expose response types for Index NG Canister class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next
+
+## Features
+
+- Expose Ledger canister response types: `Status` as `IcrcNgStatus`.
+
 # 74
 
 ## Overview

--- a/packages/ledger-icrc/src/types/index-ng.types.ts
+++ b/packages/ledger-icrc/src/types/index-ng.types.ts
@@ -3,4 +3,5 @@ export type {
   Transaction as IcrcIndexNgTransaction,
   TransactionWithId as IcrcIndexNgTransactionWithId,
   BlockIndex as IcrcNgTxId,
+  Status as IcrcNgStatus,
 } from "../../candid/icrc_index-ng";


### PR DESCRIPTION
# Motivation

Some response types for the Index NG canister were not exposed.
