### PR TITLE
feat: generate ic-mgmt candid declarations with didc v0.5.1

### DIFF
--- a/packages/ic-management/candid/ic-management.d.ts
+++ b/packages/ic-management/candid/ic-management.d.ts
@@ -45,6 +45,9 @@ export interface bitcoin_send_transaction_args {
   transaction: Uint8Array | number[];
   network: bitcoin_network;
 }
+/**
+ * Generated from dfinity/portal commit b562ec5d68bce1fef2859a9a592d9487d3b64919 for file 'docs/references/_attachments/ic.did'
+ */
 export type canister_id = Principal;
 export interface canister_info_args {
   canister_id: canister_id;
@@ -463,6 +466,9 @@ export interface vetkd_public_key_result {
 }
 export type wasm_module = Uint8Array | number[];
 export interface _SERVICE {
+  /**
+   * bitcoin interface
+   */
   bitcoin_get_balance: ActorMethod<
     [bitcoin_get_balance_args],
     bitcoin_get_balance_result
@@ -493,10 +499,16 @@ export interface _SERVICE {
     undefined
   >;
   deposit_cycles: ActorMethod<[deposit_cycles_args], undefined>;
+  /**
+   * Threshold ECDSA signature
+   */
   ecdsa_public_key: ActorMethod<
     [ecdsa_public_key_args],
     ecdsa_public_key_result
   >;
+  /**
+   * canister logging
+   */
   fetch_canister_logs: ActorMethod<
     [fetch_canister_logs_args],
     fetch_canister_logs_result
@@ -509,10 +521,16 @@ export interface _SERVICE {
     list_canister_snapshots_result
   >;
   load_canister_snapshot: ActorMethod<[load_canister_snapshot_args], undefined>;
+  /**
+   * metrics interface
+   */
   node_metrics_history: ActorMethod<
     [node_metrics_history_args],
     node_metrics_history_result
   >;
+  /**
+   * provisional interfaces for the pre-ledger world
+   */
   provisional_create_canister_with_cycles: ActorMethod<
     [provisional_create_canister_with_cycles_args],
     provisional_create_canister_with_cycles_result
@@ -530,6 +548,9 @@ export interface _SERVICE {
     [read_canister_snapshot_metadata_args],
     read_canister_snapshot_metadata_response
   >;
+  /**
+   * Threshold Schnorr signature
+   */
   schnorr_public_key: ActorMethod<
     [schnorr_public_key_args],
     schnorr_public_key_result
@@ -542,7 +563,13 @@ export interface _SERVICE {
   start_canister: ActorMethod<[start_canister_args], undefined>;
   stop_canister: ActorMethod<[stop_canister_args], undefined>;
   stored_chunks: ActorMethod<[stored_chunks_args], stored_chunks_result>;
+  /**
+   * subnet info
+   */
   subnet_info: ActorMethod<[subnet_info_args], subnet_info_result>;
+  /**
+   * Canister snapshots
+   */
   take_canister_snapshot: ActorMethod<
     [take_canister_snapshot_args],
     take_canister_snapshot_result
@@ -562,6 +589,9 @@ export interface _SERVICE {
     [vetkd_derive_key_args],
     vetkd_derive_key_result
   >;
+  /**
+   * Threshold key derivation
+   */
   vetkd_public_key: ActorMethod<
     [vetkd_public_key_args],
     vetkd_public_key_result


### PR DESCRIPTION
# Motivation

Generate the DID declarations with didc `v0.5.1`.

# Notes

The auto-generated comment added at the top of the DID file might be misinterpreted by didc as a comment for a type. 
This has been patched in Candid PR [681](https://github.com/dfinity/candid/pull/681) which we will integrate once [v0.5.2](https://github.com/dfinity/candid/pull/682) is released.

# Changes

- Copy declarations from the PR #1069 that was generated with the CI job

