### PR TITLE
feat: generate ledger-icp candid declarations with didc v0.5.1

### DIFF
--- a/packages/ledger-icp/candid/index.d.ts
+++ b/packages/ledger-icp/candid/index.d.ts
@@ -2,6 +2,9 @@ import type { ActorMethod } from "@dfinity/agent";
 import type { IDL } from "@dfinity/candid";
 import type { Principal } from "@dfinity/principal";
 
+/**
+ * Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/ledger_suite/icp/index/index.did' by import-candid
+ */
 export interface Account {
   owner: Principal;
   subaccount: [] | [Uint8Array | number[]];
@@ -25,7 +28,16 @@ export type GetAccountIdentifierTransactionsResult =
     }
   | { Err: GetAccountIdentifierTransactionsError };
 export interface GetAccountTransactionsArgs {
+  /**
+   * Maximum number of transactions to fetch.
+   */
   max_results: bigint;
+  /**
+   * The txid of the last transaction seen by the client.
+   * If None then the results will start from the most recent
+   * txid. If set then the results will start from the next
+   * most recent txid after start (start won't be included).
+   */
   start: [] | [bigint];
   account: Account;
 }


### PR DESCRIPTION
# Motivation

Generate the DID declarations with didc `v0.5.1`.

# Notes

The auto-generated comment added at the top of the DID file might be misinterpreted by didc as a comment for a type. 
This has been patched in Candid PR [681](https://github.com/dfinity/candid/pull/681) which we will integrate once [v0.5.2](https://github.com/dfinity/candid/pull/682) is released.

# Changes

- Copy declarations from the PR #1069 that was generated with the CI job

