### PR TITLE
chore: upgrade didc v0.5.1

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install didc
         run: |
           mkdir -p .bin
-          curl -L https://github.com/dfinity/candid/releases/download/2024-02-27/didc-linux64 > .bin/didc
+          curl -L https://github.com/dfinity/candid/releases/download/2025-08-04/didc-linux64 > .bin/didc
           chmod +x .bin/didc
       - name: Add didc to the PATH
         run: echo "${PWD}/.bin" >> $GITHUB_PATH

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -50,7 +50,7 @@ jobs:
           # Gets didc
           echo "$PATH" | tr : "\n"
           mkdir -p "$HOME/.local/bin"
-          curl -Lf https://github.com/dfinity/candid/releases/download/2024-02-27/didc-linux64 | install -m 755 /dev/stdin "$HOME/.local/bin/didc"
+          curl -Lf https://github.com/dfinity/candid/releases/download/2025-08-04/didc-linux64 | install -m 755 /dev/stdin "$HOME/.local/bin/didc"
           # Gets prettier in a minute
           npm ci
           # Gets candid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next
+
+## Chore
+
+- Upgrade `didc` to `0.5.1` that converts candid files into JS and TS.
+
 # v76
 
 ## Overview

--- a/scripts/compile-idl-js
+++ b/scripts/compile-idl-js
@@ -4,9 +4,9 @@
 
 set -euo pipefail
 
-if [ "$(didc --version)" != "didc 0.3.7" ]; then
+if [ "$(didc --version)" != "didc 0.5.1" ]; then
   {
-    echo "didc version 0.3.7 is required. To install it on Mac:"
+    echo "didc version 0.5.1 is required. To install it on Mac:"
     echo "curl -Lf https://github.com/dfinity/candid/releases/download/2024-02-27/didc-macos -o install_didc"
     echo "install -m 755 install_didc /$HOME/.local/bin/didc"
   } >&2


### PR DESCRIPTION
# Motivation

Before migrating to `@icp-sdk/bindgen`, we need to upgrade `didc` and regenerate the types; otherwise, we risk mixing declaration differences during the migration.  

This is especially relevant for the TypeScript definitions of functions, used in e.g. `ledger-icrc`, which were modified in this [Candid PR](https://github.com/dfinity/candid/pull/627).

It's also interesting to upgrade because latest version of `didc` parses the comments to the output files as well.

# Changes

- Upgrade `didc` to latest version `v0.5.1` published in Candid release [2025-08-04](https://github.com/dfinity/candid/releases/tag/2025-08-04)