### PR TITLE
chore(did): bump nns candid files

### DIFF
--- a/packages/nns/candid/genesis_token.did
+++ b/packages/nns/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 4565785 (2025-10-01 tags: release-2025-10-02_03-13-base) 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit ff761f3619 (2025-10-03) 'rs/nns/gtc/canister/gtc.did' by import-candid
 
 type AccountState = record {
   authenticated_principal_id : opt principal;

--- a/packages/nns/candid/governance.did
+++ b/packages/nns/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 4565785 (2025-10-01 tags: release-2025-10-02_03-13-base) 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit ff761f3619 (2025-10-03) 'rs/nns/governance/canister/governance.did' by import-candid
 
 type AccountIdentifier = record {
   hash : blob;

--- a/packages/nns/candid/governance_test.did
+++ b/packages/nns/candid/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 4565785 (2025-10-01 tags: release-2025-10-02_03-13-base) 'rs/nns/governance/canister/governance_test.did' by import-candid
+// Generated from IC repo commit ff761f3619 (2025-10-03) 'rs/nns/governance/canister/governance_test.did' by import-candid
 
 type AccountIdentifier = record {
   hash : blob;

--- a/packages/nns/candid/sns_wasm.certified.idl.js
+++ b/packages/nns/candid/sns_wasm.certified.idl.js
@@ -13,6 +13,7 @@ export const idlFactory = ({ IDL }) => {
   const AddWasmRequest = IDL.Record({
     'hash' : IDL.Vec(IDL.Nat8),
     'wasm' : IDL.Opt(SnsWasm),
+    'skip_update_latest_version' : IDL.Opt(IDL.Bool),
   });
   const SnsWasmError = IDL.Record({ 'message' : IDL.Text });
   const Result = IDL.Variant({

--- a/packages/nns/candid/sns_wasm.d.ts
+++ b/packages/nns/candid/sns_wasm.d.ts
@@ -5,6 +5,7 @@ import type { Principal } from "@dfinity/principal";
 export interface AddWasmRequest {
   hash: Uint8Array | number[];
   wasm: [] | [SnsWasm];
+  skip_update_latest_version: [] | [boolean];
 }
 export interface AddWasmResponse {
   result: [] | [Result];

--- a/packages/nns/candid/sns_wasm.did
+++ b/packages/nns/candid/sns_wasm.did
@@ -1,8 +1,9 @@
-// Generated from IC repo commit 4565785 (2025-10-01 tags: release-2025-10-02_03-13-base) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit ff761f3619 (2025-10-03) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;
+  skip_update_latest_version : opt bool;
 };
 
 type AddWasmResponse = record {

--- a/packages/nns/candid/sns_wasm.idl.js
+++ b/packages/nns/candid/sns_wasm.idl.js
@@ -13,6 +13,7 @@ export const idlFactory = ({ IDL }) => {
   const AddWasmRequest = IDL.Record({
     'hash' : IDL.Vec(IDL.Nat8),
     'wasm' : IDL.Opt(SnsWasm),
+    'skip_update_latest_version' : IDL.Opt(IDL.Bool),
   });
   const SnsWasmError = IDL.Record({ 'message' : IDL.Text });
   const Result = IDL.Variant({


### PR DESCRIPTION
# Motivation

There is a new field [skip_update_latest_version](https://sourcegraph.com/github.com/dfinity/ic@f21c91f50877772aad7bfd6b31e6fbc4f86935f7/-/blob/rs/nns/sns-wasm/canister/sns-wasm.did?L4) in `AddWasmRequest`, which is required for displaying some NNS proposals.

This new field was introduced [here](https://dashboard.internetcomputer.org/proposal/138826).

# Changes

- Checkout ic at `ff761f361981cff6a760b7d181f696551878b92a`
- Ran `./scripts/import-candid ../ic` from ic-js root folder 
- Ran `./scripts/compile-idl-js` from ic-js root folder 
- Revert changes not related to the `nns` package

# Tests

- Should pass as before

# Todos

- [] Add entry to changelog (if necessary).