### PR TITLE
refactor: extract SnapshotParams interface

### DIFF
--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -54,7 +54,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 
 ### :factory: ICManagementCanister
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L38)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L37)
 
 #### Static Methods
 
@@ -66,7 +66,7 @@ const { status, memory_size, ...rest } = await canisterStatus(YOUR_CANISTER_ID);
 | -------- | ---------------------------------------------------------------- |
 | `create` | `(options: ICManagementCanisterOptions) => ICManagementCanister` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L43)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L42)
 
 #### Methods
 
@@ -97,7 +97,7 @@ Create a new canister
 | ---------------- | ------------------------------------------------------------------------------------- |
 | `createCanister` | `({ settings, senderCanisterVersion, }?: CreateCanisterParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L67)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L66)
 
 ##### :gear: updateSettings
 
@@ -107,7 +107,7 @@ Update canister settings
 | ---------------- | ------------------------------------------------------------------------------------------- |
 | `updateSettings` | `({ canisterId, senderCanisterVersion, settings, }: UpdateSettingsParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L90)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L89)
 
 ##### :gear: installCode
 
@@ -117,7 +117,7 @@ Install code to a canister
 | ------------- | -------------------------------------------------------------------------------------------------- |
 | `installCode` | `({ canisterId, wasmModule, senderCanisterVersion, ...rest }: InstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L115)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L114)
 
 ##### :gear: uploadChunk
 
@@ -136,7 +136,7 @@ Returns:
 
 The hash of the stored chunk.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L141)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L140)
 
 ##### :gear: clearChunkStore
 
@@ -150,7 +150,7 @@ Parameters:
 
 - `params.canisterId`: The canister in which the chunks are stored.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L161)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L160)
 
 ##### :gear: storedChunks
 
@@ -168,7 +168,7 @@ Returns:
 
 The list of hash of the stored chunks.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L180)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L179)
 
 ##### :gear: installChunkedCode
 
@@ -188,7 +188,7 @@ Parameters:
 - `params.storeCanisterId`: Specifies the canister in whose chunk storage the chunks are stored (this parameter defaults to target_canister if not specified).
 - `params.wasmModuleHash`: The Wasm module hash as hex string. Used to check that the SHA-256 hash of wasm_module is equal to the wasm_module_hash parameter and can calls install_code with parameters.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L205)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L204)
 
 ##### :gear: uninstallCode
 
@@ -198,7 +198,7 @@ Uninstall code from a canister
 | --------------- | -------------------------------------------------------------------------------- |
 | `uninstallCode` | `({ canisterId, senderCanisterVersion, }: UninstallCodeParams) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L236)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L235)
 
 ##### :gear: startCanister
 
@@ -208,7 +208,7 @@ Start a canister
 | --------------- | ------------------------------------------ |
 | `startCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L254)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L253)
 
 ##### :gear: stopCanister
 
@@ -218,7 +218,7 @@ Stop a canister
 | -------------- | ------------------------------------------ |
 | `stopCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L266)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L265)
 
 ##### :gear: canisterStatus
 
@@ -228,7 +228,7 @@ Get canister details (memory size, status, etc.)
 | ---------------- | ------------------------------------------------------------ |
 | `canisterStatus` | `(canisterId: Principal) => Promise<canister_status_result>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L277)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L276)
 
 ##### :gear: deleteCanister
 
@@ -238,7 +238,7 @@ Deletes a canister
 | ---------------- | ------------------------------------------ |
 | `deleteCanister` | `(canisterId: Principal) => Promise<void>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L291)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L290)
 
 ##### :gear: provisionalCreateCanisterWithCycles
 
