### PR TITLE
feat: replace usage of Buffer in nns-js to convert hex to uint8Array

### DIFF
--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -71,7 +71,7 @@ References:
 - [https://internetcomputer.org/docs/defi/token-ledgers/setup/icp_ledger_setup](https://internetcomputer.org/docs/defi/token-ledgers/setup/icp_ledger_setup)
 - [https://internetcomputer.org/docs/references/ledger#\_operations_transactions_blocks_transaction_ledger](https://internetcomputer.org/docs/references/ledger#_operations_transactions_blocks_transaction_ledger)
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L22)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L23)
 
 #### Static Methods
 
@@ -95,7 +95,7 @@ Returns:
 
 An instance of `AccountIdentifier`.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L33)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L34)
 
 ##### :gear: fromPrincipal
 
@@ -118,7 +118,7 @@ Returns:
 
 An instance of `AccountIdentifier`.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L67)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L68)
 
 #### Methods
 
@@ -140,7 +140,7 @@ Returns:
 
 Hex representation (64-character string).
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L99)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L100)
 
 ##### :gear: toUint8Array
 
@@ -154,7 +154,7 @@ Returns:
 
 The raw bytes of the account identifier.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L108)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L109)
 
 ##### :gear: toNumbers
 
@@ -168,7 +168,7 @@ Returns:
 
 An array of byte values.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L117)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L118)
 
 ##### :gear: toAccountIdentifierHash
 
@@ -182,7 +182,7 @@ Returns:
 
 `{ hash: Uint8Array }` where `hash` is the raw 32-byte `Uint8Array`.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L126)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L127)
 
 ### :factory: SubAccount
 
@@ -193,7 +193,7 @@ References:
 
 - [https://internetcomputer.org/docs/references/ledger#\_accounts](https://internetcomputer.org/docs/references/ledger#_accounts)
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L139)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L140)
 
 #### Static Methods
 
@@ -217,7 +217,7 @@ Returns:
 
 A `SubAccount` instance.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L149)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L150)
 
 ##### :gear: fromPrincipal
 
@@ -237,7 +237,7 @@ Returns:
 
 A `SubAccount` instance.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L165)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L166)
 
 ##### :gear: fromID
 
@@ -258,7 +258,7 @@ Returns:
 
 A `SubAccount` instance.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L188)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L189)
 
 #### Methods
 
@@ -276,7 +276,7 @@ Returns:
 
 A 32-byte array.
 
-[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L217)
+[:link: Source](https://github.com/dfinity/ic-js/tree/main/packages/ledger-icp/src/account_identifier.ts#L218)
 
 ### :factory: LedgerCanister
 

--- a/packages/ledger-icp/src/account_identifier.spec.ts
+++ b/packages/ledger-icp/src/account_identifier.spec.ts
@@ -113,13 +113,13 @@ describe("AccountIdentifier", () => {
   it("should reject an invalid hex string", () => {
     expect(() => {
       AccountIdentifier.fromHex("foo bar");
-    }).toThrow("Invalid AccountIdentifier: expected 32 bytes, got 0.");
+    }).toThrow("Invalid AccountIdentifier: expected 32 bytes, got 4.");
   });
 
   it("should reject an empty hex string", () => {
     expect(() => {
       AccountIdentifier.fromHex("");
-    }).toThrow("Invalid AccountIdentifier: expected 32 bytes, got 0.");
+    }).toThrow("Invalid hex string.");
   });
 
   it("should reject an hex string too short", () => {

--- a/packages/ledger-icp/src/account_identifier.ts
+++ b/packages/ledger-icp/src/account_identifier.ts
@@ -3,6 +3,7 @@ import {
   arrayOfNumberToUint8Array,
   asciiStringToByteArray,
   bigEndianCrc32,
+  hexStringToUint8Array,
   uint8ArrayToHexString,
 } from "@dfinity/utils";
 import { sha224 } from "@noble/hashes/sha2";
@@ -31,7 +32,7 @@ export class AccountIdentifier {
    * @returns An instance of `AccountIdentifier`.
    */
   public static fromHex(hex: string): AccountIdentifier {
-    const bytes = Uint8Array.from(Buffer.from(hex, "hex"));
+    const bytes = hexStringToUint8Array(hex);
 
     if (bytes.length !== 32) {
       throw new Error(


### PR DESCRIPTION
# Motivation

We want to remove the use of `Buffer`. While testing the integration in NNS-dapp ([PR](https://github.com/dfinity/nns-dapp/pull/7348)), @yhabib noticed that the application was complaining about the missing polyfilled `Buffer`. This is likely because `nns-js` still relies on it for two features.

# Notes

The updated test case `Invalid AccountIdentifier: expected 32 bytes, got 4.` - i.e. 4 instead 0 - is due to the fact that the utility ignores spaces and the mock in place is "foo bar". An account identifier does not contain spaces, therefore I think it was ok to update the expected result. 

# Changes

- Replace usage of `Buffer` with `hexStringToUint8Array` from `@dfinity/utils`
