### PR TITLE
feat: generate ledger-icrc candid declarations with didc v0.5.1

### DIFF
--- a/packages/ledger-icrc/candid/icrc_index-ng.d.ts
+++ b/packages/ledger-icrc/candid/icrc_index-ng.d.ts
@@ -29,7 +29,16 @@ export interface FeeCollectorRanges {
   ranges: Array<[Account, Array<[BlockIndex, BlockIndex]>]>;
 }
 export interface GetAccountTransactionsArgs {
+  /**
+   * Maximum number of transactions to fetch.
+   */
   max_results: bigint;
+  /**
+   * The txid of the last transaction seen by the client.
+   * If None then the results will start from the most recent
+   * txid. If set then the results will start from the next
+   * most recent txid after start (start won't be included).
+   */
   start: [] | [BlockIndex];
   account: Account;
 }
@@ -44,6 +53,9 @@ export interface GetBlocksResponse {
 export interface GetTransactions {
   balance: Tokens;
   transactions: Array<TransactionWithId>;
+  /**
+   * The txid of the oldest transaction the account has
+   */
   oldest_tx_id: [] | [BlockIndex];
 }
 export interface GetTransactionsErr {
@@ -55,6 +67,11 @@ export type GetTransactionsResult =
 export type IndexArg = { Upgrade: UpgradeArg } | { Init: InitArg };
 export interface InitArg {
   ledger_id: Principal;
+  /**
+   * The interval in seconds in which to retrieve blocks from the ledger. A lower value makes the index more
+   * responsive in showing new blocks, but increases the consumption of cycles of both the index and ledger canisters.
+   * A higher values means that it takes longer for new blocks to show up in the index.
+   */
   retrieve_blocks_from_ledger_interval_seconds: [] | [bigint];
 }
 export interface ListSubaccountsArgs {
@@ -72,6 +89,9 @@ export interface Status {
   num_blocks_synced: BlockIndex;
 }
 export type SubAccount = Uint8Array | number[];
+/**
+ * Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/ledger_suite/icrc1/index-ng/index-ng.did' by import-candid
+ */
 export type Tokens = bigint;
 export interface Transaction {
   burn: [] | [Burn];
@@ -96,6 +116,11 @@ export interface Transfer {
 }
 export interface UpgradeArg {
   ledger_id: [] | [Principal];
+  /**
+   * The interval in seconds in which to retrieve blocks from the ledger. A lower value makes the index more
+   * responsive in showing new blocks, but increases the consumption of cycles of both the index and ledger canisters.
+   * A higher values means that it takes longer for new blocks to show up in the index.
+   */
   retrieve_blocks_from_ledger_interval_seconds: [] | [bigint];
 }
 export type Value =

--- a/packages/ledger-icrc/candid/icrc_index.d.ts
+++ b/packages/ledger-icrc/candid/icrc_index.d.ts
@@ -24,12 +24,23 @@ export interface Burn {
   spender: [] | [Account];
 }
 export interface GetAccountTransactionsArgs {
+  /**
+   * Maximum number of transactions to fetch.
+   */
   max_results: bigint;
+  /**
+   * The txid of the last transaction seen by the client.
+   * If None then the results will start from the most recent
+   * txid.
+   */
   start: [] | [TxId];
   account: Account;
 }
 export interface GetTransactions {
   transactions: Array<TransactionWithId>;
+  /**
+   * The txid of the oldest transaction the account has
+   */
   oldest_tx_id: [] | [TxId];
 }
 export interface GetTransactionsErr {
@@ -38,6 +49,9 @@ export interface GetTransactionsErr {
 export type GetTransactionsResult =
   | { Ok: GetTransactions }
   | { Err: GetTransactionsErr };
+/**
+ * The initialization parameters of the Index canister.
+ */
 export interface InitArgs {
   ledger_id: Principal;
 }
@@ -73,6 +87,9 @@ export interface Transfer {
   amount: bigint;
   spender: [] | [Account];
 }
+/**
+ * Generated from IC repo commit d9fe207 (2024-12-06 tags: release-2024-12-06_03-16-base) 'rs/ledger_suite/icrc1/index/index.did' by import-candid
+ */
 export type TxId = bigint;
 export interface _SERVICE {
   get_account_transactions: ActorMethod<

--- a/packages/ledger-icrc/candid/icrc_ledger.d.ts
+++ b/packages/ledger-icrc/candid/icrc_ledger.d.ts
@@ -59,8 +59,31 @@ export interface ArchiveInfo {
   block_range_start: BlockIndex;
 }
 export type Block = Value;
+/**
+ * Generated from IC repo commit 206b61a (2025-09-25 tags: release-2025-09-25_09-52-base) 'rs/ledger_suite/icrc1/ledger/ledger.did' by import-candid
+ */
 export type BlockIndex = bigint;
+/**
+ * A prefix of the block range specified in the [GetBlocksArgs] request.
+ */
 export interface BlockRange {
+  /**
+   * A prefix of the requested block range.
+   * The index of the first block is equal to [GetBlocksArgs.start].
+   *
+   * Note that the number of blocks might be less than the requested
+   * [GetBlocksArgs.length] for various reasons, for example:
+   *
+   * 1. The query might have hit the replica with an outdated state
+   * that doesn't have the whole range yet.
+   * 2. The requested range is too large to fit into a single reply.
+   *
+   * NOTE: the list of blocks can be empty if:
+   *
+   * 1. [GetBlocksArgs.length] was zero.
+   * 2. [GetBlocksArgs.start] was larger than the last block known to
+   * the canister.
+   */
   blocks: Array<Block>;
 }
 export interface Burn {
@@ -81,10 +104,16 @@ export interface ChangeArchiveOptions {
   controller_id: [] | [Principal];
 }
 export type ChangeFeeCollector = { SetTo: Account } | { Unset: null };
+/**
+ * Certificate for the block at `block_index`.
+ */
 export interface DataCertificate {
   certificate: [] | [Uint8Array | number[]];
   hash_tree: Uint8Array | number[];
 }
+/**
+ * Number of nanoseconds between two [Timestamp]s.
+ */
 export type Duration = bigint;
 export interface FeatureFlags {
   icrc2: boolean;
@@ -104,29 +133,90 @@ export type GetAllowancesError =
     }
   | { AccessDenied: { reason: string } };
 export interface GetArchivesArgs {
+  /**
+   * The last archive seen by the client.
+   * The Ledger will return archives coming
+   * after this one if set, otherwise it
+   * will return the first archives.
+   */
   from: [] | [Principal];
 }
 export type GetArchivesResult = Array<{
+  /**
+   * The last block in the archive
+   */
   end: bigint;
+  /**
+   * The id of the archive
+   */
   canister_id: Principal;
+  /**
+   * The first block in the archive
+   */
   start: bigint;
 }>;
 export interface GetBlocksArgs {
+  /**
+   * The index of the first block to fetch.
+   */
   start: BlockIndex;
+  /**
+   * Max number of blocks to fetch.
+   */
   length: bigint;
 }
+/**
+ * The result of a "get_blocks" call.
+ */
 export interface GetBlocksResponse {
+  /**
+   * System certificate for the hash of the latest block in the chain.
+   * Only present if `get_blocks` is called in a non-replicated query context.
+   */
   certificate: [] | [Uint8Array | number[]];
+  /**
+   * The index of the first block in "blocks".
+   * If the blocks vector is empty, the exact value of this field is not specified.
+   */
   first_index: BlockIndex;
+  /**
+   * List of blocks that were available in the ledger when it processed the call.
+   *
+   * The blocks form a contiguous range, with the first block having index
+   * [first_block_index] (see below), and the last block having index
+   * [first_block_index] + len(blocks) - 1.
+   *
+   * The block range can be an arbitrary sub-range of the originally requested range.
+   */
   blocks: Array<Block>;
+  /**
+   * The total number of blocks in the chain.
+   * If the chain length is positive, the index of the last block is `chain_len - 1`.
+   */
   chain_length: bigint;
+  /**
+   * Encoding of instructions for fetching archived blocks.
+   */
   archived_blocks: Array<{
-    callback: QueryBlockArchiveFn;
+    /**
+     * Callback to fetch the archived blocks.
+     */
+    callback: [Principal, string];
+    /**
+     * The index of the first archived block.
+     */
     start: BlockIndex;
+    /**
+     * The number of blocks that can be fetched.
+     */
     length: bigint;
   }>;
 }
 export interface GetBlocksResult {
+  /**
+   * Total number of blocks in the
+   * block log
+   */
   log_length: bigint;
   blocks: Array<{ id: bigint; block: ICRC3Value }>;
   archived_blocks: Array<{
@@ -136,6 +226,9 @@ export interface GetBlocksResult {
 }
 export type GetIndexPrincipalError =
   | {
+      /**
+       * Any error not covered by the above variants.
+       */
       GenericError: { description: string; error_code: bigint };
     }
   | { IndexPrincipalNotSet: null };
@@ -143,16 +236,56 @@ export type GetIndexPrincipalResult =
   | { Ok: Principal }
   | { Err: GetIndexPrincipalError };
 export interface GetTransactionsRequest {
+  /**
+   * The index of the first tx to fetch.
+   */
   start: TxIndex;
+  /**
+   * The number of transactions to fetch.
+   */
   length: bigint;
 }
 export interface GetTransactionsResponse {
+  /**
+   * The index of the first transaction in [transactions].
+   * If the transaction vector is empty, the exact value of this field is not specified.
+   */
   first_index: TxIndex;
+  /**
+   * The total number of transactions in the log.
+   */
   log_length: bigint;
+  /**
+   * List of transaction that were available in the ledger when it processed the call.
+   *
+   * The transactions form a contiguous range, with the first transaction having index
+   * [first_index] (see below), and the last transaction having index
+   * [first_index] + len(transactions) - 1.
+   *
+   * The transaction range can be an arbitrary sub-range of the originally requested range.
+   */
   transactions: Array<Transaction>;
+  /**
+   * Encoding of instructions for fetching archived transactions whose indices fall into the
+   * requested range.
+   *
+   * For each entry `e` in [archived_transactions], `[e.from, e.from + len)` is a sub-range
+   * of the originally requested transaction range.
+   */
   archived_transactions: Array<{
-    callback: QueryArchiveFn;
+    /**
+     * The function you should call to fetch the archived transactions.
+     * The range of the transaction accessible using this function is given by [from]
+     * and [len] fields above.
+     */
+    callback: [Principal, string];
+    /**
+     * The index of the first archived transaction you can fetch using the [callback].
+     */
     start: TxIndex;
+    /**
+     * The number of transactions you can fetch using the callback.
+     */
     length: bigint;
   }>;
 }
@@ -168,7 +301,13 @@ export interface HttpResponse {
   status_code: number;
 }
 export interface ICRC3DataCertificate {
+  /**
+   * See https://internetcomputer.org/docs/current/references/ic-interface-spec#certification
+   */
   certificate: Uint8Array | number[];
+  /**
+   * CBOR encoded hash_tree
+   */
   hash_tree: Uint8Array | number[];
 }
 export type ICRC3Value =
@@ -189,6 +328,9 @@ export type Icrc21Value =
     }
   | { TimestampSeconds: { amount: bigint } }
   | { DurationSeconds: { amount: bigint } };
+/**
+ * The initialization parameters of the Ledger
+ */
 export interface InitArgs {
   decimals: [] | [number];
   token_symbol: string;
@@ -214,6 +356,9 @@ export interface InitArgs {
 }
 export type LedgerArg = { Upgrade: [] | [UpgradeArgs] } | { Init: InitArgs };
 export type Map = Array<[string, Value]>;
+/**
+ * The value returned from the [icrc1_metadata] endpoint.
+ */
 export type MetadataValue =
   | { Int: bigint }
   | { Nat: bigint }
@@ -225,16 +370,25 @@ export interface Mint {
   created_at_time: [] | [Timestamp];
   amount: bigint;
 }
+/**
+ * A function for fetching archived transaction.
+ */
 export type QueryArchiveFn = ActorMethod<
   [GetTransactionsRequest],
   TransactionRange
 >;
+/**
+ * A function for fetching archived blocks.
+ */
 export type QueryBlockArchiveFn = ActorMethod<[GetBlocksArgs], BlockRange>;
 export interface StandardRecord {
   url: string;
   name: string;
 }
 export type Subaccount = Uint8Array | number[];
+/**
+ * Number of nanoseconds since the UNIX epoch in UTC timezone.
+ */
 export type Timestamp = bigint;
 export type Tokens = bigint;
 export interface Transaction {
@@ -245,7 +399,27 @@ export interface Transaction {
   timestamp: Timestamp;
   transfer: [] | [Transfer];
 }
+/**
+ * A prefix of the transaction range specified in the [GetTransactionsRequest] request.
+ */
 export interface TransactionRange {
+  /**
+   * A prefix of the requested transaction range.
+   * The index of the first transaction is equal to [GetTransactionsRequest.from].
+   *
+   * Note that the number of transactions might be less than the requested
+   * [GetTransactionsRequest.length] for various reasons, for example:
+   *
+   * 1. The query might have hit the replica with an outdated state
+   * that doesn't have the whole range yet.
+   * 2. The requested range is too large to fit into a single reply.
+   *
+   * NOTE: the list of transactions can be empty if:
+   *
+   * 1. [GetTransactionsRequest.length] was zero.
+   * 2. [GetTransactionsRequest.from] was larger than the last transaction known to
+   * the canister.
+   */
   transactions: Array<Transaction>;
 }
 export interface Transfer {
@@ -351,6 +525,9 @@ export interface icrc21_consent_message_spec {
 }
 export type icrc21_error =
   | {
+      /**
+       * Any error not covered by the above variants.
+       */
       GenericError: { description: string; error_code: bigint };
     }
   | { InsufficientPayment: icrc21_error_info }


### PR DESCRIPTION
# Motivation

Generate the DID declarations with didc `v0.5.1`.

# Notes

The auto-generated comment added at the top of the DID file might be misinterpreted by didc as a comment for a type. 
This has been patched in Candid PR [681](https://github.com/dfinity/candid/pull/681) which we will integrate once [v0.5.2](https://github.com/dfinity/candid/pull/682) is released.

You might noticed that a `callback` type isn't typed anymore as `QueryArchiveFn` (a function) but become a `[Principal, string]`. According SDK team this is expected and is the result of this Candid fix [PR](https://github.com/dfinity/candid/pull/627).

# Changes

- Copy declarations from the PR #1069 that was generated with the CI job

