### PR TITLE
feat: snapshot read metadata response type and mapper

### DIFF
--- a/packages/ic-management/src/types/snapshot.responses.spec.ts
+++ b/packages/ic-management/src/types/snapshot.responses.spec.ts
@@ -1,0 +1,156 @@
+import type { read_canister_snapshot_metadata_response } from "../../candid/ic-management";
+import {
+  fromReadCanisterSnapshotMetadataResponse,
+  type ReadCanisterSnapshotMetadataResponse,
+} from "./snapshot.responses";
+
+describe("snapshot.responses", () => {
+  const mockResponse: read_canister_snapshot_metadata_response = {
+    globals: [
+      { i32: 1 },
+      { i64: 2n },
+      { f32: 3.14 },
+      { f64: 6.28 },
+      { v128: 0n },
+    ],
+    canister_version: 42n,
+    source: { metadata_upload: { hello: "world test" } },
+    certified_data: new Uint8Array([1, 2, 3]),
+    global_timer: [],
+    on_low_wasm_memory_hook_status: [],
+    wasm_module_size: 1000n,
+    stable_memory_size: 2000n,
+    wasm_chunk_store: [{ hash: new Uint8Array([9, 9, 9]) }],
+    taken_at_timestamp: 123456789n,
+    wasm_memory_size: 3000n,
+  };
+
+  it("should map fields", () => {
+    const mapped = fromReadCanisterSnapshotMetadataResponse(mockResponse);
+
+    const expected: ReadCanisterSnapshotMetadataResponse = {
+      globals: mockResponse.globals,
+      canisterVersion: mockResponse.canister_version,
+      source: { metadataUpload: { hello: "world test" } },
+      certifiedData: mockResponse.certified_data,
+      globalTimer: undefined,
+      onLowWasmMemoryHookStatus: undefined,
+      wasmModuleSize: mockResponse.wasm_module_size,
+      stableMemorySize: mockResponse.stable_memory_size,
+      wasmChunkStore: mockResponse.wasm_chunk_store,
+      takenAtTimestamp: mockResponse.taken_at_timestamp,
+      wasmMemorySize: mockResponse.wasm_memory_size,
+    };
+
+    expect(mapped).toStrictEqual(expected);
+  });
+
+  it("should map source with taken_from_canister", () => {
+    const candid: read_canister_snapshot_metadata_response = {
+      ...mockResponse,
+      source: { taken_from_canister: { hello: "world" } },
+    };
+
+    const mapped = fromReadCanisterSnapshotMetadataResponse(candid);
+
+    expect(mapped.source).toStrictEqual({
+      takenFromCanister: { hello: "world" },
+    });
+  });
+
+  describe("global_timer", () => {
+    it("should map active global_timer", () => {
+      const candid: read_canister_snapshot_metadata_response = {
+        ...mockResponse,
+        global_timer: [{ active: 787n }],
+      };
+
+      const mapped = fromReadCanisterSnapshotMetadataResponse(candid);
+
+      expect(mapped.globalTimer).toStrictEqual({ active: 787n });
+    });
+
+    it("should map inactive global_timer", () => {
+      const candid: read_canister_snapshot_metadata_response = {
+        ...mockResponse,
+        global_timer: [{ inactive: null }],
+      };
+
+      const mapped = fromReadCanisterSnapshotMetadataResponse(candid);
+
+      expect(mapped.globalTimer).toStrictEqual({ inactive: null });
+    });
+  });
+
+  describe("onLowWasmMemoryHookStatus", () => {
+    it("should map condition_not_satisfied", () => {
+      const candid: read_canister_snapshot_metadata_response = {
+        ...mockResponse,
+        on_low_wasm_memory_hook_status: [{ condition_not_satisfied: null }],
+      };
+
+      const mapped = fromReadCanisterSnapshotMetadataResponse(candid);
+
+      expect(mapped.onLowWasmMemoryHookStatus).toStrictEqual({
+        conditionNotSatisfied: null,
+      });
+    });
+
+    it("should map executed", () => {
+      const candid: read_canister_snapshot_metadata_response = {
+        ...mockResponse,
+        on_low_wasm_memory_hook_status: [{ executed: null }],
+      };
+
+      const mapped = fromReadCanisterSnapshotMetadataResponse(candid);
+
+      expect(mapped.onLowWasmMemoryHookStatus).toStrictEqual({
+        executed: null,
+      });
+    });
+
+    it("should map ready", () => {
+      const candid: read_canister_snapshot_metadata_response = {
+        ...mockResponse,
+        on_low_wasm_memory_hook_status: [{ ready: null }],
+      };
+
+      const mapped = fromReadCanisterSnapshotMetadataResponse(candid);
+
+      expect(mapped.onLowWasmMemoryHookStatus).toStrictEqual({ ready: null });
+    });
+
+    it("should stays undefined when empty", () => {
+      const candid: read_canister_snapshot_metadata_response = {
+        ...mockResponse,
+        on_low_wasm_memory_hook_status: [],
+      };
+
+      const mapped = fromReadCanisterSnapshotMetadataResponse(candid);
+
+      expect(mapped.onLowWasmMemoryHookStatus).toBeUndefined();
+    });
+  });
+
+  it("should throw on unsupported source variant", () => {
+    const candid = {
+      ...mockResponse,
+      source: { something_else: 1 },
+    } as unknown as read_canister_snapshot_metadata_response;
+
+    expect(() => fromReadCanisterSnapshotMetadataResponse(candid)).toThrow(
+      "Unsupported snapshot metadata source",
+    );
+  });
+
+  it("should throw on unsupported on_low_wasm_memory_hook_status variant", () => {
+    const candid = {
+      ...mockResponse,
+      on_low_wasm_memory_hook_status: [{ unknown: null }],
+    } as unknown as read_canister_snapshot_metadata_response;
+
+    expect(() => fromReadCanisterSnapshotMetadataResponse(candid)).toThrow(
+      "Unsupported snapshot metadata on_low_wasm_memory_hook_status",
+    );
+  });
+});

