### PR TITLE
Increase SNS package size limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     {
       "name": "@dfinity/sns",
       "path": "./packages/sns/dist/index.js",
-      "limit": "20 kB",
+      "limit": "25 kB",
       "gzip": true,
       "ignore": [
         "@dfinity/agent",


### PR DESCRIPTION
# Motivation

Adding more SNS action types caused the SNS package size to exceed the current limit.  
To unblock [this PR](https://github.com/dfinity/ic-js/pull/1091), we’re increasing the allowed package size limit.

# Changes

- Increased the size limit from ~20 KB to ~25 KB.

# Tests

- All current tests pass.

# Todos

- [ ] Add entry to changelog (if necessary).
