### PR TITLE
chore: bump ic-mgmt size-limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     {
       "name": "@dfinity/ic-management",
       "path": "./packages/ic-management/dist/index.js",
-      "limit": "4 kB",
+      "limit": "10 kB",
       "gzip": true,
       "ignore": [
         "@dfinity/agent",


### PR DESCRIPTION
# Motivation

In PR #1046 the `ic-management` library overpasses its size limit. For example see this [job](https://github.com/dfinity/ic-js/actions/runs/18118951284/job/51559984088?pr=1046):

```
{
    "name": "@dfinity/ic-management",
    "passed": false,
    "size": 4417,
    "sizeLimit": 4000
  }
```

For this reason I propose to bump the size limit to 10kB.

# Changes

- Bump ic-mgmt size-limit.
