### PR TITLE
chore: generate a space after auto-generated did comment

### DIFF
--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -48,6 +48,7 @@ download_did() {
   echo "Downloading ${raw_url} -> REPO_ROOT/${out_path}"
   {
     echo "// Generated from ${repo} commit ${commit_hash} for file '${file_path}'"
+    echo ""
     curl -s "$raw_url"
   } >"${out_path}"
 }

--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -19,6 +19,7 @@ import_did() {
   echo "Copying ${in_fullpath} -> REPO_ROOT/${out_path}"
   {
     echo "// Generated from IC repo commit ${IC_COMMIT} (${IC_DATE}${IC_TAGS:+ tags: ${IC_TAGS% }}) '${in_path}' by $(basename "${0}")"
+    echo ""
     cat "$in_fullpath"
   } >"${out_path}"
 }


### PR DESCRIPTION
# Motivation

We should separate the first DID type of the auto-generated comment. On one end, they are not related, on the other, the new declarations generator `@icp-sdk/bindgen` is suppose to ignore the first comment if followed by a space.

# Changes

- Add an `echo` in `import-candid` script.