--- a/packages/ic-management/src/types/snapshot.responses.ts
+++ b/packages/ic-management/src/types/snapshot.responses.ts
@@ -1,0 +1,90 @@
+import { fromNullable, isNullish } from "@dfinity/utils";
+import type { read_canister_snapshot_metadata_response } from "../../candid/ic-management";
+
+export interface ReadCanisterSnapshotMetadataResponse {
+  globals: (
+    | { f32: number }
+    | { f64: number }
+    | { i32: number }
+    | { i64: bigint }
+    | { v128: bigint }
+  )[];
+  canisterVersion: bigint;
+  source: { metadataUpload: unknown } | { takenFromCanister: unknown };
+  certifiedData: Uint8Array | number[];
+  globalTimer?: { active: bigint } | { inactive: null };
+  onLowWasmMemoryHookStatus?:
+    | { conditionNotSatisfied: null }
+    | { executed: null }
+    | { ready: null };
+  wasmModuleSize: bigint;
+  stableMemorySize: bigint;
+  wasmChunkStore: Array<{ hash: Uint8Array | number[] }>;
+  takenAtTimestamp: bigint;
+  wasmMemorySize: bigint;
+}
+
+export const fromReadCanisterSnapshotMetadataResponse = ({
+  globals,
+  canister_version: canisterVersion,
+  source,
+  certified_data: certifiedData,
+  global_timer,
+  on_low_wasm_memory_hook_status,
+  wasm_module_size: wasmModuleSize,
+  stable_memory_size: stableMemorySize,
+  wasm_chunk_store: wasmChunkStore,
+  taken_at_timestamp: takenAtTimestamp,
+  wasm_memory_size: wasmMemorySize,
+}: read_canister_snapshot_metadata_response): ReadCanisterSnapshotMetadataResponse => {
+  const mapSource = (): ReadCanisterSnapshotMetadataResponse["source"] => {
+    if ("metadata_upload" in source) {
+      return { metadataUpload: source.metadata_upload };
+    }
+
+    if ("taken_from_canister" in source) {
+      return { takenFromCanister: source.taken_from_canister };
+    }
+
+    throw new Error("Unsupported snapshot metadata source");
+  };
+
+  const mapOnLowWasmMemoryHookStatus =
+    (): ReadCanisterSnapshotMetadataResponse["onLowWasmMemoryHookStatus"] => {
+      const value = fromNullable(on_low_wasm_memory_hook_status);
+
+      if (isNullish(value)) {
+        return undefined;
+      }
+
+      if ("condition_not_satisfied" in value) {
+        return { conditionNotSatisfied: value.condition_not_satisfied };
+      }
+
+      if ("executed" in value) {
+        return { executed: value.executed };
+      }
+
+      if ("ready" in value) {
+        return { ready: value.ready };
+      }
+
+      throw new Error(
+        "Unsupported snapshot metadata on_low_wasm_memory_hook_status",
+      );
+    };
+
+  return {
+    globals,
+    canisterVersion,
+    source: mapSource(),
+    certifiedData,
+    globalTimer: fromNullable(global_timer),
+    onLowWasmMemoryHookStatus: mapOnLowWasmMemoryHookStatus(),
+    wasmModuleSize,
+    stableMemorySize,
+    wasmChunkStore,
+    takenAtTimestamp,
+    wasmMemorySize,
+  };
+};


### PR DESCRIPTION
# Motivation

When I developed support for the read and upload snapshot feature in #1046, I was really hesitant about whether to parse/map the metadata response. On one hand, for consistency with the other functions in the module, we should not parse the response, since none of the other functions do so. On the other hand, we already use custom parameters for the exposed parts of the module, a pattern that should also apply when implementing the upload metadata of the snapshot.

Ultimately, I decided it would be more practical for the consumer to receive a mapped object when reading data. This way, the consumer can simply download a value and pass the same back on upload, without having to implement additional conversions on their side.

I validated this approach with my implementation in Juno's CLI (PR [382](https://github.com/junobuild/cli/pull/382)).

That said, I’m still not fully satisfied with it. Generally speaking, I hope we’ll find a solution in the future that makes both inputs and outputs consistent.

# Changes

- Define a response type to read metadata
- Add a utility to parse candid types to custom js type
