### PR TITLE
feat: isPrincipal instead of instanceof for json principal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Next
 
-## Breaking Changes
-
-- Improve `Principal` detection in `jsonReplacer`.
-
 ## Features
 
 - Expose Ledger canister response types: `Status` as `IcrcNgStatus`.
 - Expose Ledger canister response types: `ICRC3Value` as `Icrc3Value`, `Allowance` as `IcrcAllowance`, `GetBlocksArgs` as `IcrcGetBlocksArgs`, `GetBlocksResult` as `IcrcGetBlocksResult`, `Timestamp` as `IcrcTimestamp`.
+- Improve `Principal` detection in `jsonReplacer`.
 
 # 74
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Expose Ledger canister response types: `Status` as `IcrcNgStatus`.
 - Expose Ledger canister response types: `ICRC3Value` as `Icrc3Value`, `Allowance` as `IcrcAllowance`, `GetBlocksArgs` as `IcrcGetBlocksArgs`, `GetBlocksResult` as `IcrcGetBlocksResult`, `Timestamp` as `IcrcTimestamp`.
+- Improve `Principal` detection in `jsonReplacer`. 
 
 # 74
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Next
 
+## Breaking Changes
+
+- Improve `Principal` detection in `jsonReplacer`.
+
 ## Features
 
 - Expose Ledger canister response types: `Status` as `IcrcNgStatus`.
 - Expose Ledger canister response types: `ICRC3Value` as `Icrc3Value`, `Allowance` as `IcrcAllowance`, `GetBlocksArgs` as `IcrcGetBlocksArgs`, `GetBlocksResult` as `IcrcGetBlocksResult`, `Timestamp` as `IcrcTimestamp`.
-- Improve `Principal` detection in `jsonReplacer`. 
 
 # 74
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -498,7 +498,7 @@ Returns:
 
 The reconstructed value if it matches a known type, otherwise the original value.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/json.utils.ts#L53)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/utils/src/utils/json.utils.ts#L55)
 
 #### :gear: hashObject
 

--- a/packages/utils/src/utils/json.utils.spec.ts
+++ b/packages/utils/src/utils/json.utils.spec.ts
@@ -36,6 +36,22 @@ describe("json-utils", () => {
       );
     });
 
+    it("should stringify object representation of a Principal with a custom representation", () => {
+      const rootCanisterId = Principal.fromText("tmxop-wyaaa-aaaaa-aaapa-cai");
+
+      const obj = {
+        _arr: rootCanisterId.toUint8Array(),
+        _isPrincipal: true,
+      };
+
+      expect(JSON.stringify(obj, jsonReplacer)).toEqual(
+        '{"__principal__":"tmxop-wyaaa-aaaaa-aaapa-cai"}',
+      );
+      expect(JSON.stringify({ principal: obj }, jsonReplacer)).toEqual(
+        '{"principal":{"__principal__":"tmxop-wyaaa-aaaaa-aaapa-cai"}}',
+      );
+    });
+
     it("should stringify Uint8Array with a custom representation", () => {
       const arr = arrayOfNumberToUint8Array([1, 2, 3]);
 

--- a/packages/utils/src/utils/json.utils.ts
+++ b/packages/utils/src/utils/json.utils.ts
@@ -25,6 +25,8 @@ export const jsonReplacer = (_key: string, value: unknown): unknown => {
   }
 
   if (nonNullish(value) && Principal.isPrincipal(value)) {
+    // isPrincipal asserts if a value is a Principal, but does not assert if the object
+    // contains functions such as toText(). That's why we construct a new object.
     return { [JSON_KEY_PRINCIPAL]: Principal.from(value).toText() };
   }
 

--- a/packages/utils/src/utils/json.utils.ts
+++ b/packages/utils/src/utils/json.utils.ts
@@ -24,8 +24,8 @@ export const jsonReplacer = (_key: string, value: unknown): unknown => {
     return { [JSON_KEY_BIGINT]: `${value}` };
   }
 
-  if (nonNullish(value) && value instanceof Principal) {
-    return { [JSON_KEY_PRINCIPAL]: value.toText() };
+  if (nonNullish(value) && Principal.isPrincipal(value)) {
+    return { [JSON_KEY_PRINCIPAL]: Principal.from(value).toText() };
   }
 
   if (nonNullish(value) && value instanceof Uint8Array) {


### PR DESCRIPTION
# Motivation

While migratign Juno to AgentJS v3 ([PR](https://github.com/junobuild/juno/pull/1940)), one of my test started failing as the assertion `toBeInstanceOf(Principal)` returned false. I assume this happened because the `Principal` instance used in the test was not the same as the object returned through my library. To overcome the issue, I migrated the test to `Principal.isPrincipal`. That's why, I think we should enhance the `jsonReplacer` with same assertion to avoid those kind of issue.

# Notes

~~I assume none will be affected by the changes, thinking that aside from NNS dapp and Juno there are rare consumers of the `jsonReplacer`, but still, labelled as breaking change because clients which in the past would have serialized principal not instead of will start serializing those as principal, which is per sé not incorrect.~~

After thinking at it, let's release it as a feature. It's a breaking only if the outcome is saved in a storage and I'm probably the only one who do that. Plus, it's not a breaking per sé as we can consider that the detection was not precise enough and it can be an improvement or fix. Also easier to ship in our dapps in which it is not a breaking.

# Changes

- Use `Principal.isPrincipal` instead of `instanceof Principal` in `jsonReplacer`