### PR TITLE
chore: add spaces to did files

### DIFF
--- a/packages/ckbtc/candid/bitcoin.did
+++ b/packages/ckbtc/candid/bitcoin.did
@@ -1,4 +1,5 @@
 // Generated from dfinity/bitcoin-canister commit 47c5d1f14eff39282245ea6aec6e9f821571b024 for file 'canister/candid.did'
+
 type network = variant {
   mainnet;
   testnet;  // Bitcoin testnet4.

--- a/packages/ckbtc/candid/minter.did
+++ b/packages/ckbtc/candid/minter.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
+
 // Represents an account on the ckBTC ledger.
 type Account = record { owner : principal; subaccount : opt blob };
 

--- a/packages/cketh/candid/minter.did
+++ b/packages/cketh/candid/minter.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
+
 type EthereumNetwork = variant {
     // The public Ethereum mainnet.
     Mainnet;

--- a/packages/cketh/candid/orchestrator.did
+++ b/packages/cketh/candid/orchestrator.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did' by import-candid
+
 type OrchestratorArg = variant {
     UpgradeArg : UpgradeArg;
     InitArg : InitArg;

--- a/packages/cmc/candid/cmc.did
+++ b/packages/cmc/candid/cmc.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/nns/cmc/cmc.did' by import-candid
+
 type Cycles = nat;
 type BlockIndex = nat64;
 type log_visibility = variant {

--- a/packages/ic-management/candid/ic-management.did
+++ b/packages/ic-management/candid/ic-management.did
@@ -1,4 +1,5 @@
 // Generated from dfinity/portal commit db443d1b9c357e50d3dfe2c7a87a9d95d4325641 for file 'docs/references/_attachments/ic.did'
+
 type canister_id = principal;
 type wasm_module = blob;
 type snapshot_id = blob;

--- a/packages/ledger-icp/candid/index.did
+++ b/packages/ledger-icp/candid/index.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/ledger_suite/icp/index/index.did' by import-candid
+
 type Account = record { owner : principal; subaccount : opt vec nat8 };
 type GetAccountIdentifierTransactionsArgs = record {
   max_results : nat64;

--- a/packages/ledger-icp/candid/ledger.did
+++ b/packages/ledger-icp/candid/ledger.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/ledger_suite/icp/ledger.did' by import-candid
+
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.

--- a/packages/ledger-icrc/candid/icrc_index-ng.did
+++ b/packages/ledger-icrc/candid/icrc_index-ng.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/ledger_suite/icrc1/index-ng/index-ng.did' by import-candid
+
 type Tokens = nat;
 
 type InitArg = record {

--- a/packages/ledger-icrc/candid/icrc_index.did
+++ b/packages/ledger-icrc/candid/icrc_index.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit d9fe207 (2024-12-06 tags: release-2024-12-06_03-16-base) 'rs/ledger_suite/icrc1/index/index.did' by import-candid
+
 type TxId = nat;
 
 type Account = record { owner : principal; subaccount : opt blob };

--- a/packages/ledger-icrc/candid/icrc_ledger.did
+++ b/packages/ledger-icrc/candid/icrc_ledger.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/ledger_suite/icrc1/ledger/ledger.did' by import-candid
+
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.

--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/nns/gtc/canister/gtc.did' by import-candid
+
 type AccountState = record {
   authenticated_principal_id : opt principal;
   successfully_transferred_neurons : vec TransferredNeuron;

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/nns/governance/canister/governance.did' by import-candid
+
 type AccountIdentifier = record {
   hash : blob;
 };

--- a/packages/nns/candid/governance_test.did
+++ b/packages/nns/candid/governance_test.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/nns/governance/canister/governance_test.did' by import-candid
+
 type AccountIdentifier = record {
   hash : blob;
 };

--- a/packages/nns/candid/sns_wasm.did
+++ b/packages/nns/candid/sns_wasm.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/packages/sns/candid/sns_governance.did
+++ b/packages/sns/candid/sns_governance.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/sns/governance/canister/governance.did' by import-candid
+
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;

--- a/packages/sns/candid/sns_governance_test.did
+++ b/packages/sns/candid/sns_governance_test.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/sns/governance/canister/governance_test.did' by import-candid
+
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;

--- a/packages/sns/candid/sns_root.did
+++ b/packages/sns/candid/sns_root.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/sns/root/canister/root.did' by import-candid
+
 type CanisterCallError = record {
   code : opt int32;
   description : text;

--- a/packages/sns/candid/sns_swap.did
+++ b/packages/sns/candid/sns_swap.did
@@ -1,4 +1,5 @@
 // Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/sns/swap/canister/swap.did' by import-candid
+
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;


### PR DESCRIPTION
# Motivation

Add spaces after generated-comment in DID files as if generated after #1064.

# Notes

I proceed the change manually because there is already new types in the IC repo which I did not wanted to incoporate.

# Changes

- Add spaces after comment.