### PR TITLE
feat: replace usage of Buffer in nns-js to convert uint8Array to hex

### DIFF
--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -1363,7 +1363,7 @@ export const fromDisburseRequest = (request: DisburseRequest): PbManageNeuron =>
   if (request.toAccountId) {
     const toAccountIdentifier = new PbAccountIdentifier();
     toAccountIdentifier.setHash(
-      Uint8Array.from(Buffer.from(request.toAccountId, "hex"))
+      uint8ArrayToHexString(request.toAccountId)
     );
     disburse.setToAccount(toAccountIdentifier);
   }

--- a/packages/nns/src/utils/account_identifier.utils.ts
+++ b/packages/nns/src/utils/account_identifier.utils.ts
@@ -18,7 +18,7 @@ export const accountIdentifierToBytes = (
 
 export const accountIdentifierFromBytes = (
   accountIdentifier: Uint8Array,
-): AccountIdentifierHex => Buffer.from(accountIdentifier).toString("hex");
+): AccountIdentifierHex => uint8ArrayToHexString(accountIdentifier);
 
 // eslint-disable-next-line local-rules/prefer-object-params
 export const principalToAccountIdentifier = (


### PR DESCRIPTION
# Motivation

We want to remove the use of `Buffer`. While testing the integration in NNS-dapp ([PR](https://github.com/dfinity/nns-dapp/pull/7348)), @yhabib noticed that the application was complaining about the missing polyfilled `Buffer`. This is likely because `nns-js` still relies on it for two features.

# Changes

- Replace usage of `Buffer` with `uint8ArrayToHexString` from `@dfinity/utils`
- Updated also in a comment in the unlikely event we would uncomment it in the future, just to avoid surprises
