### PR TITLE
feat: generate sns candid declarations with didc v0.5.1

### DIFF
--- a/packages/sns/candid/sns_governance.d.ts
+++ b/packages/sns/candid/sns_governance.d.ts
@@ -2,6 +2,9 @@ import type { ActorMethod } from "@dfinity/agent";
 import type { IDL } from "@dfinity/candid";
 import type { Principal } from "@dfinity/principal";
 
+/**
+ * Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/sns/governance/canister/governance.did' by import-candid
+ */
 export interface Account {
   owner: [] | [Principal];
   subaccount: [] | [Subaccount];
@@ -444,6 +447,9 @@ export interface MergeMaturityResponse {
   new_stake_e8s: bigint;
 }
 export interface Metrics {
+  /**
+   * The metrics below are cached (albeit this is an implementation detail).
+   */
   treasury_metrics: [] | [Array<TreasuryMetrics>];
   voting_power_metrics: [] | [VotingPowerMetrics];
   last_ledger_block_timestamp: [] | [bigint];
@@ -563,6 +569,22 @@ export interface PendingVersion {
 export interface Percentage {
   basis_points: [] | [bigint];
 }
+/**
+ * This type is equivalant to `ICRC3Value`, but we give it another name since it is used here not
+ * in the context of the ICRC-3 ledger standard. The justification is the same: The candid format
+ * supports sharing information even when the client and the server involved do not have the same
+ * schema (see the Upgrading and subtyping section of the candid spec). While this mechanism allows
+ * to evolve services and clients independently without breaking them, it also means that a client
+ * may not receive all the information that the server is sending, e.g. in case the client schema
+ * lacks some fields that the server schema has.
+ *
+ * This loss of information is not an option for SNS voters deciding if an extension with particular
+ * init args should be installed or if an extension function with particular arguments should be
+ * called. The client must receive the same exact data the server sent in order to verify it.
+ *
+ * Verification of a priorly installed extension is done by hashing the extension's init arg data
+ * and checking that the result is consistent with what has been certified by the SNS.
+ */
 export type PreciseValue =
   | { Int: bigint }
   | { Map: Array<[string, PreciseValue]> }
@@ -737,12 +759,30 @@ export interface TransferSnsTreasuryFunds {
   amount_e8s: bigint;
 }
 export interface TreasuryMetrics {
+  /**
+   * A human-readable identified for this treasury, e.g., "ICP".
+   */
   name: [] | [string];
+  /**
+   * The amount of tokens in this treasury at the end of swap finalization.
+   */
   original_amount_e8s: [] | [bigint];
+  /**
+   * The regularly updated amount of tokens in this treasury.
+   */
   amount_e8s: [] | [bigint];
   account: [] | [Account];
+  /**
+   * The source of truth for the treasury balance is this ledger canister / account.
+   */
   ledger_canister_id: [] | [Principal];
+  /**
+   * Same as, e.g., `TransferSnsTreasuryFunds.from_treasury`.
+   */
   treasury: number;
+  /**
+   * When the metrics were last updated.
+   */
   timestamp_seconds: [] | [bigint];
 }
 export interface UpgradeExtension {
@@ -831,6 +871,9 @@ export interface Versions {
 }
 export interface VotingPowerMetrics {
   governance_total_potential_voting_power: [] | [bigint];
+  /**
+   * When the metrics were last updated.
+   */
   timestamp_seconds: [] | [bigint];
 }
 export interface VotingRewardsParameters {

--- a/packages/sns/candid/sns_governance_test.d.ts
+++ b/packages/sns/candid/sns_governance_test.d.ts
@@ -2,6 +2,9 @@ import type { ActorMethod } from "@dfinity/agent";
 import type { IDL } from "@dfinity/candid";
 import type { Principal } from "@dfinity/principal";
 
+/**
+ * Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/sns/governance/canister/governance_test.did' by import-candid
+ */
 export interface Account {
   owner: [] | [Principal];
   subaccount: [] | [Subaccount];
@@ -455,6 +458,9 @@ export interface MergeMaturityResponse {
   new_stake_e8s: bigint;
 }
 export interface Metrics {
+  /**
+   * The metrics below are cached (albeit this is an implementation detail).
+   */
   treasury_metrics: [] | [Array<TreasuryMetrics>];
   voting_power_metrics: [] | [VotingPowerMetrics];
   last_ledger_block_timestamp: [] | [bigint];
@@ -578,6 +584,22 @@ export interface PendingVersion {
 export interface Percentage {
   basis_points: [] | [bigint];
 }
+/**
+ * This type is equivalant to `ICRC3Value`, but we give it another name since it is used here not
+ * in the context of the ICRC-3 ledger standard. The justification is the same: The candid format
+ * supports sharing information even when the client and the server involved do not have the same
+ * schema (see the Upgrading and subtyping section of the candid spec). While this mechanism allows
+ * to evolve services and clients independently without breaking them, it also means that a client
+ * may not receive all the information that the server is sending, e.g. in case the client schema
+ * lacks some fields that the server schema has.
+ *
+ * This loss of information is not an option for SNS voters deciding if an extension with particular
+ * init args should be installed or if an extension function with particular arguments should be
+ * called. The client must receive the same exact data the server sent in order to verify it.
+ *
+ * Verification of a priorly installed extension is done by hashing the extension's init arg data
+ * and checking that the result is consistent with what has been certified by the SNS.
+ */
 export type PreciseValue =
   | { Int: bigint }
   | { Map: Array<[string, PreciseValue]> }
@@ -752,12 +774,30 @@ export interface TransferSnsTreasuryFunds {
   amount_e8s: bigint;
 }
 export interface TreasuryMetrics {
+  /**
+   * A human-readable identified for this treasury, e.g., "ICP".
+   */
   name: [] | [string];
+  /**
+   * The amount of tokens in this treasury at the end of swap finalization.
+   */
   original_amount_e8s: [] | [bigint];
+  /**
+   * The regularly updated amount of tokens in this treasury.
+   */
   amount_e8s: [] | [bigint];
   account: [] | [Account];
+  /**
+   * The source of truth for the treasury balance is this ledger canister / account.
+   */
   ledger_canister_id: [] | [Principal];
+  /**
+   * Same as, e.g., `TransferSnsTreasuryFunds.from_treasury`.
+   */
   treasury: number;
+  /**
+   * When the metrics were last updated.
+   */
   timestamp_seconds: [] | [bigint];
 }
 export interface UpgradeExtension {
@@ -846,6 +886,9 @@ export interface Versions {
 }
 export interface VotingPowerMetrics {
   governance_total_potential_voting_power: [] | [bigint];
+  /**
+   * When the metrics were last updated.
+   */
   timestamp_seconds: [] | [bigint];
 }
 export interface VotingRewardsParameters {

--- a/packages/sns/candid/sns_root.d.ts
+++ b/packages/sns/candid/sns_root.d.ts
@@ -2,6 +2,9 @@ import type { ActorMethod } from "@dfinity/agent";
 import type { IDL } from "@dfinity/candid";
 import type { Principal } from "@dfinity/principal";
 
+/**
+ * Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/sns/root/canister/root.did' by import-candid
+ */
 export interface CanisterCallError {
   code: [] | [number];
   description: string;

--- a/packages/sns/candid/sns_swap.d.ts
+++ b/packages/sns/candid/sns_swap.d.ts
@@ -2,6 +2,9 @@ import type { ActorMethod } from "@dfinity/agent";
 import type { IDL } from "@dfinity/candid";
 import type { Principal } from "@dfinity/principal";
 
+/**
+ * Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/sns/swap/canister/swap.did' by import-candid
+ */
 export interface BuyerState {
   icp: [] | [TransferableAmount];
   has_created_neuron_recipes: [] | [boolean];


### PR DESCRIPTION
# Motivation

Generate the DID declarations with didc `v0.5.1`.

# Notes

The auto-generated comment added at the top of the DID file might be misinterpreted by didc as a comment for a type. 
This has been patched in Candid PR [681](https://github.com/dfinity/candid/pull/681) which we will integrate once [v0.5.2](https://github.com/dfinity/candid/pull/682) is released.

# Changes

- Copy declarations from the PR #1069 that was generated with the CI job

