### PR TITLE
fix: optional snapshot id param

### DIFF
--- a/packages/ic-management/README.md
+++ b/packages/ic-management/README.md
@@ -264,9 +264,9 @@ Given a canister ID as input, this method returns a vector of logs of that canis
 
 This method takes a snapshot of the specified canister. A snapshot consists of the wasm memory, stable memory, certified variables, wasm chunk store and wasm binary.
 
-| Method                 | Type                                                                 |
-| ---------------------- | -------------------------------------------------------------------- |
-| `takeCanisterSnapshot` | `({ canisterId, snapshotId, }: SnapshotParams) => Promise<snapshot>` |
+| Method                 | Type                                                                                                                                     |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `takeCanisterSnapshot` | `({ canisterId, snapshotId, }: Pick<SnapshotParams, "canisterId"> and Partial<Pick<SnapshotParams, "snapshotId">>) => Promise<snapshot>` |
 
 Parameters:
 
@@ -300,7 +300,7 @@ Returns:
 
 A promise that resolves with the list of snapshots.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L380)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L383)
 
 ##### :gear: loadCanisterSnapshot
 
@@ -321,7 +321,7 @@ Returns:
 
 A promise that resolves when the snapshot is successfully loaded.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L406)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L409)
 
 ##### :gear: deleteCanisterSnapshot
 
@@ -341,7 +341,7 @@ Returns:
 
 A promise that resolves when the snapshot is successfully deleted.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L435)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ic-management/src/ic-management.canister.ts#L438)
 
 <!-- TSDOC_END -->
 

--- a/packages/ic-management/src/ic-management.canister.ts
+++ b/packages/ic-management/src/ic-management.canister.ts
@@ -354,7 +354,10 @@ export class ICManagementCanister {
   takeCanisterSnapshot = ({
     canisterId,
     snapshotId,
-  }: SnapshotParams): Promise<take_canister_snapshot_result> => {
+  }: Pick<SnapshotParams, "canisterId"> &
+    Partial<
+      Pick<SnapshotParams, "snapshotId">
+    >): Promise<take_canister_snapshot_result> => {
     const { take_canister_snapshot } = this.service;
 
     return take_canister_snapshot({


### PR DESCRIPTION
# Motivation

The test did not failed in CI when I extracted an interface for snapshots in #1047. However, there was one issue: for take snapshot the snapshot ID is optional mandatory. This was later discovered by running the test on main.

# Changes

- Redo param optional.