@@ -248,7 +248,7 @@ Creates a canister. Only available on development instances.
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `provisionalCreateCanisterWithCycles` | `({ settings, amount, canisterId, }?: ProvisionalCreateCanisterWithCyclesParams) => Promise<Principal>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L306)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L305)
 
 ##### :gear: fetchCanisterLogs
 
@@ -258,15 +258,15 @@ Given a canister ID as input, this method returns a vector of logs of that canis
 | ------------------- | ---------------------------------------------------------------- |
 | `fetchCanisterLogs` | `(canisterId: Principal) => Promise<fetch_canister_logs_result>` |
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L329)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L328)
 
 ##### :gear: takeCanisterSnapshot
 
 This method takes a snapshot of the specified canister. A snapshot consists of the wasm memory, stable memory, certified variables, wasm chunk store and wasm binary.
 
-| Method                 | Type                                                                                                                              |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `takeCanisterSnapshot` | `({ canisterId, snapshotId, }: { canisterId: Principal; snapshotId?: string or snapshot_id or undefined; }) => Promise<snapshot>` |
+| Method                 | Type                                                                 |
+| ---------------------- | -------------------------------------------------------------------- |
+| `takeCanisterSnapshot` | `({ canisterId, snapshotId, }: SnapshotParams) => Promise<snapshot>` |
 
 Parameters:
 
@@ -281,7 +281,7 @@ Returns:
 A promise that resolves with the snapshot details,
 including the snapshot ID, total size, and timestamp.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L355)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L354)
 
 ##### :gear: listCanisterSnapshots
 
@@ -300,15 +300,15 @@ Returns:
 
 A promise that resolves with the list of snapshots.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L384)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L380)
 
 ##### :gear: loadCanisterSnapshot
 
 Loads a snapshot of a canister's state.
 
-| Method                 | Type                                                                                                                                                                                |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `loadCanisterSnapshot` | `({ canisterId, snapshotId, senderCanisterVersion, }: { canisterId: Principal; snapshotId: string or snapshot_id; senderCanisterVersion?: bigint or undefined; }) => Promise<void>` |
+| Method                 | Type                                                                                                                                         |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `loadCanisterSnapshot` | `({ canisterId, snapshotId, senderCanisterVersion, }: SnapshotParams and { senderCanisterVersion?: bigint or undefined; }) => Promise<void>` |
 
 Parameters:
 
@@ -321,15 +321,15 @@ Returns:
 
 A promise that resolves when the snapshot is successfully loaded.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L410)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L406)
 
 ##### :gear: deleteCanisterSnapshot
 
 Deletes a specific snapshot of a canister.
 
-| Method                   | Type                                                                                                            |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| `deleteCanisterSnapshot` | `({ canisterId, snapshotId, }: { canisterId: Principal; snapshotId: string or snapshot_id; }) => Promise<void>` |
+| Method                   | Type                                                             |
+| ------------------------ | ---------------------------------------------------------------- |
+| `deleteCanisterSnapshot` | `({ canisterId, snapshotId, }: SnapshotParams) => Promise<void>` |
 
 Parameters:
 
@@ -341,7 +341,7 @@ Returns:
 
 A promise that resolves when the snapshot is successfully deleted.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L441)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L435)
 
 <!-- TSDOC_END -->
 

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -9,7 +9,6 @@ import type {
   _SERVICE as IcManagementService,
   chunk_hash,
   list_canister_snapshots_result,
-  snapshot_id,
   take_canister_snapshot_result,
 } from "../candid/ic-management";
 import { idlFactory as certifiedIdlFactory } from "../candid/ic-management.certified.idl";
@@ -22,7 +21,7 @@ import {
   type InstallChunkedCodeParams,
   type InstallCodeParams,
   type ProvisionalCreateCanisterWithCyclesParams,
-  type SnapshotIdText,
+  type SnapshotParams,
   type StoredChunksParams,
   type UninstallCodeParams,
   type UpdateSettingsParams,
@@ -355,10 +354,7 @@ export class ICManagementCanister {
   takeCanisterSnapshot = ({
     canisterId,
     snapshotId,
-  }: {
-    canisterId: Principal;
-    snapshotId?: SnapshotIdText | snapshot_id;
-  }): Promise<take_canister_snapshot_result> => {
+  }: SnapshotParams): Promise<take_canister_snapshot_result> => {
     const { take_canister_snapshot } = this.service;
 
     return take_canister_snapshot({
@@ -411,9 +407,7 @@ export class ICManagementCanister {
     canisterId,
     snapshotId,
     senderCanisterVersion,
-  }: {
-    canisterId: Principal;
-    snapshotId: SnapshotIdText | snapshot_id;
+  }: SnapshotParams & {
     senderCanisterVersion?: bigint;
   }): Promise<void> => {
     const { load_canister_snapshot } = this.service;
@@ -441,10 +435,7 @@ export class ICManagementCanister {
   deleteCanisterSnapshot = async ({
     canisterId,
     snapshotId,
-  }: {
-    canisterId: Principal;
-    snapshotId: SnapshotIdText | snapshot_id;
-  }): Promise<void> => {
+  }: SnapshotParams): Promise<void> => {
     const { delete_canister_snapshot } = this.service;
 
     await delete_canister_snapshot({

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -5,6 +5,7 @@ import type {
   canister_settings,
   chunk_hash,
   log_visibility,
+  snapshot_id,
   upload_chunk_args,
 } from "../../candid/ic-management";
 
@@ -115,3 +116,8 @@ export interface ProvisionalTopUpCanisterParams {
 }
 
 export type SnapshotIdText = string;
+
+export interface SnapshotParams {
+  canisterId: Principal;
+  snapshotId: SnapshotIdText | snapshot_id;
+}


### PR DESCRIPTION
# Motivation

We can avoid repeating the same types by introducing an interface for params.

# Changes

- Create and use `SnapshotParams`
