### PR TITLE
chore: prepare release v78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 | `@dfinity/ic-management` | v7.1.1  | Maintained ⚙ |
 | `@dfinity/ledger-icp`    | v6.1.0  | Enhanced 🔧️  |
 | `@dfinity/ledger-icrc`   | v4.0.4  | Maintained ⚙ |
-| `@dfinity/nns`           | v10.1.2 | Maintained ⚙ |
+| `@dfinity/nns`           | v10.2.0 | Enhanced 🔧️  |
 | `@dfinity/nns-proto`     | v2.0.2  | Unchanged️    |
 | `@dfinity/sns`           | v4.1.0  | Enhanced 🔧️  |
 | `@dfinity/utils`         | v3.2.0  | Enhanced 🔧️  |
@@ -19,6 +19,7 @@
 ## Features
 
 - Replace remaining usage of `Buffer` in `@dfinity/ledger-icp` in the `AccountIdentifier.fromHex` conversion.
+- Replace remaining usage of `Buffer` in `@dfinity/nns` in `accountIdentifierFromBytes`.
 - Add support for several SNS action types.
 - Use new utility `assertNever` in `@dfinity/sns`.
 - Update latest Candid files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 | `@dfinity/nns`           | v10.2.0 | Enhanced 🔧️  |
 | `@dfinity/nns-proto`     | v2.0.2  | Unchanged️    |
 | `@dfinity/sns`           | v4.1.0  | Enhanced 🔧️  |
-| `@dfinity/utils`         | v3.2.0  | Enhanced 🔧️  |
+| `@dfinity/utils`         | v3.2.0  | Unchanged️    |
 | `@dfinity/zod-schemas`   | v2.1.0  | Unchanged️    |
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# v78
+
+## Overview
+
+| Library                  | Version | Status        |
+| ------------------------ | ------- | ------------- |
+| `@dfinity/ckbtc`         | v4.0.4  | Maintained ⚙ |
+| `@dfinity/cketh`         | v4.0.4  | Maintained ⚙ |
+| `@dfinity/cmc`           | v6.0.4  | Maintained ⚙ |
+| `@dfinity/ic-management` | v7.1.1  | Maintained ⚙ |
+| `@dfinity/ledger-icp`    | v6.1.0  | Enhanced 🔧️  |
+| `@dfinity/ledger-icrc`   | v4.0.4  | Maintained ⚙ |
+| `@dfinity/nns`           | v10.1.2 | Maintained ⚙ |
+| `@dfinity/nns-proto`     | v2.0.2  | Unchanged️    |
+| `@dfinity/sns`           | v4.1.0  | Enhanced 🔧️  |
+| `@dfinity/utils`         | v3.2.0  | Enhanced 🔧️  |
+| `@dfinity/zod-schemas`   | v2.1.0  | Unchanged️    |
+
+## Features
+
+- Replace remaining usage of `Buffer` in `@dfinity/ledger-icp` in the `AccountIdentifier.fromHex` conversion.
+- Add support for several SNS action types.
+- Use new utility `assertNever` in `@dfinity/sns`.
+- Update latest Candid files.
+
 # v77
 
 ## Overview

--- a/package-lock.json
+++ b/package-lock.json
@@ -6603,7 +6603,7 @@
     },
     "packages/nns": {
       "name": "@dfinity/nns",
-      "version": "10.1.2",
+      "version": "10.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "77",
+  "version": "78",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/ic-js",
-      "version": "77",
+      "version": "78",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/utils",
@@ -6522,7 +6522,7 @@
     },
     "packages/ckbtc": {
       "name": "@dfinity/ckbtc",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
@@ -6548,7 +6548,7 @@
     },
     "packages/cketh": {
       "name": "@dfinity/cketh",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^3",
@@ -6559,7 +6559,7 @@
     },
     "packages/cmc": {
       "name": "@dfinity/cmc",
-      "version": "6.0.3",
+      "version": "6.0.4",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^3",
@@ -6570,7 +6570,7 @@
     },
     "packages/ic-management": {
       "name": "@dfinity/ic-management",
-      "version": "7.1.0",
+      "version": "7.1.1",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^3",
@@ -6581,7 +6581,7 @@
     },
     "packages/ledger-icp": {
       "name": "@dfinity/ledger-icp",
-      "version": "6.0.2",
+      "version": "6.1.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^3",
@@ -6592,7 +6592,7 @@
     },
     "packages/ledger-icrc": {
       "name": "@dfinity/ledger-icrc",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^3",
@@ -6603,7 +6603,7 @@
     },
     "packages/nns": {
       "name": "@dfinity/nns",
-      "version": "10.1.1",
+      "version": "10.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0"
@@ -6629,7 +6629,7 @@
     },
     "packages/sns": {
       "name": "@dfinity/sns",
-      "version": "4.0.4",
+      "version": "4.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "77",
+  "version": "78",
   "description": "A collection of library for interfacing with the Internet Computer.",
   "license": "Apache-2.0",
   "workspaces": [

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ckbtc",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "A library for interfacing with ckBTC.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/cketh/package.json
+++ b/packages/cketh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/cketh",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "A library for interfacing with ckETH.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/cmc/package.json
+++ b/packages/cmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/cmc",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "A library for interfacing with the cycle minting canister.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-management",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "A library for interfacing with the IC management canister.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/ledger-icp/package.json
+++ b/packages/ledger-icp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ledger-icp",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "description": "A library for interfacing with the ICP ledger on the Internet Computer.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/ledger-icrc/package.json
+++ b/packages/ledger-icrc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ledger-icrc",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "A library for interfacing with ICRC ledgers on the Internet Computer.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "10.1.2",
+  "version": "10.2.0",
   "description": "A library for interfacing with the Internet Computer's Network Nervous System.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "description": "A library for interfacing with the Internet Computer's Network Nervous System.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/sns",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "A library for interfacing with a Service Nervous System (SNS) project.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",


### PR DESCRIPTION
# Motivation

We want to release a version that remove Buffer in nns-js and ledger-icp. We also want to release a version before migrating to `@icp-sdk`.

# Changes

- Tag versions
- Update CHANGELOG with entries and summary