### PR TITLE
feat: update ic-management with new did type environment_variables

### DIFF
--- a/packages/ic-management/candid/ic-management.certified.idl.js
+++ b/packages/ic-management/candid/ic-management.certified.idl.js
@@ -74,7 +74,10 @@ export const idlFactory = ({ IDL }) => {
   });
   const snapshot_id = IDL.Vec(IDL.Nat8);
   const change_details = IDL.Variant({
-    'creation' : IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) }),
+    'creation' : IDL.Record({
+      'controllers' : IDL.Vec(IDL.Principal),
+      'environment_variables_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    }),
     'code_deployment' : IDL.Record({
       'mode' : IDL.Variant({
         'reinstall' : IDL.Null,
@@ -110,6 +113,10 @@ export const idlFactory = ({ IDL }) => {
     'total_num_changes' : IDL.Nat64,
   });
   const canister_status_args = IDL.Record({ 'canister_id' : canister_id });
+  const environment_variable = IDL.Record({
+    'value' : IDL.Text,
+    'name' : IDL.Text,
+  });
   const log_visibility = IDL.Variant({
     'controllers' : IDL.Null,
     'public' : IDL.Null,
@@ -118,6 +125,7 @@ export const idlFactory = ({ IDL }) => {
   const definite_canister_settings = IDL.Record({
     'freezing_threshold' : IDL.Nat,
     'wasm_memory_threshold' : IDL.Nat,
+    'environment_variables' : IDL.Vec(environment_variable),
     'controllers' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Nat,
     'log_visibility' : log_visibility,
@@ -160,6 +168,7 @@ export const idlFactory = ({ IDL }) => {
   const canister_settings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat),
     'wasm_memory_threshold' : IDL.Opt(IDL.Nat),
+    'environment_variables' : IDL.Opt(IDL.Vec(environment_variable)),
     'controllers' : IDL.Opt(IDL.Vec(IDL.Principal)),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat),
     'log_visibility' : IDL.Opt(log_visibility),

--- a/packages/ic-management/candid/ic-management.d.ts
+++ b/packages/ic-management/candid/ic-management.d.ts
@@ -79,6 +79,7 @@ export interface canister_log_record {
 export interface canister_settings {
   freezing_threshold: [] | [bigint];
   wasm_memory_threshold: [] | [bigint];
+  environment_variables: [] | [Array<environment_variable>];
   controllers: [] | [Array<Principal>];
   reserved_cycles_limit: [] | [bigint];
   log_visibility: [] | [log_visibility];
@@ -124,7 +125,10 @@ export interface change {
 }
 export type change_details =
   | {
-      creation: { controllers: Array<Principal> };
+      creation: {
+        controllers: Array<Principal>;
+        environment_variables_hash: [] | [Uint8Array | number[]];
+      };
     }
   | {
       code_deployment: {
@@ -166,6 +170,7 @@ export interface create_canister_result {
 export interface definite_canister_settings {
   freezing_threshold: bigint;
   wasm_memory_threshold: bigint;
+  environment_variables: Array<environment_variable>;
   controllers: Array<Principal>;
   reserved_cycles_limit: bigint;
   log_visibility: log_visibility;
@@ -192,6 +197,10 @@ export interface ecdsa_public_key_args {
 export interface ecdsa_public_key_result {
   public_key: Uint8Array | number[];
   chain_code: Uint8Array | number[];
+}
+export interface environment_variable {
+  value: string;
+  name: string;
 }
 export interface fetch_canister_logs_args {
   canister_id: canister_id;

--- a/packages/ic-management/candid/ic-management.did
+++ b/packages/ic-management/candid/ic-management.did
@@ -1,4 +1,4 @@
-// Generated from dfinity/portal commit db443d1b9c357e50d3dfe2c7a87a9d95d4325641 for file 'docs/references/_attachments/ic.did'
+// Generated from dfinity/portal commit b562ec5d68bce1fef2859a9a592d9487d3b64919 for file 'docs/references/_attachments/ic.did'
 type canister_id = principal;
 type wasm_module = blob;
 type snapshot_id = blob;
@@ -7,6 +7,11 @@ type log_visibility = variant {
     controllers;
     public;
     allowed_viewers : vec principal;
+};
+
+type environment_variable = record { 
+    name: text; 
+    value: text;
 };
 
 type canister_settings = record {
@@ -18,6 +23,7 @@ type canister_settings = record {
     log_visibility : opt log_visibility;
     wasm_memory_limit : opt nat;
     wasm_memory_threshold : opt nat;
+    environment_variables : opt vec environment_variable;
 };
 
 type definite_canister_settings = record {
@@ -29,6 +35,7 @@ type definite_canister_settings = record {
     log_visibility : log_visibility;
     wasm_memory_limit : nat;
     wasm_memory_threshold : nat;
+    environment_variables : vec environment_variable;
 };
 
 type change_origin = variant {
@@ -44,6 +51,7 @@ type change_origin = variant {
 type change_details = variant {
     creation : record {
         controllers : vec principal;
+        environment_variables_hash : opt blob; 
     };
     code_uninstall;
     code_deployment : record {

--- a/packages/ic-management/candid/ic-management.idl.js
+++ b/packages/ic-management/candid/ic-management.idl.js
@@ -74,7 +74,10 @@ export const idlFactory = ({ IDL }) => {
   });
   const snapshot_id = IDL.Vec(IDL.Nat8);
   const change_details = IDL.Variant({
-    'creation' : IDL.Record({ 'controllers' : IDL.Vec(IDL.Principal) }),
+    'creation' : IDL.Record({
+      'controllers' : IDL.Vec(IDL.Principal),
+      'environment_variables_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    }),
     'code_deployment' : IDL.Record({
       'mode' : IDL.Variant({
         'reinstall' : IDL.Null,
@@ -110,6 +113,10 @@ export const idlFactory = ({ IDL }) => {
     'total_num_changes' : IDL.Nat64,
   });
   const canister_status_args = IDL.Record({ 'canister_id' : canister_id });
+  const environment_variable = IDL.Record({
+    'value' : IDL.Text,
+    'name' : IDL.Text,
+  });
   const log_visibility = IDL.Variant({
     'controllers' : IDL.Null,
     'public' : IDL.Null,
@@ -118,6 +125,7 @@ export const idlFactory = ({ IDL }) => {
   const definite_canister_settings = IDL.Record({
     'freezing_threshold' : IDL.Nat,
     'wasm_memory_threshold' : IDL.Nat,
+    'environment_variables' : IDL.Vec(environment_variable),
     'controllers' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Nat,
     'log_visibility' : log_visibility,
@@ -160,6 +168,7 @@ export const idlFactory = ({ IDL }) => {
   const canister_settings = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat),
     'wasm_memory_threshold' : IDL.Opt(IDL.Nat),
+    'environment_variables' : IDL.Opt(IDL.Vec(environment_variable)),
     'controllers' : IDL.Opt(IDL.Vec(IDL.Principal)),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat),
     'log_visibility' : IDL.Opt(log_visibility),

--- a/packages/ic-management/src/ic-management.canister.spec.ts
+++ b/packages/ic-management/src/ic-management.canister.spec.ts
@@ -169,6 +169,7 @@ describe("ICManagementCanister", () => {
           log_visibility: [],
           wasm_memory_limit: [],
           wasm_memory_threshold: [],
+          environment_variables: []
         },
       });
     });
@@ -396,6 +397,7 @@ describe("ICManagementCanister", () => {
         log_visibility: { controllers: null },
         wasm_memory_limit: BigInt(500_00),
         wasm_memory_threshold: BigInt(100),
+        environment_variables: [],
       };
       const response: CanisterStatusResponse = {
         status: { running: null },

--- a/packages/ic-management/src/index.ts
+++ b/packages/ic-management/src/index.ts
@@ -10,6 +10,7 @@ export type {
   snapshot,
   snapshot_id,
   take_canister_snapshot_result,
+  environment_variable,
 } from "../candid/ic-management";
 export { ICManagementCanister } from "./ic-management.canister";
 export * from "./types/canister.options";

--- a/packages/ic-management/src/types/ic-management.params.ts
+++ b/packages/ic-management/src/types/ic-management.params.ts
@@ -4,6 +4,7 @@ import type {
   canister_install_mode,
   canister_settings,
   chunk_hash,
+  environment_variable,
   log_visibility,
   upload_chunk_args,
 } from "../../candid/ic-management";
@@ -22,6 +23,7 @@ export interface CanisterSettings {
   logVisibility?: LogVisibility;
   wasmMemoryLimit?: bigint;
   wasmMemoryThreshold?: bigint;
+  environmentVariables?: environment_variable[];
 }
 
 export class UnsupportedLogVisibility extends Error {}
@@ -35,6 +37,7 @@ export const toCanisterSettings = ({
   logVisibility,
   wasmMemoryLimit,
   wasmMemoryThreshold,
+  environmentVariables,
 }: CanisterSettings = {}): canister_settings => {
   const toLogVisibility = (): log_visibility => {
     switch (logVisibility) {
@@ -56,6 +59,7 @@ export const toCanisterSettings = ({
     log_visibility: isNullish(logVisibility) ? [] : [toLogVisibility()],
     wasm_memory_limit: toNullable(wasmMemoryLimit),
     wasm_memory_threshold: toNullable(wasmMemoryThreshold),
+    environment_variables: toNullable(environmentVariables),
   };
 };
 


### PR DESCRIPTION
# Motivation

We have to update `didc` before migrating to `icp-bindgen`, as a result, I would like to first update the latest version of the did types. Only difference is the new `environment_variables` field in `ic-management` which requires an update of the proxied types and tests.

# Changes

- Copy generated did types from #1066
- Update proxied types and tests with new field
